### PR TITLE
fix(rope): restore rotated key write-back

### DIFF
--- a/python/sglang/jit_kernel/csrc/elementwise/rope.cuh
+++ b/python/sglang/jit_kernel/csrc/elementwise/rope.cuh
@@ -201,11 +201,18 @@ __global__ void fused_rope_store_kernel(const __grid_constant__ FusedRopeStorePa
         input_vec_x[j] = cast<DType2, fp32x2_t>({out_x0, out_x1});
         input_vec_y[j] = cast<DType2, fp32x2_t>({out_y0, out_y1});
       }
-      const auto k_out = pointer::offset(k_cache, loc * cache_stride_bytes, head_id * head_stride_bytes);
-      const auto output_x = load_q ? input : k_out;
-      store_as<InputStorage>(output_x, input_vec_x, lane_id);
-      const auto output_y = pointer::offset(output_x, (kRopeDim / 2) * sizeof(DType));
-      store_as<InputStorage>(output_y, input_vec_y, lane_id);
+      // Always write rotated values back to `input` (q itself when
+      // load_q==true, k itself when load_q==false). When processing k, also
+      // write to k_cache for future decode.
+      store_as<InputStorage>(input, input_vec_x, lane_id);
+      const auto input_y_out = pointer::offset(input, (kRopeDim / 2) * sizeof(DType));
+      store_as<InputStorage>(input_y_out, input_vec_y, lane_id);
+      if (!load_q) {
+        const auto k_out = pointer::offset(k_cache, loc * cache_stride_bytes, head_id * head_stride_bytes);
+        store_as<InputStorage>(k_out, input_vec_x, lane_id);
+        const auto k_out_y = pointer::offset(k_out, (kRopeDim / 2) * sizeof(DType));
+        store_as<InputStorage>(k_out_y, input_vec_y, lane_id);
+      }
     } else {
       using CacheStorage = AlignedVector<float, kVecSize>;
       auto input_vec = load_as<InputStorage>(input, lane_id);
@@ -220,9 +227,12 @@ __global__ void fused_rope_store_kernel(const __grid_constant__ FusedRopeStorePa
         const auto out_y = x * sin + y * cos;
         input_vec[j] = cast<DType2, fp32x2_t>({out_x, out_y});
       }
-      const auto k_out = pointer::offset(k_cache, loc * cache_stride_bytes, head_id * head_stride_bytes);
-      const auto output = load_q ? input : k_out;
-      store_as<InputStorage>(output, input_vec, lane_id);
+      // Always write rotated value back to `input`; also to k_cache when processing k.
+      store_as<InputStorage>(input, input_vec, lane_id);
+      if (!load_q) {
+        const auto k_out = pointer::offset(k_cache, loc * cache_stride_bytes, head_id * head_stride_bytes);
+        store_as<InputStorage>(k_out, input_vec, lane_id);
+      }
     }
   }
 

--- a/python/sglang/jit_kernel/rope.py
+++ b/python/sglang/jit_kernel/rope.py
@@ -78,7 +78,7 @@ def apply_rope_inplace(
     module.run_rope(q, k, cos_sin_cache, positions)
 
 
-@register_custom_op(mutates_args=["q", "k_cache", "v_cache"])
+@register_custom_op(mutates_args=["q", "k", "k_cache", "v_cache"])
 def apply_rope_inplace_with_kvcache(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -95,8 +95,8 @@ def apply_rope_inplace_with_kvcache(
     """
     Fused inplace RoPE + KV cache store.
 
-    Applies rotary position embedding to q inplace. For k, applies RoPE and
-    stores the result in k_cache. The original v is also stored in v_cache.
+    Applies rotary position embedding to q and k inplace. The rotated k is
+    also stored in k_cache. The original v is stored in v_cache.
 
     Args:
         q: Query tensor of shape [num_tokens, num_qo_heads, head_dim].

--- a/python/sglang/jit_kernel/tests/test_rope.py
+++ b/python/sglang/jit_kernel/tests/test_rope.py
@@ -232,6 +232,8 @@ def test_fused_rope_store(
     atol = rtol = 1e-2
     # q should match RoPE-only result
     triton.testing.assert_close(q_ref, q_fused, atol=atol, rtol=rtol)
+    # k is consumed by attention after this fused operation and must be rotated too
+    triton.testing.assert_close(k_ref, k_fused, atol=atol, rtol=rtol)
     # k_cache should contain the rotated k
     triton.testing.assert_close(
         k_cache_ref[out_loc], k_cache_fused[out_loc], atol=atol, rtol=rtol


### PR DESCRIPTION
## Summary

- restore the rotated key write-back to the current `k` tensor in fused RoPE + KV-cache store
- continue storing the same rotated key in `k_cache` for decode
- cover both NeoX and interleaved layouts
- extend the fused RoPE test to assert the current `k` tensor, which was previously unchecked

## Background

The fused store path wrote rotated Q back in place, but wrote rotated K only to `k_cache`. Attention still consumes the current-token `k` tensor after this operation, so leaving it unrotated can produce incorrect output. This restores the behavior from the earlier RoPE write-back fix.

## Validation

- RTX 5090, BF16, Qwen3 shape: 22 tokens, 32 Q heads, 4 KV heads, head dim 128
- NeoX: Q/K/K-cache/V-cache max absolute error = 0 against FlashInfer reference
- Interleaved: Q/K/K-cache/V-cache max absolute error = 0 against FlashInfer reference
- Qwen3-30B-A3B end-to-end smoke no longer produces gibberish; the 2+2 golden prompt returns token 19 (`4`), matching Hugging Face
