### PR TITLE
[feat]: add --kt-numa-nodes for explicit NUMA node mapping

### DIFF
--- a/python/sglang/srt/layers/moe/kt_ep_wrapper.py
+++ b/python/sglang/srt/layers/moe/kt_ep_wrapper.py
@@ -82,6 +82,7 @@ class KTConfig:
     num_layers: Optional[int] = None
     gpu_prefill_token_threshold: Optional[int] = None
     kt_enable_dynamic_expert_update: bool = False
+    numa_nodes: Optional[List[int]] = None
 
 
 _SHARED_FULL_CONTEXT = None
@@ -1667,6 +1668,7 @@ def create_kt_config_from_server_args(
         num_layers=num_layers,
         gpu_prefill_token_threshold=server_args.kt_gpu_prefill_token_threshold,
         kt_enable_dynamic_expert_update=server_args.kt_enable_dynamic_expert_update,
+        numa_nodes=[int(x) for x in server_args.kt_numa_nodes.split(",")] if server_args.kt_numa_nodes else None,
     )
 
 
@@ -2105,6 +2107,7 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
                 chunked_prefill_size=self.kt_config.chunked_prefill_size,
                 method=self.kt_config.method,
                 max_deferred_experts_per_token=layer_max_deferred,
+                numa_nodes=self.kt_config.numa_nodes,
             )
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -554,6 +554,7 @@ class ServerArgs:
     kt_method: Optional[str] = None
     kt_cpuinfer: Optional[int] = None
     kt_threadpool_count: Optional[int] = None
+    kt_numa_nodes: Optional[str] = None
     kt_num_gpu_experts: Optional[int] = None
     kt_gpu_experts_ratio: Optional[float] = None
     kt_max_deferred_experts_per_token: Optional[int] = None
@@ -4451,6 +4452,15 @@ class ServerArgs:
             type=int,
             default=2,
             help="[ktransformers parameter] One-to-one with the number of NUMA nodes (one thread pool per NUMA).",
+        )
+        parser.add_argument(
+            "--kt-numa-nodes",
+            type=str,
+            default=None,
+            help="[ktransformers parameter] Comma-separated list of NUMA node IDs for subpool mapping. "
+                 "E.g. \"1\" to bind to NUMA node 1, or \"2,3\" for nodes 2 and 3. "
+                 "Must match --kt-threadpool-count in length. "
+                 "If not set, defaults to sequential IDs [0, 1, ..., threadpool_count-1].",
         )
         parser.add_argument(
             "--kt-num-gpu-experts",


### PR DESCRIPTION
## Summary

- Add `--kt-numa-nodes` CLI parameter to `ServerArgs` for specifying NUMA node IDs
- Thread `numa_nodes` through `KTConfig` dataclass to `KTMoEWrapper` instantiation
- Parse comma-separated string (e.g., `"1"` or `"0,1"`) into `List[int]`

## Motivation

Companion to kvcache-ai/ktransformers#1891.

Currently `subpool_numa_map` in kt-kernel defaults to `[0, 1, ..., threadpool_count-1]`. This makes it impossible to bind a KTransformers instance to a specific NUMA node (e.g., node 1) without external `numactl`.

## Usage

Deploy two independent instances on a dual-NUMA machine, each bound to a different NUMA node:

```bash
# Instance 1: bind to NUMA node 0
python -m sglang.launch_server \
  --model /path/to/model \
  --kt-threadpool-count 1 --kt-numa-nodes 0 \
  --kt-cpuinfer 48 \
  --port 30000 \
  ...

# Instance 2: bind to NUMA node 1
python -m sglang.launch_server \
  --model /path/to/model \
  --kt-threadpool-count 1 --kt-numa-nodes 1 \
  --kt-cpuinfer 48 \
  --port 30001 \
  ...
```

You can also specify multiple NUMA nodes in custom order:

```bash
# Reverse order
python -m sglang.launch_server \
  --kt-threadpool-count 2 --kt-numa-nodes 1,0 \
  ...
```

If `--kt-numa-nodes` is not specified, the behavior is unchanged.

## Tested on

- AMD EPYC 9355 dual-socket (2 NUMA nodes, 128 threads)
- Verified `CPUInfer` creates worker pool on correct NUMA node
- Verified backward compatibility

## Test plan

- [x] `from sglang.srt.server_args import ServerArgs` imports successfully
- [x] `--kt-numa-nodes` is accepted by argparse and parsed correctly
- [x] Backward compatible: omitting `--kt-numa-nodes` behaves as before
- [x] End-to-end with companion kt-kernel PR on a multi-NUMA machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)