### PR TITLE
fix(v4-flash): bundle V4-2604B SwiGLU clamp + hybrid SWA chunked-prefill hang fix

### DIFF
--- a/python/sglang/srt/layers/moe/kt_ep_wrapper.py
+++ b/python/sglang/srt/layers/moe/kt_ep_wrapper.py
@@ -556,9 +556,15 @@ class SharedFullContext:
             gpu_tensor = getattr(self.gpu_layer, name)
             # Only allocate 2 experts worth of buffer (double buffering)
             expert_shape = gpu_tensor.shape[1:]  # Shape per expert
-            expert_nbytes = (
-                gpu_tensor.numel() // num_experts * gpu_tensor.element_size()
-            )
+            if (
+                getattr(self, "is_mxfp4_quant", False)
+                and name in ("w13_weight_scale_inv", "w2_weight_scale_inv")
+            ):
+                buf_dtype = torch.bfloat16
+            else:
+                buf_dtype = gpu_tensor.dtype
+            element_size = torch.empty((), dtype=buf_dtype).element_size()
+            expert_nbytes = gpu_tensor.numel() // num_experts * element_size
             double_buf_nbytes = expert_nbytes * 2
 
             shm_name = f"kt_buf_{name}_r{tp_rank}_{self.shm_unique_id}"
@@ -568,7 +574,7 @@ class SharedFullContext:
             self.shm_handles[name] = shm
 
             # Shape: [2, ...expert_shape...]
