### PR TITLE
fix: align sglang-kt torch 2.9.1 runtime baseline

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -64,11 +64,11 @@ dependencies = [
   "tiktoken",
   "timm==1.0.16",
   "torch_memory_saver==0.0.9",
-  "torch>=2.10,<2.12",
+  "torch==2.9.1",
   "torchao==0.9.0",
-  "torchaudio>=2.10,<2.12",
+  "torchaudio==2.9.1",
   "torchcodec==0.8.0 ; sys_platform != 'linux' or (sys_platform == 'linux' and platform_machine != 'aarch64' and platform_machine != 'arm64' and platform_machine != 'armv7l')", # torchcodec does not exist in those systems. If not provided, transformer will use torchvision instead by default.
-  "torchvision>=0.25,<0.27",
+  "torchvision==0.24.1",
   "tqdm",
   "transformers==4.57.1",
   "uvicorn",
@@ -87,14 +87,14 @@ url = "https://pypi.org/simple"
 default = true
 
 [[tool.uv.index]]
-name = "torch-cu129"
-url = "https://download.pytorch.org/whl/cu129"
+name = "torch-cu130"
+url = "https://download.pytorch.org/whl/cu130"
 explicit = true
 
 [tool.uv.sources]
 torch = [
   { index = "pypi", marker = "platform_machine == 'x86_64'"},
-  { index = "torch-cu129", marker = "platform_machine == 'aarch64'"},
+  { index = "torch-cu130", marker = "platform_machine == 'aarch64'"},
 ]
 
 [project.optional-dependencies]

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -5415,44 +5415,85 @@ class ServerArgs:
         if get_bool_env_var("SGLANG_DISABLE_CUDNN_CHECK"):
             return
 
-        if self.get_model_config().is_multimodal:
-            import torch
+        if not self.get_model_config().is_multimodal:
+            return
 
-            if torch_release[:3] == (2, 9, 1):
-                cudnn_version = None
-                try:
-                    cudnn_version = torch.backends.cudnn.version()
-                except Exception:
-                    cudnn_version = None
-                if cudnn_version is not None:
-                    version_float = float(str(cudnn_version)[:3]) / 100
-                    if version_float < 9.15:
-                        RED = "\033[91m"
-                        BOLD = "\033[1m"
-                        RESET = "\033[0m"
-                        msg = (
-                            f"{RED}{BOLD}"
-                            "CRITICAL WARNING: PyTorch 2.9.1 & CuDNN Compatibility Issue Detected\n"
-                            "--------------------------------------------------------------------------------\n"
-                            f"Current Environment: PyTorch {torch.__version__} | CuDNN {version_float:.2f}\n\n"
-                            "Issue:     There is a KNOWN BUG in PyTorch 2.9.1's `nn.Conv3d` implementation\n"
-                            "           when used with CuDNN versions older than 9.15. This can cause\n"
-                            "           SEVERE PERFORMANCE DEGRADATION and EXCESSIVE MEMORY USAGE.\n\n"
-                            "Reference: https://github.com/pytorch/pytorch/issues/168167\n\n"
-                            "Solution:  You MUST upgrade CuDNN to version 9.15+ to ensure correctness.\n\n"
-                            "Run the following command immediately to fix:\n"
-                            "    pip install nvidia-cudnn-cu12==9.16.0.29\n\n"
-                            "Or you can disable this check by setting env var SGLANG_DISABLE_CUDNN_CHECK=1\n"
-                            "--------------------------------------------------------------------------------\n"
-                            f"{RESET}"
-                        )
-                        raise RuntimeError(msg)
-                else:
-                    RED = "\033[91m"
-                    RESET = "\033[0m"
-                    logger.warning(
-                        f"{RED}WARNING: Could not determine CuDNN version for torch==2.9.1. Please ensure CuDNN >= 9.15 to avoid nn.Conv3d bugs.{RESET}"
-                    )
+        import torch
+
+        if torch_release[:3] != (2, 9, 1):
+            return
+
+        def _format_cudnn_version(version):
+            if version is None:
+                return "unknown"
+            try:
+                version_int = int(version)
+            except (TypeError, ValueError):
+                return str(version)
+            if version_int >= 10000:
+                major = version_int // 10000
+                minor = (version_int % 10000) // 100
+                patch = version_int % 100
+            else:
+                major = version_int // 1000
+                minor = (version_int % 1000) // 100
+                patch = version_int % 100
+            return f"{major}.{minor}.{patch}"
+
+        try:
+            cudnn_version = torch.backends.cudnn.version()
+        except Exception:
+            cudnn_version = None
+
+        if cudnn_version is None:
+            RED = "\033[91m"
+            RESET = "\033[0m"
+            logger.warning(
+                "%sWARNING: Could not determine CuDNN version for torch==2.9.1. "
+                "Please ensure CuDNN >= 9.15 to avoid the known nn.Conv3d "
+                "performance and memory issue.%s",
+                RED,
+                RESET,
+            )
+            return
+
+        if int(cudnn_version) >= 91500:
+            return
+
+        cuda_version = getattr(torch.version, "cuda", None)
+        cuda_major = str(cuda_version).split(".", 1)[0] if cuda_version else ""
+        if cuda_major == "13":
+            cudnn_package = "nvidia-cudnn-cu13"
+        elif cuda_major == "12":
+            cudnn_package = "nvidia-cudnn-cu12"
+        else:
+            cudnn_package = "nvidia-cudnn-cu12_or_nvidia-cudnn-cu13"
+
+        if cudnn_package == "nvidia-cudnn-cu12_or_nvidia-cudnn-cu13":
+            install_cmd = (
+                "pip install --force-reinstall --no-deps "
+                "nvidia-cudnn-cu12==9.16.0.29  # or nvidia-cudnn-cu13 for CUDA 13"
+            )
+        else:
+            install_cmd = (
+                "pip install --force-reinstall --no-deps "
+                f"{cudnn_package}==9.16.0.29"
+            )
+
+        RED = "\033[91m"
+        RESET = "\033[0m"
+        logger.warning(
+            "%sWARNING: PyTorch 2.9.1 with CuDNN %s detected for a multimodal model. "
+            "PyTorch issue https://github.com/pytorch/pytorch/issues/168167 reports "
+            "an nn.Conv3d performance and memory regression with CuDNN older than 9.15. "
+            "SGLang will continue startup, but the recommended post-install override is:\n"
+            "    %s\n"
+            "Set SGLANG_DISABLE_CUDNN_CHECK=1 to suppress this warning.%s",
+            RED,
+            _format_cudnn_version(cudnn_version),
+            install_cmd,
+            RESET,
+        )
 
     def check_lora_server_args(self):
         assert self.max_loras_per_batch > 0, "max_loras_per_batch must be positive"

--- a/sgl-kernel/python/sgl_kernel/load_utils.py
+++ b/sgl-kernel/python/sgl_kernel/load_utils.py
@@ -56,10 +56,11 @@ def _load_architecture_specific_ops():
     sgl_kernel_dir = Path(__file__).parent
     logger.debug(f"[sgl_kernel] sgl_kernel directory: {sgl_kernel_dir}")
 
-    # Determine which version to load based on GPU architecture
-    if compute_capability == 90:
+    # Determine which version to load based on GPU architecture. The sm90 build
+    # also contains gencode for sm80/sm89 when ENABLE_BELOW_SM90 is enabled.
+    if compute_capability is not None and compute_capability < 100:
         ops_subdir = "sm90"
-        variant_name = "SM90 (Hopper/H100 with fast math optimization)"
+        variant_name = f"SM{compute_capability} via sm90 library"
     elif compute_capability is not None:
         ops_subdir = "sm100"
         variant_name = f"SM{compute_capability} (precise math for compatibility)"


### PR DESCRIPTION
Align sglang-kt metadata to torch==2.9.1 / torchaudio==2.9.1 / torchvision==0.24.1, switch uv torch index to cu130, route below-SM100 kernels through the sm90 build, and downgrade the PyTorch 2.9.1 cuDNN multimodal check from a hard error to warning-only.