### PR TITLE
fix(v4-flash): make ExpertDistributionRecorder work for DeepSeek-V4-Flash

### DIFF
--- a/python/sglang/srt/eplb/expert_distribution.py
+++ b/python/sglang/srt/eplb/expert_distribution.py
@@ -568,13 +568,26 @@ class _SelectExpertsSinglePassGatherer(_LayerBasedGpuSinglePassGatherer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs, enable_global_physical_experts=True)
 
-    # can optimize (e.g. fuse / compile)
+    # yiqiliu2 / 2026-05-08: V4-Flash-safe + CUDA-graph-capture-safe
+    # rewrite. The original `scatter_add_` on `self._data[layer_idx, :]`
+    # crashed with "Index tensor must have the same number of dimensions
+    # as self tensor" on V4-Flash routing tensors. The intermediate
+    # rewrite (with `bool(valid_mask.any())` + `flat_ids[valid_mask]`)
+    # synced device→host (.item() / nonzero) which is forbidden during
+    # cuda graph capture (the recorder hook fires during capture too,
+    # see `_on_hook`'s `is_current_stream_capturing()` clause). This
+    # version uses pure GPU ops only:
+    #   - clamp(-1 → 0) so all indices are in-range
+    #   - src = (id >= 0) so invalid entries contribute 0 (no-op writes)
+    # No host sync, no boolean indexing, no nonzero.
     def on_select_experts(self, layer_idx: int, topk_ids: torch.Tensor):
-        topk_ids = topk_ids.flatten()
-        mask = topk_ids != -1
-        self._data[layer_idx, :].scatter_add_(
-            dim=0, index=topk_ids.masked_fill(~mask, 0).long(), src=mask.int()
-        )
+        if topk_ids is None:
+            return
+        flat_ids = topk_ids.reshape(-1).to(torch.int64)
+        target = self._data[layer_idx].reshape(-1)
+        valid = (flat_ids >= 0).to(target.dtype)
+        safe_ids = flat_ids.clamp(min=0)
+        target.scatter_add_(0, safe_ids, valid)
 
 
 class _DeepepNormalSinglePassGatherer(_LayerBasedCpuSinglePassGatherer):

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -21,6 +21,8 @@ from sglang.srt.debug_utils.deepseek_v4_debug_utils import (
 from sglang.srt.distributed import get_pp_group, get_tensor_model_parallel_world_size
 from sglang.srt.distributed.parallel_state import get_moe_expert_parallel_world_size
 from sglang.srt.environ import envs, is_large_dummy_model
+from contextlib import nullcontext
+from sglang.srt.eplb.expert_distribution import get_global_expert_distribution_recorder
 from sglang.srt.eplb.expert_location import ModelConfigForExpertLocation
 from sglang.srt.layers.attention.nsa.nsa_indexer import rotate_activation
 from sglang.srt.layers.attention.nsa.utils import (
@@ -1321,13 +1323,26 @@ class DeepseekV4Model(nn.Module):
 
         for i in range(self.start_layer, self.end_layer):
             layer = self.layers[i]
-            hidden_states = layer(
-                positions=positions,
-                hidden_states=hidden_states,
-                forward_batch=forward_batch,
-                input_ids=input_ids,
-                input_ids_global=input_ids_global,
+            # yiqiliu2 / 2026-05-08: wrap each layer call with the recorder's
+            # current_layer context. Without this, the recorder hook's
+            # `self._current_layer_idx.value` stays at None and every
+            # `on_select_experts` write lands in slot 0 of the gatherer's
+            # `_data` tensor, so the dumped logical_count.pt only has
+            # data for layer 0 and torch.topk on it places all GPU
+            # experts on layer 0 regardless of K.
+            ctx = (
+                nullcontext()
+                if get_global_server_args().enable_piecewise_cuda_graph
+                else get_global_expert_distribution_recorder().with_current_layer(i)
             )
+            with ctx:
+                hidden_states = layer(
+                    positions=positions,
+                    hidden_states=hidden_states,
+                    forward_batch=forward_batch,
+                    input_ids=input_ids,
+                    input_ids_global=input_ids_global,
+                )
 
         if nsa_use_prefill_cp(forward_batch):
             hidden_states = cp_all_gather_rerange_output(


### PR DESCRIPTION
## Summary

Two coupled fixes that together make \`--expert-distribution-recorder-mode stat\` work end-to-end for V4-Flash.

### 1. \`_SelectExpertsSinglePassGatherer.on_select_experts\` cuda-graph-safe + shape-safe

The original used \`scatter_add_\` on \`self._data[layer_idx, :]\` and crashed with \`Index tensor must have the same number of dimensions as self tensor\` on V4-Flash routing tensors.

\`_on_hook\`'s \`is_current_stream_capturing()\` clause also lets the hook fire during cuda graph capture, but any host sync (\`.item()\`, boolean indexing, nonzero) inside the hook hits cudaErrorStreamCaptureInvalidated.

Rewrite uses pure GPU ops:
- \`clamp(-1 → 0)\` so all indices are in range
- \`src = (id >= 0).to(dtype)\` so invalid entries contribute 0 (no-op writes)

No host sync, no boolean indexing, no nonzero.

### 2. \`deepseek_v4.py\` forward loop wraps with \`with_current_layer(i)\` ctx

The forward loop iterated layers without the recorder context manager. Without this, every \`on_select_experts\` write lands in slot 0 of the gatherer's \`_data\` tensor → the dumped \`logical_count.pt\` only has data for layer 0 → \`torch.topk\` on it places all GPU experts on layer 0.

Other DeepSeek family models (\`deepseek_v2\`, \`qwen2_moe\`, \`qwen3_moe\`, \`exaone_moe\`, \`llada2\`, \`longcat_flash\`, \`step3p5\`) all wrap their forward loops with this context — V4 was an oversight on initial port.

## Test plan

- [x] Boot sglang server with \`--expert-distribution-recorder-mode stat\` for V4-Flash — capture succeeds, no crash
- [x] Hit \`/start_expert_distribution_record\` + a few warmup completions + \`/dump_expert_distribution_record\` — produces a 44 MB .pt with non-zero counts on 40/43 layers (was 1/43 before fix #2)
- [x] Frequency-based GPU expert placement using the dumped .pt distributes 172 experts as 2..9 per layer (was all 172 on layer 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)