### PR TITLE
perf(dsv4): accelerate consumer GPU decode on SM120 and SM89

### DIFF
--- a/python/sglang/jit_kernel/csrc/gemm/fp8_blockwise/fp8_blockwise_scaled_mm_entry.cuh
+++ b/python/sglang/jit_kernel/csrc/gemm/fp8_blockwise/fp8_blockwise_scaled_mm_entry.cuh
@@ -1,0 +1,25 @@
+/* Copyright 2026 SGLang Team. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "fp8_blockwise_scaled_mm_sm120.cuh"
+
+void fp8_blockwise_scaled_mm(
+    tvm::ffi::TensorView out,
+    tvm::ffi::TensorView mat_a,
+    tvm::ffi::TensorView mat_b,
+    tvm::ffi::TensorView scales_a,
+    tvm::ffi::TensorView scales_b) {
+  fp8_blockwise_scaled_mm_sm120(out, mat_a, mat_b, scales_a, scales_b);
+}

--- a/python/sglang/jit_kernel/csrc/gemm/fp8_blockwise/fp8_blockwise_scaled_mm_sm120.cuh
+++ b/python/sglang/jit_kernel/csrc/gemm/fp8_blockwise/fp8_blockwise_scaled_mm_sm120.cuh
@@ -1,0 +1,502 @@
+/* Copyright 2026 SGLang Team. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <sgl_kernel/tensor.h>
+#include <sgl_kernel/utils.h>
+
+#include <sgl_kernel/runtime.cuh>
+#include <sgl_kernel/utils.cuh>
+
+#include <cstddef>
+#include <cstdint>
+#include <cuda_runtime.h>
+
+using namespace host;
+
+// clang-format off
+#include "cutlass/cutlass.h"
+#include "cutlass/detail/blockwise_scale_layout.hpp"
+#include "cutlass/gemm/collective/collective_builder.hpp"
+#include "cutlass/epilogue/collective/collective_builder.hpp"
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/gemm/kernel/gemm_universal.hpp"
+#include "cutlass/gemm/dispatch_policy.hpp"
+#include "cutlass/util/packed_stride.hpp"
+// clang-format on
+
+#define CUTLASS_CHECK(status)                                                        \
+  {                                                                                  \
+    cutlass::Status error = status;                                                  \
+    RuntimeCheck(error == cutlass::Status::kSuccess, cutlassGetStatusString(error)); \
+  }
+
+using namespace cute;
+
+#if defined(CUTLASS_ARCH_MMA_SM120_SUPPORTED) || defined(CUTLASS_ARCH_MMA_SM121_SUPPORTED)
+
+template <
+    typename OutType,
+    typename MmaTileShape,
+    typename PerSmTileShape,
+    typename EpilogueTileShape,
+    typename ScalesPerTile,
+    int TileSizeM_ = 128,
+    class ClusterShape = Shape<_1, _1, _1>>
+void launch_sm120_fp8_blockwise_scaled_mm(
+    tvm::ffi::TensorView out,
+    tvm::ffi::TensorView a,
+    tvm::ffi::TensorView b,
+    tvm::ffi::TensorView scales_a,
+    tvm::ffi::TensorView scales_b,
+    cudaStream_t stream) {
+  using ElementBlockScale = float;
+
+  // A matrix configuration
+  using ElementA = cutlass::float_e4m3_t;        // Element type for A matrix operand
+  using LayoutATag = cutlass::layout::RowMajor;  // Layout type for A matrix operand
+  constexpr int AlignmentA =
+      128 / cutlass::sizeof_bits<ElementA>::value;  // Memory access granularity/alignment of A matrix in units of
+                                                    // elements (up to 16 bytes)
+
+  // B matrix configuration
+  using ElementB = cutlass::float_e4m3_t;           // Element type for B matrix operand
+  using LayoutBTag = cutlass::layout::ColumnMajor;  // Layout type for B matrix operand
+  constexpr int AlignmentB =
+      128 / cutlass::sizeof_bits<ElementB>::value;  // Memory access granularity/alignment of B matrix in units of
+                                                    // elements (up to 16 bytes)
+
+  // C/D matrix configuration
+  using ElementD = OutType;                      // Element type for D matrix operand
+  using ElementC = void;                         // Element type for C matrix operand
+  using LayoutCTag = cutlass::layout::RowMajor;  // Layout type for C matrix operand
+  using LayoutDTag = cutlass::layout::RowMajor;  // Layout type for D matrix operand
+  constexpr int AlignmentD =
+      128 / cutlass::sizeof_bits<ElementD>::value;  // Memory access granularity/alignment of C matrix in units of
+                                                    // elements (up to 16 bytes)
+  constexpr int AlignmentC =
+      AlignmentD;  // Memory access granularity/alignment of C matrix in units of elements (up to 16 bytes)
+
+  // Kernel functional config
+  using ElementAccumulator = float;      // Element type for internal accumulation
+  using ArchTag = cutlass::arch::Sm120;  // Tag indicating the minimum SM that supports the intended feature
+  using OperatorClass = cutlass::arch::OpClassTensorOp;  // Operator class tag - changed from OpClassBlockScaledTensorOp
+
+  static constexpr int ScaleMsPerTile = size<0>(ScalesPerTile{});
+  static constexpr int ScaleGranularityM = size<0>(MmaTileShape{}) / ScaleMsPerTile;
+  static constexpr int ScaleGranularityN = size<1>(MmaTileShape{}) / size<1>(ScalesPerTile{});
+  static constexpr int ScaleGranularityK = size<2>(MmaTileShape{}) / size<2>(ScalesPerTile{});
+
+  using ScaleConfig = cutlass::detail::Sm120BlockwiseScaleConfig<
+      ScaleGranularityM,
+      ScaleGranularityN,
+      ScaleGranularityK,
+      cute::UMMA::Major::MN,
+      cute::UMMA::Major::K>;
+  // FP8 Block-wise scaling configuration
+  using LayoutSFA = decltype(ScaleConfig::deduce_layoutSFA());  // Layout type for SFA matrix operand
+  using LayoutSFB = decltype(ScaleConfig::deduce_layoutSFB());  // Layout type for SFB matrix operand
+
+  constexpr bool kCanUsePingpong = (64 % ScaleGranularityM == 0);
+
+  int m = a.size(0);
+  int k = a.size(1);
+  int n = b.size(1);
+
+  auto a_ptr = static_cast<ElementA*>(a.data_ptr());
+  auto b_ptr = static_cast<ElementB*>(b.data_ptr());
+  auto c_ptr = static_cast<ElementD*>(out.data_ptr());
+
+  auto scales_a_ptr = static_cast<ElementBlockScale*>(scales_a.data_ptr());
+  auto scales_b_ptr = static_cast<ElementBlockScale*>(scales_b.data_ptr());
+
+  LayoutSFA layout_SFA = ScaleConfig::tile_atom_to_shape_SFA(make_shape(m, n, k, 1));
+  LayoutSFB layout_SFB = ScaleConfig::tile_atom_to_shape_SFB(make_shape(m, n, k, 1));
+
+  auto run_gemm = [&](auto tag) -> cutlass::Status {
+    using GemmKernel = decltype(tag);
+    using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+    Gemm gemm_op;
+
+    using StrideA = typename GemmKernel::StrideA;
+    using StrideB = typename GemmKernel::StrideB;
+    using StrideC = typename GemmKernel::StrideD;
+
+    StrideA stride_a = cutlass::make_cute_packed_stride(StrideA{}, cute::make_shape(m, k, 1));
+    StrideB stride_b = cutlass::make_cute_packed_stride(StrideB{}, cute::make_shape(n, k, 1));
+    StrideC stride_c = cutlass::make_cute_packed_stride(StrideC{}, cute::make_shape(m, n, 1));
+
+    typename GemmKernel::MainloopArguments mainloop_args{
+        a_ptr, stride_a, b_ptr, stride_b, scales_a_ptr, layout_SFA, scales_b_ptr, layout_SFB};
+
+    typename GemmKernel::EpilogueArguments epilogue_args{{}, c_ptr, stride_c, c_ptr, stride_c};
+    epilogue_args.thread.alpha = 1.0f;
+
+    typename Gemm::Arguments args = {
+        cutlass::gemm::GemmUniversalMode::kGemm,
+        {m, n, k, 1},
+        mainloop_args,
+        epilogue_args,
+    };
+
+    auto can_implement = gemm_op.can_implement(args);
+    if (can_implement != cutlass::Status::kSuccess) {
+      return can_implement;
+    }
+
+    size_t workspace_size = gemm_op.get_workspace_size(args);
+    auto workspace_tensor = alloc_workspace_tensor(workspace_size, a.device());
+    void* workspace = (workspace_size == 0) ? nullptr : workspace_tensor.data_ptr();
+
+    auto init_status = gemm_op.initialize(args, workspace, stream);
+    if (init_status != cutlass::Status::kSuccess) {
+      return init_status;
+    }
+
+    return gemm_op.run(stream);
+  };
+
+  using CooperativeCollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
+      ArchTag,
+      OperatorClass,
+      PerSmTileShape,
+      ClusterShape,
+      cutlass::epilogue::collective::EpilogueTileAuto,
+      ElementAccumulator,
+      ElementAccumulator,
+      ElementC,
+      LayoutCTag,
+      AlignmentC,
+      ElementD,
+      LayoutDTag,
+      AlignmentD,
+      cutlass::epilogue::collective::EpilogueScheduleAuto>::CollectiveOp;
+
+  using CooperativeStageCount = cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
+      sizeof(typename CooperativeCollectiveEpilogue::SharedStorage))>;
+
+  using CooperativeCollectiveMainloop = typename cutlass::gemm::collective::CollectiveBuilder<
+      ArchTag,
+      OperatorClass,
+      ElementA,
+      cute::tuple<LayoutATag, LayoutSFA>,
+      AlignmentA,
+      ElementB,
+      cute::tuple<LayoutBTag, LayoutSFB>,
+      AlignmentB,
+      ElementAccumulator,
+      MmaTileShape,
+      ClusterShape,
+      CooperativeStageCount,
+      cutlass::gemm::KernelScheduleSm120Blockwise>::CollectiveOp;
+
+  using CooperativeGemmKernelStreamK = cutlass::gemm::kernel::GemmUniversal<
+      Shape<int, int, int, int>,
+      CooperativeCollectiveMainloop,
+      CooperativeCollectiveEpilogue,
+      cutlass::gemm::StreamKScheduler>;
+  using CooperativeGemmKernelVoid = cutlass::gemm::kernel::
+      GemmUniversal<Shape<int, int, int, int>, CooperativeCollectiveMainloop, CooperativeCollectiveEpilogue, void>;
+
+  auto run_cooperative = [&]() -> cutlass::Status {
+    static const uint32_t kNumSM = host::runtime::get_sm_count(a.device().device_id);
+    constexpr int kTileM = size<0>(MmaTileShape{});
+    constexpr int kTileN = size<1>(MmaTileShape{});
+    uint64_t tiles = static_cast<uint64_t>((m + kTileM - 1) / kTileM) * ((n + kTileN - 1) / kTileN);
+    uint32_t last_wave = static_cast<uint32_t>(tiles % kNumSM);
+    if (last_wave == 0) last_wave = kNumSM;
+    float waste = 1.0f - static_cast<float>(last_wave) / static_cast<float>(kNumSM);
+    return (waste > 0.5f) ? run_gemm(CooperativeGemmKernelStreamK{}) : run_gemm(CooperativeGemmKernelVoid{});
+  };
+
+  cutlass::Status status = cutlass::Status::kSuccess;
+  if constexpr (kCanUsePingpong) {
+    using PingpongMmaTileShape_MNK = Shape<_64, _128, _128>;
+    using PingpongCollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
+        ArchTag,
+        OperatorClass,
+        PerSmTileShape,
+        ClusterShape,
+        cutlass::epilogue::collective::EpilogueTileAuto,
+        ElementAccumulator,
+        ElementAccumulator,
+        ElementC,
+        LayoutCTag,
+        AlignmentC,
+        ElementD,
+        LayoutDTag,
+        AlignmentD,
+        cutlass::epilogue::collective::EpilogueScheduleAuto>::CollectiveOp;
+
+    using PingpongStageCount = cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
+        sizeof(typename PingpongCollectiveEpilogue::SharedStorage))>;
+
+    using PingpongCollectiveMainloop = typename cutlass::gemm::collective::CollectiveBuilder<
+        ArchTag,
+        OperatorClass,
+        ElementA,
+        cute::tuple<LayoutATag, LayoutSFA>,
+        AlignmentA,
+        ElementB,
+        cute::tuple<LayoutBTag, LayoutSFB>,
+        AlignmentB,
+        ElementAccumulator,
+        PingpongMmaTileShape_MNK,
+        ClusterShape,
+        PingpongStageCount,
+        cutlass::gemm::KernelTmaWarpSpecializedBlockwisePingpongSm120>::CollectiveOp;
+
+    using PingpongGemmKernel = cutlass::gemm::kernel::
+        GemmUniversal<Shape<int, int, int, int>, PingpongCollectiveMainloop, PingpongCollectiveEpilogue, void>;
+
+    if (m <= 64) {
+      status = run_gemm(PingpongGemmKernel{});
+      if (status != cutlass::Status::kSuccess) {
+        status = run_cooperative();
+      }
+    } else {
+      status = run_cooperative();
+    }
+  } else {
+    status = run_cooperative();
+  }
+
+  CUTLASS_CHECK(status);
+}
+
+// Transposed GEMM D^T = Wgemm(weight, activation): puts tokens on the N axis.
+template <
+    typename OutType,
+    typename MmaTileShape,
+    typename PerSmTileShape,
+    typename EpilogueTileShape,
+    typename ScalesPerTile,
+    class ClusterShape = Shape<_1, _1, _1>>
+void launch_sm120_fp8_blockwise_scaled_mm_swapab(
+    tvm::ffi::TensorView out,
+    tvm::ffi::TensorView a,
+    tvm::ffi::TensorView b,
+    tvm::ffi::TensorView scales_a,
+    tvm::ffi::TensorView scales_b,
+    cudaStream_t stream) {
+  using ElementBlockScale = float;
+
+  using ElementA = cutlass::float_e4m3_t;        // A' = weight
+  using LayoutATag = cutlass::layout::RowMajor;  // weight [N, K] is row-major
+  constexpr int AlignmentA = 128 / cutlass::sizeof_bits<ElementA>::value;
+
+  using ElementB = cutlass::float_e4m3_t;           // B' = activation
+  using LayoutBTag = cutlass::layout::ColumnMajor;  // activation as [K, M] column-major
+  constexpr int AlignmentB = 128 / cutlass::sizeof_bits<ElementB>::value;
+
+  using ElementD = OutType;
+  using ElementC = void;
+  using LayoutCTag = cutlass::layout::ColumnMajor;  // D' = out^T is column-major
+  using LayoutDTag = cutlass::layout::ColumnMajor;
+  constexpr int AlignmentD = 128 / cutlass::sizeof_bits<ElementD>::value;
+  constexpr int AlignmentC = AlignmentD;
+
+  using ElementAccumulator = float;
+  using ArchTag = cutlass::arch::Sm120;
+  using OperatorClass = cutlass::arch::OpClassTensorOp;
+
+  static constexpr int ScaleMsPerTile = size<0>(ScalesPerTile{});
+  static constexpr int ScaleGranularityM = size<0>(MmaTileShape{}) / ScaleMsPerTile;
+  static constexpr int ScaleGranularityN = size<1>(MmaTileShape{}) / size<1>(ScalesPerTile{});
+  static constexpr int ScaleGranularityK = size<2>(MmaTileShape{}) / size<2>(ScalesPerTile{});
+
+  // Operands are swapped, so the scale majors swap relative to the non-swap path:
+  // SFA (weight) is K-major; SFB (per-token activation) is MN-major.
+  using ScaleConfig = cutlass::detail::Sm120BlockwiseScaleConfig<
+      ScaleGranularityM,
+      ScaleGranularityN,
+      ScaleGranularityK,
+      cute::UMMA::Major::K,
+      cute::UMMA::Major::MN>;
+  using LayoutSFA = decltype(ScaleConfig::deduce_layoutSFA());
+  using LayoutSFB = decltype(ScaleConfig::deduce_layoutSFB());
+
+  int m = a.size(0);  // original tokens  -> swapped N'
+  int k = a.size(1);
+  int n = b.size(1);  // original weight cols -> swapped M'
+
+  auto weight_ptr = static_cast<ElementA*>(b.data_ptr());
+  auto act_ptr = static_cast<ElementB*>(a.data_ptr());
+  auto c_ptr = static_cast<ElementD*>(out.data_ptr());
+  auto weight_scale_ptr = static_cast<ElementBlockScale*>(scales_b.data_ptr());
+  auto act_scale_ptr = static_cast<ElementBlockScale*>(scales_a.data_ptr());
+
+  // Swapped problem shape (M', N', K) = (n, m, k).
+  LayoutSFA layout_SFA = ScaleConfig::tile_atom_to_shape_SFA(make_shape(n, m, k, 1));
+  LayoutSFB layout_SFB = ScaleConfig::tile_atom_to_shape_SFB(make_shape(n, m, k, 1));
+
+  auto run_gemm = [&](auto tag) -> cutlass::Status {
+    using GemmKernel = decltype(tag);
+    using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+    Gemm gemm_op;
+
+    using StrideA = typename GemmKernel::StrideA;
+    using StrideB = typename GemmKernel::StrideB;
+    using StrideC = typename GemmKernel::StrideD;
+
+    StrideA stride_a = cutlass::make_cute_packed_stride(StrideA{}, cute::make_shape(n, k, 1));
+    StrideB stride_b = cutlass::make_cute_packed_stride(StrideB{}, cute::make_shape(m, k, 1));
+    StrideC stride_c = cutlass::make_cute_packed_stride(StrideC{}, cute::make_shape(n, m, 1));
+
+    typename GemmKernel::MainloopArguments mainloop_args{
+        weight_ptr, stride_a, act_ptr, stride_b, weight_scale_ptr, layout_SFA, act_scale_ptr, layout_SFB};
+
+    typename GemmKernel::EpilogueArguments epilogue_args{{}, c_ptr, stride_c, c_ptr, stride_c};
+    epilogue_args.thread.alpha = 1.0f;
+
+    typename Gemm::Arguments args = {
+        cutlass::gemm::GemmUniversalMode::kGemm,
+        {n, m, k, 1},
+        mainloop_args,
+        epilogue_args,
+    };
+
+    auto can_implement = gemm_op.can_implement(args);
+    if (can_implement != cutlass::Status::kSuccess) {
+      return can_implement;
+    }
+
+    size_t workspace_size = gemm_op.get_workspace_size(args);
+    auto workspace_tensor = alloc_workspace_tensor(workspace_size, a.device());
+    void* workspace = (workspace_size == 0) ? nullptr : workspace_tensor.data_ptr();
+
+    auto init_status = gemm_op.initialize(args, workspace, stream);
+    if (init_status != cutlass::Status::kSuccess) {
+      return init_status;
+    }
+
+    return gemm_op.run(stream);
+  };
+
+  using CollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
+      ArchTag,
+      OperatorClass,
+      PerSmTileShape,
+      ClusterShape,
+      cutlass::epilogue::collective::EpilogueTileAuto,
+      ElementAccumulator,
+      ElementAccumulator,
+      ElementC,
+      LayoutCTag,
+      AlignmentC,
+      ElementD,
+      LayoutDTag,
+      AlignmentD,
+      cutlass::epilogue::collective::EpilogueScheduleAuto>::CollectiveOp;
+
+  using StageCount = cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
+      sizeof(typename CollectiveEpilogue::SharedStorage))>;
+
+  using CollectiveMainloop = typename cutlass::gemm::collective::CollectiveBuilder<
+      ArchTag,
+      OperatorClass,
+      ElementA,
+      cute::tuple<LayoutATag, LayoutSFA>,
+      AlignmentA,
+      ElementB,
+      cute::tuple<LayoutBTag, LayoutSFB>,
+      AlignmentB,
+      ElementAccumulator,
+      MmaTileShape,
+      ClusterShape,
+      StageCount,
+      cutlass::gemm::KernelScheduleSm120Blockwise>::CollectiveOp;
+
+  using GemmKernel =
+      cutlass::gemm::kernel::GemmUniversal<Shape<int, int, int, int>, CollectiveMainloop, CollectiveEpilogue, void>;
+
+  CUTLASS_CHECK(run_gemm(GemmKernel{}));
+}
+
+// swapAB (tile N=32) beats the non-swap 128x128 path for M<=64 or M%4!=0
+// (cold-L2 CUPTI benchmarks, up to ~1.2x); tile N=16 is unsupported by the
+// SM120 blockwise collective (needs EPI_TILE_N=32 | CTA_N and B LDSM N>=32).
+template <typename OutType>
+void sm120_fp8_blockwise_dispatch_shape(
+    tvm::ffi::TensorView out,
+    tvm::ffi::TensorView a,
+    tvm::ffi::TensorView b,
+    tvm::ffi::TensorView scales_a,
+    tvm::ffi::TensorView scales_b,
+    cudaStream_t stream) {
+  const int m = a.size(0);
+  using EpilogueTileShape = Shape<_128, _64>;
+  if (m <= 64 || (m % 4 != 0)) {
+    launch_sm120_fp8_blockwise_scaled_mm_swapab<
+        OutType,
+        Shape<_128, _32, _128>,
+        Shape<_128, _32, _128>,
+        EpilogueTileShape,
+        Shape<_1, _32, _1>>(out, a, b, scales_a, scales_b, stream);
+    return;
+  }
+
+  using MmaTileShape = Shape<_128, _128, _128>;
+  using PerSmTileShape = Shape<_128, _128, _128>;
+  using ScalesPerTile = Shape<_128, _1, _1>;
+  launch_sm120_fp8_blockwise_scaled_mm<OutType, MmaTileShape, PerSmTileShape, EpilogueTileShape, ScalesPerTile>(
+      out, a, b, scales_a, scales_b, stream);
+}
+
+inline void fp8_blockwise_scaled_mm_sm120(
+    tvm::ffi::TensorView out,
+    tvm::ffi::TensorView mat_a,
+    tvm::ffi::TensorView mat_b,
+    tvm::ffi::TensorView scales_a,
+    tvm::ffi::TensorView scales_b) {
+  RuntimeCheck(mat_a.device().device_type == kDLCUDA, "mat_a must be a CUDA tensor");
+  RuntimeCheck(mat_b.device().device_type == kDLCUDA, "mat_b must be a CUDA tensor");
+
+  RuntimeCheck(mat_a.dim() == 2, "mat_a must be a 2D tensor");
+  RuntimeCheck(mat_b.dim() == 2, "mat_b must be a 2D tensor");
+  RuntimeCheck(mat_a.stride(1) == 1, "mat_a must be a row major tensor");
+  RuntimeCheck(mat_b.stride(0) == 1, "mat_b must be a column major tensor");
+  RuntimeCheck(mat_a.size(1) == mat_b.size(0), "mat_a and mat_b shapes cannot be multiplied");
+
+  RuntimeCheck(
+      (mat_a.size(1) * (mat_a.dtype().bits / 8)) % 16 == 0, "mat_a must be multiple of 16 bytes for memory alignment");
+  RuntimeCheck(
+      (mat_b.size(0) * (mat_b.dtype().bits / 8)) % 16 == 0, "mat_b must be multiple of 16 bytes for memory alignment");
+  RuntimeCheck(host::is_type<fp8_e4m3_t>(mat_a.dtype()), "mat_a must be Float8_e4m3fn");
+  RuntimeCheck(host::is_type<fp8_e4m3_t>(mat_b.dtype()), "mat_b must be Float8_e4m3fn");
+
+  RuntimeCheck(mat_a.size(0) == scales_a.size(0), "size of scales_a is not matched");
+  RuntimeCheck(mat_a.size(1) / 128 == scales_a.size(1), "size of scales_a is not matched");
+  RuntimeCheck(mat_b.size(0) / 128 == scales_b.size(0), "size of scales_b is not matched");
+  RuntimeCheck(mat_b.size(1) / 128 == scales_b.size(1), "size of scales_b is not matched");
+  RuntimeCheck(host::is_type<float>(scales_a.dtype()), "scales_a must be Float32");
+  RuntimeCheck(host::is_type<float>(scales_b.dtype()), "scales_b must be Float32");
+
+  RuntimeCheck(
+      (out.size(1) * (out.dtype().bits / 8)) % 16 == 0, "out must be multiple of 16 bytes for memory alignment");
+
+  const cudaStream_t stream = LaunchKernel::resolve_device(mat_a.device());
+
+  if (host::is_type<bf16_t>(out.dtype())) {
+    sm120_fp8_blockwise_dispatch_shape<cutlass::bfloat16_t>(out, mat_a, mat_b, scales_a, scales_b, stream);
+  } else if (host::is_type<fp16_t>(out.dtype())) {
+    sm120_fp8_blockwise_dispatch_shape<cutlass::half_t>(out, mat_a, mat_b, scales_a, scales_b, stream);
+  } else {
+    Panic("out_dtype must be Half or BFloat16");
+  }
+}
+
+#endif  // defined(CUTLASS_ARCH_MMA_SM120_SUPPORTED) || defined(CUTLASS_ARCH_MMA_SM121_SUPPORTED)

--- a/python/sglang/jit_kernel/fp8_blockwise_gemm.py
+++ b/python/sglang/jit_kernel/fp8_blockwise_gemm.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+import importlib.util
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import torch
+
+from sglang.jit_kernel.utils import cache_once, load_jit
+from sglang.srt.utils.common import is_sm120_supported
+from sglang.srt.utils.custom_op import register_custom_op
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+
+def _fp8_blockwise_cuda_flags() -> list[str]:
+    return [
+        "-DNDEBUG",
+        "-DCUTE_USE_PACKED_TUPLE=1",
+        "-DCUTLASS_ENABLE_TENSOR_CORE_MMA=1",
+        "-DCUTLASS_VERSIONS_GENERATED",
+        "-DCUTLASS_TEST_LEVEL=0",
+        "-DCUTLASS_TEST_ENABLE_CACHED_RESULTS=1",
+        "-DCUTLASS_DEBUG_TRACE_LEVEL=0",
+        "--expt-relaxed-constexpr",
+        "--expt-extended-lambda",
+    ]
+
+
+def _cutlass_include_paths() -> list[str]:
+    """Resolve the CUTLASS headers bundled by FlashInfer in the DSV4 image."""
+    spec = importlib.util.find_spec("flashinfer")
+    roots: list[Path] = []
+    if spec is not None:
+        if spec.origin is not None:
+            roots.append(Path(spec.origin).resolve().parent)
+        roots.extend(Path(p).resolve() for p in spec.submodule_search_locations or [])
+
+    include_paths: list[str] = []
+    for root in roots:
+        for candidate in (
+            root / "data" / "cutlass" / "include",
+            root / "data" / "cutlass" / "tools" / "util" / "include",
+        ):
+            if candidate.exists() and str(candidate) not in include_paths:
+                include_paths.append(str(candidate))
+    if not include_paths:
+        raise RuntimeError("Cannot find the CUTLASS headers bundled with FlashInfer")
+    return include_paths
+
+
+@contextmanager
+def _fp8_blockwise_arch_env():
+    if not is_sm120_supported():
+        raise RuntimeError(
+            "fp8_blockwise_scaled_mm JIT kernel requires SM120 (Blackwell)."
+        )
+    old_arch = os.environ.get("TVM_FFI_CUDA_ARCH_LIST")
+    # SM120 CUTLASS atoms require an architecture-specific target.
+    os.environ["TVM_FFI_CUDA_ARCH_LIST"] = "12.0a"
+    try:
+        yield
+    finally:
+        if old_arch is None:
+            os.environ.pop("TVM_FFI_CUDA_ARCH_LIST", None)
+        else:
+            os.environ["TVM_FFI_CUDA_ARCH_LIST"] = old_arch
+
+
+@cache_once
+def _jit_fp8_blockwise_module() -> Module:
+    """Compile and cache the SM120 fp8 blockwise GEMM module (handles fp16 + bf16)."""
+    with _fp8_blockwise_arch_env():
+        return load_jit(
+            "fp8_blockwise_scaled_mm",
+            cuda_files=["gemm/fp8_blockwise/fp8_blockwise_scaled_mm_entry.cuh"],
+            cuda_wrappers=[
+                ("fp8_blockwise_scaled_mm", "fp8_blockwise_scaled_mm"),
+            ],
+            extra_cuda_cflags=_fp8_blockwise_cuda_flags(),
+            extra_include_paths=_cutlass_include_paths(),
+        )
+
+
+@register_custom_op(
+    op_name="fp8_blockwise_scaled_mm",
+    mutates_args=["out"],
+)
+def _fp8_blockwise_scaled_mm_custom_op(
+    out: torch.Tensor,
+    mat_a: torch.Tensor,
+    mat_b: torch.Tensor,
+    scales_a: torch.Tensor,
+    scales_b: torch.Tensor,
+) -> None:
+    module = _jit_fp8_blockwise_module()
+    module.fp8_blockwise_scaled_mm(out, mat_a, mat_b, scales_a, scales_b)
+
+
+def fp8_blockwise_scaled_mm(
+    mat_a: torch.Tensor,
+    mat_b: torch.Tensor,
+    scales_a: torch.Tensor,
+    scales_b: torch.Tensor,
+    out_dtype: torch.dtype,
+) -> torch.Tensor:
+    """FP8 e4m3 block-wise scaled matmul on SM120."""
+    assert out_dtype in (
+        torch.float16,
+        torch.bfloat16,
+    ), f"out_dtype must be Half or BFloat16, got {out_dtype}"
+
+    out = torch.empty(
+        (mat_a.shape[0], mat_b.shape[1]),
+        dtype=out_dtype,
+        device=mat_a.device,
+    )
+    _fp8_blockwise_scaled_mm_custom_op(out, mat_a, mat_b, scales_a, scales_b)
+    return out

--- a/python/sglang/jit_kernel/fp8_blockwise_gemm.py
+++ b/python/sglang/jit_kernel/fp8_blockwise_gemm.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from contextlib import contextmanager
 import importlib.util
 import os
+from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING
 

--- a/python/sglang/jit_kernel/include/sgl_kernel/utils.cuh
+++ b/python/sglang/jit_kernel/include/sgl_kernel/utils.cuh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <sgl_kernel/ffi.h>
 #include <sgl_kernel/utils.h>
 
 #include <dlpack/dlpack.h>
@@ -147,6 +148,21 @@ inline void RuntimeDeviceCheck(::cudaError_t error, DebugInfo location = {}) {
 
 inline void RuntimeDeviceCheck(DebugInfo location = {}) {
   return RuntimeDeviceCheck(::cudaGetLastError(), location);
+}
+
+inline int getSMVersion(int device_id) {
+  int sm_major = 0;
+  int sm_minor = 0;
+  RuntimeDeviceCheck(cudaDeviceGetAttribute(&sm_major, cudaDevAttrComputeCapabilityMajor, device_id));
+  RuntimeDeviceCheck(cudaDeviceGetAttribute(&sm_minor, cudaDevAttrComputeCapabilityMinor, device_id));
+  return sm_major * 10 + sm_minor;
+}
+
+inline auto alloc_workspace_tensor(size_t required_bytes, DLDevice device) -> tvm::ffi::Tensor {
+  if (required_bytes == 0) return {};
+  DLDataType u8 = {kDLUInt, 8, 1};
+  int64_t shape[] = {static_cast<int64_t>(required_bytes)};
+  return ffi::empty(tvm::ffi::ShapeView(shape, 1), u8, device);
 }
 
 struct LaunchKernel {

--- a/python/sglang/srt/layers/attention/debug_flash_mla_adapter.py
+++ b/python/sglang/srt/layers/attention/debug_flash_mla_adapter.py
@@ -1,23 +1,23 @@
 # DeepSeek V4 Flash attention dispatcher.
 #
 # Two backends:
-#   "kernel"  -> upstream `flash_mla` PyPI package. The installed wheel's
-#                cuda*.so contains only `.target sm_90a` (Hopper); any other
-#                capability raises "Unsupported architecture" the first time
-#                the CUDA op runs. Capabilities outside the whitelist are
-#                transparently routed to the Triton fallback.
+#   "kernel"  -> Hopper uses the upstream `flash_mla` PyPI package; SM120 uses
+#                FlashInfer's DSV4 sparse MLA kernel; other capabilities use
+#                the portable Triton fallback.
 #   "triton"  -> portable Triton kernel ported from vLLM PR #40929. Works on
 #                any arch Triton supports (>= SM_80).
 #
 # This is a sglang-side change (sglang 本身), not kt-sglang coupling: the V4
-# quantizer that produces the FP8/RoPE/ue8m0-packed KV layout already lives
-# in sglang main (PR #23600), and no upstream FlashMLA build understands that
-# layout on non-Hopper arches, so the fallback has to live next to the
-# entrypoint.
+# quantizer that produces the FP8/RoPE/ue8m0-packed KV layout already lives in
+# sglang main (PR #23600), so architecture dispatch belongs at this entrypoint.
 import functools
+import logging
 from typing import Any, Tuple
 
 import torch
+
+
+logger = logging.getLogger(__name__)
 
 
 # Capabilities for which the upstream flash_mla wheel ships a CUDA binary.
@@ -34,15 +34,23 @@ def _device_capability() -> Tuple[int, int]:
 
 
 def should_use_triton_fallback() -> bool:
-    # Non-whitelist capability -> route to Triton. Used by the V4 metadata
-    # factories to skip flash_mla.get_mla_metadata() on arches the wheel
-    # cannot run on, and by flash_mla_with_kvcache_entrypoint below to
-    # transparently swap the kernel implementation.
+    # Used by the V4 metadata factories to skip the Hopper-only flash_mla
+    # metadata.  SM120's FlashInfer path does not consume this metadata either.
     return _device_capability() not in _FLASHMLA_CUDA_CAPS
 
 
 # Backward-compat alias (was private until consumed by metadata factories).
 _should_use_triton_fallback = should_use_triton_fallback
+
+
+@functools.lru_cache(maxsize=1)
+def _warn_sm120_flashinfer_unavailable() -> None:
+    logger.warning(
+        "FlashInfer does not expose the SM120 DeepSeek V4 sparse MLA API; "
+        "falling back to the portable Triton decode kernel. The optimized "
+        "path requires matching flashinfer-python and flashinfer-cubin "
+        "0.6.15.post1 or newer."
+    )
 
 
 def _v4_triton_decode_dispatch(
@@ -67,10 +75,6 @@ def _v4_triton_decode_dispatch(
     so we must return a tuple whose first element has shape
     [batch, 1, num_heads, head_dim_v].
     """
-    from sglang.srt.layers.attention.nsa.v4_triton_kernel import (
-        decode_sparse_attention_triton,
-    )
-
     assert is_fp8_kvcache, "Triton V4 fallback only handles FP8 KV cache"
     assert head_dim_v == 512, f"V4 head_dim_v must be 512, got {head_dim_v}"
 
@@ -150,18 +154,26 @@ def _v4_triton_decode_dispatch(
 
 def flash_mla_with_kvcache_entrypoint(backend: str, **kwargs):
     if backend == "kernel":
-        # Auto-fall back on architectures the upstream CUDA kernel does not
-        # cover. Set SGLANG_FLASHMLA_BACKEND_OVERRIDE=triton to force-bypass even
-        # on supported arches (useful for numerical comparison).
-        if _should_use_triton_fallback():
-            return _v4_triton_decode_dispatch(**kwargs)
-        import flash_mla
+        capability = _device_capability()
+        if capability == (12, 0):
+            from sglang.srt.layers.attention.flash_mla_sm120 import (
+                flash_mla_with_kvcache_sm120,
+                is_flashinfer_dsv4_available,
+            )
 
-        return flash_mla.flash_mla_with_kvcache(**kwargs)
+            if is_flashinfer_dsv4_available():
+                return flash_mla_with_kvcache_sm120(**kwargs)
+            _warn_sm120_flashinfer_unavailable()
+            return _v4_triton_decode_dispatch(**kwargs)
+
+        if capability in _FLASHMLA_CUDA_CAPS:
+            import flash_mla
+
+            return flash_mla.flash_mla_with_kvcache(**kwargs)
+
+        return _v4_triton_decode_dispatch(**kwargs)
 
     if backend == "triton":
         return _v4_triton_decode_dispatch(**kwargs)
 
-    raise ValueError(
-        f"unsupported backend {backend!r}; expected 'kernel' or 'triton'"
-    )
+    raise ValueError(f"unsupported backend {backend!r}; expected 'kernel' or 'triton'")

--- a/python/sglang/srt/layers/attention/debug_flash_mla_adapter.py
+++ b/python/sglang/srt/layers/attention/debug_flash_mla_adapter.py
@@ -16,7 +16,6 @@ from typing import Any, Tuple
 
 import torch
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/python/sglang/srt/layers/attention/flash_mla_sm120.py
+++ b/python/sglang/srt/layers/attention/flash_mla_sm120.py
@@ -16,7 +16,6 @@ import torch
 import triton
 import triton.language as tl
 
-
 _PBS_DST = 64
 _NOPE_ROPE_STRIDE = 576
 _SCALE_STRIDE = 8

--- a/python/sglang/srt/layers/attention/flash_mla_sm120.py
+++ b/python/sglang/srt/layers/attention/flash_mla_sm120.py
@@ -1,0 +1,289 @@
+"""FlashInfer sparse MLA decode adapter for DeepSeek V4 on SM120.
+
+DeepSeek V4 stores each FP8 KV page as one data section followed by one
+UE8M0-scale section.  FlashInfer's SM120 kernel requires 64-token pages, while
+SGLang may use a larger physical SWA page.  The split buffer below is persistent
+and only the source pages referenced by the current decode step are refreshed.
+"""
+
+from __future__ import annotations
+
+import functools
+import math
+from typing import Optional
+
+import torch
+import triton
+import triton.language as tl
+
+
+_PBS_DST = 64
+_NOPE_ROPE_STRIDE = 576
+_SCALE_STRIDE = 8
+_BYTES_PER_TOKEN = _NOPE_ROPE_STRIDE + _SCALE_STRIDE
+_BYTES_PER_DST_PAGE = _PBS_DST * _BYTES_PER_TOKEN
+_BYTES_PER_DST_PAGE_PADDED = (
+    math.ceil(_BYTES_PER_DST_PAGE / _NOPE_ROPE_STRIDE) * _NOPE_ROPE_STRIDE
+)
+
+# The base branch predates sglang.srt.runtime_context.  Keep the same grow-only,
+# per-device lifetime here.  One model process executes its layers on the same
+# CUDA stream, so reusing the page-split workspace between layers is ordered.
+_SPLIT_BUFFERS: dict[tuple[str, Optional[int]], torch.Tensor] = {}
+_MASK_BUFFERS: dict[tuple[str, Optional[int]], torch.Tensor] = {}
+
+
+def _device_key(device: torch.device) -> tuple[str, Optional[int]]:
+    return (device.type, device.index)
+
+
+@functools.lru_cache(maxsize=1)
+def is_flashinfer_dsv4_available() -> bool:
+    """Return whether the pinned FlashInfer exposes its SM120 DSV4 API."""
+    try:
+        from flashinfer.mla._sparse_mla_sm120 import (  # noqa: F401
+            _DECODE_MAX_TOKENS,
+            _sparse_mla_sm120_paged_attention,
+        )
+    except (AttributeError, ImportError, ModuleNotFoundError):
+        return False
+    return True
+
+
+@triton.jit
+def _page_mark_kernel(
+    indices_ptr,
+    mask_ptr,
+    n_indices,
+    n_pages,
+    src_page_size: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    if pid >= n_indices:
+        return
+    index = tl.load(indices_ptr + pid)
+    if index < 0:
+        return
+    page = index // src_page_size
+    if page < n_pages:
+        # Concurrent stores of the same byte value are benign.
+        tl.store(mask_ptr + page, 1)
+
+
+@triton.jit
+def _page_split_kernel(
+    src_ptr,
+    dst_ptr,
+    n_pages,
+    src_stride0: tl.constexpr,
+    dst_stride0: tl.constexpr,
+    data_per_subpage: tl.constexpr,
+    scale_per_subpage: tl.constexpr,
+    src_scale_offset: tl.constexpr,
+    dst_scale_offset: tl.constexpr,
+    ratio: tl.constexpr,
+    block_size: tl.constexpr,
+    page_mask_ptr,
+    has_page_mask: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    page = pid // ratio
+    subpage = pid % ratio
+    if page >= n_pages:
+        return
+    if has_page_mask:
+        if tl.load(page_mask_ptr + page) == 0:
+            return
+
+    src_base = src_ptr + page * src_stride0
+    dst_base = dst_ptr + (page * ratio + subpage) * dst_stride0
+
+    data_src_offset = subpage * data_per_subpage
+    for start in tl.range(0, data_per_subpage, block_size):
+        offsets = start + tl.arange(0, block_size)
+        valid = offsets < data_per_subpage
+        values = tl.load(src_base + data_src_offset + offsets, mask=valid)
+        tl.store(dst_base + offsets, values, mask=valid)
+
+    scale_src_offset = src_scale_offset + subpage * scale_per_subpage
+    for start in tl.range(0, scale_per_subpage, block_size):
+        offsets = start + tl.arange(0, block_size)
+        valid = offsets < scale_per_subpage
+        values = tl.load(src_base + scale_src_offset + offsets, mask=valid)
+        tl.store(dst_base + dst_scale_offset + offsets, values, mask=valid)
+
+
+def _split_kv_pages_to_64(
+    kv_u8: torch.Tensor,
+    src_page_size: int,
+    touched_indices: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Return a persistent 64-token-page view of a footer-layout KV pool."""
+    assert src_page_size >= _PBS_DST and src_page_size % _PBS_DST == 0
+    if src_page_size == _PBS_DST:
+        return kv_u8
+
+    num_src_pages = kv_u8.shape[0]
+    ratio = src_page_size // _PBS_DST
+    num_dst_pages = num_src_pages * ratio
+    key = _device_key(kv_u8.device)
+
+    split_buffer = _SPLIT_BUFFERS.get(key)
+    if split_buffer is None or split_buffer.shape[0] < num_dst_pages:
+        with torch.inference_mode(False):
+            split_buffer = torch.empty(
+                num_dst_pages,
+                _BYTES_PER_DST_PAGE_PADDED,
+                dtype=torch.uint8,
+                device=kv_u8.device,
+            )
+        _SPLIT_BUFFERS[key] = split_buffer
+    dst = split_buffer[:num_dst_pages]
+
+    if kv_u8.ndim == 4:
+        src_stride0 = kv_u8.stride(0)
+        src = torch.as_strided(kv_u8, (num_src_pages, src_stride0), (src_stride0, 1))
+    else:
+        src = kv_u8
+        src_stride0 = src.stride(0)
+
+    use_mask = touched_indices is not None and touched_indices.numel() > 0
+    page_mask_ptr = src  # Dummy pointer for the unmasked specialization.
+    if use_mask:
+        mask_buffer = _MASK_BUFFERS.get(key)
+        if mask_buffer is None or mask_buffer.shape[0] < num_src_pages:
+            # A tensor allocated while inference mode is active cannot later be
+            # zeroed during CUDA-graph capture.  Force a normal tensor here.
+            with torch.inference_mode(False):
+                mask_buffer = torch.empty(
+                    num_src_pages, dtype=torch.int8, device=kv_u8.device
+                )
+            _MASK_BUFFERS[key] = mask_buffer
+        page_mask = mask_buffer[:num_src_pages]
+        page_mask.zero_()
+        flat_indices = touched_indices.reshape(-1).contiguous()
+        if flat_indices.dtype != torch.int32:
+            flat_indices = flat_indices.to(torch.int32)
+        _page_mark_kernel[(flat_indices.numel(),)](
+            flat_indices,
+            page_mask,
+            flat_indices.numel(),
+            num_src_pages,
+            src_page_size,
+        )
+        page_mask_ptr = page_mask
+
+    data_per_subpage = _PBS_DST * _NOPE_ROPE_STRIDE
+    scale_per_subpage = _PBS_DST * _SCALE_STRIDE
+    _page_split_kernel[(num_dst_pages,)](
+        src,
+        dst,
+        num_src_pages,
+        src_stride0,
+        _BYTES_PER_DST_PAGE_PADDED,
+        data_per_subpage,
+        scale_per_subpage,
+        src_page_size * _NOPE_ROPE_STRIDE,
+        data_per_subpage,
+        ratio,
+        1024,
+        page_mask_ptr,
+        use_mask,
+    )
+
+    return dst.as_strided(
+        (num_dst_pages, _PBS_DST, 1, _BYTES_PER_TOKEN),
+        (_BYTES_PER_DST_PAGE_PADDED, _BYTES_PER_TOKEN, _BYTES_PER_TOKEN, 1),
+    )
+
+
+def flash_mla_with_kvcache_sm120(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    head_dim_v: int,
+    softmax_scale: float,
+    is_fp8_kvcache: bool,
+    indices: torch.Tensor,
+    topk_length: torch.Tensor,
+    attn_sink: torch.Tensor,
+    extra_k_cache: Optional[torch.Tensor] = None,
+    extra_indices_in_kvcache: Optional[torch.Tensor] = None,
+    extra_topk_length: Optional[torch.Tensor] = None,
+    **_unused,
+):
+    """Run FlashInfer's SM120 sparse MLA kernel for one DSV4 decode step."""
+    if not is_flashinfer_dsv4_available():
+        raise ImportError("FlashInfer SM120 DSV4 sparse MLA API is unavailable")
+    if not is_fp8_kvcache:
+        raise ValueError("FlashInfer SM120 DSV4 decode requires an FP8 KV cache")
+    if head_dim_v != 512:
+        raise ValueError(f"DeepSeek V4 head_dim_v must be 512, got {head_dim_v}")
+
+    from flashinfer.mla._sparse_mla_sm120 import (
+        _DECODE_MAX_TOKENS,
+        _sparse_mla_sm120_paged_attention,
+    )
+
+    q_3d = q.squeeze(1) if q.ndim == 4 else q
+    batch_size, num_heads, _ = q_3d.shape
+    idx = indices.squeeze(1) if indices.ndim == 3 else indices
+
+    kv_u8 = k_cache if k_cache.dtype == torch.uint8 else k_cache.view(torch.uint8)
+    src_page_size = k_cache.shape[1]
+    kv_64 = _split_kv_pages_to_64(kv_u8, src_page_size, idx)
+
+    extra_kv = extra_k_cache
+    if extra_kv is not None and extra_kv.dtype != torch.uint8:
+        extra_kv = extra_kv.view(torch.uint8)
+    extra_idx = extra_indices_in_kvcache
+    if extra_idx is not None and extra_idx.ndim == 3:
+        extra_idx = extra_idx.squeeze(1)
+
+    output = torch.empty(
+        batch_size, num_heads, head_dim_v, dtype=torch.bfloat16, device=q.device
+    )
+    output_lse = torch.empty(
+        batch_size, num_heads, dtype=torch.float32, device=q.device
+    )
+
+    if batch_size <= _DECODE_MAX_TOKENS:
+        split_size = 64
+        num_splits = math.ceil(idx.shape[-1] / split_size)
+        if extra_idx is not None:
+            num_splits += math.ceil(extra_idx.shape[-1] / split_size)
+        mid_output = torch.empty(
+            batch_size,
+            num_heads,
+            num_splits,
+            head_dim_v,
+            dtype=torch.bfloat16,
+            device=q.device,
+        )
+        mid_lse = torch.empty(
+            batch_size,
+            num_heads,
+            num_splits,
+            dtype=torch.float32,
+            device=q.device,
+        )
+    else:
+        mid_output = None
+        mid_lse = None
+
+    _sparse_mla_sm120_paged_attention(
+        q_3d,
+        kv_64,
+        idx,
+        output,
+        output_lse,
+        float(softmax_scale),
+        d_v=head_dim_v,
+        topk_length=topk_length,
+        attn_sink=attn_sink,
+        extra_kv_cache=extra_kv,
+        extra_indices=extra_idx,
+        extra_topk_length=extra_topk_length,
+        mid_out=mid_output,
+        mid_lse=mid_lse,
+    )
+    return (output.unsqueeze(1), None)

--- a/python/sglang/srt/layers/quantization/configs/N=1024,K=4096,device_name=NVIDIA_GeForce_RTX_4090,dtype=fp8_w8a8,block_shape=[128, 128].json
+++ b/python/sglang/srt/layers/quantization/configs/N=1024,K=4096,device_name=NVIDIA_GeForce_RTX_4090,dtype=fp8_w8a8,block_shape=[128, 128].json
@@ -1,0 +1,42 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "9": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    }
+}

--- a/python/sglang/srt/layers/quantization/configs/N=32768,K=1024,device_name=NVIDIA_GeForce_RTX_4090,dtype=fp8_w8a8,block_shape=[128, 128].json
+++ b/python/sglang/srt/layers/quantization/configs/N=32768,K=1024,device_name=NVIDIA_GeForce_RTX_4090,dtype=fp8_w8a8,block_shape=[128, 128].json
@@ -1,0 +1,42 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "9": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    }
+}

--- a/python/sglang/srt/layers/quantization/configs/N=4096,K=2048,device_name=NVIDIA_GeForce_RTX_4090,dtype=fp8_w8a8,block_shape=[128, 128].json
+++ b/python/sglang/srt/layers/quantization/configs/N=4096,K=2048,device_name=NVIDIA_GeForce_RTX_4090,dtype=fp8_w8a8,block_shape=[128, 128].json
@@ -1,0 +1,42 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 4
+    },
+    "9": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    }
+}

--- a/python/sglang/srt/layers/quantization/configs/N=4096,K=4096,device_name=NVIDIA_GeForce_RTX_4090,dtype=fp8_w8a8,block_shape=[128, 128].json
+++ b/python/sglang/srt/layers/quantization/configs/N=4096,K=4096,device_name=NVIDIA_GeForce_RTX_4090,dtype=fp8_w8a8,block_shape=[128, 128].json
@@ -1,0 +1,42 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "9": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    }
+}

--- a/python/sglang/srt/layers/quantization/configs/N=4096,K=8192,device_name=NVIDIA_GeForce_RTX_4090,dtype=fp8_w8a8,block_shape=[128, 128].json
+++ b/python/sglang/srt/layers/quantization/configs/N=4096,K=8192,device_name=NVIDIA_GeForce_RTX_4090,dtype=fp8_w8a8,block_shape=[128, 128].json
@@ -1,0 +1,42 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 4
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "9": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    }
+}

--- a/python/sglang/srt/layers/quantization/configs/N=512,K=4096,device_name=NVIDIA_GeForce_RTX_4090,dtype=fp8_w8a8,block_shape=[128, 128].json
+++ b/python/sglang/srt/layers/quantization/configs/N=512,K=4096,device_name=NVIDIA_GeForce_RTX_4090,dtype=fp8_w8a8,block_shape=[128, 128].json
@@ -1,0 +1,42 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "9": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    }
+}

--- a/python/sglang/srt/layers/quantization/configs/N=8192,K=1024,device_name=NVIDIA_GeForce_RTX_4090,dtype=fp8_w8a8,block_shape=[128, 128].json
+++ b/python/sglang/srt/layers/quantization/configs/N=8192,K=1024,device_name=NVIDIA_GeForce_RTX_4090,dtype=fp8_w8a8,block_shape=[128, 128].json
@@ -1,0 +1,42 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "9": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    }
+}

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -41,6 +41,7 @@ from sglang.srt.utils import (
     is_hip,
     is_sm90_supported,
     is_sm100_supported,
+    is_sm120_supported,
     offloader,
 )
 
@@ -63,7 +64,12 @@ if _use_aiter:
 
 
 if _is_cuda:
-    from sgl_kernel import fp8_blockwise_scaled_mm, fp8_scaled_mm
+    from sgl_kernel import fp8_scaled_mm
+
+    if is_sm120_supported():
+        from sglang.jit_kernel.fp8_blockwise_gemm import fp8_blockwise_scaled_mm
+    else:
+        from sgl_kernel import fp8_blockwise_scaled_mm
 
     @torch.library.register_fake("sgl_kernel::fp8_scaled_mm")
     def _fp8_scaled_mm_abstract(mat_a, mat_b, scales_a, scales_b, out_dtype, bias=None):
@@ -175,11 +181,8 @@ FP8_GEMM_RUNNER_BACKEND: Fp8GemmRunnerBackend | None = None
 
 
 def _check_cutlass_block_fp8_hardware_support() -> bool:
-    """Return True if CUTLASS block FP8 is supported. Hopper (SM_90) and DC
-    Blackwell (SM_100) ship working binaries; consumer Blackwell (SM_120) and
-    Ada/Ampere fall back to triton. Origin: sglang 本身 (was
-    `is_blackwell_supported()` which incorrectly included SM_120)."""
-    return is_sm90_supported() or is_sm100_supported()
+    """Return True when a block-FP8 CUTLASS implementation is available."""
+    return is_sm90_supported() or is_sm100_supported() or is_sm120_supported()
 
 
 if is_blackwell_supported() and is_flashinfer_available():
@@ -268,12 +271,9 @@ def _dispatch_auto_backend() -> Callable:
     # 1. DeepGEMM (if enabled and available — gated by DEEPGEMM_CAPS)
     # 2. FlashInfer TRTLLM (if SM_100 DC Blackwell + FlashInfer; the wheel
     #    only ships sm100f, so consumer Blackwell SM_120 must skip).
-    # 3. CUTLASS (if Hopper SM_90 or DC Blackwell SM_100 + CUDA 12.0+)
+    # 3. CUTLASS (including the JIT SwapAB kernel on SM_120)
     # 4. AITER (if AMD GPU with AITER enabled)
-    # 5. Triton (fallback — used on SM_120 / SM_89 / SM_8x)
-    # Origin: sglang 本身 (was `is_blackwell_supported()` for trtllm/cutlass,
-    # which incorrectly routed consumer Blackwell SM_120 to sm100f-only
-    # binaries that crash with "Unsupported architecture").
+    # 5. Triton fallback
 
     if deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM:
         return deepgemm_w8a8_block_fp8_linear_with_fallback

--- a/scripts/bench_sm120_attention_fp8.py
+++ b/scripts/bench_sm120_attention_fp8.py
@@ -55,7 +55,9 @@ def main() -> None:
 
     # Trigger JIT compilation before allocating the largest shape.
     x0 = torch.randn(1, 128, dtype=torch.bfloat16, device=device)
-    w0 = torch.randn(128, 128, dtype=torch.bfloat16, device=device).to(torch.float8_e4m3fn)
+    w0 = torch.randn(128, 128, dtype=torch.bfloat16, device=device).to(
+        torch.float8_e4m3fn
+    )
     s0 = torch.ones(1, 1, dtype=torch.float32, device=device)
     cutlass_w8a8_block_fp8_linear_with_fallback(x0, w0, [128, 128], s0)
     torch.cuda.synchronize()
@@ -103,7 +105,9 @@ def main() -> None:
         torch.cuda.empty_cache()
 
     triton_token_us = sum(x["triton_median_us"] * x["calls_per_token"] for x in results)
-    cutlass_token_us = sum(x["cutlass_median_us"] * x["calls_per_token"] for x in results)
+    cutlass_token_us = sum(
+        x["cutlass_median_us"] * x["calls_per_token"] for x in results
+    )
     payload = {
         "device": torch.cuda.get_device_name(),
         "repeats": args.repeats,

--- a/scripts/bench_sm120_attention_fp8.py
+++ b/scripts/bench_sm120_attention_fp8.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Compare the current Triton W8A8 path with the upstream SM120 CUTLASS port."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+
+import torch
+
+from sglang.srt.layers.quantization.fp8_utils import (
+    cutlass_w8a8_block_fp8_linear_with_fallback,
+    triton_w8a8_block_fp8_linear,
+)
+
+
+SHAPES = (
+    (512, 4096, 43),
+    (1024, 4096, 43),
+    (32768, 1024, 43),
+    (4096, 8192, 43),
+    (4096, 4096, 43),
+    (4096, 2048, 43),
+    (8192, 1024, 21),
+)
+
+
+def time_call(fn, x, weight, scale, flush, repeats: int) -> list[float]:
+    values = []
+    for _ in range(repeats):
+        flush.add_(1)
+        torch.cuda.synchronize()
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        fn(x, weight, [128, 128], scale)
+        end.record()
+        end.synchronize()
+        values.append(float(start.elapsed_time(end)) * 1000.0)
+    return values
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repeats", type=int, default=30)
+    parser.add_argument("--json-out")
+    args = parser.parse_args()
+
+    assert torch.cuda.get_device_capability() == (12, 0)
+    torch.manual_seed(1)
+    device = torch.device("cuda")
+    flush = torch.empty(256 * 1024 * 1024, dtype=torch.uint8, device=device)
+    results = []
+
+    # Trigger JIT compilation before allocating the largest shape.
+    x0 = torch.randn(1, 128, dtype=torch.bfloat16, device=device)
+    w0 = torch.randn(128, 128, dtype=torch.bfloat16, device=device).to(torch.float8_e4m3fn)
+    s0 = torch.ones(1, 1, dtype=torch.float32, device=device)
+    cutlass_w8a8_block_fp8_linear_with_fallback(x0, w0, [128, 128], s0)
+    torch.cuda.synchronize()
+
+    for n, k, calls in SHAPES:
+        x = torch.randn(1, k, dtype=torch.bfloat16, device=device)
+        weight = torch.randn(n, k, dtype=torch.bfloat16, device=device).to(
+            torch.float8_e4m3fn
+        )
+        scale = torch.ones(n // 128, k // 128, dtype=torch.float32, device=device)
+
+        triton_out = triton_w8a8_block_fp8_linear(x, weight, [128, 128], scale)
+        cutlass_out = cutlass_w8a8_block_fp8_linear_with_fallback(
+            x, weight, [128, 128], scale
+        )
+        torch.cuda.synchronize()
+        torch.testing.assert_close(cutlass_out, triton_out, rtol=0.03, atol=0.15)
+
+        triton_us = time_call(
+            triton_w8a8_block_fp8_linear,
+            x,
+            weight,
+            scale,
+            flush,
+            args.repeats,
+        )
+        cutlass_us = time_call(
+            cutlass_w8a8_block_fp8_linear_with_fallback,
+            x,
+            weight,
+            scale,
+            flush,
+            args.repeats,
+        )
+        item = {
+            "n": n,
+            "k": k,
+            "calls_per_token": calls,
+            "triton_median_us": statistics.median(triton_us),
+            "cutlass_median_us": statistics.median(cutlass_us),
+        }
+        item["speedup"] = item["triton_median_us"] / item["cutlass_median_us"]
+        results.append(item)
+        del x, weight, scale, triton_out, cutlass_out
+        torch.cuda.empty_cache()
+
+    triton_token_us = sum(x["triton_median_us"] * x["calls_per_token"] for x in results)
+    cutlass_token_us = sum(x["cutlass_median_us"] * x["calls_per_token"] for x in results)
+    payload = {
+        "device": torch.cuda.get_device_name(),
+        "repeats": args.repeats,
+        "results": results,
+        "weighted_triton_ms_per_token": triton_token_us / 1000.0,
+        "weighted_cutlass_ms_per_token": cutlass_token_us / 1000.0,
+        "weighted_speedup": triton_token_us / cutlass_token_us,
+    }
+    rendered = json.dumps(payload, indent=2)
+    print(rendered)
+    if args.json_out:
+        with open(args.json_out, "w", encoding="utf-8") as f:
+            f.write(rendered + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_sm120_attention_fp8.py
+++ b/scripts/bench_sm120_attention_fp8.py
@@ -14,7 +14,6 @@ from sglang.srt.layers.quantization.fp8_utils import (
     triton_w8a8_block_fp8_linear,
 )
 
-
 SHAPES = (
     (512, 4096, 43),
     (1024, 4096, 43),

--- a/scripts/tune_dsv4_w8a8_sm89.py
+++ b/scripts/tune_dsv4_w8a8_sm89.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Tune DSV4 decode-sized Triton W8A8 GEMMs on an RTX 4090.
+
+The benchmark evicts L2 before every timed launch, takes the median within
+three rounds, then selects from candidates within one percent of the fastest
+result by preferring fewer warps and fewer pipeline stages.  The emitted JSON
+uses SGLang's existing W8A8 configuration format.  M=9 deliberately restores
+the pre-existing default config so decode tuning is not selected for prefill.
+"""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+import json
+import statistics
+import sys
+from pathlib import Path
+
+import torch
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "python"))
+
+from sglang.srt.layers.quantization.fp8_kernel import (  # noqa: E402
+    _w8a8_block_fp8_matmul,
+)
+
+
+DEFAULT_SHAPES = (
+    (512, 4096),
+    (1024, 4096),
+    (32768, 1024),
+    (4096, 8192),
+    (4096, 4096),
+    (4096, 2048),
+    (8192, 1024),
+)
+M_VALUES = (1, 2, 4, 8)
+DEFAULT_CONFIG = {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 32,
+    "num_warps": 4,
+    "num_stages": 3,
+}
+
+
+def candidate_configs():
+    for block_m, block_n, num_warps, num_stages in itertools.product(
+        (16, 32, 64), (32, 64, 128), (4, 8), (2, 3, 4)
+    ):
+        yield {
+            "BLOCK_SIZE_M": block_m,
+            "BLOCK_SIZE_N": block_n,
+            "BLOCK_SIZE_K": 128,
+            "GROUP_SIZE_M": 1,
+            "num_warps": num_warps,
+            "num_stages": num_stages,
+        }
+
+
+def launch(a, b, out, a_scale, b_scale, config):
+    m, k = a.shape
+    n = b.shape[0]
+    grid = (
+        triton_cdiv(m, config["BLOCK_SIZE_M"]) * triton_cdiv(n, config["BLOCK_SIZE_N"]),
+    )
+    _w8a8_block_fp8_matmul[grid](
+        a,
+        b,
+        out,
+        a_scale,
+        b_scale,
+        m,
+        n,
+        k,
+        128,
+        128,
+        a.stride(0),
+        a.stride(1),
+        b.stride(1),
+        b.stride(0),
+        out.stride(0),
+        out.stride(1),
+        a_scale.stride(0),
+        a_scale.stride(1),
+        b_scale.stride(1),
+        b_scale.stride(0),
+        **config,
+        needs_masking=False,
+    )
+
+
+def triton_cdiv(lhs: int, rhs: int) -> int:
+    return (lhs + rhs - 1) // rhs
+
+
+def cold_l2_time_us(
+    launch_fn, flush: torch.Tensor, rounds: int, samples: int, warmup: int
+) -> float:
+    for _ in range(warmup):
+        launch_fn()
+    torch.cuda.synchronize()
+
+    round_medians = []
+    for round_index in range(rounds):
+        timings = []
+        for sample_index in range(samples):
+            flush.fill_((round_index * samples + sample_index) & 0xFF)
+            start = torch.cuda.Event(enable_timing=True)
+            end = torch.cuda.Event(enable_timing=True)
+            start.record()
+            launch_fn()
+            end.record()
+            end.synchronize()
+            timings.append(start.elapsed_time(end) * 1000.0)
+        round_medians.append(statistics.median(timings))
+    return statistics.median(round_medians)
+
+
+def choose_stable_fastest(results):
+    fastest = min(time_us for time_us, _ in results)
+    near_fastest = [item for item in results if item[0] <= fastest * 1.01]
+    return min(
+        near_fastest,
+        key=lambda item: (
+            item[1]["num_warps"],
+            item[1]["num_stages"],
+            item[0],
+            item[1]["BLOCK_SIZE_M"],
+            item[1]["BLOCK_SIZE_N"],
+        ),
+    )
+
+
+def tune_shape(n, k, args, flush):
+    tuned = {}
+    measurements = {}
+    for m in M_VALUES:
+        torch.manual_seed(args.seed + m)
+        a = torch.randn(m, k, device="cuda", dtype=torch.bfloat16).to(
+            torch.float8_e4m3fn
+        )
+        b = torch.randn(n, k, device="cuda", dtype=torch.bfloat16).to(
+            torch.float8_e4m3fn
+        )
+        a_scale = torch.rand(m, k // 128, device="cuda", dtype=torch.float32) + 0.5
+        b_scale = (
+            torch.rand(n // 128, k // 128, device="cuda", dtype=torch.float32) + 0.5
+        )
+        out = torch.empty(m, n, device="cuda", dtype=torch.bfloat16)
+
+        launch(a, b, out, a_scale, b_scale, DEFAULT_CONFIG)
+        torch.cuda.synchronize()
+        reference = out.clone()
+        default_time_us = cold_l2_time_us(
+            lambda: launch(a, b, out, a_scale, b_scale, DEFAULT_CONFIG),
+            flush,
+            args.rounds,
+            args.samples,
+            args.warmup,
+        )
+        results = []
+        rejected = []
+        for config in candidate_configs():
+            try:
+                launch(a, b, out, a_scale, b_scale, config)
+                torch.cuda.synchronize()
+                torch.testing.assert_close(
+                    out, reference, rtol=args.rtol, atol=args.atol
+                )
+                time_us = cold_l2_time_us(
+                    lambda: launch(a, b, out, a_scale, b_scale, config),
+                    flush,
+                    args.rounds,
+                    args.samples,
+                    args.warmup,
+                )
+                results.append((time_us, config))
+            except (AssertionError, RuntimeError) as error:
+                rejected.append(
+                    {"config": config, "error": f"{type(error).__name__}: {error}"}
+                )
+
+        if not results:
+            raise RuntimeError(f"all configurations failed for M={m}, N={n}, K={k}")
+        time_us, config = choose_stable_fastest(results)
+        tuned[str(m)] = config
+        measurements[str(m)] = {
+            "default_us": default_time_us,
+            "selected_us": time_us,
+            "speedup": default_time_us / time_us,
+            "fastest_us": min(item[0] for item in results),
+            "selected_config": config,
+            "top5": [
+                {"time_us": value, "config": candidate}
+                for value, candidate in sorted(results, key=lambda item: item[0])[:5]
+            ],
+            "rejected": rejected,
+        }
+        print(
+            json.dumps(
+                {
+                    "M": m,
+                    "N": n,
+                    "K": k,
+                    "time_us": time_us,
+                    "default_us": default_time_us,
+                    "speedup": default_time_us / time_us,
+                    "config": config,
+                },
+                sort_keys=True,
+            ),
+            flush=True,
+        )
+
+    # The loader chooses the closest M key.  This key restores the old default
+    # for every M >= 9, including all ordinary prefill batches.
+    tuned["9"] = DEFAULT_CONFIG
+    return tuned, measurements
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--n", type=int, action="append")
+    parser.add_argument("--k", type=int, action="append")
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=REPO_ROOT
+        / "python"
+        / "sglang"
+        / "srt"
+        / "layers"
+        / "quantization"
+        / "configs",
+    )
+    parser.add_argument("--measurement-dir", type=Path)
+    parser.add_argument("--rounds", type=int, default=3)
+    parser.add_argument("--samples", type=int, default=7)
+    parser.add_argument("--warmup", type=int, default=2)
+    parser.add_argument("--flush-mib", type=int, default=128)
+    parser.add_argument("--seed", type=int, default=20260806)
+    parser.add_argument("--rtol", type=float, default=0.03)
+    parser.add_argument("--atol", type=float, default=0.15)
+    args = parser.parse_args()
+    if (args.n is None) != (args.k is None):
+        parser.error("--n and --k must be supplied together")
+    if args.n is not None and len(args.n) != len(args.k):
+        parser.error("the number of --n and --k arguments must match")
+    return args
+
+
+def main():
+    args = parse_args()
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    if torch.cuda.get_device_capability() != (8, 9):
+        raise RuntimeError(
+            f"this tuner targets SM89, got {torch.cuda.get_device_capability()}"
+        )
+    shapes = tuple(zip(args.n, args.k)) if args.n is not None else DEFAULT_SHAPES
+    device_name = torch.cuda.get_device_name().replace(" ", "_")
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    if args.measurement_dir is not None:
+        args.measurement_dir.mkdir(parents=True, exist_ok=True)
+    flush = torch.empty(args.flush_mib * 1024 * 1024, dtype=torch.uint8, device="cuda")
+
+    for n, k in shapes:
+        if n % 128 or k % 128:
+            raise ValueError(f"N and K must be divisible by 128, got N={n}, K={k}")
+        tuned, measurements = tune_shape(n, k, args, flush)
+        filename = (
+            f"N={n},K={k},device_name={device_name},dtype=fp8_w8a8,"
+            "block_shape=[128, 128].json"
+        )
+        output_path = args.output_dir / filename
+        output_path.write_text(json.dumps(tuned, indent=4) + "\n")
+        if args.measurement_dir is not None:
+            measurement_path = args.measurement_dir / filename
+            measurement_path.write_text(
+                json.dumps(
+                    {
+                        "device": device_name,
+                        "rounds": args.rounds,
+                        "samples": args.samples,
+                        "flush_mib": args.flush_mib,
+                        "N": n,
+                        "K": k,
+                        "measurements": measurements,
+                    },
+                    indent=2,
+                )
+                + "\n"
+            )
+        print(json.dumps({"wrote": str(output_path)}), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tune_dsv4_w8a8_sm89.py
+++ b/scripts/tune_dsv4_w8a8_sm89.py
@@ -19,14 +19,12 @@ from pathlib import Path
 
 import torch
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT / "python"))
 
 from sglang.srt.layers.quantization.fp8_kernel import (  # noqa: E402
     _w8a8_block_fp8_matmul,
 )
-
 
 DEFAULT_SHAPES = (
     (512, 4096),

--- a/test/registered/attention/test_dsv4_flash_mla_sm120.py
+++ b/test/registered/attention/test_dsv4_flash_mla_sm120.py
@@ -1,0 +1,200 @@
+"""Focused tests for the DeepSeek V4 FlashInfer decode path on SM120."""
+
+import unittest
+
+import torch
+
+from sglang.srt.layers.attention import flash_mla_sm120 as sm120
+from sglang.srt.layers.attention.debug_flash_mla_adapter import (
+    _v4_triton_decode_dispatch,
+)
+
+
+_IS_SM120 = torch.cuda.is_available() and torch.cuda.get_device_capability() == (12, 0)
+
+
+def _build_kv_cache(
+    num_pages: int, page_size: int, device: torch.device, seed: int
+) -> torch.Tensor:
+    """Build valid FP8/BF16/UE8M0 bytes in DSV4's footer layout."""
+    generator = torch.Generator(device="cpu").manual_seed(seed)
+    nope = (
+        torch.randn(num_pages, page_size, 448, generator=generator, dtype=torch.float32)
+        .clamp(-2, 2)
+        .to(torch.float8_e4m3fn)
+        .view(torch.uint8)
+        .to(device)
+    )
+    rope = (
+        torch.randn(num_pages, page_size, 64, generator=generator, dtype=torch.float32)
+        .clamp(-2, 2)
+        .to(torch.bfloat16)
+        .view(torch.uint8)
+        .to(device)
+    )
+
+    token_data = torch.empty(
+        num_pages,
+        page_size,
+        sm120._NOPE_ROPE_STRIDE,
+        dtype=torch.uint8,
+        device=device,
+    )
+    token_data[:, :, :448] = nope
+    token_data[:, :, 448:] = rope
+    scales = torch.zeros(
+        num_pages,
+        page_size,
+        sm120._SCALE_STRIDE,
+        dtype=torch.uint8,
+        device=device,
+    )
+    scales[:, :, :7] = 127  # UE8M0 encoding for scale 1.0.
+
+    flat = torch.empty(
+        num_pages,
+        page_size * sm120._BYTES_PER_TOKEN,
+        dtype=torch.uint8,
+        device=device,
+    )
+    data_bytes = page_size * sm120._NOPE_ROPE_STRIDE
+    flat[:, :data_bytes] = token_data.reshape(num_pages, data_bytes)
+    flat[:, data_bytes:] = scales.reshape(num_pages, page_size * sm120._SCALE_STRIDE)
+    return flat.view(num_pages, page_size, 1, sm120._BYTES_PER_TOKEN)
+
+
+@unittest.skipUnless(_IS_SM120, "SM120 (compute capability 12.0) required")
+class TestDsv4TouchedPageSplit(unittest.TestCase):
+    def test_only_touched_pages_are_rewritten(self):
+        device = torch.device("cuda")
+        num_pages = 3
+        src_page_size = 128
+        ratio = src_page_size // sm120._PBS_DST
+        sentinel = 0xA5
+        cache = _build_kv_cache(num_pages, src_page_size, device, seed=17)
+        src_stride = cache.stride(0)
+        src = torch.as_strided(cache, (num_pages, src_stride), (src_stride, 1))
+
+        key = sm120._device_key(cache.device)
+        old_split = sm120._SPLIT_BUFFERS.get(key)
+        old_mask = sm120._MASK_BUFFERS.get(key)
+
+        def restore():
+            if old_split is None:
+                sm120._SPLIT_BUFFERS.pop(key, None)
+            else:
+                sm120._SPLIT_BUFFERS[key] = old_split
+            if old_mask is None:
+                sm120._MASK_BUFFERS.pop(key, None)
+            else:
+                sm120._MASK_BUFFERS[key] = old_mask
+
+        self.addCleanup(restore)
+        dst = torch.full(
+            (num_pages * ratio, sm120._BYTES_PER_DST_PAGE_PADDED),
+            sentinel,
+            dtype=torch.uint8,
+            device=device,
+        )
+        sm120._SPLIT_BUFFERS[key] = dst
+        indices = torch.tensor(
+            [0, 5, 2 * src_page_size + 3, -1],
+            dtype=torch.int32,
+            device=device,
+        )
+
+        with torch.inference_mode():
+            sm120._split_kv_pages_to_64(cache, src_page_size, indices)
+        torch.cuda.synchronize()
+        self.assertFalse(sm120._MASK_BUFFERS[key].is_inference())
+
+        dst.fill_(sentinel)
+        sm120._MASK_BUFFERS[key].fill_(-7)
+        out = sm120._split_kv_pages_to_64(cache, src_page_size, indices)
+        torch.cuda.synchronize()
+        self.assertEqual(
+            out.shape,
+            (num_pages * ratio, sm120._PBS_DST, 1, sm120._BYTES_PER_TOKEN),
+        )
+        self.assertEqual(sm120._MASK_BUFFERS[key].tolist(), [1, 0, 1])
+
+        data_size = sm120._PBS_DST * sm120._NOPE_ROPE_STRIDE
+        scale_size = sm120._PBS_DST * sm120._SCALE_STRIDE
+        src_scale_offset = src_page_size * sm120._NOPE_ROPE_STRIDE
+        for page in (0, 2):
+            for subpage in range(ratio):
+                dst_page = dst[page * ratio + subpage]
+                torch.testing.assert_close(
+                    dst_page[:data_size],
+                    src[
+                        page,
+                        subpage * data_size : (subpage + 1) * data_size,
+                    ],
+                    atol=0,
+                    rtol=0,
+                )
+                scale_offset = src_scale_offset + subpage * scale_size
+                torch.testing.assert_close(
+                    dst_page[data_size : data_size + scale_size],
+                    src[page, scale_offset : scale_offset + scale_size],
+                    atol=0,
+                    rtol=0,
+                )
+                self.assertTrue(
+                    bool((dst_page[sm120._BYTES_PER_DST_PAGE :] == sentinel).all())
+                )
+        self.assertTrue(bool((dst[ratio : 2 * ratio] == sentinel).all()))
+
+
+@unittest.skipUnless(_IS_SM120, "SM120 (compute capability 12.0) required")
+class TestDsv4FlashInferDecode(unittest.TestCase):
+    def test_flashinfer_matches_existing_triton_reference(self):
+        if not sm120.is_flashinfer_dsv4_available():
+            self.skipTest("FlashInfer SM120 DSV4 sparse MLA API unavailable")
+
+        device = torch.device("cuda")
+        generator = torch.Generator(device="cpu").manual_seed(29)
+        # This tuple hits FlashInfer's dedicated DSV4 decode dispatch rather
+        # than its generic sparse-MLA fallback.
+        batch_size, num_heads, topk = 1, 128, 128
+        num_pages, page_size = 4, 128
+        cache = _build_kv_cache(num_pages, page_size, device, seed=23)
+        q = (
+            torch.randn(
+                batch_size,
+                1,
+                num_heads,
+                512,
+                generator=generator,
+                dtype=torch.float32,
+            )
+            .clamp(-1.5, 1.5)
+            .to(torch.bfloat16)
+            .to(device)
+        )
+        indices = torch.randperm(
+            num_pages * page_size, generator=generator, dtype=torch.int64
+        )[:topk].to(device=device, dtype=torch.int32)
+        indices = indices.view(batch_size, 1, topk)
+        lengths = torch.full((batch_size,), topk, dtype=torch.int32, device=device)
+        sink = torch.full((num_heads,), -4.0, dtype=torch.float32, device=device)
+        kwargs = dict(
+            q=q,
+            k_cache=cache,
+            head_dim_v=512,
+            softmax_scale=512**-0.5,
+            is_fp8_kvcache=True,
+            indices=indices,
+            topk_length=lengths,
+            attn_sink=sink,
+        )
+
+        expected, _ = _v4_triton_decode_dispatch(**kwargs)
+        actual, _ = sm120.flash_mla_with_kvcache_sm120(**kwargs)
+        torch.testing.assert_close(
+            actual.float(), expected.float(), atol=5e-2, rtol=5e-2
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/attention/test_dsv4_flash_mla_sm120.py
+++ b/test/registered/attention/test_dsv4_flash_mla_sm120.py
@@ -9,7 +9,6 @@ from sglang.srt.layers.attention.debug_flash_mla_adapter import (
     _v4_triton_decode_dispatch,
 )
 
-
 _IS_SM120 = torch.cuda.is_available() and torch.cuda.get_device_capability() == (12, 0)
 
 


### PR DESCRIPTION
## Motivation

DeepSeek V4 Flash decode on consumer GPUs is bottlenecked by small-M block-FP8 GEMMs and sparse MLA attention. The existing portable Triton paths leave substantial performance on the table on both SM120 (RTX 5090) and SM89 (RTX 4090).

This PR adds guarded consumer-GPU fast paths while preserving the existing Triton implementations as fallbacks.

## Modifications

- Add an SM120 CUTLASS blockwise FP8 GEMM, compiled and cached through the existing TVM-FFI JIT infrastructure. Dispatch is architecture- and shape-gated and falls back to Triton for unsupported cases.
- Add a FlashInfer SM120 sparse MLA adapter for DeepSeek V4 decode. It converts SGLang's larger physical SWA pages into the 64-token layout required by FlashInfer using a persistent workspace, refreshing only pages touched by the current decode step. If the required FlashInfer API is unavailable, dispatch falls back to the existing Triton kernel.
- Add tuned RTX 4090 Triton W8A8 launch configurations for all seven matrix shapes used by DeepSeek V4. The generated tables tune `M <= 8` decode batches and deliberately restore the default configuration at `M = 9`, so ordinary prefill remains unchanged.
- Add an RTX 4090 tuning script, an SM120 FP8 benchmark, and focused SM120 sparse-MLA tests.

The SWA overlap eviction fix is intentionally not included here; it is tracked separately in #75.

## Accuracy Tests

### RTX 4090 / SM89

- Compared the selected configuration against the previous default Triton configuration for all seven DeepSeek V4 shapes at `M = 1, 2, 4, 8` (28 cases).
- All outputs were finite and numerically identical in these probes (`global_max_abs = 0`).
- End-to-end: 194-token prompt, 256 generated tokens, temperature 0, five runs per backend. The tuned and default paths produced exact token-ID and UTF-8 text matches. All five tuned runs were deterministic, with no replacement characters or garbled output.

### RTX 5090 / SM120

- `pytest -q test/registered/attention/test_dsv4_flash_mla_sm120.py`: **2 passed**. This covers byte-exact page splitting and FlashInfer-vs-Triton output comparison (`rtol=5e-2`, `atol=5e-2`).
- `python scripts/bench_sm120_attention_fp8.py --repeats 3`: all seven DeepSeek V4 GEMM shapes passed CUTLASS-vs-Triton comparison (`rtol=3e-2`, `atol=1.5e-1`).
- End-to-end: the same 194-token prompt, 256 generated tokens, temperature 0, five runs per backend. Both paths were deterministic across their five runs, strict UTF-8, and contained no replacement characters.
- The SM120 candidate is **not bit-identical** to the legacy backend: the first token-ID divergence occurred at generated model token 207. Both deterministic continuations remained coherent; this is recorded explicitly because this PR changes the numerical kernel path.

The end-to-end source used for these tests contained the same three functional commits as this PR plus the SWA scheduler fix already split into #75. The scheduler fix is not part of this branch.

## Benchmarking and Profiling

Model: DeepSeek V4 Flash 0731, TP=1, CPU MoE, one physical GPU. End-to-end results use five runs after warmup; decode rate counts the 255 measured inter-token intervals for 256 generated model tokens.

| GPU | Backend | Median decode | Result |
| --- | --- | ---: | ---: |
| RTX 5090 | Triton sparse MLA + Triton FP8 GEMM | 30.18 model tok/s | baseline |
| RTX 5090 | FlashInfer sparse MLA + CUTLASS FP8 GEMM | 39.65 model tok/s | **+31.4%** |
| RTX 4090 | Tuned Triton W8A8 | 23.44 model tok/s | 23.35-23.46 tok/s across five runs |

For the SM120 FP8 GEMM microbenchmark, weighting all seven shapes by their DeepSeek V4 call counts per token gave:

| Kernel | Weighted time/token |
| --- | ---: |
| Triton | 30.6117 ms |
| CUTLASS | 17.1878 ms |
| Speedup | **1.781x** |

An archived RTX 4090 run of the previous configuration measured 18.52 displayed chunks/s versus 22.62 chunks/s with the tuned tables (+22.1%). That comparison is directional rather than a strict current-source A/B because the archived run used a longer prompt; the controlled accuracy A/B above verifies the selected configurations directly.

## Validation

- `git diff --check kvcache/main...HEAD`
- `python -m compileall` on all changed Python files
- `ruff check` on all changed Python files
- `ruff format --check` on new and fully changed Python files
- Focused SM120 pytest and kernel benchmarks listed above
- End-to-end decode and deterministic-output checks on physical RTX 4090 and RTX 5090 hosts

## Checklist

- [x] Format code according to the project style checks used by the changed files.
- [x] Add focused unit tests for the new SM120 attention adapter.
- [ ] Update user documentation (not required for this PR: dispatch is automatic and hardware-gated).
- [x] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style guidance.
