### PR TITLE
fix(kt): restore integer Marlin weights without gradients

### DIFF
--- a/python/sglang/srt/layers/moe/kt_ep_wrapper.py
+++ b/python/sglang/srt/layers/moe/kt_ep_wrapper.py
@@ -1732,7 +1732,8 @@ class SharedFullContext:
             if _cur is None or _cur.shape != _shape or _cur.dtype != _dtype:
                 setattr(self.gpu_layer, _sn,
                         torch.nn.Parameter(
-                            torch.empty(_shape, dtype=_dtype, device=_device)))
+                            torch.empty(_shape, dtype=_dtype, device=_device),
+                            requires_grad=False))
     def load(self, layer_idx, wrapper, original_layer=None, gpu_experts_mask=None,
              logical_to_gpu_index=None):
         """Load weights from disk to GPU via shared memory.

--- a/test/srt/test_kt_ep_wrapper.py
+++ b/test/srt/test_kt_ep_wrapper.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+
+import torch
+
+
+class TestSharedFullContext(unittest.TestCase):
+
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA is required")
+    def test_restore_raw_integer_parameter_disables_grad(self):
+        from sglang.srt.layers.moe.kt_ep_wrapper import SharedFullContext
+
+        device = torch.device("cuda:0")
+        ctx = object.__new__(SharedFullContext)
+        ctx.gpu_layer = torch.nn.Module()
+        ctx.gpu_layer.w13_weight = torch.nn.Parameter(
+            torch.empty((1,), dtype=torch.float32, device=device)
+        )
+        ctx._raw_weight_shapes = {
+            "w13_weight": ((4, 8), torch.int32, device),
+        }
+
+        ctx._restore_raw_attrs()
+
+        restored = ctx.gpu_layer.w13_weight
+        self.assertEqual(tuple(restored.shape), (4, 8))
+        self.assertEqual(restored.dtype, torch.int32)
+        self.assertEqual(restored.device, device)
+        self.assertFalse(restored.requires_grad)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

`SharedFullContext._restore_raw_attrs()` reconstructs raw Marlin weight tensors as `torch.nn.Parameter` objects. For integer weights such as the `int32` Marlin layout, the default `requires_grad=True` is invalid and raises:

```text
RuntimeError: Only Tensors of floating point and complex dtype can require gradients
```

This is the failure reported after hybrid GPU prefill in kvcache-ai/ktransformers#2107.

## Modifications

- Restore raw weight parameters with `requires_grad=False`, matching inference-only model weights and supporting integer dtypes.
- Add a focused CUDA regression test that exercises the actual `SharedFullContext._restore_raw_attrs()` path.

## Accuracy Tests

Tested on an RTX 3090 with PyTorch 2.9.1+cu128:

```text
python -m pytest -q test/srt/test_kt_ep_wrapper.py

# Before
1 failed: RuntimeError: Only Tensors of floating point and complex dtype can require gradients

# After
1 passed in 19.61s
```

The test verifies the restored parameter's shape, `int32` dtype, CUDA device, and `requires_grad=False`. This change does not alter weight values or model-forward math.

Additional checks:

```text
python -m py_compile python/sglang/srt/layers/moe/kt_ep_wrapper.py test/srt/test_kt_ep_wrapper.py
python -m black --check test/srt/test_kt_ep_wrapper.py
python -m isort --check-only test/srt/test_kt_ep_wrapper.py
python -m ruff check --select=F401,F821 python/sglang/srt/layers/moe/kt_ep_wrapper.py test/srt/test_kt_ep_wrapper.py
git diff --check
```

All passed.

## Benchmarking and Profiling

Not applicable. The change only controls gradient metadata while recreating a parameter after prefill; it does not change the inference compute path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (Not applicable: no user-facing behavior or configuration changes.)
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Not applicable: no model math or performance path changes.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
