### PR TITLE
fix(dsv4): lazily allocate layerwise prefill slots

### DIFF
--- a/python/sglang/srt/layers/moe/kt_ep_wrapper.py
+++ b/python/sglang/srt/layers/moe/kt_ep_wrapper.py
@@ -2459,6 +2459,78 @@ def _mxfp4_pipeline_runtime_supported(method, layer: torch.nn.Module) -> bool:
     )
 
 
+def _mxfp4_raw_slot_storage_nbytes(
+    *, num_experts: int, hidden_size: int, intermediate_size: int
+) -> int:
+    """Return the bytes in one full-expert raw MXFP4 slot.
+
+    This mirrors ``DeepSeekMxfp4MoEMethod.create_weights`` without creating
+    any tensors.  The resulting value is used only to limit KV-cache sizing;
+    the actual full-expert slot remains lazy.
+    """
+    int8_size = torch.tensor([], dtype=torch.int8).element_size()
+    float32_size = torch.tensor([], dtype=torch.float32).element_size()
+    return (
+        num_experts * (2 * intermediate_size) * (hidden_size // 2) * int8_size
+        + num_experts * hidden_size * (intermediate_size // 2) * int8_size
+        + num_experts
+        * (2 * intermediate_size)
+        * (hidden_size // 32)
+        * float32_size
+        + num_experts
+        * hidden_size
+        * (intermediate_size // 32)
+        * float32_size
+    )
+
+
+def get_mxfp4_layerwise_prefill_reservation_bytes() -> int:
+    """Return the unallocated MXFP4 slot capacity needed after a long request.
+
+    KV-cache profiling normally consumes all currently free VRAM.  With
+    layerwise slots allocated lazily, that would leave no capacity when the
+    first threshold-qualified request arrives.  Account for two raw and two
+    prepared slots here, but do not materialize them until that request.
+    """
+    total_bytes = 0
+    for signature, registry in _MXFP4_PREFILL_LAYER_REGISTRY.items():
+        if (
+            not registry
+            or signature in _MXFP4_LAYERWISE_MANAGERS
+            or signature in _MXFP4_LAYERWISE_DISABLED_REASONS
+        ):
+            continue
+
+        first_layer_idx = min(registry)
+        method, layer = registry[first_layer_idx]
+        if not _mxfp4_pipeline_runtime_supported(method, layer):
+            continue
+
+        init_args = getattr(method, "_full_init_args", None)
+        num_experts = getattr(method, "global_num_experts", None)
+        if init_args is None or num_experts is None:
+            continue
+        hidden_size, intermediate_size, _ = init_args
+
+        from sglang.srt.layers.quantization.v4_marlin_moe import (
+            get_v4_mxfp4_marlin_storage_nbytes,
+        )
+
+        raw_slot_bytes = _mxfp4_raw_slot_storage_nbytes(
+            num_experts=num_experts,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+        )
+        prepared_slot_bytes = get_v4_mxfp4_marlin_storage_nbytes(
+            num_experts=num_experts,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+        )
+        total_bytes += 2 * (raw_slot_bytes + prepared_slot_bytes)
+
+    return total_bytes
+
+
 def _register_mxfp4_prefill_layer(method, layer: torch.nn.Module) -> None:
     if not _mxfp4_pipeline_requested(method):
         return
@@ -2552,6 +2624,7 @@ def _initialize_mxfp4_layerwise_pipeline(method, layer: torch.nn.Module) -> None
     signature = getattr(method, "_mxfp4_pipeline_signature", None)
     if signature is None:
         signature = _mxfp4_pipeline_signature(method, layer)
+        method._mxfp4_pipeline_signature = signature
     if signature in _MXFP4_LAYERWISE_MANAGERS:
         return
     if signature in _MXFP4_LAYERWISE_DISABLED_REASONS:
@@ -2655,7 +2728,7 @@ def _initialize_mxfp4_layerwise_pipeline(method, layer: torch.nn.Module) -> None
             )
         )
         logger.info(
-            "KT MXFP4 layerwise prefill initialized two raw + two Marlin "
+            "KT MXFP4 layerwise prefill lazily initialized two raw + two Marlin "
             "prepared full-layer slots on %s (raw=%.2f GiB, "
             "prepared=%.2f GiB, total=%.2f GiB)",
             manager.device,
@@ -2665,17 +2738,29 @@ def _initialize_mxfp4_layerwise_pipeline(method, layer: torch.nn.Module) -> None
         )
 
 
-def finalize_mxfp4_layerwise_prefill() -> None:
-    """Reserve pipeline slots after model setup and before KV-cache profiling."""
+def _get_or_initialize_mxfp4_layerwise_manager(
+    method, layer: torch.nn.Module
+) -> Optional[_Mxfp4LayerwisePrefillManager]:
+    """Return the persistent manager, allocating its slots on first use.
 
-    for signature, registry in list(_MXFP4_PREFILL_LAYER_REGISTRY.items()):
-        if not registry:
-            continue
-        first_layer_idx = min(registry)
-        method, layer = registry[first_layer_idx]
-        if getattr(method, "_mxfp4_pipeline_signature", None) != signature:
-            raise RuntimeError("MXFP4 layerwise prefill registry signature mismatch")
-        _initialize_mxfp4_layerwise_pipeline(method, layer)
+    This function is called only from a threshold-qualified prefill forward.
+    Each TP rank executes it before the manager enters its transport
+    collectives, and `_initialize_mxfp4_layerwise_pipeline` keeps allocation
+    failures consistent across ranks.  An OOM records a disabled reason and
+    returns ``None`` so the triggering request can use hybrid CPU/GPU MoE.
+    """
+
+    signature = getattr(method, "_mxfp4_pipeline_signature", None)
+    if signature is None:
+        signature = _mxfp4_pipeline_signature(method, layer)
+        method._mxfp4_pipeline_signature = signature
+
+    manager = _MXFP4_LAYERWISE_MANAGERS.get(signature)
+    if manager is not None or signature in _MXFP4_LAYERWISE_DISABLED_REASONS:
+        return manager
+
+    _initialize_mxfp4_layerwise_pipeline(method, layer)
+    return _MXFP4_LAYERWISE_MANAGERS.get(signature)
 
 
 def generate_front_loading_masks(
@@ -3954,6 +4039,28 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
         if _mxfp4_manager is not None and not _full_gpu_gate:
             _mxfp4_manager.abort_round()
 
+        # Allocate the persistent full-layer slots only when a request actually
+        # enters the MXFP4 layerwise path.  Startup reserves only their
+        # KV-cache budget, not the tensors themselves; an allocation OOM still
+        # records a disabled reason and this same request falls through to the
+        # existing hybrid CPU/GPU path below.
+        if (
+            _full_gpu_gate
+            and _mxfp4_requested
+            and not _mxfp4_disabled_after_oom
+            and _mxfp4_manager is None
+            and _mxfp4_pipeline_runtime_supported(self, layer)
+        ):
+            _mxfp4_manager = _get_or_initialize_mxfp4_layerwise_manager(
+                self, layer
+            )
+            _mxfp4_signature = getattr(self, "_mxfp4_pipeline_signature", None)
+            _mxfp4_disabled_after_oom = (
+                _mxfp4_signature in _MXFP4_LAYERWISE_DISABLED_REASONS
+                if _mxfp4_signature is not None
+                else False
+            )
+
         if _full_gpu_gate and not (
             _mxfp4_requested and _mxfp4_disabled_after_oom
         ):
@@ -3961,7 +4068,7 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
                 if _mxfp4_manager is None:
                     raise RuntimeError(
                         "MXFP4 layerwise prefill is supported but was not "
-                        "initialized during model finalization"
+                        "initialized during lazy slot allocation"
                     )
                 return _mxfp4_manager.apply(self, layer, dispatch_output)
 

--- a/python/sglang/srt/layers/quantization/v4_marlin_moe.py
+++ b/python/sglang/srt/layers/quantization/v4_marlin_moe.py
@@ -10,6 +10,7 @@ contains no allocator, transpose, concat, or routing conversion traffic.
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import Optional
 
@@ -118,6 +119,36 @@ def _prepared_shapes(num_experts: int, hidden_size: int, intermediate_size: int)
         (num_experts, hidden_size // V4_FP4_GROUP_SIZE, 2 * intermediate_size),
         (num_experts, intermediate_size // _MARLIN_TILE, 2 * hidden_size),
         (num_experts, intermediate_size // V4_FP4_GROUP_SIZE, hidden_size),
+    )
+
+
+def get_v4_mxfp4_marlin_storage_nbytes(
+    *, num_experts: int, hidden_size: int, intermediate_size: int
+) -> int:
+    """Return the bytes required for one prepared V4 MXFP4 layer image.
+
+    Keeping this calculation next to ``allocate_v4_mxfp4_marlin`` lets the
+    lazy layerwise-prefill path reserve KV-cache budget without allocating the
+    prepared tensors during server startup.
+    """
+    if num_experts <= 0:
+        raise ValueError(f"num_experts must be positive, got {num_experts}")
+    if hidden_size % 64 or intermediate_size % 64:
+        raise ValueError(
+            "Marlin requires hidden/intermediate multiples of 64, got "
+            f"{hidden_size}/{intermediate_size}"
+        )
+
+    w13, w13_scale, w2, w2_scale = _prepared_shapes(
+        num_experts, hidden_size, intermediate_size
+    )
+    return (
+        math.prod(w13) * torch.tensor([], dtype=torch.int32).element_size()
+        + math.prod(w13_scale)
+        * torch.tensor([], dtype=torch.float8_e8m0fnu).element_size()
+        + math.prod(w2) * torch.tensor([], dtype=torch.int32).element_size()
+        + math.prod(w2_scale)
+        * torch.tensor([], dtype=torch.float8_e8m0fnu).element_size()
     )
 
 

--- a/python/sglang/srt/model_executor/memory_profiler.py
+++ b/python/sglang/srt/model_executor/memory_profiler.py
@@ -134,6 +134,9 @@ class DSv4MemoryCalculator:
             mem_fraction_static=mr.mem_fraction_static,
             distributed=get_world_group().world_size > 1,
             cpu_group=get_world_group().cpu_group,
+            reservation_bytes=getattr(
+                mr, "mxfp4_layerwise_prefill_reservation_bytes", 0
+            ),
         )
 
         if self.is_speculative:
@@ -156,13 +159,20 @@ def profile_available_bytes(
     mem_fraction_static: float,
     distributed: bool = False,
     cpu_group=None,
+    reservation_bytes: int = 0,
 ) -> int:
     from sglang.srt.utils.common import get_available_gpu_memory
 
     available_gpu_memory = get_available_gpu_memory(
         device, gpu_id, distributed=distributed, cpu_group=cpu_group
     )
-    rest_memory = available_gpu_memory - total_gpu_memory * (1 - mem_fraction_static)
+    reservation_bytes = max(0, int(reservation_bytes))
+    reservation_gib = reservation_bytes / (1 << 30)
+    rest_memory = (
+        available_gpu_memory
+        - total_gpu_memory * (1 - mem_fraction_static)
+        - reservation_gib
+    )
 
     available_bytes = int(rest_memory * (1 << 30))
 
@@ -170,6 +180,7 @@ def profile_available_bytes(
         f"Memory profiling: available_gpu_memory={available_gpu_memory:.2f} GB, "
         f"total_gpu_memory={total_gpu_memory:.2f} GB, "
         f"mem_fraction_static={mem_fraction_static:.2f}, "
+        f"lazy_mxfp4_slot_reservation={reservation_gib:.2f} GB, "
         f"rest_memory={rest_memory:.2f} GB"
     )
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -585,27 +585,21 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         # Deduce KV cache dtype
         self.configure_kv_cache_dtype()
 
-        # Reserve MXFP4's two layerwise-prefill slots only after all model
-        # loading and adaptation work is complete.  This keeps a recoverable
-        # slot-allocation OOM from starving model construction while still
-        # accounting for the slots during KV-cache profiling below.
+        # Do not allocate the MXFP4 layerwise slots at startup.  Still account
+        # for their future capacity before KV-cache profiling, otherwise the
+        # pool can consume the VRAM needed by the first long prefill request.
+        self.mxfp4_layerwise_prefill_reservation_bytes = 0
         if (
             (server_args.kt_method or "").upper() == "MXFP4"
             and (server_args.kt_gpu_prefill_token_threshold or 0) > 0
         ):
             from sglang.srt.layers.moe.kt_ep_wrapper import (
-                finalize_mxfp4_layerwise_prefill,
+                get_mxfp4_layerwise_prefill_reservation_bytes,
             )
 
-            enable_cpu_backup = server_args.enable_weights_cpu_backup or (
-                self.is_draft_worker
-                and server_args.enable_draft_weights_cpu_backup
+            self.mxfp4_layerwise_prefill_reservation_bytes = (
+                get_mxfp4_layerwise_prefill_reservation_bytes()
             )
-            with self.memory_saver_adapter.region(
-                GPU_MEMORY_TYPE_WEIGHTS,
-                enable_cpu_backup=enable_cpu_backup,
-            ):
-                finalize_mxfp4_layerwise_prefill()
 
         # Init memory pool and attention backends
         self.init_memory_pool()

--- a/test/unit/test_mxfp4_layerwise_prefill.py
+++ b/test/unit/test_mxfp4_layerwise_prefill.py
@@ -185,7 +185,10 @@ def _stream_context(stream, log):
 
 
 def _runtime_stubs(
-    standard_combine_input=None, prepare_marlin=None, allocate_marlin=None
+    standard_combine_input=None,
+    prepare_marlin=None,
+    allocate_marlin=None,
+    marlin_storage_nbytes=None,
 ):
     stubs = {
         "sglang": _package("sglang"),
@@ -208,6 +211,9 @@ def _runtime_stubs(
         "sglang.srt.layers.quantization.v4_marlin_moe",
         prepare_v4_mxfp4_marlin=prepare_marlin or (lambda *_args, **_kwargs: None),
         allocate_v4_mxfp4_marlin=allocate_marlin or (lambda **_kwargs: object()),
+        get_v4_mxfp4_marlin_storage_nbytes=(
+            marlin_storage_nbytes or (lambda **_kwargs: 0)
+        ),
     )
     return stubs
 
@@ -215,6 +221,8 @@ def _runtime_stubs(
 class TestMxfp4LayerwiseStateMachine(unittest.TestCase):
     def setUp(self):
         kt_ep_wrapper._MXFP4_PREFILL_LAYER_REGISTRY.clear()
+        kt_ep_wrapper._MXFP4_LAYERWISE_MANAGERS.clear()
+        kt_ep_wrapper._MXFP4_LAYERWISE_DISABLED_REASONS.clear()
 
     def test_sparse_successors_are_sorted_by_registered_layer_id(self):
         signature = ("cuda:0", "sparse")
@@ -338,63 +346,77 @@ class TestMxfp4LayerwiseStateMachine(unittest.TestCase):
         self.assertIn("self.control_stream", manager_source)
         self.assertIn("get_tp_group().device_group", manager_source)
 
-    def test_slot_reservation_runs_after_model_setup_before_memory_pool(self):
+    def test_model_runner_defers_slot_allocation_until_threshold_request(self):
         target_path = (
             Path(__file__).resolve().parents[2]
             / "python/sglang/srt/model_executor/model_runner.py"
         )
         model_runner_source = target_path.read_text(encoding="utf-8")
-        runner_source = inspect.getsource(
-            kt_ep_wrapper.KTEPWrapperMethod.create_moe_runner
-        )
+        apply_source = inspect.getsource(kt_ep_wrapper.KTEPWrapperMethod.apply)
 
-        finalize_pos = model_runner_source.index("finalize_mxfp4_layerwise_prefill()")
-        memory_pool_pos = model_runner_source.index("self.init_memory_pool()")
-        weights_region_pos = model_runner_source.rfind(
-            "with self.memory_saver_adapter.region(", 0, finalize_pos
-        )
-        self.assertLess(finalize_pos, memory_pool_pos)
-        self.assertGreater(weights_region_pos, 0)
+        self.assertNotIn("finalize_mxfp4_layerwise_prefill", model_runner_source)
+        self.assertIn("self.init_memory_pool()", model_runner_source)
         self.assertIn(
-            "GPU_MEMORY_TYPE_WEIGHTS",
-            model_runner_source[weights_region_pos:finalize_pos],
+            "get_mxfp4_layerwise_prefill_reservation_bytes", model_runner_source
         )
-        self.assertNotIn("finalize_mxfp4_layerwise_prefill", runner_source)
+        self.assertIn("_get_or_initialize_mxfp4_layerwise_manager", apply_source)
 
-    def test_finalize_initializes_each_registered_signature_once(self):
-        signatures = (("cuda:0", "model-a"), ("cuda:0", "model-b"))
-        methods = {
-            signature: {
-                layer_idx: SimpleNamespace(
-                    kt_config=SimpleNamespace(layer_idx=layer_idx),
-                    _mxfp4_pipeline_signature=signature,
-                )
-                for layer_idx in layer_indices
-            }
-            for signature, layer_indices in zip(signatures, ((17, 3), (41, 9)))
-        }
-        layers = {
-            signature: {layer_idx: object() for layer_idx in signature_methods}
-            for signature, signature_methods in methods.items()
-        }
-        for signature in signatures:
-            kt_ep_wrapper._MXFP4_PREFILL_LAYER_REGISTRY[signature] = {
-                layer_idx: (methods[signature][layer_idx], layers[signature][layer_idx])
-                for layer_idx in methods[signature]
-            }
+    def test_lazy_slots_reserve_kv_budget_without_creating_a_manager(self):
+        signature = ("cuda:0", "model-a")
+        method = SimpleNamespace(
+            _full_init_args=(64, 32, torch.bfloat16), global_num_experts=2
+        )
+        layer = object()
+        kt_ep_wrapper._MXFP4_PREFILL_LAYER_REGISTRY[signature] = {0: (method, layer)}
+
+        with (
+            mock.patch.object(
+                kt_ep_wrapper, "_mxfp4_pipeline_runtime_supported", return_value=True
+            ),
+            mock.patch.dict(
+                sys.modules,
+                _runtime_stubs(marlin_storage_nbytes=lambda **_kwargs: 123),
+            ),
+        ):
+            # Per raw slot: 4096 + 2048 + 1024 + 512 bytes.  The pipeline
+            # has two raw slots plus two 123-byte prepared slots.
+            self.assertEqual(
+                kt_ep_wrapper.get_mxfp4_layerwise_prefill_reservation_bytes(),
+                2 * (4096 + 2048 + 1024 + 512 + 123),
+            )
+
+        self.assertNotIn(signature, kt_ep_wrapper._MXFP4_LAYERWISE_MANAGERS)
+
+    def test_lazy_manager_initialization_runs_once_per_signature(self):
+        signature = ("cuda:0", "model-a")
+        method = SimpleNamespace(_mxfp4_pipeline_signature=signature)
+        layer = object()
+        manager = object()
+
+        def initialize(initialized_method, initialized_layer):
+            self.assertIs(initialized_method, method)
+            self.assertIs(initialized_layer, layer)
+            kt_ep_wrapper._MXFP4_LAYERWISE_MANAGERS[signature] = manager
 
         with mock.patch.object(
-            kt_ep_wrapper, "_initialize_mxfp4_layerwise_pipeline"
-        ) as initialize:
-            kt_ep_wrapper.finalize_mxfp4_layerwise_prefill()
+            kt_ep_wrapper,
+            "_initialize_mxfp4_layerwise_pipeline",
+            side_effect=initialize,
+        ) as initialize_mock:
+            self.assertIs(
+                kt_ep_wrapper._get_or_initialize_mxfp4_layerwise_manager(
+                    method, layer
+                ),
+                manager,
+            )
+            self.assertIs(
+                kt_ep_wrapper._get_or_initialize_mxfp4_layerwise_manager(
+                    method, layer
+                ),
+                manager,
+            )
 
-        self.assertEqual(
-            initialize.call_args_list,
-            [
-                mock.call(methods[signatures[0]][3], layers[signatures[0]][3]),
-                mock.call(methods[signatures[1]][9], layers[signatures[1]][9]),
-            ],
-        )
+        initialize_mock.assert_called_once_with(method, layer)
 
     def test_compute_exception_records_consumed_fence_before_consensus(self):
         log = []
@@ -972,6 +994,43 @@ class TestMxfp4ApplyFallbacks(unittest.TestCase):
         manager.abort_round.assert_called_once_with()
         self.assertTrue(torch.equal(result.hidden_states, torch.full((8, 2), 9.0)))
 
+    def test_first_threshold_request_lazily_initializes_and_uses_manager(self):
+        wrapper = self._make_wrapper()
+        layer = self._layer()
+        manager = mock.Mock()
+        manager.apply.return_value = "pipeline-result"
+        signature = wrapper._mxfp4_pipeline_signature
+
+        def initialize(initialized_method, initialized_layer):
+            self.assertIs(initialized_method, wrapper)
+            self.assertIs(initialized_layer, layer)
+            kt_ep_wrapper._MXFP4_LAYERWISE_MANAGERS[signature] = manager
+
+        with mock.patch.object(
+            kt_ep_wrapper,
+            "_initialize_mxfp4_layerwise_pipeline",
+            side_effect=initialize,
+        ) as initialize_mock:
+            first = self._apply(wrapper, layer, self._dispatch(4), True)
+            second = self._apply(wrapper, layer, self._dispatch(4), True)
+
+        self.assertEqual(first, "pipeline-result")
+        self.assertEqual(second, "pipeline-result")
+        initialize_mock.assert_called_once_with(wrapper, layer)
+        self.assertEqual(manager.apply.call_count, 2)
+
+    def test_below_threshold_request_does_not_initialize_slots(self):
+        wrapper = self._make_wrapper()
+        layer = self._layer()
+
+        with mock.patch.object(
+            kt_ep_wrapper, "_initialize_mxfp4_layerwise_pipeline"
+        ) as initialize_mock:
+            result = self._apply(wrapper, layer, self._dispatch(3), True)
+
+        initialize_mock.assert_not_called()
+        self.assertTrue(torch.equal(result.hidden_states, torch.full((8, 2), 9.0)))
+
     def test_unsupported_backend_keeps_serial_full_gpu_fallback(self):
         wrapper = self._make_wrapper()
         layer = self._layer()
@@ -1000,6 +1059,28 @@ class TestMxfp4ApplyFallbacks(unittest.TestCase):
 
         result = self._apply(wrapper, layer, self._dispatch(4), True)
 
+        wrapper._build_full_context.assert_not_called()
+        self.assertTrue(torch.equal(result.hidden_states, torch.full((8, 2), 9.0)))
+        self.assertEqual(len(wrapper.gpu_method.calls), 1)
+
+    def test_lazy_slot_oom_falls_through_to_hybrid_for_triggering_request(self):
+        wrapper = self._make_wrapper()
+        layer = self._layer()
+        signature = wrapper._mxfp4_pipeline_signature
+        wrapper._build_full_context = mock.Mock()
+
+        def initialize(_method, _layer):
+            kt_ep_wrapper._MXFP4_LAYERWISE_DISABLED_REASONS[signature] = "slot OOM"
+
+        with mock.patch.object(
+            kt_ep_wrapper,
+            "_initialize_mxfp4_layerwise_pipeline",
+            side_effect=initialize,
+        ) as initialize_mock:
+            result = self._apply(wrapper, layer, self._dispatch(4), True)
+
+        initialize_mock.assert_called_once_with(wrapper, layer)
+        self.assertIn(signature, kt_ep_wrapper._MXFP4_LAYERWISE_DISABLED_REASONS)
         wrapper._build_full_context.assert_not_called()
         self.assertTrue(torch.equal(result.hidden_states, torch.full((8, 2), 9.0)))
         self.assertEqual(len(wrapper.gpu_method.calls), 1)


### PR DESCRIPTION
## Summary

- Defer MXFP4 layerwise-prefill raw/prepared slot allocation until the first request that reaches the configured GPU-prefill threshold.
- Reserve the corresponding capacity during profiling without allocating the slot tensors at server startup.
- Keep a coordinated fallback to hybrid CPU/GPU inference if lazy initialization cannot fit on any TP rank.
- Add unit coverage for initialization, capacity accounting, retry/fallback, and request-trigger behavior.

## Validation

- `python3 test/unit/test_mxfp4_layerwise_prefill.py` (27 tests)
- End-to-end DeepSeek-V4-Flash runs with `KT_GPU_PREFILL_TOKEN_THRESHOLD=2048` on qj5090 and sap4.

## Scope

This PR intentionally does not include the independent CPU-group barrier cleanup in #27.