### PR TITLE
fix(swa): evict overlap chunks using the actual extend boundary

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -597,6 +597,10 @@ class Req(ReqDllmMixin):
 
         # The index of the extend / decode batch
         self.extend_batch_idx = 0
+        # The prefix length at the start of the most recently scheduled extend
+        # batch. The overlap scheduler uses this as the safe eviction boundary
+        # while that batch may still be running.
+        self.last_extend_prefix_len = 0
         self.decode_batch_idx = 0
 
         # For multi-http worker
@@ -1151,6 +1155,7 @@ class Req(ReqDllmMixin):
         self.kv_overallocated_freed = False
         self.swa_evicted_seqlen = 0
         self.extend_batch_idx = 0
+        self.last_extend_prefix_len = 0
         self.decode_batch_idx = 0
 
     def offload_kv_cache(self, req_to_token_pool, token_to_kv_pool_allocator):
@@ -1545,6 +1550,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             req.req_pool_idx = req_pool_indices[i]
             assert seq_len - pre_len == req.extend_input_len
 
+            req.last_extend_prefix_len = pre_len
             req.extend_batch_idx += 1
 
             # update req-level memory management fields
@@ -2330,12 +2336,16 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                         if req.extend_batch_idx < 2:
                             continue
                         else:
-                            pre_len = (
-                                pre_len - server_args.chunked_prefill_size
-                                if server_args.chunked_prefill_size > 0
-                                else pre_len
+                            # The preceding extend batch may be smaller than the
+                            # configured chunk size. Its actual prefix boundary is
+                            # the newest point known to be safe while it is still
+                            # in flight.
+                            assert 0 <= req.last_extend_prefix_len <= pre_len, (
+                                f"Invalid overlap extend boundary: "
+                                f"{req.last_extend_prefix_len=}, {pre_len=}, "
+                                f"{req.extend_batch_idx=}"
                             )
-                            self._evict_swa(req, pre_len)
+                            self._evict_swa(req, req.last_extend_prefix_len)
                     else:
                         self._evict_swa(req, pre_len)
 

--- a/test/registered/scheduler/test_swa_chunk_eviction.py
+++ b/test/registered/scheduler/test_swa_chunk_eviction.py
@@ -1,0 +1,154 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.srt.sampling.sampling_params import SamplingParams
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+
+register_cuda_ci(est_time=1, suite="stage-b-test-small-1-gpu")
+register_amd_ci(est_time=1, suite="stage-b-test-small-1-gpu-amd")
+
+
+class TestSWAChunkEviction(unittest.TestCase):
+    def setUp(self):
+        server_args = SimpleNamespace(enable_piecewise_cuda_graph=False)
+        patcher = patch(
+            "sglang.srt.managers.schedule_batch.get_global_server_args",
+            return_value=server_args,
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def create_batch(
+        self,
+        *,
+        current_prefix_len: int,
+        last_extend_prefix_len: int,
+        extend_batch_idx: int,
+        enable_overlap: bool = True,
+    ):
+        req = MagicMock(spec=Req)
+        req.extend_batch_idx = extend_batch_idx
+        req.last_extend_prefix_len = last_extend_prefix_len
+
+        tree_cache = MagicMock()
+        tree_cache.supports_swa.return_value = True
+        tree_cache.is_chunk_cache.return_value = True
+        tree_cache.sliding_window_size = 4096
+
+        batch = ScheduleBatch(
+            reqs=[req],
+            tree_cache=tree_cache,
+            forward_mode=ForwardMode.EXTEND,
+            enable_overlap=enable_overlap,
+        )
+        batch.prefix_lens = [current_prefix_len]
+        return batch, req
+
+    def test_overlap_uses_actual_previous_extend_boundary(self):
+        batch, req = self.create_batch(
+            current_prefix_len=5632,
+            last_extend_prefix_len=4096,
+            extend_batch_idx=2,
+        )
+
+        with patch.object(batch, "_evict_swa") as evict_swa:
+            batch.maybe_evict_swa()
+
+        evict_swa.assert_called_once_with(req, 4096)
+
+    def test_overlap_keeps_fixed_size_chunk_behavior(self):
+        batch, req = self.create_batch(
+            current_prefix_len=8192,
+            last_extend_prefix_len=4096,
+            extend_batch_idx=2,
+        )
+
+        with patch.object(batch, "_evict_swa") as evict_swa:
+            batch.maybe_evict_swa()
+
+        evict_swa.assert_called_once_with(req, 4096)
+
+    def test_overlap_does_not_evict_first_two_extend_batches(self):
+        for extend_batch_idx in (0, 1):
+            with self.subTest(extend_batch_idx=extend_batch_idx):
+                batch, _ = self.create_batch(
+                    current_prefix_len=4096,
+                    last_extend_prefix_len=0,
+                    extend_batch_idx=extend_batch_idx,
+                )
+
+                with patch.object(batch, "_evict_swa") as evict_swa:
+                    batch.maybe_evict_swa()
+
+                evict_swa.assert_not_called()
+
+    def test_non_overlap_uses_current_prefix_boundary(self):
+        batch, req = self.create_batch(
+            current_prefix_len=5632,
+            last_extend_prefix_len=4096,
+            extend_batch_idx=2,
+            enable_overlap=False,
+        )
+
+        with patch.object(batch, "_evict_swa") as evict_swa:
+            batch.maybe_evict_swa()
+
+        evict_swa.assert_called_once_with(req, 5632)
+
+    def test_prepare_for_extend_records_actual_prefix_after_allocation(self):
+        req = Req("test", "", [1, 2, 3, 4, 5], SamplingParams())
+        req.fill_ids = [1, 2, 3, 4, 5]
+        req.prefix_indices = torch.tensor([10, 11], dtype=torch.int64)
+        req.set_extend_input_len(3)
+
+        model_config = SimpleNamespace(
+            is_matryoshka=False,
+            is_encoder_decoder=False,
+            vocab_size=128,
+        )
+        batch = ScheduleBatch(reqs=[req], model_config=model_config, device="cpu")
+
+        allocation = (
+            torch.tensor([20, 21, 22], dtype=torch.int64),
+            torch.tensor([0], dtype=torch.int64),
+            [0],
+        )
+        server_args = MagicMock()
+        server_args.enable_mamba_extra_buffer.return_value = False
+
+        with (
+            patch(
+                "sglang.srt.managers.schedule_batch.alloc_for_extend",
+                return_value=allocation,
+            ),
+            patch(
+                "sglang.srt.managers.schedule_batch.get_global_server_args",
+                return_value=server_args,
+            ),
+            patch(
+                "sglang.srt.managers.schedule_batch.SamplingBatchInfo.from_schedule_batch"
+            ),
+        ):
+            batch.prepare_for_extend()
+
+        self.assertEqual(req.last_extend_prefix_len, 2)
+        self.assertEqual(req.extend_batch_idx, 1)
+
+    def test_retraction_resets_actual_extend_boundary(self):
+        req = Req("test", "", [1], SamplingParams())
+        req.last_extend_prefix_len = 1536
+        req.extend_batch_idx = 2
+
+        req.reset_for_retract()
+
+        self.assertEqual(req.last_extend_prefix_len, 0)
+        self.assertEqual(req.extend_batch_idx, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

With overlap scheduling and `SWAChunkCache`, `maybe_evict_swa` currently derives the safe eviction boundary by subtracting the configured chunked-prefill size from the current prefix length. The actual preceding extend can be smaller than that configured size when the scheduler reduces a chunk to fit the available token budget.

For example, after a 4,096-token first chunk and a 1,536-token second chunk, the third scheduling pass sees a prefix length of 5,632. Subtracting the configured 4,096 produces 1,536, but the actual start of the in-flight second chunk is 4,096. The underestimated boundary can retain the first chunk and leave too few SWA slots for the next allocation, causing prefill to stop making progress.

## Modifications

- Track the real prefix length at the start of the most recently scheduled extend batch on each request.
- For the third and later overlap extend batches, evict only up to that recorded boundary while the preceding batch may still be in flight.
- Reset the recorded boundary when a request is retracted.
- Add focused tests for a reduced preceding chunk, fixed-size chunks, the first two protected overlap batches, non-overlap behavior, state recording, and retraction.

This change intentionally does not modify SWA pool sizing or admission accounting; those are separate from the incorrect overlap eviction boundary.

## Accuracy Tests

This only changes scheduler eviction metadata and does not change model arithmetic.

- `test_swa_chunk_eviction.py`: 6/6 passed on a clean `b31c4dfeb1` source tree.
- `test_prefill_adder.py`: 6/6 passed on the same source tree.
- qj5090 runtime smoke test: a 449-token Chinese prompt completed prefill and generated 31 tokens; strict UTF-8 validation passed with no replacement characters.

## Benchmarking and Profiling

No throughput claim is made. The expected effect is to unblock affected variable-size overlap-prefill sequences without changing the fixed-size fast path.

## Checklist

- [x] Code formatting checked with Black; the new test passes Ruff.
- [x] Added focused unit tests.
- [x] Documentation is not required for this internal scheduler invariant fix.
- [x] Accuracy impact is not applicable because model computation is unchanged; a runtime smoke test was completed.
- [x] Followed the existing SGLang code style.