### PR TITLE
[fix]: upgrade transformers to 5.3.0 for GLM5.1 support

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -70,7 +70,7 @@ dependencies = [
   "torchcodec==0.8.0 ; sys_platform != 'linux' or (sys_platform == 'linux' and platform_machine != 'aarch64' and platform_machine != 'arm64' and platform_machine != 'armv7l')", # torchcodec does not exist in those systems. If not provided, transformer will use torchvision instead by default.
   "torchvision",
   "tqdm",
-  "transformers==4.57.1",
+  "transformers==5.3.0",
   "uvicorn",
   "uvloop",
   "xgrammar==0.1.27",


### PR DESCRIPTION
  Motivation :                                                              
  Upgrade transformers to 5.3.0 to support GLM 5.1 models, which require features   
  introduced in that version.
                                                                                
  Modifications  :                                        
  Bumped transformers version requirement to >=5.3.0 in the install             
  configuration.

  Benchmarking and Profiling :
  N/A
