### PR TITLE
fix(qwen3.5): normalize MoE nested configs

### DIFF
--- a/python/sglang/srt/configs/qwen3_5.py
+++ b/python/sglang/srt/configs/qwen3_5.py
@@ -1,7 +1,23 @@
+from collections.abc import Mapping
+
 from transformers import PretrainedConfig
 
 from sglang.srt.configs.qwen3_next import Qwen3NextConfig
 from sglang.srt.configs.qwen3_vl import Qwen3VLVisionConfig
+
+
+def _coerce_qwen3_5_sub_config(config, config_class):
+    if config is None:
+        return config_class()
+    if isinstance(config, config_class):
+        return config
+    if isinstance(config, Mapping):
+        return config_class(**dict(config))
+    if isinstance(config, PretrainedConfig):
+        return config
+    if hasattr(config, "to_dict"):
+        return config_class(**config.to_dict())
+    return config
 
 
 class Qwen3_5VisionConfig(Qwen3VLVisionConfig):
@@ -90,29 +106,40 @@ class Qwen3_5Config(PretrainedConfig):
         tie_word_embeddings=False,
         **kwargs,
     ):
-        if isinstance(vision_config, dict):
-            self.vision_config = self.sub_configs["vision_config"](**vision_config)
-        elif vision_config is None:
-            self.vision_config = self.sub_configs["vision_config"]()
-
-        if isinstance(text_config, dict):
-            self.text_config = self.sub_configs["text_config"](**text_config)
-        elif text_config is None:
-            self.text_config = self.sub_configs["text_config"]()
+        self.vision_config = _coerce_qwen3_5_sub_config(
+            vision_config, self.sub_configs["vision_config"]
+        )
+        self.text_config = _coerce_qwen3_5_sub_config(
+            text_config, self.sub_configs["text_config"]
+        )
 
         self.image_token_id = image_token_id
         self.video_token_id = video_token_id
         self.vision_start_token_id = vision_start_token_id
         self.vision_end_token_id = vision_end_token_id
         super().__init__(**kwargs, tie_word_embeddings=tie_word_embeddings)
+        self.vision_config = _coerce_qwen3_5_sub_config(
+            getattr(self, "vision_config", vision_config),
+            self.sub_configs["vision_config"],
+        )
+        self.text_config = _coerce_qwen3_5_sub_config(
+            getattr(self, "text_config", text_config),
+            self.sub_configs["text_config"],
+        )
 
 
 class Qwen3_5MoeVisionConfig(Qwen3_5VisionConfig):
     model_type = "qwen3_5_moe"
 
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
 
 class Qwen3_5MoeTextConfig(Qwen3_5TextConfig):
     model_type = "qwen3_5_moe_text"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
 
 
 class Qwen3_5MoeConfig(Qwen3_5Config):
@@ -121,3 +148,6 @@ class Qwen3_5MoeConfig(Qwen3_5Config):
         "vision_config": Qwen3_5MoeVisionConfig,
         "text_config": Qwen3_5MoeTextConfig,
     }
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)


### PR DESCRIPTION
## Summary
- normalize Qwen3.5 nested text/vision configs from dicts into config objects
- add explicit Qwen3.5 MoE config initializers so Transformers v5 dataclass wrapping preserves the inherited init path
- preserve recursive propagation of attn/expert implementation settings into nested configs

## Verification
- py_compile python/sglang/srt/configs/qwen3_5.py
- Qwen3_5Config and Qwen3_5MoeConfig dict/default init checks
- Qwen3_5MoeConfig.from_pretrained(/mnt/data2/models/Qwen3.5-397B-A17B)
- ModelConfig(..., context_length=131072) against /mnt/data2/models/Qwen3.5-397B-A17B
