### PR TITLE
[fix] Qwen3.5 AWQ quantization startup crash

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -160,6 +160,7 @@ from sglang.srt.utils import (
     get_cpu_ids_by_node,
     get_local_ip_auto,
     init_custom_process_group,
+    is_blackwell,
     is_hip,
     is_host_cpu_arm64,
     is_npu,
@@ -675,6 +676,18 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             )
             server_args.attention_backend = "triton"
             server_args.disable_cuda_graph = True
+
+        if (
+            self.hybrid_gdn_config is not None
+            and getattr(self.hybrid_gdn_config, "model_type", None)
+            in {"qwen3_5_text", "qwen3_5_moe_text"}
+            and is_blackwell()
+            and server_args.attention_backend == "flashinfer"
+        ):
+            logger.info(
+                "Switching attention backend to triton for Qwen3.5 hybrid GDN on Blackwell."
+            )
+            server_args.attention_backend = "triton"
 
         if self.is_multimodal:
             if not self.is_multimodal_chunked_prefill_supported:

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -70,6 +70,7 @@ from sglang.srt.models.qwen2_moe import Qwen2MoeMLP, Qwen2MoeSparseMoeBlock
 
 # Models
 from sglang.srt.models.qwen3_vl import Qwen3VLForConditionalGeneration
+from sglang.srt.models.utils import WeightsMapper
 
 # Utils
 from sglang.srt.utils import add_prefix, is_cuda, is_npu, make_layers, set_weight_attrs
@@ -1027,6 +1028,14 @@ class Qwen3_5MoeForCausalLM(Qwen3_5ForCausalLM):
 
 
 class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration):
+    # Qwen3.5 already remaps weight names in load_weights().
+    # Keep mapper simple so quant ignore names still match Qwen3.5 layer names.
+    hf_to_sglang_mapper = WeightsMapper(
+        orig_to_new_substr={
+            "attn.qkv": "attn.qkv_proj",
+        },
+    )
+
     def __init__(
         self,
         config: Qwen3_5Config,
@@ -1119,6 +1128,12 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration):
 
 class Qwen3_5MoeForConditionalGeneration(Qwen3VLForConditionalGeneration):
     """Qwen3.5 MoE Vision-Language Model."""
+
+    hf_to_sglang_mapper = WeightsMapper(
+        orig_to_new_substr={
+            "attn.qkv": "attn.qkv_proj",
+        },
+    )
 
     def __init__(
         self,


### PR DESCRIPTION
Here's a filled-in PR description for cherry-picking the Qwen3.5 AWQ fix:

---

## Motivation

Cherry-pick fix from [sgl-project/sglang#20370](https://github.com/sgl-project/sglang/pull/20370) to resolve Qwen3.5 AWQ quantization startup crash:

```
RuntimeError: gptq_marlin_repack.cuh:309: size_n = 32 is not divisible by tile_n_size = 64
```

The upstream PR has not been merged yet. Bringing the fix in early so our fork can support Qwen3.5 AWQ models now.

## Modifications

- **`qwen3_5.py`**: Added `hf_to_sglang_mapper` override for `Qwen3_5ForConditionalGeneration` and `Qwen3_5MoeForConditionalGeneration` so quant ignore names match correctly and `in_proj_a/in_proj_b` layers are not mistakenly quantized.
- **`model_runner.py`**: Added Blackwell backend guard to auto-switch from `flashinfer` to `triton` for Qwen3.5 GDN models.

All changes are identical to upstream PR [#20370](https://github.com/sgl-project/sglang/pull/20370).

## Accuracy Tests

See upstream PR for results (4B AWQ 4-bit: 74.4 on C-Eval vs 75.3 original).

## Benchmarking and Profiling

N/A — bug fix only, no performance impact expected.