### PR TITLE
feat(kt): add --kt-skip-gpu-expert-cpu-copy to reclaim host RAM for GPU experts

### DIFF
--- a/python/sglang/srt/layers/moe/kt_ep_wrapper.py
+++ b/python/sglang/srt/layers/moe/kt_ep_wrapper.py
@@ -107,6 +107,7 @@ class KTConfig:
     num_layers: Optional[int] = None
     gpu_prefill_token_threshold: Optional[int] = None
     kt_enable_dynamic_expert_update: bool = False
+    kt_skip_gpu_expert_cpu_copy: bool = False
     expert_lora_path: Optional[str] = None
 
 
@@ -2136,6 +2137,7 @@ def create_kt_config_from_server_args(
         num_layers=num_layers,
         gpu_prefill_token_threshold=server_args.kt_gpu_prefill_token_threshold,
         kt_enable_dynamic_expert_update=server_args.kt_enable_dynamic_expert_update,
+        kt_skip_gpu_expert_cpu_copy=server_args.kt_skip_gpu_expert_cpu_copy,
         expert_lora_path=getattr(server_args, "kt_expert_lora_path", None),
     )
 
@@ -2658,12 +2660,29 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
                     max_cache_depth=1,
                 )
             else:
+                _method = (self.kt_config.method or "").upper()
+                _dyn = self.kt_config.kt_enable_dynamic_expert_update
+                _mask_static = _method == "MXFP4" or (_method == "MXFP8" and not _dyn)
+                _kt_skip_cpu_copy = self.kt_config.kt_skip_gpu_expert_cpu_copy and _mask_static
+                if (
+                    self.kt_config.kt_skip_gpu_expert_cpu_copy
+                    and not _kt_skip_cpu_copy
+                    and self.kt_config.layer_idx == 0
+                ):
+                    logger.warning(
+                        "--kt-skip-gpu-expert-cpu-copy ignored: requires MXFP4, or "
+                        "MXFP8 with dynamic expert update disabled "
+                        "(method=%s, kt_enable_dynamic_expert_update=%s).",
+                        _method,
+                        _dyn,
+                    )
                 self.wrapper = KTMoEWrapper(
                     **common_wrapper_kwargs,
                     swiglu_limit=_kt_swiglu_limit,
                     swiglu_alpha=_kt_swiglu_alpha,
                     method=self.kt_config.method,
                     max_deferred_experts_per_token=layer_max_deferred,
+                    skip_gpu_expert_cpu_copy=_kt_skip_cpu_copy,
                 )
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -732,6 +732,7 @@ class ServerArgs:
     kt_gpu_prefill_token_threshold: Optional[int] = None
     record_kt_gpu_expert_distribution: bool = False
     kt_enable_dynamic_expert_update: bool = False
+    kt_skip_gpu_expert_cpu_copy: bool = False
     kt_expert_placement_strategy: str = "uniform"
     kt_lora_path: Optional[str] = None
     kt_expert_lora_path: Optional[str] = None
@@ -4892,6 +4893,15 @@ class ServerArgs:
             action="store_true",
             default=ServerArgs.kt_enable_dynamic_expert_update,
             help="[ktransformers parameter] Enable dynamic GPU expert updates based on runtime statistics. After full GPU fallback computation, updates original layer's GPU experts to match the most frequently activated experts in the current batch.",
+        )
+        parser.add_argument(
+            "--kt-skip-gpu-expert-cpu-copy",
+            action="store_true",
+            default=ServerArgs.kt_skip_gpu_expert_cpu_copy,
+            help="[ktransformers parameter] Skip allocating/loading the CPU copies of "
+                 "GPU-resident experts (placed on GPU via --kt-num-gpu-experts), reclaiming "
+                 "host RAM. Auto-ignored unless the path is mask-aware (MXFP4/MXFP8) and "
+                 "dynamic expert update is disabled.",
         )
         parser.add_argument(
             "--kt-expert-placement-strategy",


### PR DESCRIPTION
Companion to the kt-kernel PR (kvcache-ai/ktransformers#2085); see kvcache-ai/ktransformers#2084 for the full rationale and numbers.

Adds the user-facing `--kt-skip-gpu-expert-cpu-copy` server arg and resolves it into an effective flag passed to `KTMoEWrapper`:

```
_mask_static = method == "MXFP4" or (method == "MXFP8" and not kt_enable_dynamic_expert_update)
skip = kt_skip_gpu_expert_cpu_copy and _mask_static
```

Only paths whose full-GPU prefill fallback is mask-aware may skip: MXFP4's `_prepare_weight_mxfp4` → `_prepare_weight_fp8` copies GPU experts device-to-device from `original_layer` and never reads the CPU copies; MXFP4's dynamic-update mask rewrite is unconditionally skipped, so its mask is static even with `--kt-enable-dynamic-expert-update` on. If the flag cannot be honored (e.g. MXFP8 + dynamic update), it warns once at layer 0 and falls back to stock behavior — safe by construction.

Measured on DeepSeek-V4-Flash (MXFP4, 100–110 GPU experts, RTX PRO 6000 + 123GB RAM): scheduler RSS ~172GB → ~99GB, decode swap io → 0, identical output.

Diff is pure additions (+29, 2 files: `server_args.py`, `kt_ep_wrapper.py`), rebased on current main.
