### PR TITLE
feat: support end-to-end KT LoRA serving for Qwen3.5 MoE

### DIFF
--- a/python/sglang/srt/layers/moe/kt_ep_wrapper.py
+++ b/python/sglang/srt/layers/moe/kt_ep_wrapper.py
@@ -199,6 +199,9 @@ def _get_expert_lora_tensor(
     )
 
 
+_KT_LORA_STATE_DICT_CACHE: Dict[str, Dict[str, torch.Tensor]] = {}
+
+
 def _load_kt_expert_lora_weights(
     adapter_path: str,
     layer_idx: int,
@@ -210,9 +213,14 @@ def _load_kt_expert_lora_weights(
     adapter_dir = Path(adapter_path)
     rank_from_config, alpha = _load_adapter_config(adapter_dir)
     weight_file = _find_adapter_weight_file(adapter_dir)
-    from safetensors.torch import load_file
+    weight_file_str = str(weight_file)
+    if weight_file_str not in _KT_LORA_STATE_DICT_CACHE:
+        from safetensors.torch import load_file
 
-    state_dict = load_file(str(weight_file), device="cpu")
+        _KT_LORA_STATE_DICT_CACHE[weight_file_str] = load_file(
+            weight_file_str, device="cpu"
+        )
+    state_dict = _KT_LORA_STATE_DICT_CACHE[weight_file_str]
     sample = _get_expert_lora_tensor(
         state_dict, layer_idx, 0, "gate_proj", "lora_A"
     )

--- a/python/sglang/srt/layers/moe/kt_ep_wrapper.py
+++ b/python/sglang/srt/layers/moe/kt_ep_wrapper.py
@@ -29,13 +29,15 @@ Diagnostic / escape-hatch environment variables (KT-DEBUG-ONLY; not for prod):
 
 import copy
 import ctypes
+import json
 import logging
 import os
 import time
 import uuid
 from dataclasses import dataclass, replace
 from multiprocessing import shared_memory
-from typing import TYPE_CHECKING, Dict, List, Optional
+from pathlib import Path
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 import torch
 import torch.distributed as dist
@@ -90,6 +92,7 @@ class KTConfig:
         num_layers: Total number of layers in the model (optional)
         gpu_prefill_token_threshold: token threshold for enabling full GPU fallback
         kt_enable_dynamic_expert_update: Enable dynamic GPU expert updates based on runtime statistics
+        expert_lora_path: Optional PEFT adapter directory for KT CPU expert LoRA
     """
 
     layer_idx: int
@@ -104,6 +107,164 @@ class KTConfig:
     num_layers: Optional[int] = None
     gpu_prefill_token_threshold: Optional[int] = None
     kt_enable_dynamic_expert_update: bool = False
+    expert_lora_path: Optional[str] = None
+
+
+@dataclass
+class KTExpertLoraWeights:
+    gate_lora_a: torch.Tensor
+    gate_lora_b: torch.Tensor
+    up_lora_a: torch.Tensor
+    up_lora_b: torch.Tensor
+    down_lora_a: torch.Tensor
+    down_lora_b: torch.Tensor
+    rank: int
+    alpha: float
+
+
+_KT_SFT_METHOD_BY_INFERENCE_METHOD = {
+    "AMXBF16": "AMXBF16_SFT",
+    "BF16": "AMXBF16_SFT",
+    "AMXINT8": "AMXINT8_SFT",
+    "AMXINT4": "AMXINT4_SFT",
+}
+
+
+def _map_kt_method_to_sft_method(method: str) -> str:
+    normalized = method.upper()
+    if normalized in _KT_SFT_METHOD_BY_INFERENCE_METHOD:
+        return _KT_SFT_METHOD_BY_INFERENCE_METHOD[normalized]
+    raise ValueError(
+        f"--kt-expert-lora-path currently supports only AMX/BF16 SFT-compatible "
+        f"KT methods {sorted(_KT_SFT_METHOD_BY_INFERENCE_METHOD)}, got {method!r}."
+    )
+
+
+def _load_adapter_config(adapter_path: Path) -> Tuple[Optional[int], float]:
+    config_path = adapter_path / "adapter_config.json"
+    if not config_path.is_file():
+        raise FileNotFoundError(
+            f"KT expert LoRA adapter config not found: {config_path}"
+        )
+    with config_path.open("r", encoding="utf-8") as f:
+        config = json.load(f)
+    rank = config.get("r")
+    if rank is not None:
+        rank = int(rank)
+    alpha = float(config.get("lora_alpha", rank if rank is not None else 1.0))
+    return rank, alpha
+
+
+def _find_adapter_weight_file(adapter_path: Path) -> Path:
+    preferred = adapter_path / "adapter_model.safetensors"
+    if preferred.is_file():
+        return preferred
+    candidates = sorted(adapter_path.glob("*.safetensors"))
+    if not candidates:
+        raise FileNotFoundError(
+            f"No safetensors adapter weights found under {adapter_path}"
+        )
+    if len(candidates) > 1:
+        logger.warning(
+            "Multiple safetensors files found under %s; using %s for KT expert LoRA",
+            adapter_path,
+            candidates[0],
+        )
+    return candidates[0]
+
+
+def _get_expert_lora_tensor(
+    state_dict: Dict[str, torch.Tensor],
+    layer_idx: int,
+    expert_idx: int,
+    proj_name: str,
+    lora_name: str,
+) -> torch.Tensor:
+    suffixes = [
+        f"model.layers.{layer_idx}.mlp.experts.{expert_idx}.{proj_name}.{lora_name}.weight",
+        f"model.layers.{layer_idx}.mlp.experts.{expert_idx}.{proj_name}.{lora_name}.default.weight",
+    ]
+    prefixes = ["", "base_model.", "base_model.model.", "base_model.model.model."]
+    for suffix in suffixes:
+        for prefix in prefixes:
+            key = prefix + suffix
+            if key in state_dict:
+                return state_dict[key]
+    for key, tensor in state_dict.items():
+        if any(key.endswith(suffix) for suffix in suffixes):
+            return tensor
+    raise KeyError(
+        f"Missing KT expert LoRA tensor for layer={layer_idx}, expert={expert_idx}, "
+        f"proj={proj_name}, lora={lora_name}. Expected suffix like {suffixes[0]!r}."
+    )
+
+
+def _load_kt_expert_lora_weights(
+    adapter_path: str,
+    layer_idx: int,
+    num_experts: int,
+    hidden_size: int,
+    moe_intermediate_size: int,
+    dtype: torch.dtype = torch.bfloat16,
+) -> KTExpertLoraWeights:
+    adapter_dir = Path(adapter_path)
+    rank_from_config, alpha = _load_adapter_config(adapter_dir)
+    weight_file = _find_adapter_weight_file(adapter_dir)
+    from safetensors.torch import load_file
+
+    state_dict = load_file(str(weight_file), device="cpu")
+    sample = _get_expert_lora_tensor(
+        state_dict, layer_idx, 0, "gate_proj", "lora_A"
+    )
+    rank = rank_from_config or int(sample.shape[0])
+    if int(sample.shape[0]) != rank:
+        raise ValueError(
+            f"KT expert LoRA rank mismatch for layer {layer_idx}: "
+            f"adapter_config r={rank}, sample tensor rank={int(sample.shape[0])}"
+        )
+
+    # SGLang may set the default torch device to CUDA during model loading.
+    # KT SFT CPU kernels consume raw host pointers, so these adapter staging
+    # buffers must be explicitly allocated on CPU.
+    device = torch.device("cpu")
+    gate_lora_a = torch.zeros((num_experts, rank, hidden_size), dtype=dtype, device=device)
+    gate_lora_b = torch.zeros((num_experts, moe_intermediate_size, rank), dtype=dtype, device=device)
+    up_lora_a = torch.zeros((num_experts, rank, hidden_size), dtype=dtype, device=device)
+    up_lora_b = torch.zeros((num_experts, moe_intermediate_size, rank), dtype=dtype, device=device)
+    down_lora_a = torch.zeros((num_experts, rank, moe_intermediate_size), dtype=dtype, device=device)
+    down_lora_b = torch.zeros((num_experts, hidden_size, rank), dtype=dtype, device=device)
+
+    targets = [
+        ("gate_proj", "lora_A", gate_lora_a),
+        ("gate_proj", "lora_B", gate_lora_b),
+        ("up_proj", "lora_A", up_lora_a),
+        ("up_proj", "lora_B", up_lora_b),
+        ("down_proj", "lora_A", down_lora_a),
+        ("down_proj", "lora_B", down_lora_b),
+    ]
+    for expert_idx in range(num_experts):
+        for proj_name, lora_name, dst in targets:
+            tensor = _get_expert_lora_tensor(
+                state_dict, layer_idx, expert_idx, proj_name, lora_name
+            )
+            if tuple(tensor.shape) != tuple(dst[expert_idx].shape):
+                raise ValueError(
+                    f"KT expert LoRA shape mismatch for layer={layer_idx}, "
+                    f"expert={expert_idx}, {proj_name}.{lora_name}: expected "
+                    f"{tuple(dst[expert_idx].shape)}, got {tuple(tensor.shape)}"
+                )
+            dst[expert_idx].copy_(tensor.to(dtype=dtype, device=device))
+
+    return KTExpertLoraWeights(
+        gate_lora_a=gate_lora_a.contiguous(),
+        gate_lora_b=gate_lora_b.contiguous(),
+        up_lora_a=up_lora_a.contiguous(),
+        up_lora_b=up_lora_b.contiguous(),
+        down_lora_a=down_lora_a.contiguous(),
+        down_lora_b=down_lora_b.contiguous(),
+        rank=rank,
+        alpha=alpha,
+    )
 
 
 _SHARED_FULL_CONTEXT = None
@@ -1855,6 +2016,7 @@ def create_kt_config_from_server_args(
         num_layers=num_layers,
         gpu_prefill_token_threshold=server_args.kt_gpu_prefill_token_threshold,
         kt_enable_dynamic_expert_update=server_args.kt_enable_dynamic_expert_update,
+        expert_lora_path=getattr(server_args, "kt_expert_lora_path", None),
     )
 
 
@@ -2177,9 +2339,31 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
         self.kt_config = kt_config
         self.gpu_experts_mask = kt_config.gpu_experts_mask  # bool tensor [num_experts], on CPU
         self.num_gpu_experts = int(self.gpu_experts_mask.sum().item())
+        self.kt_expert_lora_path = kt_config.expert_lora_path
+        self.kt_expert_lora_enabled = bool(self.kt_expert_lora_path)
+        self.kt_expert_lora_weights: Optional[KTExpertLoraWeights] = None
         self.override_num_local_experts = True
         self.gpu_method.num_gpu_experts = self.num_gpu_experts
         self.tp_rank = get_tensor_model_parallel_rank()
+        if self.kt_expert_lora_enabled:
+            if self.num_gpu_experts != 0:
+                raise ValueError(
+                    "--kt-expert-lora-path first supports CPU experts only. "
+                    "Set --kt-num-gpu-experts 0 and do not enable "
+                    "--kt-gpu-experts-ratio."
+                )
+            if kt_config.gpu_prefill_token_threshold:
+                raise ValueError(
+                    "--kt-expert-lora-path is not compatible with "
+                    "--kt-gpu-prefill-token-threshold in the first single-adapter "
+                    "implementation."
+                )
+            if kt_config.kt_enable_dynamic_expert_update:
+                raise ValueError(
+                    "--kt-expert-lora-path is not compatible with "
+                    "--kt-enable-dynamic-expert-update in the first single-adapter "
+                    "implementation."
+                )
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(
                 "[kt-wrap-init] tp_rank=%d layer_idx=%s num_gpu_experts=%d "
@@ -2308,7 +2492,7 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
             _kt_swiglu_limit = (
                 10.0 if _envs.SGLANG_DSV4_2604_SUBMODE.get() == "2604B" else 0.0
             )
-            self.wrapper = KTMoEWrapper(
+            common_wrapper_kwargs = dict(
                 layer_idx=self.kt_config.layer_idx,
                 num_experts=num_experts,
                 num_experts_per_tok=num_experts_per_tok,
@@ -2317,13 +2501,39 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
                 gpu_experts_mask=self.gpu_experts_mask,
                 cpuinfer_threads=self.kt_config.cpuinfer_threads,
                 threadpool_count=self.kt_config.threadpool_count,
-                swiglu_limit=_kt_swiglu_limit,
                 numa_nodes=self.kt_config.numa_nodes,
                 weight_path=self.kt_config.weight_path,
                 chunked_prefill_size=self.kt_config.chunked_prefill_size,
-                method=self.kt_config.method,
-                max_deferred_experts_per_token=layer_max_deferred,
             )
+            if self.kt_expert_lora_enabled:
+                if _kt_swiglu_limit != 0.0:
+                    raise ValueError(
+                        "--kt-expert-lora-path uses KT SFT wrappers, which do not "
+                        "support the V4-2604B swiglu_limit path."
+                    )
+                self.kt_expert_lora_weights = _load_kt_expert_lora_weights(
+                    adapter_path=self.kt_expert_lora_path,
+                    layer_idx=self.kt_config.layer_idx,
+                    num_experts=num_experts,
+                    hidden_size=hidden_size,
+                    moe_intermediate_size=intermediate_size_full,
+                )
+                self.wrapper = KTMoEWrapper(
+                    **common_wrapper_kwargs,
+                    method=_map_kt_method_to_sft_method(self.kt_config.method),
+                    mode="sft",
+                    num_gpu_experts=0,
+                    lora_rank=self.kt_expert_lora_weights.rank,
+                    lora_alpha=self.kt_expert_lora_weights.alpha,
+                    max_cache_depth=1,
+                )
+            else:
+                self.wrapper = KTMoEWrapper(
+                    **common_wrapper_kwargs,
+                    swiglu_limit=_kt_swiglu_limit,
+                    method=self.kt_config.method,
+                    max_deferred_experts_per_token=layer_max_deferred,
+                )
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         """Process weights after loading from checkpoint.
@@ -2359,6 +2569,52 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
                     layer.num_experts, dtype=torch.int64, device="cpu"
                 )
             self.wrapper.load_weights(physical_to_logical_map_cpu)
+            if self.kt_expert_lora_enabled:
+                if self.kt_expert_lora_weights is None:
+                    raise RuntimeError(
+                        "KT expert LoRA is enabled but adapter weights were not loaded."
+                    )
+                lora = self.kt_expert_lora_weights
+                if os.environ.get("SGLANG_KT_EXPERT_LORA_DEBUG") == "1":
+                    print(
+                        "[KT expert LoRA debug] "
+                        f"layer={self.kt_config.layer_idx} "
+                        f"rank={lora.rank} alpha={lora.alpha} "
+                        f"gate_a={tuple(lora.gate_lora_a.shape)}/{lora.gate_lora_a.dtype}/"
+                        f"{lora.gate_lora_a.device}/ptr={lora.gate_lora_a.data_ptr()} "
+                        f"gate_b={tuple(lora.gate_lora_b.shape)}/{lora.gate_lora_b.dtype}/"
+                        f"{lora.gate_lora_b.device}/ptr={lora.gate_lora_b.data_ptr()} "
+                        f"up_a={tuple(lora.up_lora_a.shape)}/{lora.up_lora_a.dtype}/"
+                        f"{lora.up_lora_a.device}/ptr={lora.up_lora_a.data_ptr()} "
+                        f"up_b={tuple(lora.up_lora_b.shape)}/{lora.up_lora_b.dtype}/"
+                        f"{lora.up_lora_b.device}/ptr={lora.up_lora_b.data_ptr()} "
+                        f"down_a={tuple(lora.down_lora_a.shape)}/{lora.down_lora_a.dtype}/"
+                        f"{lora.down_lora_a.device}/ptr={lora.down_lora_a.data_ptr()} "
+                        f"down_b={tuple(lora.down_lora_b.shape)}/{lora.down_lora_b.dtype}/"
+                        f"{lora.down_lora_b.device}/ptr={lora.down_lora_b.data_ptr()}",
+                        flush=True,
+                    )
+                self.wrapper.init_lora_weights(
+                    lora.gate_lora_a,
+                    lora.gate_lora_b,
+                    lora.up_lora_a,
+                    lora.up_lora_b,
+                    lora.down_lora_a,
+                    lora.down_lora_b,
+                    torch.zeros_like(lora.gate_lora_a),
+                    torch.zeros_like(lora.gate_lora_b),
+                    torch.zeros_like(lora.up_lora_a),
+                    torch.zeros_like(lora.up_lora_b),
+                    torch.zeros_like(lora.down_lora_a),
+                    torch.zeros_like(lora.down_lora_b),
+                )
+                logger.info(
+                    "Loaded KT expert LoRA for layer %d from %s (rank=%d, alpha=%.3f)",
+                    self.kt_config.layer_idx,
+                    self.kt_expert_lora_path,
+                    lora.rank,
+                    lora.alpha,
+                )
 
     def create_moe_runner(
         self, layer: torch.nn.Module, moe_runner_config: "MoeRunnerConfig"
@@ -2387,6 +2643,37 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
         # Delegate to GPU method to create its runner
         self.gpu_method.create_moe_runner(layer, gpu_runner_config)
 
+    def _submit_cpu_forward(
+        self,
+        hidden_states: torch.Tensor,
+        topk_ids: torch.Tensor,
+        topk_weights: torch.Tensor,
+    ) -> None:
+        if self.kt_expert_lora_enabled:
+            self.wrapper.submit_forward_inference(
+                hidden_states,
+                topk_ids,
+                topk_weights,
+                torch.cuda.current_stream(hidden_states.device).cuda_stream,
+            )
+        else:
+            self.wrapper.submit_forward(
+                hidden_states,
+                topk_ids,
+                topk_weights,
+                torch.cuda.current_stream(hidden_states.device).cuda_stream,
+            )
+
+    def _sync_cpu_forward(self, ref_tensor: torch.Tensor) -> torch.Tensor:
+        if self.kt_expert_lora_enabled:
+            return self.wrapper.sync_forward_inference(
+                torch.cuda.current_stream(ref_tensor.device).cuda_stream,
+            )
+        return self.wrapper.sync_forward(
+            ref_tensor,
+            torch.cuda.current_stream(ref_tensor.device).cuda_stream,
+        )
+
     def submit(
         self,
         layer: torch.nn.Module,
@@ -2413,9 +2700,7 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
         topk_weights, topk_ids, _ = topk_output
 
         # Submit forward task to CPU (non-blocking)
-        self.wrapper.submit_forward(
-            x, topk_ids, topk_weights, torch.cuda.current_stream(x.device).cuda_stream
-        )
+        self._submit_cpu_forward(x, topk_ids, topk_weights)
 
     def sync(self, x: torch.Tensor) -> torch.Tensor:
         """Synchronize and retrieve CPU expert computation results.
@@ -2432,9 +2717,7 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
             return torch.zeros_like(x)
 
         # Wait for CPU computation and retrieve results
-        return self.wrapper.sync_forward(
-            x, torch.cuda.current_stream(x.device).cuda_stream
-        )
+        return self._sync_cpu_forward(x)
 
     def _submit_with_staged_input(
         self,
@@ -2460,12 +2743,7 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
         topk_weights, topk_ids, _ = topk_output
 
         # Submit forward task using staged buffer
-        self.wrapper.submit_forward(
-            staged_hidden_states,
-            topk_ids,
-            topk_weights,
-            torch.cuda.current_stream(staged_hidden_states.device).cuda_stream,
-        )
+        self._submit_cpu_forward(staged_hidden_states, topk_ids, topk_weights)
 
     def _sync_with_staged_input(
         self, staged_hidden_states: torch.Tensor
@@ -2481,10 +2759,7 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
         if self.tp_rank != 0 or self.wrapper is None:
             return torch.zeros_like(staged_hidden_states)
 
-        return self.wrapper.sync_forward(
-            staged_hidden_states,
-            torch.cuda.current_stream(staged_hidden_states.device).cuda_stream,
-        )
+        return self._sync_cpu_forward(staged_hidden_states)
 
     def apply(
         self,

--- a/python/sglang/srt/lora/layers.py
+++ b/python/sglang/srt/lora/layers.py
@@ -431,6 +431,7 @@ class MergedColumnParallelLinearWithLoRA(ColumnParallelLinearWithLoRA):
         lora_backend: BaseLoRABackend,
     ) -> None:
         super().__init__(base_layer, lora_backend)
+        self.use_gate_up_backend = len(self.base_layer.output_sizes) == 2
 
     def set_lora_info(
         self,
@@ -438,21 +439,37 @@ class MergedColumnParallelLinearWithLoRA(ColumnParallelLinearWithLoRA):
         B_buffer: torch.Tensor,
     ):
         self.set_lora = True
-        self.A_buffer_gate_up = A_buffer
-        self.B_buffer_gate_up = B_buffer
+        if self.use_gate_up_backend:
+            self.A_buffer_gate_up = A_buffer
+            self.B_buffer_gate_up = B_buffer
 
-        shard_size = self.base_layer.output_partition_sizes[0]
-        self.output_offset = torch.tensor(
-            [
-                0,
-                shard_size,
-                2 * shard_size,
-            ],
-            dtype=torch.int32,
-            device=next(self.base_layer.parameters()).device,
-        )
+            shard_size = self.base_layer.output_partition_sizes[0]
+            self.output_offset = torch.tensor(
+                [
+                    0,
+                    shard_size,
+                    2 * shard_size,
+                ],
+                dtype=torch.int32,
+                device=next(self.base_layer.parameters()).device,
+            )
+        else:
+            self.A_buffer = A_buffer
+            self.B_buffer = B_buffer
+            output_size_per_partition = sum(self.base_layer.output_partition_sizes)
+            self.output_offset = torch.tensor(
+                [
+                    0,
+                    output_size_per_partition,
+                ],
+                dtype=torch.int32,
+                device=next(self.base_layer.parameters()).device,
+            )
 
     def apply_lora(self, base_output: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
+        if not self.use_gate_up_backend:
+            return super().apply_lora(base_output, x)
+
         lora_output = self.lora_backend.run_gate_up_lora(
             x=x,
             gate_up_lora_a=self.A_buffer_gate_up,
@@ -466,6 +483,19 @@ class MergedColumnParallelLinearWithLoRA(ColumnParallelLinearWithLoRA):
         return A
 
     def slice_lora_b_weights(self, B: torch.Tensor, tp_rank: int):
+        if not self.use_gate_up_backend:
+            shards = []
+            offset = 0
+            for output_size, shard_size in zip(
+                self.base_layer.output_sizes,
+                self.base_layer.output_partition_sizes,
+            ):
+                start_idx = offset + tp_rank * shard_size
+                end_idx = start_idx + shard_size
+                shards.append(B[start_idx:end_idx, :])
+                offset += output_size
+            return torch.concat(shards, dim=0).contiguous()
+
         # Since the outputs for both gate and up are identical, we use a random one.
         shard_size = self.base_layer.output_partition_sizes[0]
         gate_size = self.base_layer.output_sizes[0]

--- a/python/sglang/srt/lora/lora_manager.py
+++ b/python/sglang/srt/lora/lora_manager.py
@@ -47,6 +47,23 @@ from sglang.srt.utils.hf_transformers_utils import AutoConfig
 logger = logging.getLogger(__name__)
 
 
+def _get_lora_hf_config(base_hf_config: AutoConfig) -> AutoConfig:
+    if getattr(base_hf_config, "num_hidden_layers", None) is not None:
+        return base_hf_config
+
+    get_text_config = getattr(base_hf_config, "get_text_config", None)
+    if callable(get_text_config):
+        text_config = get_text_config()
+        if getattr(text_config, "num_hidden_layers", None) is not None:
+            return text_config
+
+    text_config = getattr(base_hf_config, "text_config", None)
+    if getattr(text_config, "num_hidden_layers", None) is not None:
+        return text_config
+
+    return base_hf_config
+
+
 class LoRAManager:
     def __init__(
         self,
@@ -64,7 +81,7 @@ class LoRAManager:
         lora_paths: Optional[List[LoRARef]] = None,
     ):
         self.base_model: torch.nn.Module = base_model
-        self.base_hf_config: AutoConfig = base_hf_config
+        self.base_hf_config: AutoConfig = _get_lora_hf_config(base_hf_config)
         self.max_loras_per_batch: int = max_loras_per_batch
         self.load_config: LoadConfig = load_config
         self.dtype: torch.dtype = dtype

--- a/python/sglang/srt/lora/mem_pool.py
+++ b/python/sglang/srt/lora/mem_pool.py
@@ -68,6 +68,7 @@ class LoRAMemoryPool:
         self.lora_added_tokens_size: int = lora_added_tokens_size
         self.max_lora_rank: int = max_lora_rank
         self.target_modules: Set[str] = target_modules
+        self.base_model: torch.nn.Module = base_model
 
         # Initialize eviction policy
         self.eviction_policy = get_eviction_policy(eviction_policy)
@@ -395,6 +396,61 @@ class LoRAMemoryPool:
                 ), f"LoRA buffer shape {buffer_view.shape} does not match weight shape {weight.shape}."
                 buffer_view.copy_(weight, non_blocking=True)
 
+        def get_column_output_sizes(target_module: str) -> Optional[Tuple[int, ...]]:
+            config = self.base_hf_config
+            if target_module == "qkv_proj":
+                hidden_size = config.hidden_size
+                head_dim = getattr(
+                    config, "head_dim", hidden_size // config.num_attention_heads
+                )
+                gate_multiplier = 1 + int(getattr(config, "attn_output_gate", False))
+                q_dim = config.num_attention_heads * head_dim * gate_multiplier
+                kv_dim = config.num_key_value_heads * head_dim
+                return q_dim, kv_dim, kv_dim
+            if target_module == "in_proj_qkv":
+                key_dim = config.linear_num_key_heads * config.linear_key_head_dim
+                value_dim = (
+                    config.linear_num_value_heads * config.linear_value_head_dim
+                )
+                return key_dim, key_dim, value_dim
+            if target_module == "gate_up_proj":
+                _, output_dim = get_hidden_dim(
+                    target_module, self.base_hf_config, self.base_model, 0
+                )
+                return output_dim // 2, output_dim // 2
+            return None
+
+        def slice_column_lora_b_if_needed(
+            target_module: str,
+            weights: Optional[torch.Tensor],
+            expected_shape: torch.Size,
+        ) -> Optional[torch.Tensor]:
+            if weights is None or weights.shape == expected_shape:
+                return weights
+            if weights.ndim != 2 or weights.shape[1] != expected_shape[1]:
+                return weights
+
+            output_sizes = get_column_output_sizes(target_module)
+            if output_sizes is not None and sum(output_sizes) == weights.shape[0]:
+                shards = []
+                offset = 0
+                for output_size in output_sizes:
+                    shard_size = output_size // self.tp_size
+                    start_idx = offset + self.tp_rank * shard_size
+                    end_idx = start_idx + shard_size
+                    shards.append(weights[start_idx:end_idx, :])
+                    offset += output_size
+                sliced = torch.cat(shards, dim=0).contiguous()
+                if sliced.shape == expected_shape:
+                    return sliced
+
+            if weights.shape[0] == expected_shape[0] * self.tp_size:
+                start_idx = self.tp_rank * expected_shape[0]
+                end_idx = start_idx + expected_shape[0]
+                return weights[start_idx:end_idx, :].contiguous()
+
+            return weights
+
         if uid is None:
             for i in range(self.num_layer):
                 for k in self.A_buffer.keys():
@@ -440,6 +496,40 @@ class LoRAMemoryPool:
                     )
                     temp_B_buffer[target_module] = module.slice_lora_b_weights(
                         temp_B_buffer[target_module], self.tp_rank
+                    )
+
+                for target_module in ROW_PARALLELISM_LINEAR_LORA_NAMES:
+                    weights = temp_A_buffer.get(target_module)
+                    if weights is None or target_module not in self.A_buffer:
+                        continue
+
+                    c = get_stacked_multiply(target_module)
+                    expected_shape = self.A_buffer[target_module][layer_id][
+                        buffer_id, : lora_rank * c, :
+                    ].shape
+                    if weights.shape == expected_shape:
+                        continue
+                    if (
+                        weights.ndim == 2
+                        and weights.shape[0] == expected_shape[0]
+                        and weights.shape[1] == expected_shape[1] * self.tp_size
+                    ):
+                        start_idx = self.tp_rank * expected_shape[1]
+                        end_idx = start_idx + expected_shape[1]
+                        temp_A_buffer[target_module] = weights[
+                            :, start_idx:end_idx
+                        ].contiguous()
+
+                for target_module, weights in temp_B_buffer.items():
+                    if weights is None:
+                        continue
+                    expected_shape = self.B_buffer[target_module][layer_id][
+                        buffer_id, :, :lora_rank
+                    ].shape
+                    temp_B_buffer[target_module] = slice_column_lora_b_if_needed(
+                        target_module,
+                        weights,
+                        expected_shape,
                     )
 
             for name, weights in temp_A_buffer.items():

--- a/python/sglang/srt/lora/triton_ops/sgemm_lora_b.py
+++ b/python/sglang/srt/lora/triton_ops/sgemm_lora_b.py
@@ -96,7 +96,8 @@ def _sgemm_lora_b_kernel(
         )
         w_tile = tl.load(
             w_ptrs,
-            mask=(k_offset[:, None] < K - k * BLOCK_K),
+            mask=(k_offset[:, None] < K - k * BLOCK_K)
+            & (n_offset[None, :] < N),
             other=0.0,
         )
         partial_sum += tl.dot(x_tile, w_tile)
@@ -110,8 +111,8 @@ def _sgemm_lora_b_kernel(
     output_ptr = (output + seg_start * output_stride_0) + (
         s_offset[:, None] * output_stride_0 + n_offset[None, :] * output_stride_1
     )
-    output_mask = s_offset[:, None] < seg_len
-    partial_sum += tl.load(output_ptr, mask=output_mask)
+    output_mask = (s_offset[:, None] < seg_len) & (n_offset[None, :] < N)
+    partial_sum += tl.load(output_ptr, mask=output_mask, other=0.0)
     tl.store(output_ptr, partial_sum, mask=output_mask)
 
 

--- a/python/sglang/srt/lora/utils.py
+++ b/python/sglang/srt/lora/utils.py
@@ -132,6 +132,10 @@ def get_normalized_target_modules(
     result = set()
     for name in target_modules:
         base_name = name.split(".")[-1]
+        # Qwen3.5 split GatedDeltaNet modules such as in_proj_qkv,
+        # in_proj_z, in_proj_b, in_proj_a, and out_proj are intentionally
+        # preserved here. Only the legacy checkpoint-side q/k/v and gate/up
+        # names are normalized to SGLang fused module names.
         normalized_name = params_mapping.get(base_name, base_name)
         result.add(normalized_name)
     return result
@@ -164,7 +168,7 @@ def get_target_module_name(full_module_name: str, target_modules: Set[str]) -> s
 
 
 EMBEDDING_NAMES = ["embed_tokens", "lm_head"]
-ROW_PARALLELISM_LINEAR_LORA_NAMES = ["o_proj", "down_proj"]
+ROW_PARALLELISM_LINEAR_LORA_NAMES = ["o_proj", "down_proj", "out_proj"]
 
 
 def generate_sequence_lengths(

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -499,6 +499,12 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         # Load the model
         self.sampler = create_sampler()
         self.load_model()
+        if self.server_args.kt_lora_path:
+            if not hasattr(self.model, "load_kt_lora"):
+                raise ValueError(
+                    f"{type(self.model).__name__} does not support --kt-lora-path."
+                )
+            self.model.load_kt_lora(self.server_args.kt_lora_path)
 
         if (
             self.server_args.remote_instance_weight_loader_use_transfer_engine()

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -16,6 +16,7 @@
 
 import json
 import logging
+import re
 from functools import lru_cache
 from pathlib import Path
 from typing import Dict, Iterable, Optional, Set, Tuple, Union
@@ -86,6 +87,12 @@ cached_get_processor = lru_cache(get_processor)
 
 
 _LORA_PREFIXES = ("", "base_model.", "base_model.model.", "base_model.model.model.")
+_QWEN3_5_LORA_PATTERN = re.compile(
+    r"^model(?:\.language_model)?\.layers\.(\d+)\.(?:"
+    r"self_attn\.(?:qkv_proj|o_proj)|"
+    r"linear_attn\.(?:in_proj_qkv|in_proj_z|in_proj_b|in_proj_a|out_proj)"
+    r")$"
+)
 
 
 def _load_kt_lora_config(adapter_path: str) -> Tuple[int, float]:
@@ -1045,6 +1052,58 @@ class Qwen3_5ForCausalLM(nn.Module):
     def get_input_embeddings(self) -> nn.Embedding:
         return self.embed_tokens
 
+    def get_hidden_dim(self, module_name: str, layer_idx: int):
+        config = self.config
+        hidden_size = config.hidden_size
+
+        head_dim = getattr(
+            config, "head_dim", hidden_size // config.num_attention_heads
+        )
+        attn_gate_multiplier = 1 + int(getattr(config, "attn_output_gate", True))
+        full_q_dim = config.num_attention_heads * head_dim * attn_gate_multiplier
+        full_kv_dim = config.num_key_value_heads * head_dim
+
+        linear_key_dim = config.linear_num_key_heads * config.linear_key_head_dim
+        linear_value_dim = (
+            config.linear_num_value_heads * config.linear_value_head_dim
+        )
+        intermediate_size = getattr(config, "intermediate_size", None)
+        if intermediate_size is None:
+            intermediate_size = getattr(config, "moe_intermediate_size", None)
+
+        if module_name == "qkv_proj":
+            return hidden_size, full_q_dim + 2 * full_kv_dim
+        elif module_name == "o_proj":
+            return config.num_attention_heads * head_dim, hidden_size
+        elif module_name == "in_proj_qkv":
+            return hidden_size, 2 * linear_key_dim + linear_value_dim
+        elif module_name == "in_proj_z":
+            return hidden_size, linear_value_dim
+        elif module_name in ("in_proj_b", "in_proj_a"):
+            return hidden_size, config.linear_num_value_heads
+        elif module_name == "out_proj":
+            return linear_value_dim, hidden_size
+        elif module_name == "gate_up_proj":
+            if intermediate_size is None:
+                raise NotImplementedError(
+                    "Qwen3.5 config does not define an MLP intermediate size"
+                )
+            return hidden_size, intermediate_size * 2
+        elif module_name == "down_proj":
+            if intermediate_size is None:
+                raise NotImplementedError(
+                    "Qwen3.5 config does not define an MLP intermediate size"
+                )
+            return intermediate_size, hidden_size
+        elif module_name == "embed_tokens":
+            return config.vocab_size, hidden_size
+        elif module_name == "lm_head":
+            return hidden_size, config.vocab_size
+        else:
+            raise NotImplementedError(
+                f"get_hidden_dim not implemented for {module_name}"
+            )
+
     def load_kt_lora(self, adapter_path: str) -> None:
         rank, alpha = _load_kt_lora_config(adapter_path)
         state_dict = _load_kt_lora_state_dict(adapter_path)
@@ -1432,6 +1491,12 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration):
     def load_kt_lora(self, adapter_path: str) -> None:
         self.model.load_kt_lora(adapter_path)
 
+    def get_hidden_dim(self, module_name: str, layer_idx: int):
+        return self.model.get_hidden_dim(module_name, layer_idx)
+
+    def should_apply_lora(self, module_name: str) -> bool:
+        return bool(_QWEN3_5_LORA_PATTERN.match(module_name))
+
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
@@ -1534,6 +1599,12 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3VLForConditionalGeneration):
 
     def load_kt_lora(self, adapter_path: str) -> None:
         self.model.load_kt_lora(adapter_path)
+
+    def get_hidden_dim(self, module_name: str, layer_idx: int):
+        return self.model.get_hidden_dim(module_name, layer_idx)
+
+    def should_apply_lora(self, module_name: str) -> bool:
+        return bool(_QWEN3_5_LORA_PATTERN.match(module_name))
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -880,39 +880,28 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
         """Full attention forward pass."""
         qkv, _ = self.qkv_proj(hidden_states)
         if self._kt_lora_scale is not None:
-            qkv_delta_parts = []
-            for pair in (
-                self._kt_lora_q_proj,
-                self._kt_lora_k_proj,
-                self._kt_lora_v_proj,
-            ):
-                if pair is None:
-                    qkv_delta_parts.append(None)
-                else:
-                    qkv_delta_parts.append(
-                        _lora_delta(hidden_states, pair[0], pair[1], self._kt_lora_scale)
-                    )
-            if any(part is not None for part in qkv_delta_parts):
-                q_delta, k_delta, v_delta = qkv_delta_parts
-                if q_delta is None:
-                    q_delta = torch.zeros(
-                        qkv.shape[:-1] + ((self.q_size * (2 if self.attn_output_gate else 1)),),
-                        dtype=qkv.dtype,
-                        device=qkv.device,
-                    )
-                if k_delta is None:
-                    k_delta = torch.zeros(
-                        qkv.shape[:-1] + (self.kv_size,),
-                        dtype=qkv.dtype,
-                        device=qkv.device,
-                    )
-                if v_delta is None:
-                    v_delta = torch.zeros(
-                        qkv.shape[:-1] + (self.kv_size,),
-                        dtype=qkv.dtype,
-                        device=qkv.device,
-                    )
-                qkv = qkv + torch.cat((q_delta, k_delta, v_delta), dim=-1)
+            q_dim = self.q_size * (2 if self.attn_output_gate else 1)
+            if self._kt_lora_q_proj is not None:
+                qkv[..., :q_dim] += _lora_delta(
+                    hidden_states,
+                    self._kt_lora_q_proj[0],
+                    self._kt_lora_q_proj[1],
+                    self._kt_lora_scale,
+                )
+            if self._kt_lora_k_proj is not None:
+                qkv[..., q_dim : q_dim + self.kv_size] += _lora_delta(
+                    hidden_states,
+                    self._kt_lora_k_proj[0],
+                    self._kt_lora_k_proj[1],
+                    self._kt_lora_scale,
+                )
+            if self._kt_lora_v_proj is not None:
+                qkv[..., q_dim + self.kv_size :] += _lora_delta(
+                    hidden_states,
+                    self._kt_lora_v_proj[0],
+                    self._kt_lora_v_proj[1],
+                    self._kt_lora_scale,
+                )
 
         if self.attn_output_gate:
             q_gate, k, v = qkv.split(

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -14,12 +14,15 @@
 # ==============================================================================
 """Inference-only Qwen3.5 model and Qwen3.5 MoE model compatible with HuggingFace weights."""
 
+import json
 import logging
 from functools import lru_cache
-from typing import Iterable, Optional, Set, Tuple, Union
+from pathlib import Path
+from typing import Dict, Iterable, Optional, Set, Tuple, Union
 
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 from einops import rearrange
 
 # Configs
@@ -80,6 +83,139 @@ _is_cuda = is_cuda()
 _is_npu = is_npu()
 
 cached_get_processor = lru_cache(get_processor)
+
+
+_LORA_PREFIXES = ("", "base_model.", "base_model.model.", "base_model.model.model.")
+
+
+def _load_kt_lora_config(adapter_path: str) -> Tuple[int, float]:
+    config_path = Path(adapter_path) / "adapter_config.json"
+    if not config_path.is_file():
+        raise FileNotFoundError(f"KT LoRA adapter config not found: {config_path}")
+    with config_path.open("r", encoding="utf-8") as f:
+        config = json.load(f)
+    rank = int(config["r"])
+    alpha = float(config.get("lora_alpha", rank))
+    return rank, alpha
+
+
+def _load_kt_lora_state_dict(adapter_path: str) -> Dict[str, torch.Tensor]:
+    from safetensors.torch import load_file
+
+    adapter_dir = Path(adapter_path)
+    weight_file = adapter_dir / "adapter_model.safetensors"
+    if not weight_file.is_file():
+        candidates = sorted(adapter_dir.glob("*.safetensors"))
+        if not candidates:
+            raise FileNotFoundError(
+                f"No safetensors adapter weights found under {adapter_dir}"
+            )
+        weight_file = candidates[0]
+    return load_file(str(weight_file), device="cpu")
+
+
+def _find_lora_tensor(
+    state_dict: Dict[str, torch.Tensor],
+    suffix: str,
+) -> Tuple[Optional[str], Optional[torch.Tensor]]:
+    for prefix in _LORA_PREFIXES:
+        key = prefix + suffix
+        if key in state_dict:
+            return key, state_dict[key]
+    matches = [(key, tensor) for key, tensor in state_dict.items() if key.endswith(suffix)]
+    if len(matches) > 1:
+        raise ValueError(f"Ambiguous KT LoRA tensor suffix {suffix!r}: {[x[0] for x in matches[:4]]}")
+    if matches:
+        return matches[0]
+    return None, None
+
+
+def _get_lora_pair(
+    state_dict: Dict[str, torch.Tensor],
+    consumed_keys: Set[str],
+    layer_id: int,
+    block_name: str,
+    proj_name: str,
+) -> Optional[Tuple[torch.Tensor, torch.Tensor]]:
+    base = f"model.layers.{layer_id}.{block_name}.{proj_name}"
+    key_a, tensor_a = _find_lora_tensor(state_dict, f"{base}.lora_A.weight")
+    key_b, tensor_b = _find_lora_tensor(state_dict, f"{base}.lora_B.weight")
+    if tensor_a is None and tensor_b is None:
+        key_a, tensor_a = _find_lora_tensor(state_dict, f"{base}.lora_A.default.weight")
+        key_b, tensor_b = _find_lora_tensor(state_dict, f"{base}.lora_B.default.weight")
+    if (tensor_a is None) != (tensor_b is None):
+        raise ValueError(f"Incomplete KT LoRA pair for {base}")
+    if tensor_a is None or tensor_b is None:
+        return None
+    consumed_keys.add(key_a)
+    consumed_keys.add(key_b)
+    return tensor_a, tensor_b
+
+
+def _as_lora_weight(
+    tensor: torch.Tensor,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    return tensor.to(device=device, dtype=dtype, non_blocking=True).contiguous()
+
+
+def _slice_column_lora_b(
+    tensor: torch.Tensor,
+    tp_rank: int,
+    tp_size: int,
+) -> torch.Tensor:
+    shard = tensor.shape[0] // tp_size
+    return tensor[tp_rank * shard : (tp_rank + 1) * shard, :]
+
+
+def _slice_merged_column_lora_b(
+    tensor: torch.Tensor,
+    output_sizes: Tuple[int, ...],
+    tp_rank: int,
+    tp_size: int,
+) -> torch.Tensor:
+    shards = []
+    offset = 0
+    for size in output_sizes:
+        shard = size // tp_size
+        shards.append(tensor[offset + tp_rank * shard : offset + (tp_rank + 1) * shard, :])
+        offset += size
+    return torch.cat(shards, dim=0).contiguous()
+
+
+def _slice_row_lora_a(
+    tensor: torch.Tensor,
+    tp_rank: int,
+    tp_size: int,
+) -> torch.Tensor:
+    shard = tensor.shape[1] // tp_size
+    return tensor[:, tp_rank * shard : (tp_rank + 1) * shard]
+
+
+def _slice_full_attention_kv_lora_b(
+    tensor: torch.Tensor,
+    total_kv_heads: int,
+    head_dim: int,
+    tp_rank: int,
+    tp_size: int,
+) -> torch.Tensor:
+    if total_kv_heads >= tp_size:
+        shard = tensor.shape[0] // tp_size
+        return tensor[tp_rank * shard : (tp_rank + 1) * shard, :]
+    replicas = tp_size // total_kv_heads
+    kv_rank = tp_rank // replicas
+    start = kv_rank * head_dim
+    return tensor[start : start + head_dim, :]
+
+
+def _lora_delta(
+    hidden_states: torch.Tensor,
+    lora_a: torch.Tensor,
+    lora_b: torch.Tensor,
+    scale: float,
+) -> torch.Tensor:
+    return F.linear(F.linear(hidden_states, lora_a), lora_b) * scale
 
 
 class Qwen3_5GatedDeltaNet(nn.Module):
@@ -233,6 +369,64 @@ class Qwen3_5GatedDeltaNet(nn.Module):
             tp_size=self.attn_tp_size,
             prefix=add_prefix("out_proj", prefix),
         )
+        self._kt_lora_scale: Optional[float] = None
+        self._kt_lora_in_proj_qkv: Optional[Tuple[torch.Tensor, torch.Tensor]] = None
+        self._kt_lora_in_proj_z: Optional[Tuple[torch.Tensor, torch.Tensor]] = None
+        self._kt_lora_in_proj_b: Optional[Tuple[torch.Tensor, torch.Tensor]] = None
+        self._kt_lora_in_proj_a: Optional[Tuple[torch.Tensor, torch.Tensor]] = None
+        self._kt_lora_out_proj: Optional[Tuple[torch.Tensor, torch.Tensor]] = None
+
+    def load_kt_lora(
+        self,
+        state_dict: Dict[str, torch.Tensor],
+        consumed_keys: Set[str],
+        rank: int,
+        alpha: float,
+    ) -> int:
+        device = self.in_proj_qkv.weight.device
+        dtype = self.in_proj_qkv.weight.dtype
+        self._kt_lora_scale = alpha / float(rank or 1)
+        loaded = 0
+
+        def set_column(name: str, attr: str, output_sizes: Tuple[int, ...]) -> None:
+            nonlocal loaded
+            pair = _get_lora_pair(state_dict, consumed_keys, self.layer_id, "linear_attn", name)
+            if pair is None:
+                return
+            lora_a, lora_b = pair
+            lora_b = (
+                _slice_merged_column_lora_b(lora_b, output_sizes, self.attn_tp_rank, self.attn_tp_size)
+                if len(output_sizes) > 1
+                else _slice_column_lora_b(lora_b, self.attn_tp_rank, self.attn_tp_size)
+            )
+            setattr(
+                self,
+                attr,
+                (
+                    _as_lora_weight(lora_a, device, dtype),
+                    _as_lora_weight(lora_b, device, dtype),
+                ),
+            )
+            loaded += 1
+
+        set_column("in_proj_qkv", "_kt_lora_in_proj_qkv", (self.key_dim, self.key_dim, self.value_dim))
+        set_column("in_proj_z", "_kt_lora_in_proj_z", (self.value_dim,))
+        set_column("in_proj_b", "_kt_lora_in_proj_b", (self.num_v_heads,))
+        set_column("in_proj_a", "_kt_lora_in_proj_a", (self.num_v_heads,))
+
+        pair = _get_lora_pair(state_dict, consumed_keys, self.layer_id, "linear_attn", "out_proj")
+        if pair is not None:
+            lora_a, lora_b = pair
+            self._kt_lora_out_proj = (
+                _as_lora_weight(
+                    _slice_row_lora_a(lora_a, self.attn_tp_rank, self.attn_tp_size),
+                    device,
+                    dtype,
+                ),
+                _as_lora_weight(lora_b, device, dtype),
+            )
+            loaded += 1
+        return loaded
 
     def fix_query_key_value_ordering(
         self,
@@ -259,10 +453,38 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         seq_len, _ = hidden_states.shape
 
         mixed_qkv, _ = self.in_proj_qkv(hidden_states)
+        if self._kt_lora_in_proj_qkv is not None:
+            mixed_qkv = mixed_qkv + _lora_delta(
+                hidden_states,
+                self._kt_lora_in_proj_qkv[0],
+                self._kt_lora_in_proj_qkv[1],
+                self._kt_lora_scale,
+            )
         z, _ = self.in_proj_z(hidden_states)
+        if self._kt_lora_in_proj_z is not None:
+            z = z + _lora_delta(
+                hidden_states,
+                self._kt_lora_in_proj_z[0],
+                self._kt_lora_in_proj_z[1],
+                self._kt_lora_scale,
+            )
         z = z.reshape(z.size(0), -1, self.head_v_dim)
         b, _ = self.in_proj_b(hidden_states)
+        if self._kt_lora_in_proj_b is not None:
+            b = b + _lora_delta(
+                hidden_states,
+                self._kt_lora_in_proj_b[0],
+                self._kt_lora_in_proj_b[1],
+                self._kt_lora_scale,
+            )
         a, _ = self.in_proj_a(hidden_states)
+        if self._kt_lora_in_proj_a is not None:
+            a = a + _lora_delta(
+                hidden_states,
+                self._kt_lora_in_proj_a[0],
+                self._kt_lora_in_proj_a[1],
+                self._kt_lora_scale,
+            )
 
         b = b.contiguous()
         a = a.contiguous()
@@ -281,6 +503,13 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         core_attn_out = core_attn_out.reshape(z_shape_og)
         core_attn_out = rearrange(core_attn_out, "... h d -> ... (h d)")
         output, _ = self.out_proj(core_attn_out)
+        if self._kt_lora_out_proj is not None:
+            output = output + _lora_delta(
+                core_attn_out,
+                self._kt_lora_out_proj[0],
+                self._kt_lora_out_proj[1],
+                self._kt_lora_scale,
+            )
         return output
 
 
@@ -545,6 +774,73 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
         )
 
         self.alt_stream = alt_stream
+        self._kt_lora_scale: Optional[float] = None
+        self._kt_lora_q_proj: Optional[Tuple[torch.Tensor, torch.Tensor]] = None
+        self._kt_lora_k_proj: Optional[Tuple[torch.Tensor, torch.Tensor]] = None
+        self._kt_lora_v_proj: Optional[Tuple[torch.Tensor, torch.Tensor]] = None
+        self._kt_lora_o_proj: Optional[Tuple[torch.Tensor, torch.Tensor]] = None
+
+    def load_kt_lora(
+        self,
+        state_dict: Dict[str, torch.Tensor],
+        consumed_keys: Set[str],
+        rank: int,
+        alpha: float,
+    ) -> int:
+        device = self.qkv_proj.weight.device
+        dtype = self.qkv_proj.weight.dtype
+        self._kt_lora_scale = alpha / float(rank or 1)
+        loaded = 0
+
+        q_pair = _get_lora_pair(state_dict, consumed_keys, self.layer_id, "self_attn", "q_proj")
+        if q_pair is not None:
+            lora_a, lora_b = q_pair
+            q_out_per_rank = self.q_size * (2 if self.attn_output_gate else 1)
+            lora_b = lora_b[
+                self.attn_tp_rank * q_out_per_rank : (self.attn_tp_rank + 1) * q_out_per_rank,
+                :,
+            ]
+            self._kt_lora_q_proj = (
+                _as_lora_weight(lora_a, device, dtype),
+                _as_lora_weight(lora_b, device, dtype),
+            )
+            loaded += 1
+
+        for proj_name, attr in (("k_proj", "_kt_lora_k_proj"), ("v_proj", "_kt_lora_v_proj")):
+            pair = _get_lora_pair(state_dict, consumed_keys, self.layer_id, "self_attn", proj_name)
+            if pair is None:
+                continue
+            lora_a, lora_b = pair
+            lora_b = _slice_full_attention_kv_lora_b(
+                lora_b,
+                self.total_num_kv_heads,
+                self.head_dim,
+                self.attn_tp_rank,
+                self.attn_tp_size,
+            )
+            setattr(
+                self,
+                attr,
+                (
+                    _as_lora_weight(lora_a, device, dtype),
+                    _as_lora_weight(lora_b, device, dtype),
+                ),
+            )
+            loaded += 1
+
+        o_pair = _get_lora_pair(state_dict, consumed_keys, self.layer_id, "self_attn", "o_proj")
+        if o_pair is not None:
+            lora_a, lora_b = o_pair
+            self._kt_lora_o_proj = (
+                _as_lora_weight(
+                    _slice_row_lora_a(lora_a, self.attn_tp_rank, self.attn_tp_size),
+                    device,
+                    dtype,
+                ),
+                _as_lora_weight(lora_b, device, dtype),
+            )
+            loaded += 1
+        return loaded
 
     def _apply_qk_norm(
         self, q: torch.Tensor, k: torch.Tensor
@@ -576,6 +872,40 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
     ) -> torch.Tensor:
         """Full attention forward pass."""
         qkv, _ = self.qkv_proj(hidden_states)
+        if self._kt_lora_scale is not None:
+            qkv_delta_parts = []
+            for pair in (
+                self._kt_lora_q_proj,
+                self._kt_lora_k_proj,
+                self._kt_lora_v_proj,
+            ):
+                if pair is None:
+                    qkv_delta_parts.append(None)
+                else:
+                    qkv_delta_parts.append(
+                        _lora_delta(hidden_states, pair[0], pair[1], self._kt_lora_scale)
+                    )
+            if any(part is not None for part in qkv_delta_parts):
+                q_delta, k_delta, v_delta = qkv_delta_parts
+                if q_delta is None:
+                    q_delta = torch.zeros(
+                        qkv.shape[:-1] + ((self.q_size * (2 if self.attn_output_gate else 1)),),
+                        dtype=qkv.dtype,
+                        device=qkv.device,
+                    )
+                if k_delta is None:
+                    k_delta = torch.zeros(
+                        qkv.shape[:-1] + (self.kv_size,),
+                        dtype=qkv.dtype,
+                        device=qkv.device,
+                    )
+                if v_delta is None:
+                    v_delta = torch.zeros(
+                        qkv.shape[:-1] + (self.kv_size,),
+                        dtype=qkv.dtype,
+                        device=qkv.device,
+                    )
+                qkv = qkv + torch.cat((q_delta, k_delta, v_delta), dim=-1)
 
         if self.attn_output_gate:
             q_gate, k, v = qkv.split(
@@ -598,6 +928,13 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
             attn_output = attn_output * gate
 
         output, _ = self.o_proj(attn_output)
+        if self._kt_lora_o_proj is not None:
+            output = output + _lora_delta(
+                attn_output,
+                self._kt_lora_o_proj[0],
+                self._kt_lora_o_proj[1],
+                self._kt_lora_scale,
+            )
         return output
 
     def forward(
@@ -707,6 +1044,44 @@ class Qwen3_5ForCausalLM(nn.Module):
 
     def get_input_embeddings(self) -> nn.Embedding:
         return self.embed_tokens
+
+    def load_kt_lora(self, adapter_path: str) -> None:
+        rank, alpha = _load_kt_lora_config(adapter_path)
+        state_dict = _load_kt_lora_state_dict(adapter_path)
+        consumed_keys: Set[str] = set()
+        loaded_modules = 0
+
+        for layer_id, layer in enumerate(self.layers):
+            if hasattr(layer, "linear_attn"):
+                loaded_modules += layer.linear_attn.load_kt_lora(
+                    state_dict, consumed_keys, rank, alpha
+                )
+            elif hasattr(layer, "load_kt_lora"):
+                loaded_modules += layer.load_kt_lora(
+                    state_dict, consumed_keys, rank, alpha
+                )
+
+        expert_tensors = sum(".mlp.experts." in key for key in state_dict)
+        unknown_nonexpert = sorted(
+            key
+            for key in state_dict
+            if ".mlp.experts." not in key and key not in consumed_keys
+        )
+        if unknown_nonexpert:
+            raise ValueError(
+                "Unrecognized KT non-expert LoRA tensors: "
+                + ", ".join(unknown_nonexpert[:8])
+            )
+        logger.info(
+            "Loaded static KT non-expert LoRA from %s: modules=%d tensors=%d "
+            "expert_tensors_skipped=%d rank=%d alpha=%.3f",
+            adapter_path,
+            loaded_modules,
+            len(consumed_keys),
+            expert_tensors,
+            rank,
+            alpha,
+        )
 
     @torch.no_grad()
     def forward(
@@ -1054,6 +1429,9 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration):
         torch.cuda.empty_cache()
         torch.cuda.synchronize()
 
+    def load_kt_lora(self, adapter_path: str) -> None:
+        self.model.load_kt_lora(adapter_path)
+
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
@@ -1153,6 +1531,9 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3VLForConditionalGeneration):
         self.lm_head.weight = head
         torch.cuda.empty_cache()
         torch.cuda.synchronize()
+
+    def load_kt_lora(self, adapter_path: str) -> None:
+        self.model.load_kt_lora(adapter_path)
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import argparse
 import dataclasses
+import getpass
 import hashlib
 import importlib
 import importlib.util
@@ -169,7 +170,8 @@ def _prepare_kt_composite_lora_adapter(adapter_path: str) -> Optional[tuple[str,
     cache_root = (
         Path(os.environ.get("SGLANG_KT_LORA_CACHE_DIR", ""))
         if os.environ.get("SGLANG_KT_LORA_CACHE_DIR")
-        else Path(tempfile.gettempdir()) / "sglang_kt_lora_cache"
+        else Path(tempfile.gettempdir())
+        / f"sglang_kt_lora_cache_{getpass.getuser()}"
     )
     cache_dir = cache_root / digest.hexdigest()[:16]
     expert_dir = cache_dir / "expert"
@@ -904,14 +906,6 @@ class ServerArgs:
 
         # Set missing default values.
         self._handle_missing_default_values()
-
-        if self.max_running_requests is not None and self.max_running_requests < 2:
-            logger.warning(
-                "max_running_requests=%d leaves no usable request slots in this "
-                "SGLang fork; setting it to 2.",
-                self.max_running_requests,
-            )
-            self.max_running_requests = 2
 
         if self.kt_lora_path:
             if (
@@ -5609,6 +5603,7 @@ class ServerArgs:
 
         # Check LoRA
         self.check_lora_server_args()
+        self._validate_kt_expert_lora_max_running_requests()
 
         # torch 2.9.1 has compatibility issues with cuDNN 9.14 and below,
         # causing extremely slow nn.Conv3d performance.
@@ -5750,6 +5745,17 @@ class ServerArgs:
                     logger.warning(
                         f"{RED}WARNING: Could not determine CuDNN version for torch==2.9.1. Please ensure CuDNN >= 9.15 to avoid nn.Conv3d bugs.{RESET}"
                     )
+
+    def _validate_kt_expert_lora_max_running_requests(self) -> None:
+        if not (self.kt_lora_path or self.kt_expert_lora_path):
+            return
+        if self.max_running_requests is not None and self.max_running_requests < 2:
+            raise ValueError(
+                "KT expert LoRA serving requires --max-running-requests >= 2 "
+                f"(got {self.max_running_requests}). With max_running_requests=1, "
+                "the request pool has no allocatable slots and requests will not "
+                "enter prefill/forward."
+            )
 
     def check_lora_server_args(self):
         assert self.max_loras_per_batch > 0, "max_loras_per_batch must be positive"

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -564,6 +564,8 @@ class ServerArgs:
     record_kt_gpu_expert_distribution: bool = False
     kt_enable_dynamic_expert_update: bool = False
     kt_expert_placement_strategy: str = "uniform"
+    kt_lora_path: Optional[str] = None
+    kt_expert_lora_path: Optional[str] = None
 
     # Diffusion LLM
     dllm_algorithm: Optional[str] = None
@@ -737,6 +739,32 @@ class ServerArgs:
 
         # Set missing default values.
         self._handle_missing_default_values()
+
+        if self.max_running_requests is not None and self.max_running_requests < 2:
+            logger.warning(
+                "max_running_requests=%d leaves no usable request slots in this "
+                "SGLang fork; setting it to 2.",
+                self.max_running_requests,
+            )
+            self.max_running_requests = 2
+
+        if self.kt_lora_path:
+            if (
+                self.kt_expert_lora_path
+                and self.kt_expert_lora_path != self.kt_lora_path
+            ):
+                raise ValueError(
+                    "--kt-lora-path and --kt-expert-lora-path cannot point to "
+                    "different adapters in the static single-adapter implementation."
+                )
+            self.kt_expert_lora_path = self.kt_lora_path
+
+        if (self.kt_lora_path or self.kt_expert_lora_path) and not self.disable_cuda_graph:
+            logger.warning(
+                "Cuda graph is disabled because KT LoRA uses "
+                "KT SFT CPU expert forward with host-side input copies."
+            )
+            self.disable_cuda_graph = True
 
         # Handle device-specific backends.
         self._handle_hpu_backends()
@@ -4583,6 +4611,23 @@ class ServerArgs:
                  "front-loading: Fill layers from first MoE layer onwards. "
                  "uniform: Equal experts per layer. "
                  "random: Random placement with fixed seed.",
+        )
+        parser.add_argument(
+            "--kt-lora-path",
+            type=str,
+            default=ServerArgs.kt_lora_path,
+            help="[experimental ktransformers parameter] Single PEFT adapter directory "
+                 "for static full KT LoRA. Expert tensors are served by the KT CPU "
+                 "SFT path and Qwen3.5 non-expert tensors are applied statically in "
+                 "the model forward.",
+        )
+        parser.add_argument(
+            "--kt-expert-lora-path",
+            type=str,
+            default=ServerArgs.kt_expert_lora_path,
+            help="[experimental ktransformers parameter] Single PEFT adapter directory "
+                 "for KT CPU expert LoRA. This bypasses SGLang's normal LoRA manager "
+                 "for expert weights and runs the KT CPU expert path through forward_sft.",
         )
 
         # Diffusion LLM

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import argparse
 import dataclasses
+import hashlib
 import importlib
 import importlib.util
 import json
@@ -24,6 +25,7 @@ import logging
 import os
 import random
 import tempfile
+from pathlib import Path
 from typing import Any, Callable, Dict, List, Literal, Optional, Union
 
 import orjson
@@ -72,6 +74,169 @@ from sglang.srt.utils.hf_transformers_utils import check_gguf_file, get_config
 from sglang.utils import is_in_ci
 
 logger = logging.getLogger(__name__)
+
+KT_EXPERT_LORA_MODULES = {"gate_proj", "up_proj", "down_proj"}
+KT_COMPOSITE_LORA_CACHE_VERSION = "v1"
+
+
+def _infer_lora_target_module_from_key(key: str) -> Optional[str]:
+    if "lora_embedding_A" in key or "lora_embedding_B" in key:
+        if "embed_tokens" in key:
+            return "embed_tokens"
+        if "lm_head" in key or "unembed_tokens" in key:
+            return "lm_head"
+
+    marker = ".lora_"
+    if marker not in key:
+        return None
+    prefix = key.split(marker, 1)[0]
+    if "." not in prefix:
+        return prefix
+    return prefix.rsplit(".", 1)[-1]
+
+
+def _is_kt_expert_lora_key(key: str) -> bool:
+    return ".mlp.experts." in key and any(
+        f".{module}." in key for module in KT_EXPERT_LORA_MODULES
+    )
+
+
+def _ordered_lora_target_modules(modules: set[str]) -> List[str]:
+    preferred = [
+        "q_proj",
+        "k_proj",
+        "v_proj",
+        "o_proj",
+        "gate_proj",
+        "up_proj",
+        "down_proj",
+        "in_proj_qkv",
+        "in_proj_z",
+        "in_proj_b",
+        "in_proj_a",
+        "out_proj",
+        "embed_tokens",
+        "lm_head",
+    ]
+    ordered = [name for name in preferred if name in modules]
+    ordered.extend(sorted(modules.difference(ordered)))
+    return ordered
+
+
+def _prepare_kt_composite_lora_adapter(adapter_path: str) -> Optional[tuple[str, str]]:
+    """Split a merged KT MoE LoRA adapter into runtime expert/non-expert dirs.
+
+    Returns (expert_dir, nonexpert_dir) when adapter_path is a local merged KT
+    adapter. Returns None for ordinary LoRA adapters.
+    """
+    adapter_dir = Path(adapter_path).expanduser().resolve()
+    weight_path = adapter_dir / "adapter_model.safetensors"
+    config_path = adapter_dir / "adapter_config.json"
+    if not adapter_dir.is_dir() or not weight_path.is_file() or not config_path.is_file():
+        return None
+
+    try:
+        from safetensors.torch import load_file, save_file
+    except Exception as exc:
+        raise RuntimeError(
+            "safetensors is required to prepare a merged KT LoRA adapter."
+        ) from exc
+
+    try:
+        tensors = load_file(str(weight_path), device="cpu")
+    except Exception:
+        # Let the normal LoRA loader handle non-safetensors or malformed adapters.
+        return None
+
+    expert_keys = [key for key in tensors if _is_kt_expert_lora_key(key)]
+    if not expert_keys:
+        return None
+
+    nonexpert_keys = [key for key in tensors if key not in expert_keys]
+    if not nonexpert_keys:
+        raise ValueError(
+            f"KT composite LoRA adapter {adapter_dir} contains expert tensors "
+            "but no non-expert tensors for SGLang --lora-paths."
+        )
+
+    digest = hashlib.sha256()
+    digest.update(KT_COMPOSITE_LORA_CACHE_VERSION.encode())
+    digest.update(str(adapter_dir).encode())
+    for path in (weight_path, config_path):
+        stat = path.stat()
+        digest.update(str(stat.st_mtime_ns).encode())
+        digest.update(str(stat.st_size).encode())
+    cache_root = (
+        Path(os.environ.get("SGLANG_KT_LORA_CACHE_DIR", ""))
+        if os.environ.get("SGLANG_KT_LORA_CACHE_DIR")
+        else Path(tempfile.gettempdir()) / "sglang_kt_lora_cache"
+    )
+    cache_dir = cache_root / digest.hexdigest()[:16]
+    expert_dir = cache_dir / "expert"
+    nonexpert_dir = cache_dir / "nonexpert"
+
+    if (
+        (expert_dir / "adapter_model.safetensors").is_file()
+        and (expert_dir / "adapter_config.json").is_file()
+        and (nonexpert_dir / "adapter_model.safetensors").is_file()
+        and (nonexpert_dir / "adapter_config.json").is_file()
+    ):
+        return str(expert_dir), str(nonexpert_dir)
+
+    with config_path.open("r", encoding="utf-8") as f:
+        base_config = json.load(f)
+
+    expert_targets = {
+        target
+        for key in expert_keys
+        if (target := _infer_lora_target_module_from_key(key)) is not None
+    }
+    nonexpert_targets = {
+        target
+        for key in nonexpert_keys
+        if (target := _infer_lora_target_module_from_key(key)) is not None
+    }
+    if not expert_targets:
+        expert_targets = set(KT_EXPERT_LORA_MODULES)
+
+    expert_config = dict(base_config)
+    expert_config["target_modules"] = _ordered_lora_target_modules(expert_targets)
+    expert_config["kt_adapter_format"] = "qwen3_5_moe_expert"
+
+    nonexpert_config = dict(base_config)
+    nonexpert_config["target_modules"] = _ordered_lora_target_modules(nonexpert_targets)
+    nonexpert_config["kt_adapter_format"] = "qwen3_5_moe_nonexpert"
+
+    expert_dir.mkdir(parents=True, exist_ok=True)
+    nonexpert_dir.mkdir(parents=True, exist_ok=True)
+    save_file(
+        {key: tensors[key] for key in expert_keys},
+        str(expert_dir / "adapter_model.safetensors"),
+        metadata={"format": "pt"},
+    )
+    save_file(
+        {key: tensors[key] for key in nonexpert_keys},
+        str(nonexpert_dir / "adapter_model.safetensors"),
+        metadata={"format": "pt"},
+    )
+    for output_dir, config in (
+        (expert_dir, expert_config),
+        (nonexpert_dir, nonexpert_config),
+    ):
+        with (output_dir / "adapter_config.json").open("w", encoding="utf-8") as f:
+            json.dump(config, f, indent=2, sort_keys=True)
+            f.write("\n")
+
+    logger.info(
+        "Prepared merged KT LoRA adapter %s for runtime: expert=%s (%d tensors), "
+        "nonexpert=%s (%d tensors)",
+        adapter_dir,
+        expert_dir,
+        len(expert_keys),
+        nonexpert_dir,
+        len(nonexpert_keys),
+    )
+    return str(expert_dir), str(nonexpert_dir)
 
 # Define constants
 DEFAULT_UVICORN_ACCESS_LOG_EXCLUDE_PREFIXES = ()
@@ -3937,7 +4102,14 @@ class ServerArgs:
             nargs="*",
             default=None,
             action=LoRAPathAction,
-            help='The list of LoRA adapters to load. Each adapter must be specified in one of the following formats: <PATH> | <NAME>=<PATH> | JSON with schema {"lora_name":str,"lora_path":str,"pinned":bool}',
+            help=(
+                "The list of LoRA adapters to load. Each adapter must be specified "
+                'in one of the following formats: <PATH> | <NAME>=<PATH> | JSON '
+                'with schema {"lora_name":str,"lora_path":str,"pinned":bool}. '
+                "For KT Qwen3.5 MoE, <PATH> may be a merged adapter directory; "
+                "it will be split internally into KT expert and SGLang non-expert "
+                "runtime adapters."
+            ),
         )
         parser.add_argument(
             "--max-loras-per-batch",
@@ -5657,6 +5829,62 @@ class ServerArgs:
                     f"Invalid type for --lora-paths: {type(self.lora_paths)}. "
                     "Expected a list or a dictionary."
                 )
+
+            kt_composite_lora_ref: Optional[LoRARef] = None
+            kt_composite_expert_path: Optional[str] = None
+            rewritten_lora_paths: List[LoRARef] = []
+            for lora_ref in self.lora_paths:
+                prepared = _prepare_kt_composite_lora_adapter(lora_ref.lora_path)
+                if prepared is None:
+                    rewritten_lora_paths.append(lora_ref)
+                    continue
+
+                if kt_composite_lora_ref is not None:
+                    raise ValueError(
+                        "Only one merged KT composite LoRA adapter is supported "
+                        "in the current single-adapter implementation."
+                    )
+                if len(self.lora_paths) != 1:
+                    raise ValueError(
+                        "Merged KT composite LoRA cannot be mixed with other "
+                        "LoRA adapters in the current single-adapter implementation."
+                    )
+                if self.kt_expert_lora_path:
+                    raise ValueError(
+                        "--lora-paths with a merged KT composite adapter cannot be "
+                        "combined with --kt-expert-lora-path. Pass only "
+                        "--lora-paths <name>=<merged_adapter_dir>."
+                    )
+
+                expert_path, nonexpert_path = prepared
+                kt_composite_lora_ref = lora_ref
+                kt_composite_expert_path = expert_path
+                rewritten_lora_paths.append(
+                    LoRARef(
+                        lora_id=lora_ref.lora_id,
+                        lora_name=lora_ref.lora_name,
+                        lora_path=nonexpert_path,
+                        pinned=lora_ref.pinned,
+                    )
+                )
+
+            if kt_composite_lora_ref is not None:
+                self.lora_paths = rewritten_lora_paths
+                self.kt_expert_lora_path = kt_composite_expert_path
+                logger.warning(
+                    "Using merged KT composite LoRA adapter %s as %s. "
+                    "The adapter is internally split into expert/non-expert "
+                    "runtime directories. In this first implementation the KT "
+                    "expert LoRA is loaded statically at server startup.",
+                    kt_composite_lora_ref.lora_path,
+                    kt_composite_lora_ref.lora_name,
+                )
+                if not self.disable_cuda_graph:
+                    logger.warning(
+                        "Cuda graph is disabled because KT expert LoRA uses "
+                        "KT SFT CPU expert forward with host-side input copies."
+                    )
+                    self.disable_cuda_graph = True
 
             # Expand target modules
             if self.lora_target_modules:


### PR DESCRIPTION
## Summary

This PR adds the SGLang runtime side of the Qwen3.5 MoE KT LoRA serving workflow.

Main changes:

- Add KT expert LoRA serving support for Qwen3.5 MoE expert modules.
- Add Qwen3.5 non-expert LoRA support for attention / shared modules.
- Allow a merged KT LoRA adapter passed through `--lora-paths name=<adapter_dir>` to be detected and split internally at server startup.
- Route expert LoRA weights to the KT CPU expert path and non-expert LoRA weights to SGLang's LoRA manager.
- Fix Triton LoRA B masking for non-aligned tile shapes.

## Motivation

KT-SFT for Qwen3.5 MoE produces LoRA weights that need two runtime paths:

- expert LoRA through the KT CPU expert forward path
- non-expert LoRA through SGLang's LoRA manager

Earlier serving required users to manually pass separate expert and non-expert adapter paths. With this change, users can pass one merged adapter through `--lora-paths`, while SGLang handles the expert/non-expert split internally.

## Test Plan

- Served a converted Qwen3.5 MoE KT-SFT merged adapter with `--lora-paths <name>=<merged_adapter_dir>`.
- Verified startup logs show internal expert/non-expert adapter preparation.
- Verified OpenAI-compatible chat completion with `model=<served_model>:<adapter_name>`.
- Verified base-model requests still use `weight_version=default` and do not require LoRA.