### PR TITLE
fix(marlin): support FP16 FE8M0 scale dequant

### DIFF
--- a/python/sglang/jit_kernel/csrc/gemm/marlin/dequant.h
+++ b/python/sglang/jit_kernel/csrc/gemm/marlin/dequant.h
@@ -458,6 +458,28 @@ __device__ inline void dequant_fp8_scales<nv_bfloat162>(int q, nv_bfloat162* fra
 template <typename scalar_t2, host::ScalarTypeId s_type_id>
 __device__ inline void dequant_fp8_scales(int q, scalar_t2* frag_b);
 
+__device__ inline uint16_t ue8m0_to_half_bits(uint32_t x) {
+  const int exp = static_cast<int>(x & 0xff) - 112;
+  if (exp >= 31) {
+    return static_cast<uint16_t>(0x7c00);
+  }
+  if (exp > 0) {
+    return static_cast<uint16_t>(exp << 10);
+  }
+
+  const int subnormal_shift = static_cast<int>(x & 0xff) - 103;
+  if (subnormal_shift >= 0) {
+    return static_cast<uint16_t>(1u << subnormal_shift);
+  }
+  return 0;
+}
+
+__device__ inline half2 pack_ue8m0_half2(uint32_t low, uint32_t high) {
+  const uint32_t packed =
+      static_cast<uint32_t>(ue8m0_to_half_bits(low)) | (static_cast<uint32_t>(ue8m0_to_half_bits(high)) << 16);
+  return *reinterpret_cast<const half2*>(&packed);
+}
+
 template <>
 __device__ inline void dequant_fp8_scales<half2, host::kFE4M3fn.id()>(int q, half2* frag_b) {
   int Out1 = (q & 0xFF00FF00) >> 1;
@@ -484,6 +506,15 @@ __device__ inline void dequant_fp8_scales<nv_bfloat162, host::kFE4M3fn.id()>(int
   // Note: reverse indexing is intentional because weights are permuted
   frag_b[1] = *reinterpret_cast<const nv_bfloat162*>(&Out1);
   frag_b[0] = *reinterpret_cast<const nv_bfloat162*>(&Out2);
+}
+
+template <>
+__device__ inline void dequant_fp8_scales<half2, host::kFE8M0fnu.id()>(int q, half2* frag_b) {
+  const uint32_t uq = static_cast<uint32_t>(q);
+
+  // Note: reverse indexing is intentional because weights are permuted
+  frag_b[1] = pack_ue8m0_half2((uq >> 8) & 0xff, (uq >> 24) & 0xff);
+  frag_b[0] = pack_ue8m0_half2(uq & 0xff, (uq >> 16) & 0xff);
 }
 
 template <>


### PR DESCRIPTION
Add the missing half2 specialization for FE8M0fnu scale dequantization. This fixes ptxas unresolved extern errors in the float16 MXFP4 MoE Marlin JIT path.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Run Qwen3.5-35B-A3B-GPTQ-Int4 with avx2 backend, will get error
`ptxas fatal   : Unresolved extern function '_ZN6device6marlin18dequant_fp8_scalesI7__half2Ll2814749767106568EEEviPT_' ninja: build stopped: subcommand failed.`

## Modifications

This PR adds the missing `half2` specialization for `FE8M0fnu` scale
dequantization in Marlin.

The existing code already provides a `nv_bfloat162` specialization for
`FE8M0fnu`, but not the corresponding `half2` specialization. When a
Marlin kernel needs to dequantize UE8M0 scales in an FP16 path, this can
instantiate:

```cpp
dequant_fp8_scales<half2, host::kFE8M0fnu.id()>
```

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
