### PR TITLE
fix(v4): auto-bump swa_full_tokens_ratio to fit chunks_in_flight

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1440,6 +1440,13 @@ class ServerArgs:
 
             if self.swa_full_tokens_ratio == ServerArgs.swa_full_tokens_ratio:
                 self.swa_full_tokens_ratio = 0.1
+                # Bump default just enough to fit `chunks_in_flight × chunked_prefill_size`
+                # in the SWA pool. Otherwise long prompts (input >= 0.1 × max_total_tokens)
+                # silently hang on NO_TOKEN. Only acts when both knobs are explicit.
+                if self.chunked_prefill_size and self.max_total_tokens:
+                    chunks_in_flight = 1 if self.disable_overlap_schedule else 2
+                    needed = chunks_in_flight * self.chunked_prefill_size * 1.05
+                    self.swa_full_tokens_ratio = min(0.9, max(0.1, needed / self.max_total_tokens))
                 logger.info(
                     f"Setting swa_full_tokens_ratio to {self.swa_full_tokens_ratio} for {model_arch}."
                 )


### PR DESCRIPTION
Default 0.1 sized SWA pool = max_total_tokens × 0.1. With chunked_prefill_size=8192 and max_total_tokens=32768, the SWA pool is only 3072 tokens — too small for a single prefill chunk. The request fails NO_TOKEN repeatedly in get_new_batch_prefill, batch_is_full gets latched, and the scheduler silently hangs (input >= 4096).

When both chunked_prefill_size and max_total_tokens are explicit, bump the default ratio to chunks_in_flight × chunked_prefill_size × 1.05 / max_total_tokens (clamped to [0.1, 0.9]). chunks_in_flight = 2 with the overlap scheduler, 1 without. The 5% headroom covers the window/page padding inside _swa_budget_for_req.

Users can still override explicitly with --swa-full-tokens-ratio.