### PR TITLE
feat: fp8 moe marlin backend for gpu expert and gpu prefill

### DIFF
--- a/python/sglang/srt/layers/moe/fused_moe_triton/fused_marlin_moe.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/fused_marlin_moe.py
@@ -21,7 +21,7 @@ def get_scalar_type(num_bits: int, has_zp: bool):
         assert num_bits == 4
         return scalar_types.uint4
     else:
-        return scalar_types.uint4b8 if num_bits == 4 else scalar_types.float8_e4m3fn
+        return scalar_types.uint4b8 if num_bits == 4 else scalar_types.uint8b128
 
 
 def fused_marlin_moe(
@@ -46,6 +46,7 @@ def fused_marlin_moe(
     is_k_full: bool = True,
     inplace: bool = False,
     routed_scaling_factor: float = None,
+    b_q_type: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """
     This function computes a Mixture of Experts (MoE) layer using two sets of
@@ -144,8 +145,8 @@ def fused_marlin_moe(
             max_workspace_size, dtype=torch.int, device=device, requires_grad=False
         )
 
-    scalar_type1 = get_scalar_type(num_bits, w1_zeros is not None)
-    scalar_type2 = get_scalar_type(num_bits, w2_zeros is not None)
+    scalar_type1 = b_q_type if b_q_type is not None else get_scalar_type(num_bits, w1_zeros is not None)
+    scalar_type2 = b_q_type if b_q_type is not None else get_scalar_type(num_bits, w2_zeros is not None)
 
     intermediate_cache2 = torch.empty(
         (M * topk_ids.shape[1], N),
@@ -264,6 +265,7 @@ def fused_marlin_moe_fake(
     is_k_full: bool = True,
     inplace: bool = False,
     routed_scaling_factor: float = None,
+    b_q_type: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     return torch.empty_like(hidden_states)
 

--- a/python/sglang/srt/layers/moe/fused_moe_triton/fused_marlin_moe.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/fused_marlin_moe.py
@@ -1,12 +1,9 @@
 import functools
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
 
 import torch
 
 from sglang.srt.utils import is_cuda
-
-if TYPE_CHECKING:
-    from sgl_kernel.scalar_type import ScalarType
 
 _is_cuda = is_cuda()
 
@@ -49,7 +46,7 @@ def fused_marlin_moe(
     is_k_full: bool = True,
     inplace: bool = False,
     routed_scaling_factor: float = None,
-    b_q_type: Optional["ScalarType"] = None,
+    b_q_type: Optional[torch.Tensor] = None,  # really ScalarType; Tensor for infer_schema compat
 ) -> torch.Tensor:
     """
     This function computes a Mixture of Experts (MoE) layer using two sets of
@@ -268,7 +265,7 @@ def fused_marlin_moe_fake(
     is_k_full: bool = True,
     inplace: bool = False,
     routed_scaling_factor: float = None,
-    b_q_type: Optional["ScalarType"] = None,
+    b_q_type: Optional[torch.Tensor] = None,  # really ScalarType; Tensor for infer_schema compat
 ) -> torch.Tensor:
     return torch.empty_like(hidden_states)
 

--- a/python/sglang/srt/layers/moe/fused_moe_triton/fused_marlin_moe.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/fused_marlin_moe.py
@@ -1,9 +1,12 @@
 import functools
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import torch
 
 from sglang.srt.utils import is_cuda
+
+if TYPE_CHECKING:
+    from sgl_kernel.scalar_type import ScalarType
 
 _is_cuda = is_cuda()
 
@@ -46,7 +49,7 @@ def fused_marlin_moe(
     is_k_full: bool = True,
     inplace: bool = False,
     routed_scaling_factor: float = None,
-    b_q_type: Optional[torch.Tensor] = None,
+    b_q_type: Optional["ScalarType"] = None,
 ) -> torch.Tensor:
     """
     This function computes a Mixture of Experts (MoE) layer using two sets of
@@ -265,7 +268,7 @@ def fused_marlin_moe_fake(
     is_k_full: bool = True,
     inplace: bool = False,
     routed_scaling_factor: float = None,
-    b_q_type: Optional[torch.Tensor] = None,
+    b_q_type: Optional["ScalarType"] = None,
 ) -> torch.Tensor:
     return torch.empty_like(hidden_states)
 

--- a/python/sglang/srt/layers/moe/fused_moe_triton/fused_marlin_moe.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/fused_marlin_moe.py
@@ -21,7 +21,7 @@ def get_scalar_type(num_bits: int, has_zp: bool):
         assert num_bits == 4
         return scalar_types.uint4
     else:
-        return scalar_types.uint4b8 if num_bits == 4 else scalar_types.uint8b128
+        return scalar_types.uint4b8 if num_bits == 4 else scalar_types.float8_e4m3fn
 
 
 def fused_marlin_moe(

--- a/python/sglang/srt/layers/moe/kt_ep_wrapper.py
+++ b/python/sglang/srt/layers/moe/kt_ep_wrapper.py
@@ -3216,7 +3216,7 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
         # Step 2: Copy selected expert weights from ctx.gpu_layer to layer.
         # Both are already in inference format: apply() already called
         # process_weights_after_loading() which handles Marlin repack.
-        if ctx.is_fp8_quant:
+        if ctx._is_fp8_quant:
             # Ampere Marlin vs native FP8 block quant: Marlin repack renames
             # w13_weight_scale_inv → w13_weight_scale and changes w13_weight
             # dtype fp8→int32.  Use gpu_method class name (invariant) to pick
@@ -3231,13 +3231,13 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
                     src_layer=ctx.gpu_layer, dst_layer=layer,
                     selected_experts=selected_experts,
                 )
-        elif ctx.is_fp8_channel_quant:
+        elif ctx._is_fp8_channel_quant:
             copy_experts_weights_fp8_channel(
                 src_layer=ctx.gpu_layer,
                 dst_layer=layer,
                 selected_experts=selected_experts,
             )
-        elif ctx.is_bf16_quant:
+        elif ctx._is_bf16_quant:
             copy_experts_weights_bf16(
                 src_layer=ctx.gpu_layer,
                 dst_layer=layer,

--- a/python/sglang/srt/layers/moe/kt_ep_wrapper.py
+++ b/python/sglang/srt/layers/moe/kt_ep_wrapper.py
@@ -460,6 +460,7 @@ class SharedFullContext:
             if hasattr(self, _attr):
                 setattr(self, f"_{_attr}", getattr(self, _attr))
 
+
         # Save weight/scale shapes before any repack so we can re-create
         # the raw (pre-repack) attributes during layerwise prefill loading.
         self._raw_weight_shapes = {}
@@ -1633,7 +1634,6 @@ class SharedFullContext:
                 setattr(self.gpu_layer, _sn,
                         torch.nn.Parameter(
                             torch.empty(_shape, dtype=_dtype, device=_target_device)))
-
     def load(self, layer_idx, wrapper, original_layer=None, gpu_experts_mask=None,
              logical_to_gpu_index=None):
         """Load weights from disk to GPU via shared memory.
@@ -2957,8 +2957,7 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
             # Re-run quant post-processing on the full-expert gpu_layer
             # if supported (e.g. Marlin repack for Fp8MarlinMoEMethod).
             # The ctx.load() call writes raw fp8 weights; downstream apply()
-            # expects repacked format.  Restore raw format afterwards so
-            # the context is clean for the next layer.
+            # expects repacked format.
             _needs_repack = hasattr(ctx.gpu_method, "process_weights_after_loading")
             if _needs_repack:
                 ctx.gpu_method.process_weights_after_loading(ctx.gpu_layer)
@@ -2969,25 +2968,20 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
                 torch.cuda.synchronize()
             compute_time = (time.perf_counter() - t_compute) * 1000.0
 
-            if _needs_repack:
-                ctx._restore_raw_attrs()
-
             # Dynamic expert update: analyze batch and update GPU experts.
+            # MUST run BEFORE _restore_raw_attrs() because on Ampere FP8 the
+            # Marlin repack changes weight shapes/dtypes, and
+            # _restore_raw_attrs() creates empty tensors (torch.empty) to
+            # restore the raw fp8 format, destroying the weight data.
             # Skip for V4-Flash MXFP4 — `_update_gpu_experts_from_batch` →
             # `copy_experts_weights_int4` hardcodes int4 weight names
             # (`w13_weight_packed` etc.) and crashes on MXFP4 layouts. The
             # full-GPU fallback re-loads all 256 experts on every fire anyway,
             # so the dynamic-promote optimization is a no-op for MXFP4. Origin:
             # sglang 本身 (V4-Flash full-GPU prefill fallback compat).
-            _mxfp4_skip_dyn_update = getattr(ctx, "is_mxfp4_quant", False)
-            # After Marlin repack, ctx.gpu_layer is in raw format but the
-            # inference layer is Marlin — the copy functions can't bridge
-            # the format gap.  Prefill already handles full-GPU compute;
-            # skip dynamic update for FP8 Marlin paths.
-            _marlin_skip_dyn_update = ctx.is_fp8_quant or ctx.is_fp8_channel_quant
+            _mxfp4_skip_dyn_update = getattr(ctx, "_is_mxfp4_quant", False)
             if (self.kt_config.kt_enable_dynamic_expert_update
-                    and not _mxfp4_skip_dyn_update
-                    and not _marlin_skip_dyn_update):
+                    and not _mxfp4_skip_dyn_update):
                 t_update = time.perf_counter()
                 self._update_gpu_experts_from_batch(
                     layer=layer,
@@ -3012,6 +3006,11 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
                         self.kt_config.layer_idx,
                         compute_time,
                     )
+
+            # Restore raw format AFTER dynamic update so the context is
+            # clean for the next layer's load() call.
+            if _needs_repack:
+                ctx._restore_raw_attrs()
 
             return result
 
@@ -3214,13 +3213,24 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
         if dist.is_initialized():
             dist.broadcast(selected_experts, src=0, group=get_tp_group().device_group)
 
-        # Step 2: Copy weights from temporary layer to original layer
+        # Step 2: Copy selected expert weights from ctx.gpu_layer to layer.
+        # Both are already in inference format: apply() already called
+        # process_weights_after_loading() which handles Marlin repack.
         if ctx.is_fp8_quant:
-            copy_experts_weights_fp8(
-                src_layer=ctx.gpu_layer,
-                dst_layer=layer,
-                selected_experts=selected_experts,
-            )
+            # Ampere Marlin vs native FP8 block quant: Marlin repack renames
+            # w13_weight_scale_inv → w13_weight_scale and changes w13_weight
+            # dtype fp8→int32.  Use gpu_method class name (invariant) to pick
+            # the right attribute-name list.
+            if ctx.gpu_method.__class__.__name__.endswith("MarlinMoEMethod"):
+                copy_experts_weights_fp8_channel(
+                    src_layer=ctx.gpu_layer, dst_layer=layer,
+                    selected_experts=selected_experts,
+                )
+            else:
+                copy_experts_weights_fp8(
+                    src_layer=ctx.gpu_layer, dst_layer=layer,
+                    selected_experts=selected_experts,
+                )
         elif ctx.is_fp8_channel_quant:
             copy_experts_weights_fp8_channel(
                 src_layer=ctx.gpu_layer,

--- a/python/sglang/srt/layers/moe/kt_ep_wrapper.py
+++ b/python/sglang/srt/layers/moe/kt_ep_wrapper.py
@@ -460,19 +460,18 @@ class SharedFullContext:
             if hasattr(self, _attr):
                 setattr(self, f"_{_attr}", getattr(self, _attr))
 
+        # Move all parameters to target device
+        for param in self.gpu_layer.parameters():
+            if param.device != target_device:
+                param.data = param.data.to(target_device)
 
-        # Save weight/scale shapes before any repack so we can re-create
-        # the raw (pre-repack) attributes during layerwise prefill loading.
+        # Save weight/scale shapes after device move so _restore_raw_attrs
+        # can re-create tensors on the correct device later.
         self._raw_weight_shapes = {}
         for _sn in self.weight_names:
             if hasattr(self.gpu_layer, _sn):
                 _t = getattr(self.gpu_layer, _sn)
                 self._raw_weight_shapes[_sn] = (tuple(_t.shape), _t.dtype, _t.device)
-
-        # Move all parameters to target device
-        for param in self.gpu_layer.parameters():
-            if param.device != target_device:
-                param.data = param.data.to(target_device)
 
         # Create runner config - update both num_experts and num_local_experts for full GPU fallback
         # Set routed_scaling_factor=None to avoid double scaling:

--- a/python/sglang/srt/layers/moe/kt_ep_wrapper.py
+++ b/python/sglang/srt/layers/moe/kt_ep_wrapper.py
@@ -1624,16 +1624,15 @@ class SharedFullContext:
         and _weight_scale_inv is renamed to _weight_scale.  This helper
         reverts those changes so downstream code always sees raw format.
         """
-        _target_device = self.gpu_layer.w13_weight.device
         for _stale in ("w13_weight_scale", "w2_weight_scale"):
             if hasattr(self.gpu_layer, _stale):
                 delattr(self.gpu_layer, _stale)
-        for _sn, (_shape, _dtype, _) in self._raw_weight_shapes.items():
+        for _sn, (_shape, _dtype, _device) in self._raw_weight_shapes.items():
             _cur = getattr(self.gpu_layer, _sn, None)
             if _cur is None or _cur.shape != _shape or _cur.dtype != _dtype:
                 setattr(self.gpu_layer, _sn,
                         torch.nn.Parameter(
-                            torch.empty(_shape, dtype=_dtype, device=_target_device)))
+                            torch.empty(_shape, dtype=_dtype, device=_device)))
     def load(self, layer_idx, wrapper, original_layer=None, gpu_experts_mask=None,
              logical_to_gpu_index=None):
         """Load weights from disk to GPU via shared memory.

--- a/python/sglang/srt/layers/moe/kt_ep_wrapper.py
+++ b/python/sglang/srt/layers/moe/kt_ep_wrapper.py
@@ -359,7 +359,7 @@ class SharedFullContext:
         # scale Parameter objects so `_prepare_weight_mxfp8` can rebind to
         # them before each byte-copy. Native MXFP8 path keeps the scale in
         # this layout throughout (no convert to block-fp8).
-        if getattr(self, "is_mxfp8_quant", False):
+        if getattr(self, "_is_mxfp8_quant", False):
             self._init_mxfp8_aux()
 
     def _init_mxfp8_aux(self) -> None:
@@ -451,18 +451,14 @@ class SharedFullContext:
         # Detect quantization type for weight loading based on actually created weights.
         # This is more robust than class-based detection when quant methods are wrapped
         # (e.g., KT wrapper -> compressed-tensors scheme), especially in layerwise prefill.
+        # Run once at init.  Freeze the result into _is_* so downstream
+        # always sees the original quant type even if a Marlin repack
+        # later renames attributes (e.g. _inv → _weight_scale).
         self._detect_quant_type_from_created_weights()
-
-        # The detection writes internal state into _is_fp8_quant /
-        # _is_fp8_channel_quant.  Copy to the public attributes and freeze
-        # them — downstream code (weight_names, load(),
-        # _update_gpu_experts_from_batch) reads the public names and must
-        # never see Marlin-repack state flips.
         for _attr in ("is_mxfp4_quant", "is_mxfp8_quant", "is_fp8_quant",
                        "is_fp8_channel_quant", "is_bf16_quant"):
-            _priv = f"_{_attr}"
-            if hasattr(self, _priv):
-                setattr(self, _attr, getattr(self, _priv))
+            if hasattr(self, _attr):
+                setattr(self, f"_{_attr}", getattr(self, _attr))
 
         # Save weight/scale shapes before any repack so we can re-create
         # the raw (pre-repack) attributes during layerwise prefill loading.
@@ -530,19 +526,19 @@ class SharedFullContext:
         # prefill fallback compat).
         if self.gpu_method.__class__.__name__ == "DeepSeekMxfp4MoEMethod":
             self.is_mxfp4_quant = True
-            self._is_mxfp8_quant = False
-            self._is_fp8_quant = False
-            self._is_fp8_channel_quant = False
-            self._is_bf16_quant = False
+            self.is_mxfp8_quant = False
+            self.is_fp8_quant = False
+            self.is_fp8_channel_quant = False
+            self.is_bf16_quant = False
             return
 
         # INT4 Marlin
         if hasattr(layer, "w13_weight_packed") and hasattr(layer, "w2_weight_packed"):
-            self._is_mxfp4_quant = False
-            self._is_mxfp8_quant = False
-            self._is_fp8_quant = False
-            self._is_fp8_channel_quant = False
-            self._is_bf16_quant = False
+            self.is_mxfp4_quant = False
+            self.is_mxfp8_quant = False
+            self.is_fp8_quant = False
+            self.is_fp8_channel_quant = False
+            self.is_bf16_quant = False
             return
 
         # M3 MXFP8 block (must come before FP8 block — both register
@@ -556,46 +552,46 @@ class SharedFullContext:
             and hasattr(layer, "w2_weight_scale_inv")
             and getattr(layer.w13_weight_scale_inv, "format_ue8m0", False)
         ):
-            self._is_mxfp4_quant = False
-            self._is_mxfp8_quant = True
-            self._is_fp8_quant = False
-            self._is_fp8_channel_quant = False
-            self._is_bf16_quant = False
+            self.is_mxfp4_quant = False
+            self.is_mxfp8_quant = True
+            self.is_fp8_quant = False
+            self.is_fp8_channel_quant = False
+            self.is_bf16_quant = False
             return
 
         # FP8 block
         if hasattr(layer, "w13_weight_scale_inv") and hasattr(layer, "w2_weight_scale_inv"):
-            self._is_mxfp4_quant = False
-            self._is_mxfp8_quant = False
-            self._is_fp8_quant = True
-            self._is_fp8_channel_quant = False
-            self._is_bf16_quant = False
+            self.is_mxfp4_quant = False
+            self.is_mxfp8_quant = False
+            self.is_fp8_quant = True
+            self.is_fp8_channel_quant = False
+            self.is_bf16_quant = False
             return
 
         # FP8 per-channel
         if hasattr(layer, "w13_weight_scale") and hasattr(layer, "w2_weight_scale"):
-            self._is_mxfp4_quant = False
-            self._is_mxfp8_quant = False
-            self._is_fp8_quant = False
-            self._is_fp8_channel_quant = True
-            self._is_bf16_quant = False
+            self.is_mxfp4_quant = False
+            self.is_mxfp8_quant = False
+            self.is_fp8_quant = False
+            self.is_fp8_channel_quant = True
+            self.is_bf16_quant = False
             return
 
         # BF16 / unquantized
         if hasattr(layer, "w13_weight") and hasattr(layer, "w2_weight"):
-            self._is_mxfp4_quant = False
-            self._is_mxfp8_quant = False
-            self._is_fp8_quant = False
-            self._is_fp8_channel_quant = False
-            self._is_bf16_quant = True
+            self.is_mxfp4_quant = False
+            self.is_mxfp8_quant = False
+            self.is_fp8_quant = False
+            self.is_fp8_channel_quant = False
+            self.is_bf16_quant = True
             return
 
         # Fallback to class-based detection for unknown layouts.
-        self._is_mxfp4_quant = False
-        self._is_mxfp8_quant = False
-        self._is_fp8_quant = self._detect_fp8_quant()
-        self._is_fp8_channel_quant = self._detect_fp8_channel_quant()
-        self._is_bf16_quant = self._detect_bf16_quant()
+        self.is_mxfp4_quant = False
+        self.is_mxfp8_quant = False
+        self.is_fp8_quant = self._detect_fp8_quant()
+        self.is_fp8_channel_quant = self._detect_fp8_channel_quant()
+        self.is_bf16_quant = self._detect_bf16_quant()
 
     def _detect_fp8_quant(self) -> bool:
         """Detect if the quantization method is FP8 block quant.
@@ -705,24 +701,24 @@ class SharedFullContext:
     @property
     def weight_names(self) -> list:
         """Get weight names based on quantization type."""
-        if getattr(self, "is_mxfp4_quant", False):
+        if getattr(self, "_is_mxfp4_quant", False):
             # V4-Flash MXFP4 uses the same flat names as FP8 block (w13_weight,
             # w13_weight_scale_inv, w2_weight, w2_weight_scale_inv); the
             # underlying byte payload differs (FP4 nibble + ue8m0 scale) but
             # the staging buffers don't care about content.
             return self.WEIGHT_NAMES_FP8
-        if getattr(self, "is_mxfp8_quant", False):
+        if getattr(self, "_is_mxfp8_quant", False):
             # M3 MXFP8 reuses the FP8 block flat names. Byte payload is
             # MXFP8 (fp8 + uint8 ue8m0 [1,32]) — staging buffer dtype/shape
             # follow gpu_layer.w13_weight_scale_inv (uint8) so byte-copy
             # transports the canonical layout. fused_experts_mxfp8 consumes
             # it directly; no convert step.
             return self.WEIGHT_NAMES_FP8
-        if self.is_fp8_quant:
+        if self._is_fp8_quant:
             return self.WEIGHT_NAMES_FP8
-        elif self.is_fp8_channel_quant:
+        elif self._is_fp8_channel_quant:
             return self.WEIGHT_NAMES_FP8_CHANNEL
-        elif self.is_bf16_quant:
+        elif self._is_bf16_quant:
             return self.WEIGHT_NAMES_BF16
         else:
             return self.WEIGHT_NAMES_INT4
@@ -794,7 +790,7 @@ class SharedFullContext:
             # Only allocate 2 experts worth of buffer (double buffering)
             expert_shape = gpu_tensor.shape[1:]  # Shape per expert
             if (
-                getattr(self, "is_mxfp4_quant", False)
+                getattr(self, "_is_mxfp4_quant", False)
                 and name in ("w13_weight_scale_inv", "w2_weight_scale_inv")
             ):
                 buf_dtype = torch.bfloat16
@@ -1665,28 +1661,28 @@ class SharedFullContext:
 
         # Select appropriate prepare_weight method based on quantization type
         # FP8/BF16 methods support GPU expert optimization; INT4 uses full CPU pipeline
-        if getattr(self, "is_mxfp4_quant", False):
+        if getattr(self, "_is_mxfp4_quant", False):
             # V4-Flash MXFP4: byte-copy via FP8 path + re-swizzle into
             # triton_kernels form. Origin: sglang 本身.
             self._prepare_weight_mxfp4(wrapper, original_layer, gpu_experts_mask,
                                        logical_to_gpu_index)
-        elif getattr(self, "is_mxfp8_quant", False):
+        elif getattr(self, "_is_mxfp8_quant", False):
             # M3 MXFP8: byte-copy via FP8 path with original_layer=None
             # (Phase 1 shortcut disabled) + Triton MXFP8->block-FP8 convert
             # on shadow gpu_layer so apply() runs the standard block-FP8
             # deep_gemm path. Origin: kt-sglang 耦合 (v2 bridge).
             self._prepare_weight_mxfp8(wrapper, original_layer, gpu_experts_mask,
                                        logical_to_gpu_index)
-        elif self.is_fp8_quant:
+        elif self._is_fp8_quant:
             # When the inference layer is Marlin-repacked (int32), the
             # raw fp8 context layer can't share GPU→GPU copies.
             # Disable Phase 1 shortcut by passing original_layer=None.
             self._prepare_weight_fp8(wrapper, None, gpu_experts_mask,
                                      logical_to_gpu_index)
-        elif self.is_fp8_channel_quant:
+        elif self._is_fp8_channel_quant:
             self._prepare_weight_fp8_channel(wrapper, None, gpu_experts_mask,
                                              logical_to_gpu_index)
-        elif self.is_bf16_quant:
+        elif self._is_bf16_quant:
             self._prepare_weight_bf16(wrapper, original_layer, gpu_experts_mask,
                                       logical_to_gpu_index)
         else:

--- a/python/sglang/srt/layers/moe/kt_ep_wrapper.py
+++ b/python/sglang/srt/layers/moe/kt_ep_wrapper.py
@@ -453,6 +453,25 @@ class SharedFullContext:
         # (e.g., KT wrapper -> compressed-tensors scheme), especially in layerwise prefill.
         self._detect_quant_type_from_created_weights()
 
+        # The detection writes internal state into _is_fp8_quant /
+        # _is_fp8_channel_quant.  Copy to the public attributes and freeze
+        # them — downstream code (weight_names, load(),
+        # _update_gpu_experts_from_batch) reads the public names and must
+        # never see Marlin-repack state flips.
+        for _attr in ("is_mxfp4_quant", "is_mxfp8_quant", "is_fp8_quant",
+                       "is_fp8_channel_quant", "is_bf16_quant"):
+            _priv = f"_{_attr}"
+            if hasattr(self, _priv):
+                setattr(self, _attr, getattr(self, _priv))
+
+        # Save weight/scale shapes before any repack so we can re-create
+        # the raw (pre-repack) attributes during layerwise prefill loading.
+        self._raw_weight_shapes = {}
+        for _sn in self.weight_names:
+            if hasattr(self.gpu_layer, _sn):
+                _t = getattr(self.gpu_layer, _sn)
+                self._raw_weight_shapes[_sn] = (tuple(_t.shape), _t.dtype, _t.device)
+
         # Move all parameters to target device
         for param in self.gpu_layer.parameters():
             if param.device != target_device:
@@ -511,19 +530,19 @@ class SharedFullContext:
         # prefill fallback compat).
         if self.gpu_method.__class__.__name__ == "DeepSeekMxfp4MoEMethod":
             self.is_mxfp4_quant = True
-            self.is_mxfp8_quant = False
-            self.is_fp8_quant = False
-            self.is_fp8_channel_quant = False
-            self.is_bf16_quant = False
+            self._is_mxfp8_quant = False
+            self._is_fp8_quant = False
+            self._is_fp8_channel_quant = False
+            self._is_bf16_quant = False
             return
 
         # INT4 Marlin
         if hasattr(layer, "w13_weight_packed") and hasattr(layer, "w2_weight_packed"):
-            self.is_mxfp4_quant = False
-            self.is_mxfp8_quant = False
-            self.is_fp8_quant = False
-            self.is_fp8_channel_quant = False
-            self.is_bf16_quant = False
+            self._is_mxfp4_quant = False
+            self._is_mxfp8_quant = False
+            self._is_fp8_quant = False
+            self._is_fp8_channel_quant = False
+            self._is_bf16_quant = False
             return
 
         # M3 MXFP8 block (must come before FP8 block — both register
@@ -537,46 +556,46 @@ class SharedFullContext:
             and hasattr(layer, "w2_weight_scale_inv")
             and getattr(layer.w13_weight_scale_inv, "format_ue8m0", False)
         ):
-            self.is_mxfp4_quant = False
-            self.is_mxfp8_quant = True
-            self.is_fp8_quant = False
-            self.is_fp8_channel_quant = False
-            self.is_bf16_quant = False
+            self._is_mxfp4_quant = False
+            self._is_mxfp8_quant = True
+            self._is_fp8_quant = False
+            self._is_fp8_channel_quant = False
+            self._is_bf16_quant = False
             return
 
         # FP8 block
         if hasattr(layer, "w13_weight_scale_inv") and hasattr(layer, "w2_weight_scale_inv"):
-            self.is_mxfp4_quant = False
-            self.is_mxfp8_quant = False
-            self.is_fp8_quant = True
-            self.is_fp8_channel_quant = False
-            self.is_bf16_quant = False
+            self._is_mxfp4_quant = False
+            self._is_mxfp8_quant = False
+            self._is_fp8_quant = True
+            self._is_fp8_channel_quant = False
+            self._is_bf16_quant = False
             return
 
         # FP8 per-channel
         if hasattr(layer, "w13_weight_scale") and hasattr(layer, "w2_weight_scale"):
-            self.is_mxfp4_quant = False
-            self.is_mxfp8_quant = False
-            self.is_fp8_quant = False
-            self.is_fp8_channel_quant = True
-            self.is_bf16_quant = False
+            self._is_mxfp4_quant = False
+            self._is_mxfp8_quant = False
+            self._is_fp8_quant = False
+            self._is_fp8_channel_quant = True
+            self._is_bf16_quant = False
             return
 
         # BF16 / unquantized
         if hasattr(layer, "w13_weight") and hasattr(layer, "w2_weight"):
-            self.is_mxfp4_quant = False
-            self.is_mxfp8_quant = False
-            self.is_fp8_quant = False
-            self.is_fp8_channel_quant = False
-            self.is_bf16_quant = True
+            self._is_mxfp4_quant = False
+            self._is_mxfp8_quant = False
+            self._is_fp8_quant = False
+            self._is_fp8_channel_quant = False
+            self._is_bf16_quant = True
             return
 
         # Fallback to class-based detection for unknown layouts.
-        self.is_mxfp4_quant = False
-        self.is_mxfp8_quant = False
-        self.is_fp8_quant = self._detect_fp8_quant()
-        self.is_fp8_channel_quant = self._detect_fp8_channel_quant()
-        self.is_bf16_quant = self._detect_bf16_quant()
+        self._is_mxfp4_quant = False
+        self._is_mxfp8_quant = False
+        self._is_fp8_quant = self._detect_fp8_quant()
+        self._is_fp8_channel_quant = self._detect_fp8_channel_quant()
+        self._is_bf16_quant = self._detect_bf16_quant()
 
     def _detect_fp8_quant(self) -> bool:
         """Detect if the quantization method is FP8 block quant.
@@ -1601,6 +1620,24 @@ class SharedFullContext:
 
         torch.cuda.current_stream(device).wait_stream(post_stream)
 
+    def _restore_raw_attrs(self):
+        """Restore ctx.gpu_layer weight/scale attributes to raw (pre-repack) format.
+
+        After Marlin repack, attribute shapes and dtypes change (fp8→int32)
+        and _weight_scale_inv is renamed to _weight_scale.  This helper
+        reverts those changes so downstream code always sees raw format.
+        """
+        _target_device = self.gpu_layer.w13_weight.device
+        for _stale in ("w13_weight_scale", "w2_weight_scale"):
+            if hasattr(self.gpu_layer, _stale):
+                delattr(self.gpu_layer, _stale)
+        for _sn, (_shape, _dtype, _) in self._raw_weight_shapes.items():
+            _cur = getattr(self.gpu_layer, _sn, None)
+            if _cur is None or _cur.shape != _shape or _cur.dtype != _dtype:
+                setattr(self.gpu_layer, _sn,
+                        torch.nn.Parameter(
+                            torch.empty(_shape, dtype=_dtype, device=_target_device)))
+
     def load(self, layer_idx, wrapper, original_layer=None, gpu_experts_mask=None,
              logical_to_gpu_index=None):
         """Load weights from disk to GPU via shared memory.
@@ -1623,6 +1660,9 @@ class SharedFullContext:
         tp_rank = get_tensor_model_parallel_rank()
         t0 = time.perf_counter()
 
+        # Restore raw format before loading new layer's weights
+        self._restore_raw_attrs()
+
         # Select appropriate prepare_weight method based on quantization type
         # FP8/BF16 methods support GPU expert optimization; INT4 uses full CPU pipeline
         if getattr(self, "is_mxfp4_quant", False):
@@ -1638,10 +1678,13 @@ class SharedFullContext:
             self._prepare_weight_mxfp8(wrapper, original_layer, gpu_experts_mask,
                                        logical_to_gpu_index)
         elif self.is_fp8_quant:
-            self._prepare_weight_fp8(wrapper, original_layer, gpu_experts_mask,
+            # When the inference layer is Marlin-repacked (int32), the
+            # raw fp8 context layer can't share GPU→GPU copies.
+            # Disable Phase 1 shortcut by passing original_layer=None.
+            self._prepare_weight_fp8(wrapper, None, gpu_experts_mask,
                                      logical_to_gpu_index)
         elif self.is_fp8_channel_quant:
-            self._prepare_weight_fp8_channel(wrapper, original_layer, gpu_experts_mask,
+            self._prepare_weight_fp8_channel(wrapper, None, gpu_experts_mask,
                                              logical_to_gpu_index)
         elif self.is_bf16_quant:
             self._prepare_weight_bf16(wrapper, original_layer, gpu_experts_mask,
@@ -1652,6 +1695,7 @@ class SharedFullContext:
 
         if torch.cuda.is_available():
             torch.cuda.synchronize()
+
         total_time = (time.perf_counter() - t0) * 1000.0
 
         if tp_rank == 0:
@@ -2914,11 +2958,23 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
         ):
             ctx = self._build_full_context(layer)
 
+            # Re-run quant post-processing on the full-expert gpu_layer
+            # if supported (e.g. Marlin repack for Fp8MarlinMoEMethod).
+            # The ctx.load() call writes raw fp8 weights; downstream apply()
+            # expects repacked format.  Restore raw format afterwards so
+            # the context is clean for the next layer.
+            _needs_repack = hasattr(ctx.gpu_method, "process_weights_after_loading")
+            if _needs_repack:
+                ctx.gpu_method.process_weights_after_loading(ctx.gpu_layer)
+
             t_compute = time.perf_counter()
             result = ctx.gpu_method.apply(ctx.gpu_layer, dispatch_output)
             if torch.cuda.is_available():
                 torch.cuda.synchronize()
             compute_time = (time.perf_counter() - t_compute) * 1000.0
+
+            if _needs_repack:
+                ctx._restore_raw_attrs()
 
             # Dynamic expert update: analyze batch and update GPU experts.
             # Skip for V4-Flash MXFP4 — `_update_gpu_experts_from_batch` →
@@ -2928,7 +2984,14 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
             # so the dynamic-promote optimization is a no-op for MXFP4. Origin:
             # sglang 本身 (V4-Flash full-GPU prefill fallback compat).
             _mxfp4_skip_dyn_update = getattr(ctx, "is_mxfp4_quant", False)
-            if self.kt_config.kt_enable_dynamic_expert_update and not _mxfp4_skip_dyn_update:
+            # After Marlin repack, ctx.gpu_layer is in raw format but the
+            # inference layer is Marlin — the copy functions can't bridge
+            # the format gap.  Prefill already handles full-GPU compute;
+            # skip dynamic update for FP8 Marlin paths.
+            _marlin_skip_dyn_update = ctx.is_fp8_quant or ctx.is_fp8_channel_quant
+            if (self.kt_config.kt_enable_dynamic_expert_update
+                    and not _mxfp4_skip_dyn_update
+                    and not _marlin_skip_dyn_update):
                 t_update = time.perf_counter()
                 self._update_gpu_experts_from_batch(
                     layer=layer,

--- a/python/sglang/srt/layers/moe/moe_runner/marlin.py
+++ b/python/sglang/srt/layers/moe/moe_runner/marlin.py
@@ -15,6 +15,8 @@ from sglang.srt.layers.moe.moe_runner.base import (
 from sglang.srt.layers.moe.utils import MoeRunnerBackend
 
 if TYPE_CHECKING:
+    from sgl_kernel.scalar_type import ScalarType
+
     from sglang.srt.layers.moe.token_dispatcher import (
         StandardCombineInput,
         StandardDispatchOutput,
@@ -74,7 +76,7 @@ class MarlinMoeQuantInfo(MoeQuantInfo):
     # Explicit scalar type override — when set, fused_marlin_moe uses it
     # directly instead of inferring from weight_bits.  Needed for FP8
     # Marlin (float8_e4m3fn) vs INT8 Marlin (uint8b128).
-    b_q_type: Optional[torch.Tensor] = None
+    b_q_type: Optional["ScalarType"] = None
 
 
 @register_fused_func("none", "marlin")

--- a/python/sglang/srt/layers/moe/moe_runner/marlin.py
+++ b/python/sglang/srt/layers/moe/moe_runner/marlin.py
@@ -71,6 +71,10 @@ class MarlinMoeQuantInfo(MoeQuantInfo):
 
     # Optional
     expert_map: Optional[torch.Tensor] = None
+    # Explicit scalar type override — when set, fused_marlin_moe uses it
+    # directly instead of inferring from weight_bits.  Needed for FP8
+    # Marlin (float8_e4m3fn) vs INT8 Marlin (uint8b128).
+    b_q_type: Optional[torch.Tensor] = None
 
 
 @register_fused_func("none", "marlin")
@@ -118,6 +122,7 @@ def fused_experts_none_to_marlin(
         is_k_full=quant_info.is_k_full,
         inplace=runner_config.inplace,
         routed_scaling_factor=runner_config.routed_scaling_factor,
+        b_q_type=quant_info.b_q_type,
     ).to(hidden_states.dtype)
 
     return StandardCombineInput(

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -84,6 +84,7 @@ from sglang.srt.utils import (
     set_weight_attrs,
     use_intel_amx_backend,
 )
+from sglang.srt.utils.common import get_device_capability
 
 if TYPE_CHECKING:
     from sglang.srt.layers.moe.token_dispatcher import CombineInput, DispatchOutput
@@ -211,6 +212,31 @@ class Fp8Config(QuantizationConfig):
             from sglang.srt.environ import envs
 
             fp8_method = Fp8MoEMethod(self)
+
+            # --- Ampere / pre-Ada Marlin routing (standard FP8 only) ---
+            # On SM 80-88 (Ampere), native fp8_e4m3fn tensors are
+            # unsupported on GPU.  Route to Marlin weight-only backend
+            # which packs weights to int32 on CPU before GPU transfer.
+            #
+            # NOTE: DeepSeek V4 Flash MXFP4 is handled by the existing
+            # DeepSeekMxfp4MoEMethod (mxfp4_deepseek.py) which creates
+            # int8 tensors and works on Ampere out of the box — do NOT
+            # intercept its path.
+            if (
+                _is_cuda and not _is_hip
+                and not (
+                    envs.SGLANG_DSV4_MODE.get() == "2604"
+                    and envs.SGLANG_DSV4_FP4_EXPERTS.get()
+                )
+            ):
+                major, minor = get_device_capability()
+                sm = major * 10 + minor
+                if sm < 89:  # Ampere / pre-Ada: no native FP8 hardware
+                    from sglang.srt.layers.quantization.fp8_marlin_moe import (
+                        Fp8MarlinMoEMethod,
+                    )
+                    return Fp8MarlinMoEMethod(fp8_method, prefix=prefix)
+            # --- End Ampere Marlin routing ---
 
             if (
                 envs.SGLANG_DSV4_MODE.get() == "2604"

--- a/python/sglang/srt/layers/quantization/fp8_marlin_moe.py
+++ b/python/sglang/srt/layers/quantization/fp8_marlin_moe.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import torch
+from torch.nn import Module
+
+from sglang.srt.layers.moe.moe_runner.marlin import MarlinMoeQuantInfo
+from sglang.srt.layers.moe.utils import MoeRunnerBackend
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.moe.token_dispatcher import CombineInput, DispatchOutput
+
+logger = logging.getLogger(__name__)
+
+
+class Fp8MarlinMoEMethod:
+    """Standard FP8 MoE method for GPUs without native FP8 hardware (SM < 89).
+
+    Uses the Marlin kernel for weight-only FP8 quantization on Ampere GPUs
+    (SM 80-88).  Weights are created as ``float8_e4m3fn`` on CPU during
+    init/loading (where that dtype is always legal), then repacked to
+    Marlin int32 format in ``process_weights_after_loading`` **before**
+    ``model.to(device)``, so the GPU never sees a native fp8 tensor.
+    """
+
+    _logged_once = False
+
+    def __init__(self, fp8_method, prefix: str):
+        self._fp8 = fp8_method
+        self.prefix = prefix
+        self.runner = None
+        if not Fp8MarlinMoEMethod._logged_once:
+            Fp8MarlinMoEMethod._logged_once = True
+            logger.warning(
+                "Enabling FP8 Marlin MoE for Ampere GPU — using weight-only "
+                "FP8 quantization with Marlin kernel."
+            )
+
+    # -- MoeRunner wiring ------------------------------------------------
+
+    def create_moe_runner(self, layer, moe_runner_config):
+        from sglang.srt.layers.moe.moe_runner import MoeRunner
+
+        self.runner = MoeRunner(MoeRunnerBackend.MARLIN, moe_runner_config)
+
+    # -- Weight creation -------------------------------------------------
+
+    def create_weights(
+        self,
+        layer: Module,
+        num_experts: int,
+        hidden_size: int,
+        intermediate_size_per_partition: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ):
+        """Delegate to the inner Fp8MoEMethod.
+
+        Tensors are created on CPU at this point, so ``float8_e4m3fn`` is
+        perfectly legal even on Ampere hosts — the Marlin repack runs
+        before ``model.to(device)``.
+        """
+        self._fp8.create_weights(
+            layer=layer,
+            num_experts=num_experts,
+            hidden_size=hidden_size,
+            intermediate_size_per_partition=intermediate_size_per_partition,
+            params_dtype=params_dtype,
+            **extra_weight_attrs,
+        )
+        # Fp8MoEMethod stores block_quant / weight_block_size on itself
+        # but never on the layer.  prepare_moe_fp8_layer_for_marlin reads
+        # these from the layer, so copy them over.
+        if not hasattr(layer, "orig_dtype"):
+            layer.orig_dtype = params_dtype
+        if getattr(self._fp8, "block_quant", False):
+            layer.weight_block_size = getattr(
+                self._fp8, "weight_block_size",
+                self._fp8.quant_config.weight_block_size,
+            )
+
+    # -- Post-load processing --------------------------------------------
+
+    def process_weights_after_loading(self, layer: Module) -> None:
+        """Run base FP8 post-processing, then repack for Marlin."""
+        from sglang.srt.layers.quantization.marlin_utils_fp8 import (
+            prepare_moe_fp8_layer_for_marlin,
+        )
+
+        # Let the base Fp8MoEMethod handle ROCm normalization,
+        # static-scale collapsing, etc.
+        self._fp8.process_weights_after_loading(layer)
+
+        if getattr(layer, "_mega_moe_weights_built", False):
+            return
+
+        # num_gpu_experts=0 means all experts run on CPU — weights are
+        # empty (shape[0]==0) and the Marlin repack loop has no work.
+        if layer.w13_weight.shape[0] == 0:
+            return
+
+        logger.debug(
+            "Preparing FP8 MoE weights for Marlin backend (layer: %s, "
+            "experts: %d)...",
+            self.prefix,
+            layer.num_experts,
+        )
+
+        # Fp8MoEMethod.create_weights produces (e, N, K) layout for weights
+        # and (e, N_blocks, K_blocks) for block-quant scales.  But
+        # prepare_moe_fp8_layer_for_marlin expects everything in (e, K, *)
+        # layout.  Transpose weight dims 1↔2 AND scale dims 1↔2 so the
+        # pack/repack/permute logic produces correct Marlin format.
+        layer.w13_weight.data = layer.w13_weight.data.transpose(1, 2).contiguous()
+        layer.w2_weight.data = layer.w2_weight.data.transpose(1, 2).contiguous()
+        for _sn in ("w13_weight_scale_inv", "w2_weight_scale_inv",
+                     "w13_weight_scale", "w2_weight_scale"):
+            if hasattr(layer, _sn):
+                _s = getattr(layer, _sn)
+                if _s.dim() >= 3:
+                    _s.data = _s.data.transpose(1, 2).contiguous()
+
+        # Repack float8_e4m3fn weights -> Marlin int32, permute scales,
+        # and set ``layer.workspace``.
+        prepare_moe_fp8_layer_for_marlin(layer, size_k_first=True)
+
+    # -- Forward ---------------------------------------------------------
+
+    def apply(
+        self,
+        layer: Module,
+        dispatch_output: DispatchOutput,
+    ) -> CombineInput:
+        from sglang.srt.layers.moe.token_dispatcher.standard import (
+            StandardCombineInput,
+        )
+        from sglang.srt.layers.moe.topk import TopKOutputChecker
+
+        topk_output = dispatch_output.topk_output
+        if not TopKOutputChecker.format_is_standard(topk_output):
+            raise ValueError(
+                f"Unsupported topk output format: {topk_output.format}"
+            )
+
+        quant_info = MarlinMoeQuantInfo(
+            w13_qweight=layer.w13_weight,
+            w2_qweight=layer.w2_weight,
+            w13_scales=layer.w13_weight_scale,
+            w2_scales=layer.w2_weight_scale,
+            w13_g_idx_sort_indices=None,
+            w2_g_idx_sort_indices=None,
+            weight_bits=8,
+            is_k_full=True,
+        )
+
+        runner_output = self.runner.run(dispatch_output, quant_info=quant_info)
+
+        return StandardCombineInput(hidden_states=runner_output.hidden_states)

--- a/python/sglang/srt/layers/quantization/fp8_marlin_moe.py
+++ b/python/sglang/srt/layers/quantization/fp8_marlin_moe.py
@@ -144,6 +144,8 @@ class Fp8MarlinMoEMethod:
                 f"Unsupported topk output format: {topk_output.format}"
             )
 
+        from sgl_kernel.scalar_type import scalar_types
+
         quant_info = MarlinMoeQuantInfo(
             w13_qweight=layer.w13_weight,
             w2_qweight=layer.w2_weight,
@@ -153,6 +155,7 @@ class Fp8MarlinMoEMethod:
             w2_g_idx_sort_indices=None,
             weight_bits=8,
             is_k_full=True,
+            b_q_type=scalar_types.float8_e4m3fn,
         )
 
         runner_output = self.runner.run(dispatch_output, quant_info=quant_info)

--- a/python/sglang/srt/layers/quantization/marlin_utils_fp8.py
+++ b/python/sglang/srt/layers/quantization/marlin_utils_fp8.py
@@ -190,6 +190,18 @@ def prepare_moe_fp8_layer_for_marlin(
     n = layer.intermediate_size_per_partition
     weight_block_size = getattr(layer, "weight_block_size", None)
 
+    # When wrapped by kt_ep_wrapper, the layer only holds num_gpu_experts
+    # weights while layer.num_experts still reports the global total.
+    # Derive the actual expert count from the weight tensor itself.
+    actual_e = layer.w13_weight.shape[0]
+    if actual_e != e:
+        logger.debug(
+            "layer.num_experts=%d but w13_weight.shape[0]=%d — using the "
+            "latter (kt_ep_wrapper GPU-expert subset).",
+            e, actual_e,
+        )
+        e = actual_e
+
     # WORKSPACE
     device = layer.w13_weight.device
     layer.workspace = marlin_make_workspace(device, 4)

--- a/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
@@ -200,7 +200,8 @@ class EAGLEDraftCudaGraphRunner:
             torch.cuda.synchronize()
             self.model_runner.tp_group.barrier()
             run_once_fn()
-            self.model_runner.draft_attn_backend.on_after_cuda_graph_warmup_pass()
+            if hasattr(self.model_runner.draft_attn_backend, "on_after_cuda_graph_warmup_pass"):
+                self.model_runner.draft_attn_backend.on_after_cuda_graph_warmup_pass()
 
     def _capture_graph(self, graph, pool, stream, run_once_fn):
         with torch.cuda.graph(graph, pool=pool, stream=stream):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Ampere GPUs (SM 80-88, e.g. A100, A6000, RTX 3090) lack native FP8 Tensor Cores (torch.float8_e4m3fn requires SM 89+). When running FP8-quantized MoE models with --kt-method FP8 --kt-num-gpu-experts N (N>0), the existing Fp8MoEMethod creates float8_e4m3fn tensors directly on GPU, causing PyTorch to crash with "fp8e4nv data type is not supported on CUDA arch < 89". This PR adds a Marlin weight-only FP8 path that repacks weights to int32 on CPU before GPU transfer, enabling FP8 MoE inference on Ampere GPUs.

## Modifications

1. Fp8MarlinMoEMethod — new FP8 MoE Marlin backend (fp8_marlin_moe.py based on upstream sglang)

  Wraps Fp8MoEMethod and delegates weight creation (fp8 tensors created on CPU are safe), then repacks to Marlin int32 format in process_weights_after_loading before model.to(device). Uses the existing fused_marlin_moe kernel via MoeRunner(MARLIN).

  Key fixes during repack:
  - Transpose weights/scales from (e, N, K) to (e, K, N) layout expected by prepare_moe_fp8_layer_for_marlin
  - Copy weight_block_size to layer (missing from Fp8MoEMethod)
  - Derive expert count from weight tensor shape (differs from layer.num_experts when wrapped by kt_ep_wrapper)

2. Ampere auto-routing (fp8.py)

  Fp8Config.get_quant_method() now detects Ampere (SM < 89) and routes FusedMoE layers to Fp8MarlinMoEMethod. DeepSeek V4 Flash MXFP4 path is explicitly excluded (already handled by DeepSeekMxfp4MoEMethod). All other platforms (Hopper, Ada, AMD, CPU) are unaffected.

3. Scalar type fix (fused_marlin_moe.py, marlin.py)

  get_scalar_type(8, False) returned uint8b128, but gptq_marlin_repack produces float8_e4m3fn memory layout. Added optional b_q_type field to MarlinMoeQuantInfo so callers can override the scalar type without affecting INT/AWQ paths. Fp8MarlinMoEMethod sets b_q_type=float8_e4m3fn.

4. GPU prefill + dynamic expert update compatibility (kt_ep_wrapper.py)

  Marlin repack mutates attribute names and shapes (_scale_inv → _scale, fp8→int32). Fixed SharedFullContext to:

  - Freeze quant type detection at init time into _is_* prefixed attributes, immune to downstream Marlin repack renames (e.g. _inv → _weight_scale)
  - Save _raw_weight_shapes at init to enable clean raw format restoration
  - Add _restore_raw_attrs() to revert Marlin-repacked tensors back to raw fp8 shapes, so the shared context is clean for the next layer's load()
  - Reorder _restore_raw_attrs() to run AFTER _update_gpu_experts_from_batch(). Previously _restore_raw_attrs() (which calls torch.empty() on repacked tensors) destroyed weight data before the dynamic update could copy it.
  - Replace mutable _needs_marlin_repack state flag with invariant gpu_method.__class__.__name__ check for dispatch between Marlin (copy_experts_weights_fp8_channel) and native FP8 (copy_experts_weights_fp8) copy functions
  - Disable Phase 1 GPU→GPU shortcut in _prepare_weight_fp8/fp8_channel when the inference layer is Marlin-repacked (int32), since raw fp8 context layer can't share GPU copies with Marlin inference layer

5. EAGLE MTP draft backend fix (eagle_draft_cuda_graph_runner.py)

  FlashInferMultiStepDraftBackend doesn't inherit from BaseAttnBackend and lacks on_after_cuda_graph_warmup_pass. Added hasattr guard.

## Tests
Tested models: qwen3.6-35b-a3b (bf16 and fp8), minimax-m2.7 (fp8), deepseek v4 flash (mxfp4)
All the models above worked fine with num-gpu-experts>0, dynamic-expert-update, and gpu-prefill on Ampere GPUs.

**Note:** The Nvidia GPU with sm>=89 such as 4090 was not tested yet. Please test some different models with 4090 gpu or above.
