### PR TITLE
fix: align sglang kt post1 deps and fp8 alias

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -70,7 +70,7 @@ dependencies = [
   "torchcodec==0.8.0 ; sys_platform != 'linux' or (sys_platform == 'linux' and platform_machine != 'aarch64' and platform_machine != 'arm64' and platform_machine != 'armv7l')", # torchcodec does not exist in those systems. If not provided, transformer will use torchvision instead by default.
   "torchvision==0.24.1",
   "tqdm",
-  "transformers==4.57.1",
+  "transformers-kt==5.6.0.post1",
   "uvicorn",
   "uvloop",
   "xgrammar==0.1.27",

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -5283,6 +5283,7 @@ class ServerArgs:
         assert (
             self.tp_size * self.pp_size
         ) % self.nnodes == 0, "tp_size must be divisible by number of nodes"
+        self.normalize_kt_method_aliases()
 
         if self.pp_size > 1:
             assert (
@@ -5410,6 +5411,26 @@ class ServerArgs:
             raise ValueError(
                 "When enabling two batch overlap, moe_a2a_backend cannot be 'none'."
             )
+
+    def normalize_kt_method_aliases(self):
+        if self.kt_method is None:
+            return
+
+        kt_method_aliases = {
+            "RAWFP8": "FP8",
+        }
+        normalized_method = kt_method_aliases.get(self.kt_method)
+        if normalized_method is None:
+            return
+
+        logger.warning(
+            "--kt-method %s is deprecated; using %s. "
+            "Use --kt-method %s in new scripts.",
+            self.kt_method,
+            normalized_method,
+            normalized_method,
+        )
+        self.kt_method = normalized_method
 
     def check_torch_2_9_1_cudnn_compatibility(self):
         if get_bool_env_var("SGLANG_DISABLE_CUDNN_CHECK"):


### PR DESCRIPTION
## Summary
- depend on transformers-kt==5.6.0.post1 for sglang-kt post1 instead of upstream transformers
- normalize legacy --kt-method RAWFP8 to FP8 with a warning so existing KT scripts pass server arg checks

## Validation
- Built clean sglang_kt-0.6.1.post1 wheel from a fresh worktree; verified no build/lib or __pycache__ entries
- Fresh conda py312 env passed pip check with torch 2.9.1+cu130 and KT post1 wheels
- LLaMA-Factory actual 4-GPU accelerate launch reached distributed/model processor path; stopped only on missing Qwen3.5 processor files
- SGLang actual DeepSeek-V3 launch with --kt-method RAWFP8 reached ready; /model_info and /generate returned 200
