### PR TITLE
[fix](kt): Fix barrier call to use cpu_group instead of device_group

### DIFF
--- a/python/sglang/srt/layers/moe/kt_ep_wrapper.py
+++ b/python/sglang/srt/layers/moe/kt_ep_wrapper.py
@@ -464,11 +464,7 @@ class SharedFullContext:
         else:
             self.shm_unique_id = None
         if dist.is_initialized():
-            unique_id_list = [self.shm_unique_id]
-            dist.broadcast_object_list(
-                unique_id_list, src=0, group=get_tp_group().cpu_group
-            )
-            self.shm_unique_id = unique_id_list[0]
+            self.shm_unique_id = get_tp_group().broadcast_object(self.shm_unique_id)
 
         for name in self.weight_names:
             gpu_tensor = getattr(self.gpu_layer, name)
@@ -499,14 +495,14 @@ class SharedFullContext:
             self.cpu_buffers[name] = cpu_buffer
 
         if dist.is_initialized():
-            dist.barrier(group=get_tp_group().device_group)
+            get_tp_group().barrier()
 
         self.all_rank_buffer_ptrs = self._collect_all_rank_buffer_pointers()
 
         # Unlink shared memory after all ranks have collected pointers.
         # The memory remains accessible as long as we hold references via mmap.
         if dist.is_initialized():
-            dist.barrier(group=get_tp_group().device_group)
+            get_tp_group().barrier()
         for shm in self.shm_handles.values():
             shm.unlink()
 
@@ -706,7 +702,7 @@ class SharedFullContext:
 
             # Barrier to ensure all ranks see the written data
             if dist.is_initialized():
-                dist.barrier(group=get_tp_group().device_group)
+                get_tp_group().barrier()
 
             with torch.cuda.stream(copy_stream):
                 slot = e % 2  # Double buffering
@@ -874,7 +870,7 @@ class SharedFullContext:
 
             # Barrier to ensure all ranks see the written data
             if dist.is_initialized():
-                dist.barrier(group=get_tp_group().device_group)
+                get_tp_group().barrier()
 
             with torch.cuda.stream(copy_stream):
                 for _, cpu_buf, gpu_t in weight_infos:
@@ -1046,7 +1042,7 @@ class SharedFullContext:
 
             # Barrier to ensure all ranks see the written data
             if dist.is_initialized():
-                dist.barrier(group=get_tp_group().device_group)
+                get_tp_group().barrier()
 
             with torch.cuda.stream(copy_stream):
                 for _, cpu_buf, gpu_t in weight_infos:
@@ -1198,7 +1194,7 @@ class SharedFullContext:
 
             # Barrier to ensure all ranks see the written data
             if dist.is_initialized():
-                dist.barrier(group=get_tp_group().device_group)
+                get_tp_group().barrier()
 
             with torch.cuda.stream(copy_stream):
                 for _, cpu_buf, gpu_t in weight_infos:


### PR DESCRIPTION
## Summary

The comment in the `GroupCoordinator.barrier` method in `parallel_state.py` explicitly states: "don't use device_group here." However, the current implementation frequently uses `device_group` in `dist.barrier` calls, which introduces unnecessary latency during the expert transfer process in layerwise-prefill. This latency scales with both the number of layers and the number of experts per layer, degrading performance.

### Profling
On a system with `Quadro RTX 5000`x1 and `PyTorch 2.7.1`, using `device_group` in `dist.barrier` adds around 75 microseconds of latency per expert transfer compare with using `cpu_group`. For a model like Qwen3-30B-A3B (128 experts per layer, 48 layers), this accumulates to nearly 460.8ms of additional overhead.

### Modifications
Replace the explicit `dist.barrier(group=get_tp_group().device_group)` call with the already wrapped `GroupCoordinator.barrier` method which use `cpu_group` inside.
