### PR TITLE
fix: five small guards (NextN post-load, MLA draft warmup hook, zero-expert Marlin, deep_gemm)

### DIFF
--- a/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
@@ -1032,6 +1032,10 @@ class FlashInferMLAMultiStepDraftBackend:
 
         self.common_template(forward_batch, self.cuda_graph_kv_indices, call_fn)
 
+    def on_after_cuda_graph_warmup_pass(self):
+        for backend in self.attn_backends:
+            backend.on_after_cuda_graph_warmup_pass()
+
     def init_forward_metadata_replay_cuda_graph(
         self, forward_batch: ForwardBatch, bs: int
     ):

--- a/python/sglang/srt/layers/deep_gemm_wrapper/entrypoint.py
+++ b/python/sglang/srt/layers/deep_gemm_wrapper/entrypoint.py
@@ -161,7 +161,9 @@ def update_deep_gemm_config(gpu_id: int, server_args: ServerArgs):
 
 @contextmanager
 def configure_deep_gemm_num_sms(num_sms):
-    if num_sms is None:
+    if num_sms is None or "deep_gemm" not in globals():
+        # deep_gemm is only imported when JIT DeepGEMM is enabled; on
+        # unsupported archs (e.g. sm_120) it stays unimported.
         yield
     else:
         original_num_sms = deep_gemm.get_num_sms()

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16_moe.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16_moe.py
@@ -257,6 +257,14 @@ class CompressedTensorsWNA16MoE(CompressedTensorsMoEScheme):
         num_experts = layer.w13_weight_g_idx.shape[0]
         device = layer.w13_weight_g_idx.device
 
+        # With all routed experts handled on CPU (e.g. KT EP wrapper with
+        # --kt-num-gpu-experts 0), the GPU layer owns zero experts and every
+        # weight tensor here is empty; the Marlin repack kernels cannot handle
+        # 0-expert inputs, so there is nothing to convert.
+        if num_experts == 0 or layer.w13_weight_packed.numel() == 0:
+            layer.is_marlin_converted = True
+            return
+
         # when running models with grouped act order,
         # resort to g_idx values provided in checkpoint
         if self.actorder == "group":

--- a/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
+++ b/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
@@ -97,6 +97,7 @@ class DeepseekV2WeightLoaderMixin:
         self,
         weights: Iterable[Tuple[str, torch.Tensor]],
         is_nextn: bool = False,
+        run_post_load: bool = True,
     ):
         """Load model weights from checkpoint.
 
@@ -291,6 +292,22 @@ class DeepseekV2WeightLoaderMixin:
                                     []
                                 ) and kv_a_proj_weight.shape == torch.Size([]):
                                     fused_weight = q_a_proj_weight
+                                elif name.endswith("weight_shape") and (
+                                    q_a_proj_weight.numel() == 2
+                                ):
+                                    # compressed-tensors shape metadata [out, in]:
+                                    # the fused projection stacks outputs, so sum
+                                    # the out dims instead of concatenating the
+                                    # 2-element metadata vectors into a 4-vector.
+                                    assert q_a_proj_weight[1] == kv_a_proj_weight[1]
+                                    fused_weight = torch.tensor(
+                                        [
+                                            int(q_a_proj_weight[0])
+                                            + int(kv_a_proj_weight[0]),
+                                            int(q_a_proj_weight[1]),
+                                        ],
+                                        dtype=q_a_proj_weight.dtype,
+                                    )
                                 else:
                                     cat_dim = 0
                                     if self.quant_config is not None and (
@@ -361,7 +378,8 @@ class DeepseekV2WeightLoaderMixin:
             for future in concurrent.futures.as_completed(futures):
                 future.result()
 
-        self.post_load_weights(is_nextn=is_nextn, weight_names=weight_names)
+        if run_post_load:
+            self.post_load_weights(is_nextn=is_nextn, weight_names=weight_names)
 
     def _initialize_nextn_conf(self, is_nextn: bool) -> NextNConfig:
         """

--- a/python/sglang/srt/models/deepseek_nextn.py
+++ b/python/sglang/srt/models/deepseek_nextn.py
@@ -247,8 +247,15 @@ class DeepseekV3ForCausalLMNextN(DeepseekV3ForCausalLM):
             input_ids, hidden_states, self.lm_head, forward_batch
         )
 
-    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
-        super().load_weights(weights, is_nextn=True)
+    def load_weights(
+        self,
+        weights: Iterable[Tuple[str, torch.Tensor]],
+        run_post_load: bool = True,
+    ):
+        # Forward run_post_load so the loader can defer post_load_weights
+        # until quant schemes (e.g. wNa16/Marlin) have repacked their params;
+        # post_load_weights applies kv_b_proj, which crashes pre-repack.
+        super().load_weights(weights, is_nextn=True, run_post_load=run_post_load)
 
 
 EntryClass = [DeepseekV3ForCausalLMNextN]


### PR DESCRIPTION
Five independent small fixes found while serving GLM-5.2 with kt-kernel CPU experts:

1. NextN draft model: \`run_post_load\` passthrough (post-load hooks never ran for the draft weights).
2. Deepseek weight loader: fused \`weight_shape\` metadata merge (loading MTP checkpoints with fused shards).
3. \`FlashInferMLAMultiStepDraftBackend\`: \`on_after_cuda_graph_warmup_pass\` hook so draft backends can finalize after warmup.
4. Marlin MoE repack: skip when a layer has zero GPU experts (crash when all experts are CPU-offloaded).
5. \`configure_deep_gemm_num_sms\`: no-op when deep_gemm was never imported (NameError on the dual-stream decode path with JIT deepgemm disabled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)