-            cpu_buffer = torch.frombuffer(shm.buf, dtype=gpu_tensor.dtype).reshape(
+            cpu_buffer = torch.frombuffer(shm.buf, dtype=buf_dtype).reshape(
                 (2,) + expert_shape
             )
 

--- a/python/sglang/srt/layers/moe/kt_ep_wrapper.py
+++ b/python/sglang/srt/layers/moe/kt_ep_wrapper.py
@@ -2291,6 +2291,18 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
         # 2. Initialize KT wrapper for CPU experts
         # CPU experts are identified by gpu_experts_mask=False
         if self.tp_rank == 0:
+            # V4-Flash 2604B SwiGLU clamp on routed experts. The full
+            # moe_runner_config (which carries swiglu_limit) does not arrive
+            # until create_moe_runner(), but the value is fully determined
+            # by the DSV4 submode env (fixed at process start), so we read
+            # it here without waiting. Matches the assert
+            # `swiglu_limit == 10` in moe_runner/deep_gemm.py:_apply_swiglu_limit
+            # and the default 10.0 set for 2604B in mxfp4_deepseek.py.
+            # Origin: kt-sglang 耦合 (carries V4-2604B limit into kt-kernel).
+            from sglang.srt.environ import envs as _envs
+            _kt_swiglu_limit = (
+                10.0 if _envs.SGLANG_DSV4_2604_SUBMODE.get() == "2604B" else 0.0
+            )
             self.wrapper = KTMoEWrapper(
                 layer_idx=self.kt_config.layer_idx,
                 num_experts=num_experts,
@@ -2300,6 +2312,7 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
                 gpu_experts_mask=self.gpu_experts_mask,
                 cpuinfer_threads=self.kt_config.cpuinfer_threads,
                 threadpool_count=self.kt_config.threadpool_count,
+                swiglu_limit=_kt_swiglu_limit,
                 numa_nodes=self.kt_config.numa_nodes,
                 weight_path=self.kt_config.weight_path,
                 chunked_prefill_size=self.kt_config.chunked_prefill_size,

--- a/python/sglang/srt/layers/quantization/mxfp4_deepseek.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_deepseek.py
@@ -481,6 +481,12 @@ class DeepSeekMxfp4MoEMethod:
                     topk_ids,
                 )
             rsf = layer.moe_runner_config.routed_scaling_factor
+            # 2604B SwiGLU clamp: thread swiglu_limit through so the triton-
+            # kernels GPU MoE path applies the same gate/up clamp as
+            # trtllm's gemm1_clamp_limit and deep_gemm's _apply_swiglu_limit.
+            # When submode != 2604B, moe_runner_config.swiglu_limit is None
+            # and apply_v4_triton_kernels_moe skips the clamp.
+            # Origin: sglang 本身.
             output = apply_v4_triton_kernels_moe(
                 hidden_states=hidden_states,
                 w13_swiz=layer._v4_tk_w13,
@@ -492,6 +498,7 @@ class DeepSeekMxfp4MoEMethod:
                 intermediate_size=layer._v4_tk_intermediate_size,
                 num_experts=layer._v4_tk_num_experts,
                 routed_scaling_factor=rsf if rsf is not None else 1.0,
+                swiglu_limit=layer.moe_runner_config.swiglu_limit,
             )
             if envs.SGLANG_DSV4_2604_SUBMODE.get() == '2604B' and (
                 self._gemm1_clamp_limit_tensor is not None

--- a/python/sglang/srt/layers/quantization/v4_triton_kernels_moe.py
+++ b/python/sglang/srt/layers/quantization/v4_triton_kernels_moe.py
@@ -362,6 +362,7 @@ def apply_v4_triton_kernels_moe(
     intermediate_size: int,         # per-partition N
     num_experts: int,
     routed_scaling_factor: float = 1.0,
+    swiglu_limit: Optional[float] = None,
 ) -> torch.Tensor:
     """Run V4 sparse MoE through `triton_kernels.matmul_ogs`.
 
@@ -369,6 +370,14 @@ def apply_v4_triton_kernels_moe(
     byte-level reproducible under same input.
 
     Activation: silu_and_mul (V4 default), applied between the two GEMMs.
+
+    `swiglu_limit` (DSV4 2604B): if not None, applies the same gate/up
+    asymmetric clamp the trtllm path's `gemm1_clamp_limit` and the
+    deep_gemm path's `_apply_swiglu_limit` use, on the gemm1 output before
+    silu_and_mul:
+        gate = clamp(gate, max=limit)            # one-sided
+        up   = clamp(up, min=-limit, max=limit)  # symmetric
+    Origin: sglang 本身 (matches `moe_runner/deep_gemm.py:_apply_swiglu_limit`).
     """
     from triton_kernels.matmul_ogs import matmul_ogs
     from sgl_kernel import silu_and_mul
@@ -396,7 +405,16 @@ def apply_v4_triton_kernels_moe(
         gather_indx=gather_indx,
         precision_config=w13_pcg,
     )
-    # intermediate1 shape: [M*topk, 2*N]
+    # intermediate1 shape: [M*topk, 2*N]; layout = [gate, up] along last dim.
+    # We skipped reorder_w1w3_to_w3w1 for this path so the natural [w1, w3]
+    # = [gate, up] order from the checkpoint is preserved.
+    if swiglu_limit is not None:
+        # 2604B asymmetric SwiGLU clamp. View slices and clamp_ in place to
+        # avoid chunk+cat copy; safe because intermediate1 is a fresh
+        # matmul_ogs output, not a cached buffer.
+        N_int = intermediate1.shape[-1] // 2
+        intermediate1[..., :N_int].clamp_(max=swiglu_limit)
+        intermediate1[..., N_int:].clamp_(min=-swiglu_limit, max=swiglu_limit)
     M_topk = intermediate1.shape[0]
     intermediate2 = torch.empty(
         (M_topk, N), device=hidden_states.device, dtype=hidden_states.dtype

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2071,9 +2071,17 @@ class Scheduler(
         # as the space for the chunked requests has just been released.
         # In PP case, chunked requests (or dllm requests) can start in one microbatch and end in another microbatch, so the max_running_requests per microbatch should not be strict.
         # Instead, we should always allow chunked requests to be added, otherwise, there will be a memory leak.
+        # issue1985 fix (sglang 本身): the inline comment above explicitly says
+        # "Ignore the check if self.chunked_req is not None", but the code below
+        # used `is not None`, which is the opposite. With --disable-radix-cache +
+        # hybrid SWA, the chunked_req keeps holding its req_pool slot across
+        # chunks (ChunkCache.cache_unfinished_req does not release), so when the
+        # req pool only has one slot effectively (ReqToTokenPool initializes
+        # free_slots = list(range(1, size)), wasting index 0), available_size
+        # becomes 0 and this early-return fires forever -> silent hang.
         if (
             self.get_num_allocatable_reqs(running_bs) <= 0
-            and self.chunked_req is not None
+            and self.chunked_req is None
             and not self.try_preemption
         ):
             self.running_batch.batch_is_full = True

--- a/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
+++ b/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
@@ -412,6 +412,17 @@ class SchedulerRuntimeCheckerMixin:
             self.tree_cache.sanity_check()
 
     def self_check_during_idle(self: Scheduler):
+        # issue1985 fix (sglang 本身): skip self-check when any in-flight work
+        # is still holding KV slots. With --disable-radix-cache + hybrid SWA +
+        # chunked prefill, between chunks the chunked_req keeps the chunk's
+        # slots in `used` state but they do not count toward evictable nor
+        # protected. _check_hybrid_memory's `used != 0` then false-positives.
+        if (
+            self.chunked_req is not None
+            or not self.running_batch.is_empty()
+            or len(self.waiting_queue) > 0
+        ):
+            return
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
             if len(self.disagg_prefill_inflight_queue) > 0:
                 return


### PR DESCRIPTION
Bundles 5 commits addressing V4 2604B / V4 Flash issues encountered while reproducing kvcache-ai/ktransformers#1985.

## What's in this PR

1. `fix(kt-ep)`: match cpu_buf dtype to kt-kernel's bf16 scale write for MXFP4
2. `feat(v4-2604b)`: apply SwiGLU clamp on triton-kernels GPU MoE path
3. `feat(v4-2604b)`: pass swiglu_limit through KTEPWrapper to kt-kernel
4. `fix(scheduler)`: correct inverted chunked_req check that hangs hybrid SWA chunked prefill — **root fix for #1985**
5. `fix(scheduler)`: skip self_check_during_idle when in-flight work still holds KV slots — defense-in-depth, prevents the false-positive `memory leak detected` SIGQUIT that originally reported the bug

## kvcache-ai/ktransformers#1985 — what users see

With `--disable-radix-cache + hybrid SWA + chunked-prefill-size < prompt`, a single multi-chunk prompt either:

- **(a) crashes** with `token_to_kv_pool_allocator memory leak detected!` SIGQUIT after chunk 1 — false positive (the slot is in-flight, not leaked), OR
- **(b) silently hangs** (chunk 1 prefill completes, chunk 2 never starts, TP CPUs busy-spin) once the self-check is masked.

## Root cause (commits 4 & 5)

`scheduler.py:_get_new_batch_prefill_raw` line 2082 has an inverted check that **contradicts its own preceding comment** ("Ignore the check if `self.chunked_req is not None`"). The sister check at line 2065 is correctly inverted; this PR aligns 2082 with both.

Once `chunked_req` is holding the only available req-pool slot (`ChunkCache.cache_unfinished_req` doesn't release it; `ReqToTokenPool.__init__` uses `free_slots = list(range(1, size))` and wastes index 0), the inverted check fires every iter and the scheduler returns None forever.

Commit 5 adds a defensive early-return in `self_check_during_idle` matching what the disagg PREFILL/DECODE branches already do, so a double-None batch frame can no longer be misinterpreted as a leak.

## Verified on

DeepSeek-V4-Flash + kt-kernel MXFP4, 8× RTX 5090 (TP=4), Linux:

- 5001-token English prompt → 3 chunks, HTTP 200 in 26.4 s
- 6695-token Chinese 红楼梦 prompt → 4 chunks, HTTP 200 in 52.2 s, finish_reason=stop (natural EOS), output is coherent 章回体续写
- Server log clean of `memory leak detected` / `Scheduler hit an exception` / `SIGQUIT`

Without these patches, both prompts crash or hang at chunk 2.

Fixes kvcache-ai/ktransformers#1985
