### PR TITLE
(Not Vibe Coded) Added Tool Calling for DeepSeek V4 Flash

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -73,7 +73,7 @@ dependencies = [
   "transformers-kt==5.6.0.post1",
   "uvicorn",
   "uvloop",
-  "xgrammar==0.1.27",
+  "xgrammar==0.2.1",
 
   "smg-grpc-proto>=0.3.3",
   "grpcio>=1.78.0",

--- a/python/pyproject_cpu.toml
+++ b/python/pyproject_cpu.toml
@@ -67,7 +67,7 @@ dependencies = [
   "triton==3.5.0",
   "uvicorn",
   "uvloop",
-  "xgrammar==0.1.27",
+  "xgrammar==0.2.1",
   "smg-grpc-proto>=0.3.3",
   "grpcio>=1.78.0",
   "grpcio-reflection>=1.78.0",

--- a/python/pyproject_npu.toml
+++ b/python/pyproject_npu.toml
@@ -61,7 +61,7 @@ dependencies = [
   "transformers==4.57.1",
   "uvicorn",
   "uvloop",
-  "xgrammar==0.1.27",
+  "xgrammar==0.2.1",
   "smg-grpc-proto>=0.3.3",
   "grpcio>=1.78.0",
   "grpcio-reflection>=1.78.0",

--- a/python/pyproject_other.toml
+++ b/python/pyproject_other.toml
@@ -63,7 +63,7 @@ runtime_common = [
   "transformers==4.57.1",
   "uvicorn",
   "uvloop",
-  "xgrammar==0.1.27",
+  "xgrammar==0.2.1",
   "smg-grpc-proto>=0.3.3",
   "grpcio>=1.78.0",
   "grpcio-reflection>=1.78.0",

--- a/python/pyproject_xpu.toml
+++ b/python/pyproject_xpu.toml
@@ -66,7 +66,7 @@ dependencies = [
   "transformers==4.57.1",
   "uvicorn",
   "uvloop",
-  # "xgrammar==0.1.24", , xgrammar depends on CUDA PyTorch and Triton only
+  # "xgrammar==0.2.1", xgrammar depends on CUDA PyTorch and Triton only
   "smg-grpc-proto>=0.3.3",
   "grpcio>=1.78.0",
   "grpcio-reflection>=1.78.0",

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -585,6 +585,7 @@ class ChatCompletionRequest(BaseModel):
     tool_choice: Union[ToolChoice, Literal["auto", "required", "none"]] = Field(
         default="auto", examples=["none"]
     )  # noqa
+    parallel_tool_calls: bool = True
     return_hidden_states: bool = False
     return_routed_experts: bool = False
     return_cached_tokens_details: bool = False

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -336,6 +336,13 @@ class OpenAIServingChat(OpenAIServingBase):
         if self.is_gpt_oss:
             request.skip_special_tokens = False
 
+        thinking_mode = self._get_reasoning_from_request(request)
+        # SGLang's ReasonerGrammarBackend owns the reasoning prefix
+        # when --reasoning-parser is configured, so builtin xgrammar
+        # tags must describe only the post-reasoning tool-call suffix.
+        xgrammar_reasoning = thinking_mode and (
+            self.tokenizer_manager.server_args.reasoning_parser is None
+        )
         tool_call_constraint = None
 
         # Apply chat template and its stop strings
@@ -353,14 +360,20 @@ class OpenAIServingChat(OpenAIServingBase):
             if self.tool_call_parser:
                 parser = FunctionCallParser(request.tools, self.tool_call_parser)
                 tool_call_constraint = parser.get_structure_constraint(
-                    request.tool_choice
+                    request.tool_choice,
+                    parallel_tool_calls=request.parallel_tool_calls,
+                    thinking_mode=xgrammar_reasoning,
                 )
-            # Handle JSON schema constraint directly for required or named tool choice
-            if request.tool_choice == "required" or isinstance(
-                request.tool_choice, ToolChoice
+            # Fallback: use generic JSON schema for required/named tool choice
+            # only when no parser-specific constraint was set
+            if tool_call_constraint is None and (
+                request.tool_choice == "required"
+                or isinstance(request.tool_choice, ToolChoice)
             ):
                 json_schema = get_json_schema_constraint(
-                    request.tools, request.tool_choice
+                    request.tools,
+                    request.tool_choice,
+                    parallel_tool_calls=request.parallel_tool_calls,
                 )
                 tool_call_constraint = ("json_schema", json_schema)
 
@@ -1112,22 +1125,56 @@ class OpenAIServingChat(OpenAIServingBase):
     ) -> ToolCallProcessingResult:
         """Process tool calls in the response"""
 
-        # Handle required or named tool choice
-        if tool_choice == "required" or (
-            isinstance(tool_choice, ToolChoice) and tool_choice.type == "function"
-        ):
-            # Set finish reason to tool_calls since we're processing tool calls
+        is_required = tool_choice == "required" or isinstance(tool_choice, ToolChoice)
+
+        # Try model-specific parser when output is in native format.
+        # For required/named: only use parser when structural_tag was used
+        # as constraint (mirrors the streaming path). For auto: always try.
+        if self.tool_call_parser:
+            parser = FunctionCallParser(tools, self.tool_call_parser)
+            should_try_parser = (
+                not is_required or parser.detector.supports_structural_tag()
+            )
+            if should_try_parser and parser.has_tool_call(text):
+                original_finish_type = finish_reason["type"]
+                if finish_reason["type"] == "stop":
+                    finish_reason["type"] = "tool_calls"
+                    finish_reason["matched"] = None
+                try:
+                    text, call_info_list = parser.parse_non_stream(text)
+                    tool_calls = []
+                    for call_info in call_info_list:
+                        tool_id = self._process_tool_call_id(
+                            call_info, history_tool_calls_cnt
+                        )
+                        tool_calls.append(
+                            ToolCall(
+                                id=tool_id,
+                                index=getattr(call_info, "tool_index", None),
+                                function=FunctionResponse(
+                                    name=call_info.name,
+                                    arguments=call_info.parameters,
+                                ),
+                            )
+                        )
+                    return ToolCallProcessingResult(tool_calls, text, finish_reason)
+                except Exception as e:
+                    logger.error(f"Tool call parsing error: {e}")
+                    finish_reason["type"] = original_finish_type
+                    return ToolCallProcessingResult(None, text, finish_reason)
+
+        # json_schema constraint → JSON array output for required/named
+        if is_required:
+            original_finish_type = finish_reason["type"]
             if finish_reason["type"] == "stop":
                 finish_reason["type"] = "tool_calls"
                 finish_reason["matched"] = None
             try:
-                # For required tool choice, we expect a JSON array of tool calls
                 tool_call_data = orjson.loads(text)
                 tool_calls = []
                 for i, tool in enumerate(tool_call_data):
-                    # Create a ToolCallItem from the JSON data
                     call_info = ToolCallItem(
-                        tool_index=i,  # Use the loop index as tool_index
+                        tool_index=i,
                         name=tool["name"],
                         parameters=json.dumps(tool["parameters"], ensure_ascii=False),
                     )
@@ -1147,36 +1194,9 @@ class OpenAIServingChat(OpenAIServingBase):
                         )
                     )
                 return ToolCallProcessingResult(tool_calls, "", finish_reason)
-            except json.JSONDecodeError as e:
-                logger.error(f"Tool call parsing error: {e}")
-                return ToolCallProcessingResult(None, text, finish_reason)
-
-        # Use parser since output is not constrained by JSON schema
-        parser = FunctionCallParser(tools, self.tool_call_parser)
-        if parser.has_tool_call(text):
-            if finish_reason["type"] == "stop":
-                finish_reason["type"] = "tool_calls"
-                finish_reason["matched"] = None
-            try:
-                text, call_info_list = parser.parse_non_stream(text)
-                tool_calls = []
-                for call_info in call_info_list:
-                    tool_id = self._process_tool_call_id(
-                        call_info, history_tool_calls_cnt
-                    )
-                    tool_calls.append(
-                        ToolCall(
-                            id=tool_id,
-                            index=getattr(call_info, "tool_index", None),
-                            function=FunctionResponse(
-                                name=call_info.name, arguments=call_info.parameters
-                            ),
-                        )
-                    )
-                return ToolCallProcessingResult(tool_calls, text, finish_reason)
             except Exception as e:
                 logger.error(f"Tool call parsing error: {e}")
-                # Return error but don't fail the whole request
+                finish_reason["type"] = original_finish_type
                 return ToolCallProcessingResult(None, text, finish_reason)
 
         return ToolCallProcessingResult(None, text, finish_reason)
@@ -1275,11 +1295,26 @@ class OpenAIServingChat(OpenAIServingBase):
     ):
         """Process tool calls in streaming response"""
         if index not in parser_dict:
-            # Use JSON detector directly for required or named tool choice
-            if request.tool_choice == "required" or isinstance(
+            is_required = request.tool_choice == "required" or isinstance(
                 request.tool_choice, ToolChoice
-            ):
-                parser_dict[index] = JsonArrayParser()
+            )
+            # For required/named tool choice: use JsonArrayParser when the
+            # constrained output is plain JSON (detector doesn't support
+            # structural_tag or no parser configured). Use FunctionCallParser
+            # only when the detector supports structural_tag and will produce
+            # native format output.
+            if is_required:
+                use_native_parser = False
+                if self.tool_call_parser:
+                    probe = FunctionCallParser(
+                        tools=request.tools,
+                        tool_call_parser=self.tool_call_parser,
+                    )
+                    use_native_parser = probe.detector.supports_structural_tag()
+                if use_native_parser:
+                    parser_dict[index] = probe
+                else:
+                    parser_dict[index] = JsonArrayParser()
             else:
                 parser_dict[index] = FunctionCallParser(
                     tools=request.tools,

--- a/python/sglang/srt/function_call/base_format_detector.py
+++ b/python/sglang/srt/function_call/base_format_detector.py
@@ -1,13 +1,19 @@
 import json
 import logging
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Literal, Optional, Union
 
 import orjson
 from partial_json_parser.core.exceptions import MalformedJSON
 from partial_json_parser.core.options import Allow
 
-from sglang.srt.entrypoints.openai.protocol import Tool
+try:
+    from xgrammar import StructuralTag, get_model_structural_tag
+except ImportError:
+    StructuralTag = Any
+    get_model_structural_tag = None
+
+from sglang.srt.entrypoints.openai.protocol import Tool, ToolChoice
 from sglang.srt.environ import envs
 from sglang.srt.function_call.core_types import (
     StreamingParseResult,
@@ -171,12 +177,13 @@ class BaseFormatDetector(ABC):
                 # parallel tool calls because the bot_token (e.g., '[') can also
                 # appear inside array parameters of the current tool, and we must not
                 # mistakenly identify that as the start of a new tool.
+                used_separator_branch = False
                 if self.current_tool_id > 0 and current_text.startswith(
                     self.tool_call_separator
                 ):
                     start_idx = len(self.tool_call_separator)
+                    used_separator_branch = True
                 else:
-                    # Only search for bot_token if not processing subsequent tool
                     tool_call_pos = current_text.find(self.bot_token)
                     if tool_call_pos != -1:
                         start_idx = tool_call_pos + len(self.bot_token)
@@ -186,7 +193,23 @@ class BaseFormatDetector(ABC):
                 if start_idx >= len(current_text):
                     return StreamingParseResult()
 
-                obj, end_idx = _partial_json_loads(current_text[start_idx:], flags)
+                try:
+                    obj, end_idx = _partial_json_loads(current_text[start_idx:], flags)
+                except (MalformedJSON, json.JSONDecodeError):
+                    # Separator landed on non-JSON markup; fall back to
+                    # bot_token which skips past all inter-object markup.
+                    # e.g. Qwen25: separator "," matches between eot/bot tags.
+                    if used_separator_branch and self.bot_token in current_text:
+                        start_idx = current_text.find(self.bot_token) + len(
+                            self.bot_token
+                        )
+                        if start_idx >= len(current_text):
+                            return StreamingParseResult()
+                        obj, end_idx = _partial_json_loads(
+                            current_text[start_idx:], flags
+                        )
+                    else:
+                        raise
 
                 is_current_complete = _is_complete_json(
                     current_text[start_idx : start_idx + end_idx]
@@ -212,7 +235,7 @@ class BaseFormatDetector(ABC):
 
                 current_tool_call = obj
 
-            except MalformedJSON:
+            except (MalformedJSON, json.JSONDecodeError):
                 return StreamingParseResult()
 
             if not current_tool_call:
@@ -253,7 +276,7 @@ class BaseFormatDetector(ABC):
                 cur_arguments = current_tool_call.get("arguments")
                 res = StreamingParseResult()
 
-                if cur_arguments:
+                if cur_arguments is not None:
                     # Calculate how much of the arguments we've already streamed
                     sent = len(self.streamed_args_for_tool[self.current_tool_id])
                     cur_args_json = json.dumps(cur_arguments, ensure_ascii=False)
@@ -344,3 +367,45 @@ class BaseFormatDetector(ABC):
             A function that takes a tool name (str) and returns StructureInfo
         """
         raise NotImplementedError()
+
+    def get_structural_tag_name(self) -> Optional[str]:
+        """Return the XGrammar model name for native structural tags, if supported."""
+        return None
+
+    def get_structural_tag(
+        self,
+        tools: Union[List[Tool], None] = None,
+        tool_choice: Union[ToolChoice, Literal["auto", "required"]] = "auto",
+        thinking_mode: bool = False,
+    ) -> Optional[StructuralTag]:
+        """
+        Return a model-native XGrammar structural tag when supported.
+
+        Args:
+            tools: List of available tools
+            tool_choice: The tool choice setting from the request
+            thinking_mode: Whether to include the model's reasoning prefix in
+                the returned structural tag. Pass False when SGLang's
+                ReasonerGrammarBackend will own the <think>...</think> prefix
+                (the typical case when --reasoning-parser is configured) so
+                only one layer constrains the reasoning section.
+
+        Returns:
+            StructuralTag if this detector supports model-native tags, otherwise None
+        """
+        structural_tag_name = self.get_structural_tag_name()
+        if not structural_tag_name or get_model_structural_tag is None:
+            return None
+
+        converted_tools = [tool.model_dump() for tool in tools or []]
+        converted_tool_choice = (
+            tool_choice.model_dump()
+            if isinstance(tool_choice, ToolChoice)
+            else tool_choice
+        )
+        return get_model_structural_tag(
+            model=structural_tag_name,
+            tools=converted_tools,
+            tool_choice=converted_tool_choice,
+            reasoning=thinking_mode,
+        )

--- a/python/sglang/srt/function_call/deepseekv32_detector.py
+++ b/python/sglang/srt/function_call/deepseekv32_detector.py
@@ -81,21 +81,41 @@ class DeepSeekV32Detector(BaseFormatDetector):
         self.function_calls_regex = (
             r"<｜DSML｜function_calls>(.*?)</｜DSML｜function_calls>"
         )
+        # Long-form `<｜DSML｜invoke name="x">...</｜DSML｜invoke>` and the
+        # self-closing `<｜DSML｜invoke name="x"/>` shape V4 emits for zero-arg
+        # tools. The `end` group is empty when the closer hasn't streamed in.
         self.invoke_regex = (
-            r'<｜DSML｜invoke\s+name="([^"]+)"\s*>(.*?)(</｜DSML｜invoke>|$)'
+            r'<｜DSML｜invoke\s+name="(?P<name>[^"]+)"\s*'
+            r"(?:(?P<self_close>/>)"
+            r"|>(?P<body>.*?)(?P<end>(?:</｜DSML｜invoke>|$)))"
         )
         self.prefix_parameter_end_call = ["</", "｜DSML｜", "parameter"]
+        self.prefix_invoke_end_call = ["</", "｜DSML｜", "inv", "oke"]
         self.current_tool_id = -1
 
     def has_tool_call(self, text: str) -> bool:
         """Check if the text contains a deepseek v32 format tool call."""
         return self.bot_token in text or "<｜DSML｜invoke" in text
 
+    @staticmethod
+    def _unpack_invoke_match(m: "re.Match[str]") -> tuple[str, str, bool]:
+        """Returns (name, body, is_complete) for an invoke_regex match.
+
+        Self-closing invokes have empty body and are always complete.
+        Long-form bodies are always strings (possibly empty); they're
+        incomplete when matched against `$` because the closing tag
+        hasn't streamed in yet.
+        """
+        name = m.group("name").strip()
+        if m.group("self_close"):
+            return name, "", True
+        return name, m.group("body"), bool(m.group("end"))
+
     def _parse_parameters_from_xml(
         self, invoke_content: str, allow_partial: bool = False
-    ) -> dict:
+    ) -> str:
         """
-        Parse parameters from either XML-like format or JSON format to dict.
+        Parse parameters from either XML-like format or JSON format to str.
 
         Supports two formats:
         1. XML parameter tags: <｜DSML｜parameter name="..." string="...">value</｜DSML｜parameter>
@@ -103,17 +123,14 @@ class DeepSeekV32Detector(BaseFormatDetector):
         """
         # First, try to parse as direct JSON (new format)
         invoke_content_stripped = invoke_content.strip()
-
-        if invoke_content_stripped.startswith("{") and invoke_content_stripped.endswith(
-            "}"
-        ):
-            try:
-                parameters = json.loads(invoke_content_stripped)
-                if isinstance(parameters, dict):
-                    return parameters
-            except (json.JSONDecodeError, ValueError):
-                # If JSON parsing fails, fall through to XML parsing
-                pass
+        if invoke_content_stripped.startswith("{"):
+            if allow_partial:
+                # Remove incomplete invoke end call prefix in case they are captured by param
+                for token in reversed(self.prefix_invoke_end_call):
+                    invoke_content_stripped = invoke_content_stripped.rstrip(token)
+                return invoke_content_stripped
+            elif invoke_content_stripped.endswith("}"):
+                return invoke_content_stripped
 
         # Fall back to XML parameter tag parsing (original format)
         parameters = {}
@@ -158,11 +175,14 @@ class DeepSeekV32Detector(BaseFormatDetector):
                 if partial_match.group(2) == "true":
                     parameters[param_name] = param_value.strip()
                 else:
-                    parameters[param_name] = _partial_json_loads(
-                        param_value, Allow.ALL
-                    )[0]
+                    try:
+                        parameters[param_name] = _partial_json_loads(
+                            param_value, Allow.ALL
+                        )[0]
+                    except json.JSONDecodeError:
+                        parameters[param_name] = param_value.strip()
 
-        return parameters
+        return json.dumps(parameters, ensure_ascii=False)
 
     def detect_and_parse(self, text: str, tools: list[Tool]) -> StreamingParseResult:
         """
@@ -173,7 +193,7 @@ class DeepSeekV32Detector(BaseFormatDetector):
         :return: ParseResult indicating success or failure, consumed text, leftover text, and parsed calls.
         """
         idx = text.find(self.bot_token)
-        normal_text = text[:idx].strip() if idx != -1 else text
+        normal_text = text[:idx].removesuffix("\n\n") if idx != -1 else text
         if self.bot_token not in text:
             return StreamingParseResult(normal_text=normal_text, calls=[])
 
@@ -191,15 +211,13 @@ class DeepSeekV32Detector(BaseFormatDetector):
             function_calls_content = function_calls_match.group(1)
 
             # Find all invoke blocks
-            invoke_matches = re.findall(
+            for invoke_match in re.finditer(
                 self.invoke_regex, function_calls_content, re.DOTALL
-            )
-
-            for func_name, invoke_content, _ in invoke_matches:
-                # Parse parameters from XML format
+            ):
+                func_name, invoke_content, _ = self._unpack_invoke_match(invoke_match)
                 func_args = self._parse_parameters_from_xml(invoke_content)
                 # construct match_result for parse_base_json
-                match_result = {"name": func_name, "parameters": func_args}
+                match_result = {"name": func_name, "parameters": json.loads(func_args)}
                 calls.extend(self.parse_base_json(match_result, tools))
 
             return StreamingParseResult(normal_text=normal_text, calls=calls)
@@ -253,10 +271,9 @@ class DeepSeekV32Detector(BaseFormatDetector):
                 if not invoke_match:
                     break
 
-                func_name = invoke_match.group(1).strip()
-                invoke_content = invoke_match.group(2)
-                # group(3) is either "</｜DSML｜invoke>" (complete) or "" (incomplete, matched with $)
-                is_tool_end = bool(invoke_match.group(3))
+                func_name, invoke_content, is_tool_end = self._unpack_invoke_match(
+                    invoke_match
+                )
 
                 # Initialize state if this is the first tool call
                 if self.current_tool_id == -1:
@@ -285,7 +302,6 @@ class DeepSeekV32Detector(BaseFormatDetector):
                 current_params = self._parse_parameters_from_xml(
                     invoke_content, allow_partial=not is_tool_end
                 )
-                current_args_json = json.dumps(current_params, ensure_ascii=False)
 
                 # 3. Calculate and send incremental arguments
                 sent_len = len(self.streamed_args_for_tool[self.current_tool_id])
@@ -297,12 +313,11 @@ class DeepSeekV32Detector(BaseFormatDetector):
 
                 if is_tool_end:
                     # If complete, send everything remaining
-                    argument_diff = current_args_json[sent_len:]
+                    argument_diff = current_params[sent_len:]
                 elif prev_params is not None:
                     # If partial, send stable prefix diff
-                    prev_args_json = json.dumps(prev_params, ensure_ascii=False)
-                    if current_args_json != prev_args_json:
-                        prefix = _find_common_prefix(prev_args_json, current_args_json)
+                    if current_params != prev_params:
+                        prefix = _find_common_prefix(current_params, prev_params)
                         if len(prefix) > sent_len:
                             argument_diff = prefix[sent_len:]
 
@@ -350,5 +365,8 @@ class DeepSeekV32Detector(BaseFormatDetector):
         return lambda name: StructureInfo(
             begin=f'<｜DSML｜invoke name="{name}">',
             end="</｜DSML｜invoke>",
-            trigger=f"<｜DSML｜invoke",
+            trigger="<｜DSML｜invoke",
         )
+
+    def get_structural_tag_name(self) -> str:
+        return "deepseek_v3_2"

--- a/python/sglang/srt/function_call/deepseekv4_detector.py
+++ b/python/sglang/srt/function_call/deepseekv4_detector.py
@@ -25,3 +25,6 @@ class DeepSeekV4Detector(DeepSeekV32Detector):
         self.bot_token = "<｜DSML｜tool_calls>"
         self.eot_token = "</｜DSML｜tool_calls>"
         self.function_calls_regex = r"<｜DSML｜tool_calls>(.*?)</｜DSML｜tool_calls>"
+
+    def get_structural_tag_name(self) -> str:
+        return "deepseek_v4"

--- a/python/sglang/srt/function_call/function_call_parser.py
+++ b/python/sglang/srt/function_call/function_call_parser.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Literal, Optional, Set, Tuple, Type, Union
 
 from sglang.srt.entrypoints.openai.protocol import (
     LegacyStructuralTagResponseFormat,
+    StructuralTagResponseFormat,
     StructuresResponseFormat,
     Tool,
     ToolCallConstraint,
@@ -12,6 +13,7 @@ from sglang.srt.environ import ToolStrictLevel, envs
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
 from sglang.srt.function_call.core_types import ToolCallItem
 from sglang.srt.function_call.deepseekv3_detector import DeepSeekV3Detector
+from sglang.srt.function_call.deepseekv4_detector import DeepSeekV4Detector
 from sglang.srt.function_call.deepseekv31_detector import DeepSeekV31Detector
 from sglang.srt.function_call.deepseekv32_detector import DeepSeekV32Detector
 from sglang.srt.function_call.gigachat3_detector import GigaChat3Detector
@@ -31,7 +33,10 @@ from sglang.srt.function_call.qwen3_coder_detector import Qwen3CoderDetector
 from sglang.srt.function_call.qwen25_detector import Qwen25Detector
 from sglang.srt.function_call.step3_detector import Step3Detector
 from sglang.srt.function_call.trinity_detector import TrinityDetector
-from sglang.srt.function_call.utils import get_json_schema_constraint
+from sglang.srt.function_call.utils import (
+    _get_tool_schema_defs,
+    get_json_schema_constraint,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +54,7 @@ class FunctionCallParser:
         "deepseekv3": DeepSeekV3Detector,
         "deepseekv31": DeepSeekV31Detector,
         "deepseekv32": DeepSeekV32Detector,
+        "deepseekv4": DeepSeekV4Detector,
         "glm": Glm4MoeDetector,
         "glm45": Glm4MoeDetector,
         "glm47": Glm47MoeDetector,
@@ -144,12 +150,24 @@ class FunctionCallParser:
 
         return final_normal_text, final_calls
 
-    def get_structure_tag(self) -> LegacyStructuralTagResponseFormat:
+    def get_legacy_structural_tag(
+        self, at_least_one: bool = False
+    ) -> StructuralTagResponseFormat:
         """
         Generate a structural tag response format for all available tools.
 
         This creates the necessary structural tags that guide the model's output format.
+
+        Args:
+            at_least_one: If True, the grammar forces at least one tool call
+                (no free text allowed). Used for required/named tool_choice.
+
+        Raises:
+            ValueError: If tools have conflicting $defs schemas.
         """
+        # Validate $defs consistency before building structural tags
+        _get_tool_schema_defs(self.tools)
+
         tool_structures: List[StructuresResponseFormat] = list()
         tool_trigger_set: Set[str] = set()
 
@@ -181,10 +199,14 @@ class FunctionCallParser:
             type="structural_tag",
             structures=tool_structures,
             triggers=list(tool_trigger_set),
+            at_least_one=at_least_one,
         )
 
     def get_structure_constraint(
-        self, tool_choice: Union[ToolChoice, Literal["auto", "required"]]
+        self,
+        tool_choice: Union[ToolChoice, Literal["auto", "required"]],
+        parallel_tool_calls: bool = True,
+        thinking_mode: bool = False,
     ) -> Optional[ToolCallConstraint]:
         """
         Returns the appropriate structure constraint for tool calls based on the tool_choice.
@@ -197,18 +219,37 @@ class FunctionCallParser:
             A tuple of (constraint_type, constraint_value) to be added to sampling parameters,
             or None if no constraint applies.
         """
-        # NOTE: structural_tag only supports JSON-compatible content between the begin and end.
-        # It cannot parse or validate function call Pythonic or XML-ish syntax.
-        if (
-            self.detector.supports_structural_tag()
-            and tool_choice == "auto"
-            and (
-                any(tool.function.strict for tool in self.tools)
-                or self.tool_strict_level >= ToolStrictLevel.FUNCTION
-            )
-        ):
-            tag = self.get_structure_tag()
-            return ("structural_tag", tag)
-        elif tool_choice == "required" or isinstance(tool_choice, ToolChoice):
-            json_schema = get_json_schema_constraint(self.tools, tool_choice)
-            return ("json_schema", json_schema)
+        is_required = tool_choice == "required" or isinstance(tool_choice, ToolChoice)
+        should_constrain_auto = tool_choice == "auto" and (
+            any(tool.function.strict for tool in self.tools)
+            or self.tool_strict_level >= ToolStrictLevel.FUNCTION
+        )
+
+        # Highest priority: model-native structural_tag when available.
+        try:
+            if is_required or should_constrain_auto:
+                structural_tag = self.detector.get_structural_tag(
+                    tools=self.tools,
+                    thinking_mode=thinking_mode,
+                    tool_choice=tool_choice,
+                )
+                if structural_tag is not None:
+                    return ("structural_tag", structural_tag)
+
+                # Fallback to legacy structural tag if model-native tag is not supported.
+                if self.detector.supports_structural_tag():
+                    # For "required"/named: always use structural_tag to preserve the
+                    # model's native tool call format. Schema is only included when
+                    # strict=True, per OpenAI protocol semantics.
+                    # For "auto": only constrain when strict is enabled.
+                    tag = self.get_legacy_structural_tag(at_least_one=is_required)
+                    return ("structural_tag", tag)
+
+            if tool_choice == "required" or isinstance(tool_choice, ToolChoice):
+                json_schema = get_json_schema_constraint(
+                    self.tools, tool_choice, parallel_tool_calls=parallel_tool_calls
+                )
+                return ("json_schema", json_schema)
+        except Exception as e:
+            logger.error(f"Error getting structure constraint: {e}")
+            return None

--- a/python/sglang/srt/function_call/utils.py
+++ b/python/sglang/srt/function_call/utils.py
@@ -205,13 +205,16 @@ def infer_type_from_json_schema(schema: Dict[str, Any]) -> Optional[str]:
 
 
 def get_json_schema_constraint(
-    tools: List[Tool], tool_choice: Union[ToolChoice, Literal["required"]]
+    tools: List[Tool],
+    tool_choice: Union[ToolChoice, Literal["required"]],
+    parallel_tool_calls: bool = True,
 ) -> Optional[dict]:
     """
     Get the JSON schema constraint for the specified tool choice.
 
     Args:
         tool_choice: The tool choice specification
+        parallel_tool_calls: If False, constrain to exactly one tool call (maxItems=1)
 
     Returns:
         JSON schema dict, or None if no valid tools found
@@ -222,12 +225,14 @@ def get_json_schema_constraint(
         fn_name = tool_choice.function.name
         for tool in tools:
             if tool.function.name == fn_name:
-                return {
+                schema = {
                     "type": "array",
                     "minItems": 1,
-                    "maxItems": 1,
                     "items": _get_tool_schema(tool),
                 }
+                if not parallel_tool_calls:
+                    schema["maxItems"] = 1
+                return schema
         return None
     elif tool_choice == "required":
         json_schema = {
@@ -238,6 +243,8 @@ def get_json_schema_constraint(
                 "anyOf": [_get_tool_schema(tool) for tool in tools],
             },
         }
+        if not parallel_tool_calls:
+            json_schema["maxItems"] = 1
         json_schema_defs = _get_tool_schema_defs(tools)
         if json_schema_defs:
             json_schema["$defs"] = json_schema_defs


### PR DESCRIPTION
## Motivation

Wanted to compare a hybrid GPU / CPU memory inference run of DeepSeek V4 Flash on KTransformers+SGLang vs llama.cpp, through 1xH200. Discovered tool calling wasn't implemented, yet could find a solution from observing the main SGLang branch with confirmed DeepSeek V4 Flash tool call parser integration.

## Modifications

Manually updated the following files to closely match the DeepSeek V4 tool call parser & parallel tool calls from SGLang's main repo at commit: sgl-project/sglang@c06220159bca623b139018c8fe5c3822a8ded5de

>   python/pyproject.toml
>   python/pyproject_cpu.toml
>   python/pyproject_npu.toml
>   python/pyproject_other.toml
>   python/pyproject_xpu.toml
>   python/sglang/srt/entrypoints/openai/protocol.py
>   python/sglang/srt/entrypoints/openai/serving_chat.py
>   python/sglang/srt/function_call/base_format_detector.py
>   python/sglang/srt/function_call/deepseekv32_detector.py
>   python/sglang/srt/function_call/deepseekv4_detector.py
>   python/sglang/srt/function_call/function_call_parser.py
>   python/sglang/srt/function_call/utils.py

## Accuracy Tests & Profiling

Here the following are provided: Installation Steps, SGLang Flags, and OpenCode tool calling to build a Super Mario Bros 1 Level 1 via web server.

<h3>1. Install Main KTransformers</h3>

```
git clone https://github.com/kvcache-ai/ktransformers.git
cd ktransformers
git submodule update --init --recursive
cd kt-kernel && ./install.sh
```

<h3>2. Install Forked SGLang with DeepSeek V4 Tool Calling</h3>

```
cd ../..
git clone -b deepseekv4_tool_calls https://github.com/keennay/sglang.git
cd sglang
python -m pip install -e python
```

<h3>3. PIP Install Required Packages</h3>

```
python -m pip install "tilelang==0.1.8"
python -m pip install "apache-tvm-ffi==0.1.9"
python -m pip install --upgrade flashinfer-python flashinfer-cubin
python -m pip install "transformers==4.57.1"
```

<h3>4. Build Flash-MLA Package (Requires CUDA 12.9)</h3>

```
cd ..
python -m pip install --no-build-isolation 'flash-mla @ git+https://github.com/deepseek-ai/FlashMLA.git@9241ae3ef9bac614dd25e45e507e089f888280e0'
```

<h3>5. Update NVIDIA cuDNN libraries for CUDA 12</h3>

```
python -m pip install nvidia-cudnn-cu12==9.16.0.29
```

<h3> 6. SGLang flags for running on 2x NVIDIA RTX PRO 6000 on Port 8000</h3>

```
env CUDA_VISIBLE_DEVICES=0,1 \
FLASHINFER_CUDA_ARCH_LIST=12.0a \
TORCH_CUDA_ARCH_LIST=12.0+PTX \
SGLANG_DSV4_MODE=2604 \
SGLANG_DSV4_2604_SUBMODE=2604B \
SGLANG_FP8_PAGED_MQA_LOGITS_TORCH=1 \
SGLANG_OPT_USE_TILELANG_INDEXER=1 \
SGLANG_FLASHMLA_BACKEND_OVERRIDE=triton \
    python -m sglang.launch_server \
      --host 0.0.0.0 \
      --port 8000 \
      --model-path <models--deepseek-ai--DeepSeek-V4-Flash-snapshots-path> \
      --kt-weight-path <models--deepseek-ai--DeepSeek-V4-Flash-snapshots-path> \
      --kt-cpuinfer 30 \
      --kt-threadpool-count 1 \
      --kt-num-gpu-experts 128 \
      --kt-method MXFP4 \
      --kt-max-deferred-experts-per-token 2 \
      --kt-expert-placement-strategy uniform \
      --trust-remote-code \
      --context-length 1048576 \
      --max-total-tokens 1048576 \
      --mem-fraction-static 0.85 \
      --chunked-prefill-size 16384 \
      --served-model-name deepseek \
      --enable-mixed-chunk \
      --tensor-parallel-size 2 \
      --enable-p2p-check \
      --disable-shared-experts-fusion \
      --kt-gpu-prefill-token-threshold 1024 \
      --tool-call-parser deepseekv4 \
      --reasoning-parser deepseek-v4 \
      --max-running-requests 128 \
      --cuda-graph-max-bs 128 \
      --cuda-graph-bs 1 2 4 8 16 32 64 128
```

<h3>7. Install OpenCode & Set Config for Local SGLang Instance</h3>

Installation Steps:
https://github.com/anomalyco/opencode

Edit config file to point to local SGLang Instance on Port 8001:
$HOME/.config/opencode/opencode.json

```
{
  "$schema": "https://opencode.ai/config.json",
  "provider": {
    "deepseek-v4-8000": {
      "npm": "@ai-sdk/openai-compatible",
      "name": "DeepSeek V4 Flash 8000",
      "options": {
        "baseURL": "http://localhost:8000/v1"
      },
      "models": {
        "deepseek_v4": {
          "name": "DeepSeek V4 Flash (8000)"
        }
      }
    },
    "deepseek-v4-8001": {
      "npm": "@ai-sdk/openai-compatible",
      "name": "DeepSeek V4 Flash 8001",
      "options": {
        "baseURL": "http://localhost:8001/v1"
      },
      "models": {
        "deepseek_v4": {
          "name": "DeepSeek V4 Flash (8001)"
        }
      }
    }
  },
  "model": "deepseek-v4-8001/deepseek_v4"
}
```

<h3>8. Screenshots on 1xH200 with TMUX running SGLang, OpenCode, and resulting Super Mario Bros code</h3>

<img width="1440" height="900" alt="Screenshot 2026-06-03 at 23 42 25" src="https://github.com/user-attachments/assets/7f82abf9-2560-4672-97b3-69c4fc7e6253" />

<img width="811" height="778" alt="Screenshot 2026-06-04 at 00 25 44" src="https://github.com/user-attachments/assets/83e7c0cd-f9bf-43d6-9b2c-a4e5d04f1ded" />

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
