### PR TITLE
[perf] Overlap GLM-5-Next FP8 layerwise prefill transport

### DIFF
--- a/examples/chat_template/glm5_next_multimodal.jinja
+++ b/examples/chat_template/glm5_next_multimodal.jinja
@@ -1,0 +1,28 @@
+{%- macro render_content(content) -%}
+{%- if content is string -%}
+{{ content }}
+{%- else -%}
+{%- for item in content -%}
+{%- if item['type'] == 'text' -%}
+{{ item['text'] }}
+{%- elif item['type'] == 'image' -%}
+{{ '<|image|>' }}
+{%- else -%}
+{{ raise_exception('GLM-5-Next supports only text and image chat content.') }}
+{%- endif -%}
+{%- endfor -%}
+{%- endif -%}
+{%- endmacro -%}
+{%- if messages and messages[0]['role'] == 'system' -%}
+{{ '[gMASK]<sop><|system|>\n' }}{{ render_content(messages[0]['content']) }}
+{%- set loop_messages = messages[1:] -%}
+{%- else -%}
+{{ '[gMASK]<sop>' }}
+{%- set loop_messages = messages -%}
+{%- endif -%}
+{%- for message in loop_messages -%}
+{{ '<|' + message['role'] + '|>\n' }}{{ render_content(message['content']) }}
+{%- endfor -%}
+{%- if add_generation_prompt -%}
+{{ '<|assistant|>\n' }}
+{%- endif -%}

--- a/python/sglang/srt/configs/glm5_next.py
+++ b/python/sglang/srt/configs/glm5_next.py
@@ -7,14 +7,69 @@ runtime vision implementation without changing text-only config loading.
 """
 
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any, List, Optional, Union
 
 from transformers.configuration_utils import PretrainedConfig
 
 from sglang.srt.configs.mamba_utils import KimiLinearCacheParams, KimiLinearStateShape
 
-
 _GLM5_NEXT_ARCH = "Glm5NextForConditionalGeneration"
+
+
+class Glm5NextGPUProfile(str, Enum):
+    """Validated cache/kernel policy for one GLM-5-Next GPU family.
+
+    Consumer GPUs deliberately use explicit profiles instead of inheriting the
+    generic DeepSeek NSA capability checks.  In particular, SM86 cannot execute
+    the E4M3 tensor-core index-cache path and therefore keeps both the latent and
+    KPool caches in BF16.
+    """
+
+    SM86_BF16 = "sm86_bf16"
+    SM89_FP8 = "sm89_fp8"
+    BLACKWELL_FP8 = "blackwell_fp8"
+
+    @property
+    def kv_cache_dtype(self) -> str:
+        return (
+            "bfloat16"
+            if self is Glm5NextGPUProfile.SM86_BF16
+            else "fp8_e4m3"
+        )
+
+    @property
+    def index_cache_dtype(self) -> str:
+        return "bfloat16" if self is Glm5NextGPUProfile.SM86_BF16 else "fp8_e4m3"
+
+    @property
+    def is_consumer_gpu(self) -> bool:
+        return self in (
+            Glm5NextGPUProfile.SM86_BF16,
+            Glm5NextGPUProfile.SM89_FP8,
+        )
+
+
+def get_glm5_next_gpu_profile(
+    capability: tuple[int, int],
+) -> Glm5NextGPUProfile:
+    """Resolve the exact GLM runtime policy or fail closed.
+
+    Keep the pre-existing major>=10 acceptance boundary intact while adding
+    only the two requested consumer architectures.  SM90 and other Ampere/Ada
+    variants remain unsupported until separately validated.
+    """
+
+    if capability == (8, 6):
+        return Glm5NextGPUProfile.SM86_BF16
+    if capability == (8, 9):
+        return Glm5NextGPUProfile.SM89_FP8
+    if capability[0] >= 10:
+        return Glm5NextGPUProfile.BLACKWELL_FP8
+    raise ValueError(
+        "GLM-5-Next supports NVIDIA SM86, SM89, or Blackwell (SM>=100); "
+        f"got SM{capability[0]}{capability[1]}."
+    )
 
 _GLM5_NEXT_TOP_LEVEL_CONFIG_KEYS = (
     "architectures",

--- a/python/sglang/srt/layers/attention/linear/kernels/glm5_next_kda_ops.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/glm5_next_kda_ops.py
@@ -17,9 +17,25 @@ import triton.language as tl
 
 
 _MAX_TRITON_GRID_Z = 65535
-_SAFE_GATE_BLOCK_T = 32
-_SAFE_GATE_NUM_WARPS = 8
-_SAFE_GATE_NUM_STAGES = 3
+
+
+def glm5_next_kda_launch_config(
+    capability: tuple[int, int],
+) -> tuple[tuple[int, int, int], tuple[int, int]]:
+    """Return ``(gate, decode)`` static Triton configs for GLM GPUs."""
+
+    if capability == (8, 6):
+        # Four decode warps remove the single-warp kernel's local-memory
+        # spills on Ampere (verified with ptxas 12.8).
+        return (16, 4, 2), (4, 1)
+    if capability == (8, 9):
+        # The same geometry is spill-free on Ada; keep the larger gate tile
+        # selected for its higher-throughput BF16 prefill path.
+        return (32, 4, 3), (4, 1)
+    # Preserve the previously accepted kernel geometry for every other CUDA
+    # test/runtime.  The exact GLM server gate, not this low-level helper,
+    # controls which architectures can launch the model.
+    return (32, 8, 3), (1, 3)
 
 
 def _cdiv(a: int, b: int) -> int:
@@ -201,7 +217,11 @@ def glm5_next_safe_gate(
         )
     output = torch.empty_like(raw_gate, dtype=torch.float32)
 
-    grid = (_cdiv(num_tokens, _SAFE_GATE_BLOCK_T), num_heads)
+    gate_config, _ = glm5_next_kda_launch_config(
+        torch.cuda.get_device_capability(raw_gate.device)
+    )
+    block_t, num_warps, num_stages = gate_config
+    grid = (_cdiv(num_tokens, block_t), num_heads)
 
     _glm5_next_safe_gate_kernel[grid](
         raw_gate,
@@ -212,11 +232,11 @@ def glm5_next_safe_gate(
         num_tokens,
         num_heads,
         head_k_dim,
-        BT=_SAFE_GATE_BLOCK_T,
+        BT=block_t,
         BD=_next_power_of_2(head_k_dim),
         HAS_BIAS=dt_bias is not None,
-        num_warps=_SAFE_GATE_NUM_WARPS,
-        num_stages=_SAFE_GATE_NUM_STAGES,
+        num_warps=num_warps,
+        num_stages=num_stages,
     )
     return output.view(*original_shape, num_heads, head_k_dim)
 
@@ -480,6 +500,10 @@ def glm5_next_safe_decode(
     raw_beta = raw_beta.contiguous()
     output = q.new_empty(nk, *v.shape)
     grid, split_grid = glm5_next_decode_grid(nk, nv, num_sequences, num_value_heads)
+    _, decode_config = glm5_next_kda_launch_config(
+        torch.cuda.get_device_capability(q.device)
+    )
+    num_warps, num_stages = decode_config
     _glm5_next_safe_decode_kernel[grid](
         A_log=A_log,
         raw_gate=raw_gate,
@@ -506,7 +530,7 @@ def glm5_next_safe_decode(
         USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
         IS_VARLEN=query_start_loc is not None,
         SPLIT_N_HV_GRID=split_grid,
-        num_warps=1,
-        num_stages=3,
+        num_warps=num_warps,
+        num_stages=num_stages,
     )
     return output.squeeze(0)

--- a/python/sglang/srt/layers/attention/nsa/glm5_next_indexer_triton.py
+++ b/python/sglang/srt/layers/attention/nsa/glm5_next_indexer_triton.py
@@ -1,0 +1,386 @@
+"""Architecture-local Triton scorer for GLM-5-Next KPool.
+
+The scorer keeps the model's exact contract: one ReLU dot product per index
+head, followed by the learned head reduction and the optional per-key FP8
+descale.  SM86 consumes BF16 Q/K directly; SM89 consumes E4M3 Q/K.  SM120
+continues to use its accepted eager implementation.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import torch
+import triton
+import triton.language as tl
+
+INDEX_HEAD_DIM = 128
+INDEX_PAGE_SIZE = 64
+
+
+def use_glm5_next_triton_indexer(device: torch.device) -> bool:
+    if device.type != "cuda" or not torch.cuda.is_available():
+        return False
+    return torch.cuda.get_device_capability(device) in ((8, 6), (8, 9))
+
+
+def glm5_next_indexer_launch_config(
+    capability: tuple[int, int],
+) -> tuple[int, int, int]:
+    """Return the offline-selected conservative config for SM86/SM89."""
+
+    if capability == (8, 6):
+        return 32, 4, 2
+    if capability == (8, 9):
+        return 64, 4, 3
+    raise ValueError(
+        f"GLM Triton indexer is unsupported on SM{capability[0]}{capability[1]}"
+    )
+
+
+def _validate_glm5_next_indexer_profile(
+    query: torch.Tensor,
+    index_k: torch.Tensor,
+    k_scale: torch.Tensor | None,
+) -> tuple[int, int]:
+    """Fail closed if cache precision does not match the consumer GPU profile."""
+
+    if not use_glm5_next_triton_indexer(query.device):
+        raise RuntimeError("GLM Triton indexer requires SM86 or SM89")
+    capability = torch.cuda.get_device_capability(query.device)
+    if index_k.device != query.device or (
+        k_scale is not None and k_scale.device != query.device
+    ):
+        raise ValueError("GLM Triton indexer inputs must share one CUDA device")
+    if capability == (8, 6):
+        if query.dtype != torch.bfloat16 or index_k.dtype != torch.bfloat16:
+            raise TypeError("SM86 GLM indexer requires BF16 query and KPool cache")
+        if k_scale is not None:
+            raise TypeError("SM86 GLM indexer must not receive an FP8 K scale")
+    else:
+        if query.dtype != torch.float8_e4m3fn or index_k.dtype != torch.float8_e4m3fn:
+            raise TypeError("SM89 GLM indexer requires E4M3 query and KPool cache")
+        if k_scale is None:
+            raise TypeError("SM89 GLM indexer requires the FP8 KPool scale")
+        if k_scale.dtype != torch.float32:
+            raise TypeError("SM89 GLM indexer requires an FP32 KPool scale")
+    return capability
+
+
+@triton.jit
+def _glm5_next_flat_mqa_logits_kernel(
+    q_ptr,
+    k_ptr,
+    k_scale_ptr,
+    weights_ptr,
+    ks_ptr,
+    ke_ptr,
+    logits_ptr,
+    num_keys: tl.int32,
+    stride_q_row: tl.constexpr,
+    stride_q_head: tl.constexpr,
+    stride_q_dim: tl.constexpr,
+    stride_k_row: tl.constexpr,
+    stride_k_dim: tl.constexpr,
+    stride_weights_row: tl.constexpr,
+    stride_weights_head: tl.constexpr,
+    stride_logits_row: tl.constexpr,
+    NUM_HEADS: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    USE_K_SCALE: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    row = tl.program_id(0)
+    key_block = tl.program_id(1)
+    key_offsets = key_block * BLOCK_K + tl.arange(0, BLOCK_K)
+    dim_offsets = tl.arange(0, HEAD_DIM)
+    head_offsets = tl.arange(0, NUM_HEADS)
+
+    keys = tl.load(
+        k_ptr
+        + key_offsets[:, None] * stride_k_row
+        + dim_offsets[None, :] * stride_k_dim,
+        mask=key_offsets[:, None] < num_keys,
+        other=0.0,
+    )
+    queries = tl.load(
+        q_ptr
+        + row * stride_q_row
+        + head_offsets[:, None] * stride_q_head
+        + dim_offsets[None, :] * stride_q_dim
+    )
+    head_scores = tl.dot(keys, tl.trans(queries), out_dtype=tl.float32)
+    head_scores = tl.maximum(head_scores, 0.0)
+    weights = tl.load(
+        weights_ptr + row * stride_weights_row + head_offsets * stride_weights_head
+    ).to(tl.float32)
+    logits = tl.sum(head_scores * weights[None, :], axis=1)
+    if USE_K_SCALE:
+        key_scale = tl.load(
+            k_scale_ptr + key_offsets,
+            mask=key_offsets < num_keys,
+            other=0.0,
+        ).to(tl.float32)
+        logits *= key_scale
+
+    row_start = tl.load(ks_ptr + row)
+    row_end = tl.load(ke_ptr + row)
+    valid = (
+        (key_offsets >= row_start) & (key_offsets < row_end) & (key_offsets < num_keys)
+    )
+    tl.store(
+        logits_ptr + row * stride_logits_row + key_offsets,
+        tl.where(valid, logits, -float("inf")),
+        mask=key_offsets < num_keys,
+    )
+
+
+@triton.jit
+def _glm5_next_paged_mqa_logits_kernel(
+    q_ptr,
+    cache_ptr,
+    cache_scale_ptr,
+    weights_ptr,
+    seq_lens_ptr,
+    page_table_ptr,
+    logits_ptr,
+    max_seq_len: tl.int32,
+    num_cache_pages: tl.int32,
+    stride_q_row: tl.constexpr,
+    stride_q_head: tl.constexpr,
+    stride_q_dim: tl.constexpr,
+    stride_cache_page: tl.constexpr,
+    stride_weights_row: tl.constexpr,
+    stride_weights_head: tl.constexpr,
+    stride_page_table_row: tl.constexpr,
+    stride_page_table_col: tl.constexpr,
+    stride_logits_row: tl.constexpr,
+    SCALE_OFFSET: tl.constexpr,
+    SCALE_PAGE_STRIDE: tl.constexpr,
+    NUM_HEADS: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    USE_K_SCALE: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    row = tl.program_id(0)
+    key_block = tl.program_id(1)
+    key_offsets = key_block * BLOCK_K + tl.arange(0, BLOCK_K)
+    dim_offsets = tl.arange(0, HEAD_DIM)
+    head_offsets = tl.arange(0, NUM_HEADS)
+
+    page_cols = key_offsets // PAGE_SIZE
+    token_offsets = key_offsets % PAGE_SIZE
+    pages = tl.load(
+        page_table_ptr
+        + row * stride_page_table_row
+        + page_cols * stride_page_table_col,
+        mask=key_offsets < max_seq_len,
+        other=0,
+    ).to(tl.int64)
+    page_valid = (pages >= 0) & (pages < num_cache_pages)
+    safe_pages = tl.minimum(tl.maximum(pages, 0), num_cache_pages - 1)
+    keys = tl.load(
+        cache_ptr
+        + safe_pages[:, None] * stride_cache_page
+        + token_offsets[:, None] * HEAD_DIM
+        + dim_offsets[None, :],
+        mask=page_valid[:, None] & (key_offsets[:, None] < max_seq_len),
+        other=0.0,
+    )
+    queries = tl.load(
+        q_ptr
+        + row * stride_q_row
+        + head_offsets[:, None] * stride_q_head
+        + dim_offsets[None, :] * stride_q_dim
+    )
+    head_scores = tl.dot(keys, tl.trans(queries), out_dtype=tl.float32)
+    head_scores = tl.maximum(head_scores, 0.0)
+    weights = tl.load(
+        weights_ptr + row * stride_weights_row + head_offsets * stride_weights_head
+    ).to(tl.float32)
+    logits = tl.sum(head_scores * weights[None, :], axis=1)
+    if USE_K_SCALE:
+        scales = tl.load(
+            cache_scale_ptr
+            + safe_pages * SCALE_PAGE_STRIDE
+            + SCALE_OFFSET
+            + token_offsets,
+            mask=page_valid & (key_offsets < max_seq_len),
+            other=0.0,
+        ).to(tl.float32)
+        logits *= scales
+
+    seq_len = tl.load(seq_lens_ptr + row)
+    valid = page_valid & (key_offsets < seq_len) & (key_offsets < max_seq_len)
+    tl.store(
+        logits_ptr + row * stride_logits_row + key_offsets,
+        tl.where(valid, logits, -float("inf")),
+        mask=key_offsets < max_seq_len,
+    )
+
+
+def iter_glm5_next_triton_mqa_logits(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    weights: torch.Tensor,
+    ks: torch.Tensor,
+    ke: torch.Tensor,
+    *,
+    k_scale: torch.Tensor | None = None,
+    query_chunk_size: int = 32,
+) -> Iterator[tuple[int, int, torch.Tensor]]:
+    capability = _validate_glm5_next_indexer_profile(q, k, k_scale)
+    if q.ndim != 3 or q.shape[-1] != INDEX_HEAD_DIM:
+        raise ValueError(f"q must have shape [Q,H,128], got {tuple(q.shape)}")
+    if k.ndim != 2 or k.shape[-1] != INDEX_HEAD_DIM:
+        raise ValueError(f"k must have shape [K,128], got {tuple(k.shape)}")
+    if weights.shape != q.shape[:2]:
+        raise ValueError(f"weights must have shape {tuple(q.shape[:2])}")
+    if weights.dtype != torch.float32:
+        raise TypeError("GLM Triton indexer weights must use FP32")
+    if k_scale is not None and k_scale.shape != (k.shape[0],):
+        raise ValueError("k_scale must have shape [K]")
+    if ks.dtype != torch.int32 or ke.dtype != torch.int32:
+        raise TypeError("GLM Triton ragged bounds must use int32")
+    if ks.shape != (q.shape[0],) or ke.shape != (q.shape[0],):
+        raise ValueError("GLM Triton ragged bounds must have one entry per query")
+    if weights.device != q.device or ks.device != q.device or ke.device != q.device:
+        raise ValueError("GLM Triton indexer metadata must share the query device")
+    if query_chunk_size <= 0:
+        raise ValueError("query_chunk_size must be positive")
+
+    block_k, num_warps, num_stages = glm5_next_indexer_launch_config(capability)
+    dummy_scale = k if k_scale is None else k_scale
+    for q_start in range(0, q.shape[0], query_chunk_size):
+        q_end = min(q_start + query_chunk_size, q.shape[0])
+        q_chunk = q[q_start:q_end].contiguous()
+        weights_chunk = weights[q_start:q_end].contiguous()
+        logits = torch.empty(
+            (q_end - q_start, k.shape[0]), dtype=torch.float32, device=q.device
+        )
+        grid = (q_end - q_start, triton.cdiv(k.shape[0], block_k))
+        _glm5_next_flat_mqa_logits_kernel[grid](
+            q_chunk,
+            k,
+            dummy_scale,
+            weights_chunk,
+            ks[q_start:q_end],
+            ke[q_start:q_end],
+            logits,
+            k.shape[0],
+            q_chunk.stride(0),
+            q_chunk.stride(1),
+            q_chunk.stride(2),
+            k.stride(0),
+            k.stride(1),
+            weights_chunk.stride(0),
+            weights_chunk.stride(1),
+            logits.stride(0),
+            NUM_HEADS=q.shape[1],
+            HEAD_DIM=INDEX_HEAD_DIM,
+            USE_K_SCALE=k_scale is not None,
+            BLOCK_K=block_k,
+            num_warps=num_warps,
+            num_stages=num_stages,
+        )
+        yield q_start, q_end, logits
+
+
+def glm5_next_triton_paged_mqa_logits(
+    q: torch.Tensor,
+    cache: torch.Tensor,
+    weights: torch.Tensor,
+    seq_lens: torch.Tensor,
+    page_table: torch.Tensor,
+    max_seq_len: int,
+    *,
+    use_k_scale: bool,
+) -> torch.Tensor:
+    if q.ndim == 4:
+        if q.shape[1] != 1:
+            raise ValueError("paged q next-token dimension must be one")
+        q = q[:, 0]
+    q = q.contiguous()
+    weights = weights.contiguous()
+    if q.ndim != 3 or q.shape[-1] != INDEX_HEAD_DIM:
+        raise ValueError(f"q must have shape [B,H,128], got {tuple(q.shape)}")
+    if weights.shape != q.shape[:2]:
+        raise ValueError(f"weights must have shape {tuple(q.shape[:2])}")
+    if weights.dtype != torch.float32:
+        raise TypeError("GLM Triton indexer weights must use FP32")
+    if cache.ndim != 2 or page_table.ndim != 2:
+        raise ValueError("cache and page_table must be two-dimensional")
+    if max_seq_len <= 0:
+        raise ValueError("max_seq_len must be positive")
+    if max_seq_len > page_table.shape[1] * INDEX_PAGE_SIZE:
+        raise ValueError("max_seq_len exceeds the KPool page-table capacity")
+    if cache.shape[0] == 0 or cache.stride(1) != 1:
+        raise ValueError("KPool cache must contain contiguous physical pages")
+    if seq_lens.dtype != torch.int32 or page_table.dtype != torch.int32:
+        raise TypeError("KPool lengths and page table must use int32")
+    if seq_lens.shape not in ((q.shape[0],), (q.shape[0], 1)):
+        raise ValueError("KPool lengths must have one entry per query")
+    seq_lens = seq_lens.view(-1)
+    if page_table.shape[0] != q.shape[0]:
+        raise ValueError("KPool page table must have one row per query")
+    if weights.device != q.device or seq_lens.device != q.device:
+        raise ValueError("KPool scorer metadata must share the query device")
+    if page_table.device != q.device or cache.device != q.device:
+        raise ValueError("KPool cache metadata must share the query device")
+
+    if use_k_scale:
+        if cache.dtype != torch.uint8:
+            raise TypeError("scaled KPool cache must use packed uint8 storage")
+        cache_values = cache.view(torch.float8_e4m3fn)
+        cache_scales = cache.view(torch.float32)
+        scale_offset = INDEX_PAGE_SIZE * INDEX_HEAD_DIM // 4
+        scale_page_stride = cache.shape[1] // 4
+    else:
+        if cache.dtype != torch.bfloat16:
+            raise TypeError("unscaled KPool cache must be BF16")
+        cache_values = cache
+        cache_scales = cache
+        scale_offset = 0
+        scale_page_stride = 0
+
+    capability = _validate_glm5_next_indexer_profile(
+        q,
+        cache_values,
+        cache_scales if use_k_scale else None,
+    )
+    block_k, num_warps, num_stages = glm5_next_indexer_launch_config(capability)
+    logits = torch.empty(
+        (q.shape[0], max_seq_len), dtype=torch.float32, device=q.device
+    )
+    grid = (q.shape[0], triton.cdiv(max_seq_len, block_k))
+    _glm5_next_paged_mqa_logits_kernel[grid](
+        q,
+        cache_values,
+        cache_scales,
+        weights,
+        seq_lens,
+        page_table,
+        logits,
+        max_seq_len,
+        cache.shape[0],
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        cache_values.stride(0),
+        weights.stride(0),
+        weights.stride(1),
+        page_table.stride(0),
+        page_table.stride(1),
+        logits.stride(0),
+        SCALE_OFFSET=scale_offset,
+        SCALE_PAGE_STRIDE=scale_page_stride,
+        NUM_HEADS=q.shape[1],
+        HEAD_DIM=INDEX_HEAD_DIM,
+        PAGE_SIZE=INDEX_PAGE_SIZE,
+        USE_K_SCALE=use_k_scale,
+        BLOCK_K=block_k,
+        num_warps=num_warps,
+        num_stages=num_stages,
+    )
+    return logits

--- a/python/sglang/srt/layers/attention/nsa/glm5_next_sparse_attention.py
+++ b/python/sglang/srt/layers/attention/nsa/glm5_next_sparse_attention.py
@@ -24,7 +24,22 @@ GLM5_NEXT_LATENT_SCALE_GROUP_SIZE = 128
 GLM5_NEXT_LATENT_SCALE_GROUPS = (
     GLM5_NEXT_SPARSE_HEAD_DIM // GLM5_NEXT_LATENT_SCALE_GROUP_SIZE
 )
-_TRITON_TOKEN_BLOCK = 16
+
+
+def glm5_next_sparse_mla_launch_config(
+    capability: tuple[int, int],
+) -> tuple[int, int, int]:
+    """Return static decode geometry tuned per supported GPU family."""
+
+    if capability == (8, 6):
+        # Ampere has a smaller register file per SM; halve the selected-token
+        # tile so the 512-wide online-softmax accumulator remains resident.
+        return 8, 4, 2
+    if capability == (8, 9):
+        return 16, 8, 2
+    # Retain the original geometry for existing CUDA unit tests and future
+    # backends.  The model/server dispatch remains the architecture gate.
+    return 16, 8, 2
 
 
 @triton.jit
@@ -135,6 +150,23 @@ def _glm5_next_sparse_mla_cuda(
 ) -> torch.Tensor:
     """Launch the graph-safe BF16-Q/raw-or-scaled-FP8-KV decode kernel."""
 
+    capability = torch.cuda.get_device_capability(query.device)
+    if capability == (8, 6):
+        if (
+            query.dtype != torch.bfloat16
+            or kv_cache.dtype != torch.bfloat16
+            or kv_scale is not None
+        ):
+            raise TypeError("SM86 GLM sparse MLA requires unscaled BF16 Q/KV")
+    elif capability == (8, 9):
+        if (
+            query.dtype != torch.bfloat16
+            or kv_cache.dtype != torch.float8_e4m3fn
+            or kv_scale is None
+            or kv_scale.dtype != torch.float32
+        ):
+            raise TypeError("SM89 GLM sparse MLA requires BF16 Q and scaled E4M3 KV")
+
     flat_kv = kv_cache.reshape(-1, GLM5_NEXT_SPARSE_HEAD_DIM)
     query_3d = query.contiguous()
     indices_2d = indices.contiguous()
@@ -147,6 +179,7 @@ def _glm5_next_sparse_mla_cuda(
         kv_scale_2d = flat_kv
     output = torch.empty_like(query_3d, dtype=torch.bfloat16)
     grid = (query_3d.shape[0], query_3d.shape[1])
+    block_t, num_warps, num_stages = glm5_next_sparse_mla_launch_config(capability)
     _glm5_next_sparse_mla_decode_kernel[grid](
         query_3d,
         flat_kv,
@@ -171,9 +204,9 @@ def _glm5_next_sparse_mla_cuda(
         HEAD_DIM=GLM5_NEXT_SPARSE_HEAD_DIM,
         SCALE_GROUP_SIZE=GLM5_NEXT_LATENT_SCALE_GROUP_SIZE,
         USE_KV_SCALE=use_kv_scale,
-        BLOCK_T=_TRITON_TOKEN_BLOCK,
-        num_warps=8,
-        num_stages=2,
+        BLOCK_T=block_t,
+        num_warps=num_warps,
+        num_stages=num_stages,
     )
     return output
 

--- a/python/sglang/srt/layers/attention/nsa/kpool_fp8_index.py
+++ b/python/sglang/srt/layers/attention/nsa/kpool_fp8_index.py
@@ -72,6 +72,62 @@ def gather_index_k_scale_prefix_into(
     )
 
 
+def gather_index_k_bf16_prefix_into(
+    pool,
+    buf: torch.Tensor,
+    page_indices: torch.Tensor,
+    seq_len: int,
+    k_out: torch.Tensor,
+) -> None:
+    """Gather a paged all-BF16 GLM KPool prefix into bounded scratch."""
+
+    assert buf.dtype == torch.bfloat16
+    assert page_indices.dtype in (torch.int32, torch.int64)
+    assert k_out.dtype == torch.bfloat16
+    assert pool.page_size == BLOCK_SIZE_K
+    assert k_out.shape[0] >= seq_len
+    assert k_out.shape[1] == INDEX_HEAD_DIM
+    assert buf.is_contiguous()
+    assert page_indices.is_contiguous()
+    assert k_out.is_contiguous()
+    if seq_len == 0:
+        return
+
+    _gather_index_k_bf16_prefix_into_kernel[(seq_len,)](
+        buf,
+        page_indices,
+        k_out,
+        PAGE_SIZE=pool.page_size,
+        BUF_NUMEL_PER_PAGE=buf.shape[1],
+        HEAD_DIM=INDEX_HEAD_DIM,
+        BLOCK_D=triton.next_power_of_2(INDEX_HEAD_DIM),
+        num_warps=4,
+    )
+
+
+@triton.jit
+def _gather_index_k_bf16_prefix_into_kernel(
+    buf_ptr,
+    page_indices_ptr,
+    k_out_ptr,
+    PAGE_SIZE: tl.constexpr,
+    BUF_NUMEL_PER_PAGE: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    token_id = tl.program_id(0)
+    page_idx = token_id // PAGE_SIZE
+    token_offset_in_page = token_id % PAGE_SIZE
+    page = tl.load(page_indices_ptr + page_idx)
+
+    offs = tl.arange(0, BLOCK_D)
+    mask = offs < HEAD_DIM
+    src = page * BUF_NUMEL_PER_PAGE + token_offset_in_page * HEAD_DIM + offs
+    dst = token_id * HEAD_DIM + offs
+    value = tl.load(buf_ptr + src, mask=mask, other=0.0)
+    tl.store(k_out_ptr + dst, value, mask=mask)
+
+
 @triton.jit
 def _gather_index_k_scale_prefix_into_kernel(
     buf_u8_ptr,
@@ -629,11 +685,24 @@ def kpool_softmax_rotate_write_cache(
     assert slot_k.dtype == torch.bfloat16
     assert slot_score.dtype in KPOOL_SCORE_DTYPES
     assert ape.dtype == torch.float32
-    assert buf.dtype == torch.uint8
     assert pool.page_size == BLOCK_SIZE_K
     assert pool.index_head_dim == INDEX_HEAD_DIM
     assert loc.dtype == torch.int64
     assert write_cache or return_compressed
+
+    if buf.dtype == torch.bfloat16:
+        return _kpool_softmax_rotate_write_cache_bf16(
+            pool=pool,
+            buf=buf,
+            slot_k=slot_k,
+            slot_score=slot_score,
+            ape=ape,
+            loc=loc,
+            write_mask=write_mask,
+            return_compressed=return_compressed,
+            write_cache=write_cache,
+        )
+    assert buf.dtype == torch.uint8
 
     slot_k = slot_k.contiguous()
     slot_score = slot_score.contiguous()
@@ -705,6 +774,177 @@ def kpool_softmax_rotate_write_cache(
     return None
 
 
+def _kpool_softmax_rotate_write_cache_bf16(
+    *,
+    pool,
+    buf: torch.Tensor,
+    slot_k: torch.Tensor,
+    slot_score: torch.Tensor,
+    ape: torch.Tensor,
+    loc: torch.Tensor,
+    write_mask: torch.Tensor | None,
+    return_compressed: bool,
+    write_cache: bool,
+) -> Optional[Tuple[torch.Tensor, torch.Tensor]]:
+    """SM86 KPool writer with no FP8 quantization or scale sidecar."""
+
+    slot_k = slot_k.contiguous()
+    slot_score = slot_score.contiguous()
+    ape = ape.contiguous()
+    loc = loc.contiguous()
+    if write_mask is None:
+        write_mask = torch.empty((1,), dtype=torch.bool, device=slot_k.device)
+        has_write_mask = False
+    else:
+        assert write_mask.shape == (slot_k.shape[0],)
+        assert not return_compressed
+        write_mask = write_mask.contiguous()
+        has_write_mask = True
+
+    if slot_k.shape[0] == 0:
+        if return_compressed:
+            return (
+                torch.empty(
+                    (0, slot_k.shape[2]),
+                    dtype=torch.bfloat16,
+                    device=slot_k.device,
+                ),
+                torch.empty((0,), dtype=torch.float32, device=slot_k.device),
+            )
+        return None
+
+    compressed_k = (
+        torch.empty(
+            (slot_k.shape[0], slot_k.shape[2]),
+            dtype=torch.bfloat16,
+            device=slot_k.device,
+        )
+        if return_compressed
+        else buf
+    )
+    compressed_scale = (
+        torch.empty(
+            (slot_k.shape[0],), dtype=torch.float32, device=slot_k.device
+        )
+        if return_compressed
+        else buf
+    )
+    _kpool_softmax_rotate_write_cache_bf16_kernel[(slot_k.shape[0],)](
+        buf,
+        slot_k,
+        slot_score,
+        ape,
+        loc,
+        write_mask,
+        compressed_k,
+        compressed_scale,
+        slot_k.stride(0),
+        slot_k.stride(1),
+        slot_score.stride(0),
+        slot_score.stride(1),
+        ape.stride(0),
+        PAGE_SIZE=pool.page_size,
+        BUF_NUMEL_PER_PAGE=buf.shape[1],
+        POOL_SIZE=slot_k.shape[1],
+        HEAD_DIM=slot_k.shape[2],
+        HAS_WRITE_MASK=has_write_mask,
+        RETURN_COMPRESSED=return_compressed,
+        WRITE_CACHE=write_cache,
+        BLOCK_D=triton.next_power_of_2(slot_k.shape[2]),
+        num_warps=4,
+        num_stages=2,
+    )
+    if return_compressed:
+        return compressed_k, compressed_scale
+    return None
+
+
+@triton.jit
+def _kpool_softmax_rotate_write_cache_bf16_kernel(
+    buf_ptr,
+    slot_k_ptr,
+    slot_score_ptr,
+    ape_ptr,
+    loc_ptr,
+    write_mask_ptr,
+    compressed_k_ptr,
+    compressed_scale_ptr,
+    slot_k_stride_0,
+    slot_k_stride_1,
+    slot_score_stride_0,
+    slot_score_stride_1,
+    ape_stride_0,
+    PAGE_SIZE: tl.constexpr,
+    BUF_NUMEL_PER_PAGE: tl.constexpr,
+    POOL_SIZE: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    HAS_WRITE_MASK: tl.constexpr,
+    RETURN_COMPRESSED: tl.constexpr,
+    WRITE_CACHE: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    row = tl.program_id(0)
+    do_write = True
+    if HAS_WRITE_MASK:
+        do_write = tl.load(write_mask_ptr + row)
+
+    offs = tl.arange(0, BLOCK_D)
+    mask = (offs < HEAD_DIM) & do_write
+    max_score = tl.full((BLOCK_D,), -float("inf"), tl.float32)
+    for slot in tl.static_range(0, POOL_SIZE):
+        score = tl.load(
+            slot_score_ptr
+            + row * slot_score_stride_0
+            + slot * slot_score_stride_1
+            + offs,
+            mask=mask,
+            other=0.0,
+        ).to(tl.float32)
+        score += tl.load(
+            ape_ptr + slot * ape_stride_0 + offs, mask=mask, other=0.0
+        ).to(tl.float32)
+        max_score = tl.maximum(max_score, score)
+
+    acc = tl.zeros((BLOCK_D,), tl.float32)
+    denom = tl.zeros((BLOCK_D,), tl.float32)
+    for slot in tl.static_range(0, POOL_SIZE):
+        score = tl.load(
+            slot_score_ptr
+            + row * slot_score_stride_0
+            + slot * slot_score_stride_1
+            + offs,
+            mask=mask,
+            other=0.0,
+        ).to(tl.float32)
+        score += tl.load(
+            ape_ptr + slot * ape_stride_0 + offs, mask=mask, other=0.0
+        ).to(tl.float32)
+        prob = tl.exp(score - max_score)
+        denom += prob
+        key = tl.load(
+            slot_k_ptr + row * slot_k_stride_0 + slot * slot_k_stride_1 + offs,
+            mask=mask,
+            other=0.0,
+        ).to(tl.float32)
+        acc += key * prob
+
+    compressed = (acc / denom).to(tl.bfloat16).to(tl.float32)
+    compressed = _hadamard128(compressed).to(tl.bfloat16)
+    if WRITE_CACHE:
+        loc = tl.load(loc_ptr + row, mask=do_write, other=0)
+        page = loc // PAGE_SIZE
+        token = loc % PAGE_SIZE
+        out = page * BUF_NUMEL_PER_PAGE + token * HEAD_DIM + offs
+        tl.store(buf_ptr + out, compressed, mask=mask)
+    if RETURN_COMPRESSED:
+        tl.store(
+            compressed_k_ptr + row * HEAD_DIM + offs,
+            compressed,
+            mask=offs < HEAD_DIM,
+        )
+        tl.store(compressed_scale_ptr + row, 1.0)
+
+
 def kpool_decode_update_and_maybe_write_cache(
     pool,
     buf: torch.Tensor,
@@ -732,7 +972,6 @@ def kpool_decode_update_and_maybe_write_cache(
     assert tail_score.dtype in KPOOL_SCORE_DTYPES
     assert slot_score.dtype == tail_score.dtype
     assert ape.dtype == torch.float32
-    assert buf.dtype == torch.uint8
     assert pool.page_size == BLOCK_SIZE_K
     assert pool.index_head_dim == INDEX_HEAD_DIM
     assert tail_k.is_contiguous()
@@ -741,6 +980,24 @@ def kpool_decode_update_and_maybe_write_cache(
     batch = key.shape[0]
     if batch == 0:
         return
+
+    if buf.dtype == torch.bfloat16:
+        _kpool_decode_update_and_maybe_write_cache_bf16(
+            pool=pool,
+            buf=buf,
+            tail_k=tail_k,
+            tail_score=tail_score,
+            key=key,
+            slot_score=slot_score,
+            ape=ape,
+            block_tables=block_tables,
+            req_pool_indices=req_pool_indices,
+            positions=positions,
+            seq_lens=seq_lens,
+            out_cache_loc=out_cache_loc,
+        )
+        return
+    assert buf.dtype == torch.uint8
 
     key = key.contiguous()
     slot_score = slot_score.contiguous()
@@ -792,6 +1049,64 @@ def kpool_decode_update_and_maybe_write_cache(
         ROUND_SCALE=round_scale,
         BLOCK_D=triton.next_power_of_2(tail_k.shape[2]),
         SLOTS_PER_PAGE=pool.slots_per_page,
+    )
+
+
+def _kpool_decode_update_and_maybe_write_cache_bf16(
+    *,
+    pool,
+    buf: torch.Tensor,
+    tail_k: torch.Tensor,
+    tail_score: torch.Tensor,
+    key: torch.Tensor,
+    slot_score: torch.Tensor,
+    ape: torch.Tensor,
+    block_tables: torch.Tensor,
+    req_pool_indices: torch.Tensor,
+    positions: torch.Tensor,
+    seq_lens: torch.Tensor,
+    out_cache_loc: torch.Tensor,
+) -> None:
+    key = key.contiguous()
+    slot_score = slot_score.contiguous()
+    ape = ape.contiguous()
+    req_pool_indices = req_pool_indices.contiguous()
+    positions = positions.contiguous()
+    seq_lens = seq_lens.contiguous()
+    out_cache_loc = out_cache_loc.contiguous()
+    batch = key.shape[0]
+
+    _kpool_decode_update_and_maybe_write_cache_bf16_kernel[(batch,)](
+        buf,
+        tail_k,
+        tail_score,
+        key,
+        slot_score,
+        ape,
+        block_tables,
+        req_pool_indices,
+        positions,
+        seq_lens,
+        out_cache_loc,
+        tail_k.stride(0),
+        tail_k.stride(1),
+        tail_score.stride(0),
+        tail_score.stride(1),
+        key.stride(0),
+        slot_score.stride(0),
+        ape.stride(0),
+        block_tables.stride(0),
+        block_tables.stride(1),
+        REQ_POOL_SIZE=tail_k.shape[0],
+        BUF_NUMEL_PER_PAGE=buf.shape[1],
+        POOL_SIZE=pool.index_kpool,
+        TAIL_SIZE=tail_k.shape[1],
+        HEAD_DIM=tail_k.shape[2],
+        BLOCK_TABLE_COLS=block_tables.shape[1],
+        BLOCK_D=triton.next_power_of_2(tail_k.shape[2]),
+        SLOTS_PER_PAGE=pool.slots_per_page,
+        num_warps=4,
+        num_stages=2,
     )
 
 
@@ -1102,6 +1417,136 @@ def _kpool_decode_update_and_maybe_write_cache_kernel(
 
 
 @triton.jit
+def _kpool_decode_update_and_maybe_write_cache_bf16_kernel(
+    buf_ptr,
+    tail_k_ptr,
+    tail_score_ptr,
+    key_ptr,
+    slot_score_ptr,
+    ape_ptr,
+    block_tables_ptr,
+    req_pool_indices_ptr,
+    positions_ptr,
+    seq_lens_ptr,
+    out_cache_loc_ptr,
+    tail_k_stride_0,
+    tail_k_stride_1,
+    tail_score_stride_0,
+    tail_score_stride_1,
+    key_stride_0,
+    slot_score_stride_0,
+    ape_stride_0,
+    block_tables_stride_0,
+    block_tables_stride_1,
+    REQ_POOL_SIZE: tl.constexpr,
+    BUF_NUMEL_PER_PAGE: tl.constexpr,
+    POOL_SIZE: tl.constexpr,
+    TAIL_SIZE: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_TABLE_COLS: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    SLOTS_PER_PAGE: tl.constexpr,
+):
+    row = tl.program_id(0)
+    offs = tl.arange(0, BLOCK_D)
+    dim_mask = offs < HEAD_DIM
+
+    req_raw = tl.load(req_pool_indices_ptr + row)
+    req_valid = (req_raw >= 0) & (req_raw < REQ_POOL_SIZE)
+    req = tl.minimum(tl.maximum(req_raw, 0), REQ_POOL_SIZE - 1)
+    pos = tl.load(positions_ptr + row)
+    safe_pos = tl.maximum(pos, 0)
+    seq_len = tl.load(seq_lens_ptr + row)
+    cache_loc = tl.load(out_cache_loc_ptr + row)
+    pos_valid = req_valid & (cache_loc != 0) & (pos >= 0) & (pos < seq_len)
+    slot = safe_pos % POOL_SIZE
+    phys_slot = safe_pos % TAIL_SIZE
+
+    key = tl.load(
+        key_ptr + row * key_stride_0 + offs, mask=dim_mask, other=0.0
+    ).to(tl.float32)
+    score_current = tl.load(
+        slot_score_ptr + row * slot_score_stride_0 + offs,
+        mask=dim_mask,
+        other=0.0,
+    ).to(tl.float32)
+
+    if pos_valid & (slot == POOL_SIZE - 1):
+        pool_logical_start = safe_pos - slot
+        max_score = tl.full((BLOCK_D,), -float("inf"), tl.float32)
+        for pool_slot in tl.static_range(0, POOL_SIZE):
+            is_current = pool_slot == slot
+            phys = (pool_logical_start + pool_slot) % TAIL_SIZE
+            score_buf = tl.load(
+                tail_score_ptr
+                + req * tail_score_stride_0
+                + phys * tail_score_stride_1
+                + offs,
+                mask=dim_mask,
+                other=0.0,
+            ).to(tl.float32)
+            score = tl.where(is_current, score_current, score_buf)
+            score += tl.load(
+                ape_ptr + pool_slot * ape_stride_0 + offs,
+                mask=dim_mask,
+                other=0.0,
+            ).to(tl.float32)
+            max_score = tl.maximum(max_score, score)
+
+        acc = tl.zeros((BLOCK_D,), tl.float32)
+        denom = tl.zeros((BLOCK_D,), tl.float32)
+        for pool_slot in tl.static_range(0, POOL_SIZE):
+            is_current = pool_slot == slot
+            phys = (pool_logical_start + pool_slot) % TAIL_SIZE
+            score_buf = tl.load(
+                tail_score_ptr
+                + req * tail_score_stride_0
+                + phys * tail_score_stride_1
+                + offs,
+                mask=dim_mask,
+                other=0.0,
+            ).to(tl.float32)
+            score = tl.where(is_current, score_current, score_buf)
+            score += tl.load(
+                ape_ptr + pool_slot * ape_stride_0 + offs,
+                mask=dim_mask,
+                other=0.0,
+            ).to(tl.float32)
+            prob = tl.exp(score - max_score)
+            denom += prob
+            key_buf = tl.load(
+                tail_k_ptr + req * tail_k_stride_0 + phys * tail_k_stride_1 + offs,
+                mask=dim_mask,
+                other=0.0,
+            ).to(tl.float32)
+            acc += tl.where(is_current, key, key_buf) * prob
+
+        compressed = (acc / denom).to(tl.bfloat16).to(tl.float32)
+        compressed = _hadamard128(compressed).to(tl.bfloat16)
+        pool_id = safe_pos // POOL_SIZE
+        pool_page_group = pool_id // SLOTS_PER_PAGE
+        token_page_row = tl.minimum(
+            tl.maximum(pool_page_group * POOL_SIZE, 0), BLOCK_TABLE_COLS - 1
+        )
+        packed_page = tl.load(
+            block_tables_ptr
+            + row * block_tables_stride_0
+            + token_page_row * block_tables_stride_1
+        ).to(tl.int64)
+        token = pool_id % SLOTS_PER_PAGE
+        out = packed_page * BUF_NUMEL_PER_PAGE + token * HEAD_DIM + offs
+        tl.store(buf_ptr + out, compressed, mask=dim_mask)
+
+    tail_k_offset = req * tail_k_stride_0 + phys_slot * tail_k_stride_1 + offs
+    tail_score_offset = (
+        req * tail_score_stride_0 + phys_slot * tail_score_stride_1 + offs
+    )
+    update_mask = dim_mask & pos_valid
+    tl.store(tail_k_ptr + tail_k_offset, key, mask=update_mask)
+    tl.store(tail_score_ptr + tail_score_offset, score_current, mask=update_mask)
+
+
+@triton.jit
 def _hadamard_quantize_fp8(acc, denom, ROUND_SCALE: tl.constexpr):
     x = (acc / denom).to(tl.bfloat16).to(tl.float32)
     x = _hadamard128(x).to(tl.bfloat16).to(tl.float32)
@@ -1222,6 +1667,25 @@ def kpool_assemble_softmax_rotate_write_cache(
     if n_pools == 0:
         return
 
+    if buf.dtype == torch.bfloat16:
+        _kpool_assemble_softmax_rotate_write_cache_bf16(
+            pool=pool,
+            buf=buf,
+            chunk_k=chunk_k,
+            chunk_score=chunk_score,
+            tail_k=tail_k,
+            tail_score=tail_score,
+            req_pool_idx=req_pool_idx,
+            n_from_tail=n_from_tail,
+            chunk_src_start=chunk_src_start,
+            tail_logical_base=tail_logical_base,
+            ape=ape,
+            loc=loc,
+            write_mask=write_mask,
+        )
+        return
+    assert buf.dtype == torch.uint8
+
     chunk_k = chunk_k.contiguous()
     chunk_score = chunk_score.contiguous()
     ape = ape.contiguous()
@@ -1302,6 +1766,138 @@ def scatter_kpool_tail_updates(
         HEAD_DIM=INDEX_HEAD_DIM,
         BLOCK_D=triton.next_power_of_2(INDEX_HEAD_DIM),
     )
+
+
+def _kpool_assemble_softmax_rotate_write_cache_bf16(
+    *,
+    pool,
+    buf: torch.Tensor,
+    chunk_k: torch.Tensor,
+    chunk_score: torch.Tensor,
+    tail_k: torch.Tensor,
+    tail_score: torch.Tensor,
+    req_pool_idx: torch.Tensor,
+    n_from_tail: torch.Tensor,
+    chunk_src_start: torch.Tensor,
+    tail_logical_base: torch.Tensor,
+    ape: torch.Tensor,
+    loc: torch.Tensor,
+    write_mask: torch.Tensor | None,
+) -> None:
+    chunk_k = chunk_k.contiguous()
+    chunk_score = chunk_score.contiguous()
+    ape = ape.contiguous()
+    loc = loc.contiguous()
+    if write_mask is None:
+        write_mask = torch.empty((1,), dtype=torch.bool, device=chunk_k.device)
+        has_write_mask = False
+    else:
+        write_mask = write_mask.contiguous()
+        has_write_mask = True
+
+    _kpool_assemble_softmax_rotate_write_cache_bf16_kernel[
+        (req_pool_idx.shape[0],)
+    ](
+        buf,
+        chunk_k,
+        chunk_score,
+        tail_k,
+        tail_score,
+        req_pool_idx,
+        n_from_tail,
+        chunk_src_start,
+        tail_logical_base,
+        ape,
+        loc,
+        write_mask,
+        chunk_k.stride(0),
+        tail_k.stride(0),
+        tail_k.stride(1),
+        ape.stride(0),
+        BUF_NUMEL_PER_PAGE=buf.shape[1],
+        POOL_SIZE=pool.index_kpool,
+        TAIL_SIZE=tail_k.shape[1],
+        HEAD_DIM=INDEX_HEAD_DIM,
+        HAS_WRITE_MASK=has_write_mask,
+        BLOCK_D=triton.next_power_of_2(INDEX_HEAD_DIM),
+        SLOTS_PER_PAGE=pool.slots_per_page,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+@triton.jit
+def _kpool_assemble_softmax_rotate_write_cache_bf16_kernel(
+    buf_ptr,
+    chunk_k_ptr,
+    chunk_score_ptr,
+    tail_k_ptr,
+    tail_score_ptr,
+    req_pool_idx_ptr,
+    n_from_tail_ptr,
+    chunk_src_start_ptr,
+    tail_logical_base_ptr,
+    ape_ptr,
+    loc_ptr,
+    write_mask_ptr,
+    chunk_stride_0,
+    tail_stride_0,
+    tail_stride_1,
+    ape_stride_0,
+    BUF_NUMEL_PER_PAGE: tl.constexpr,
+    POOL_SIZE: tl.constexpr,
+    TAIL_SIZE: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    HAS_WRITE_MASK: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    SLOTS_PER_PAGE: tl.constexpr,
+):
+    row = tl.program_id(0)
+    if HAS_WRITE_MASK:
+        if not tl.load(write_mask_ptr + row):
+            return
+
+    offs = tl.arange(0, BLOCK_D)
+    mask = offs < HEAD_DIM
+    n_tail = tl.load(n_from_tail_ptr + row)
+    req = tl.load(req_pool_idx_ptr + row)
+    chunk_src = tl.load(chunk_src_start_ptr + row)
+    tail_base = tl.load(tail_logical_base_ptr + row)
+
+    running_max = tl.full((BLOCK_D,), -float("inf"), tl.float32)
+    acc = tl.zeros((BLOCK_D,), tl.float32)
+    denom = tl.zeros((BLOCK_D,), tl.float32)
+    for slot in tl.static_range(0, POOL_SIZE):
+        if slot < n_tail:
+            phys = (tail_base + slot) % TAIL_SIZE
+            src = req * tail_stride_0 + phys * tail_stride_1 + offs
+            score = tl.load(tail_score_ptr + src, mask=mask, other=0.0).to(
+                tl.float32
+            )
+            key = tl.load(tail_k_ptr + src, mask=mask, other=0.0).to(tl.float32)
+        else:
+            src = (chunk_src + (slot - n_tail)) * chunk_stride_0 + offs
+            score = tl.load(chunk_score_ptr + src, mask=mask, other=0.0).to(
+                tl.float32
+            )
+            key = tl.load(chunk_k_ptr + src, mask=mask, other=0.0).to(tl.float32)
+        score += tl.load(
+            ape_ptr + slot * ape_stride_0 + offs, mask=mask, other=0.0
+        ).to(tl.float32)
+        next_max = tl.maximum(running_max, score)
+        rescale = tl.exp(running_max - next_max)
+        prob = tl.exp(score - next_max)
+        denom = denom * rescale + prob
+        acc = acc * rescale + key * prob
+        running_max = next_max
+
+    compressed = (acc / denom).to(tl.bfloat16).to(tl.float32)
+    compressed = _hadamard128(compressed).to(tl.bfloat16)
+    loc = tl.load(loc_ptr + row)
+    page = loc // SLOTS_PER_PAGE
+    token = loc % SLOTS_PER_PAGE
+    out = page * BUF_NUMEL_PER_PAGE + token * HEAD_DIM + offs
+    tl.store(buf_ptr + out, compressed, mask=mask)
 
 
 @triton.jit

--- a/python/sglang/srt/layers/attention/nsa/kpool_plan.py
+++ b/python/sglang/srt/layers/attention/nsa/kpool_plan.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 
 _RAGGED_SCRATCH_K_U8: Optional[torch.Tensor] = None
 _RAGGED_SCRATCH_K_SCALE: Optional[torch.Tensor] = None
+_RAGGED_SCRATCH_K_BF16: Optional[torch.Tensor] = None
 
 
 def _req_to_token_table_from_batch(forward_batch: ForwardBatch) -> torch.Tensor:
@@ -65,6 +66,24 @@ def _get_ragged_scratch(
     return _RAGGED_SCRATCH_K_U8[:total_k_rows], _RAGGED_SCRATCH_K_SCALE[:total_k_rows]
 
 
+def _get_ragged_bf16_scratch(
+    total_k_rows: int, device: torch.device
+) -> torch.Tensor:
+    global _RAGGED_SCRATCH_K_BF16
+    cur = _RAGGED_SCRATCH_K_BF16
+    grow = (
+        cur is None
+        or cur.device.type != device.type
+        or (device.index is not None and cur.device.index != device.index)
+        or cur.shape[0] < total_k_rows
+    )
+    if grow:
+        _RAGGED_SCRATCH_K_BF16 = torch.empty(
+            (total_k_rows, INDEX_HEAD_DIM), dtype=torch.bfloat16, device=device
+        )
+    return _RAGGED_SCRATCH_K_BF16[:total_k_rows]
+
+
 @dataclass(frozen=True)
 class PoolWriteRows:
     req: torch.Tensor
@@ -103,6 +122,7 @@ class KPoolExtendPlan:
     ragged_total_k_rows: int
     ragged_k_u8: Optional[torch.Tensor]
     ragged_k_scale: Optional[torch.Tensor]
+    ragged_k_bf16: Optional[torch.Tensor]
     ragged_paged_page_table: Optional[torch.Tensor]
     ragged_paged_page_table_row_index: Optional[torch.Tensor]
 
@@ -270,6 +290,7 @@ def _kpool_plan_to_gpu(
     pool_size: int,
     slots_per_page: int,
     topk_transform_method: TopkTransformMethod,
+    index_cache_dtype: torch.dtype,
 ) -> KPoolExtendPlan:
     from sglang.srt.layers.attention.nsa_backend import TopkTransformMethod
 
@@ -405,11 +426,17 @@ def _kpool_plan_to_gpu(
         )
         ragged_paged_page_table = req_to_token
 
-    if ragged_total_k_rows > 0:
+    if ragged_total_k_rows > 0 and index_cache_dtype == torch.bfloat16:
+        ragged_k_u8 = None
+        ragged_k_scale = None
+        ragged_k_bf16 = _get_ragged_bf16_scratch(ragged_total_k_rows, device)
+    elif ragged_total_k_rows > 0:
         ragged_k_u8, ragged_k_scale = _get_ragged_scratch(ragged_total_k_rows, device)
+        ragged_k_bf16 = None
     else:
         ragged_k_u8 = None
         ragged_k_scale = None
+        ragged_k_bf16 = None
 
     return KPoolExtendPlan(
         writes=PoolWriteRows(
@@ -434,6 +461,7 @@ def _kpool_plan_to_gpu(
         ragged_total_k_rows=ragged_total_k_rows,
         ragged_k_u8=ragged_k_u8,
         ragged_k_scale=ragged_k_scale,
+        ragged_k_bf16=ragged_k_bf16,
         ragged_paged_page_table=ragged_paged_page_table,
         ragged_paged_page_table_row_index=ragged_paged_page_table_row_index,
     )
@@ -454,6 +482,7 @@ def init_kpool_extend_metadata(
     local_extend_seq_lens_cpu: Optional[List[int]] = None,
     local_seq_lens_cpu: Optional[List[int]] = None,
     local_req_pool_indices: Optional[torch.Tensor] = None,
+    index_cache_dtype: torch.dtype = torch.float8_e4m3fn,
 ) -> NSAMetadata:
     mode = forward_batch.forward_mode
     is_extend_like = mode.is_extend_without_speculative()
@@ -489,6 +518,7 @@ def init_kpool_extend_metadata(
         pool_size,
         slots_per_page,
         topk_transform_method,
+        index_cache_dtype,
     )
     return dataclasses.replace(metadata, kpool_extend_plan=plan)
 

--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer_kpool.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer_kpool.py
@@ -651,6 +651,14 @@ class IndexerKPool(MultiPlatformOp):
 
         return use_glm5_next_eager_logits_on_device(q_fp8.device)
 
+    @staticmethod
+    def _should_use_triton_logits(query: torch.Tensor) -> bool:
+        from sglang.srt.layers.attention.nsa.glm5_next_indexer_triton import (
+            use_glm5_next_triton_indexer,
+        )
+
+        return use_glm5_next_triton_indexer(query.device)
+
     def _get_topk_paged(
         self,
         forward_batch: ForwardBatch,
@@ -670,7 +678,7 @@ class IndexerKPool(MultiPlatformOp):
         # NOTE(dark): this support extend/decode/decode+graph
         block_tables = metadata.get_page_table_64()
 
-        kv_cache_fp8 = self._get_index_k_read_buffer(pool, layer_id)
+        kv_cache = self._get_index_k_read_buffer(pool, layer_id)
 
         blocksize = page_size
         seqlens_32 = metadata.get_seqlens_int32()
@@ -681,17 +689,15 @@ class IndexerKPool(MultiPlatformOp):
             q_fp8 = q_fp8[:n_real]
             weights = weights[:n_real]
         q_fp8 = q_fp8.unsqueeze(1)  # the next_n dim is 1 now
-        assert len(kv_cache_fp8.shape) == 2
+        assert len(kv_cache.shape) == 2
         block_kv = 64
         num_heads_kv = 1
         head_dim_with_sf = 132
-        kv_cache_fp8 = kv_cache_fp8.view(
-            kv_cache_fp8.shape[0], block_kv, num_heads_kv, head_dim_with_sf
-        )
         assert len(weights.shape) == 3
         weights = weights.squeeze(2)
         use_tilelang_paged_mqa = self._should_use_tilelang_paged_mqa_logits(q_fp8)
         use_eager_logits = self._should_use_eager_logits(q_fp8)
+        use_triton_logits = self._should_use_triton_logits(q_fp8)
 
         pool_seqlens, pool_context_lens, pool_block_tables, pool_schedule_metadata = (
             self._get_kpool_decode_metadata(
@@ -700,14 +706,32 @@ class IndexerKPool(MultiPlatformOp):
                 seqlens_32,
                 blocksize,
                 build_schedule_metadata=not (
-                    use_tilelang_paged_mqa or use_eager_logits
+                    use_tilelang_paged_mqa or use_eager_logits or use_triton_logits
                 ),
             )
         )
         pool_max_seq_len = pool_block_tables.shape[1] * blocksize
-        if use_eager_logits:
+        if use_triton_logits:
+            from sglang.srt.layers.attention.nsa.glm5_next_indexer_triton import (
+                glm5_next_triton_paged_mqa_logits,
+            )
+
+            logits = glm5_next_triton_paged_mqa_logits(
+                q_fp8,
+                kv_cache,
+                weights,
+                pool_seqlens,
+                pool_block_tables,
+                pool_max_seq_len,
+                use_k_scale=not getattr(pool, "index_cache_is_bf16", False),
+            )
+        elif use_eager_logits:
             from sglang.srt.layers.attention.nsa.glm5_next_indexer_logits import (
                 glm5_next_eager_fp8_paged_mqa_logits,
+            )
+
+            kv_cache_fp8 = kv_cache.view(
+                kv_cache.shape[0], block_kv, num_heads_kv, head_dim_with_sf
             )
 
             logits = glm5_next_eager_fp8_paged_mqa_logits(
@@ -723,6 +747,9 @@ class IndexerKPool(MultiPlatformOp):
                 tilelang_fp8_paged_mqa_logits,
             )
 
+            kv_cache_fp8 = kv_cache.view(
+                kv_cache.shape[0], block_kv, num_heads_kv, head_dim_with_sf
+            )
             logits = tilelang_fp8_paged_mqa_logits(
                 q_fp8,
                 kv_cache_fp8,
@@ -734,6 +761,9 @@ class IndexerKPool(MultiPlatformOp):
                 clean_logits=False,
             )
         else:
+            kv_cache_fp8 = kv_cache.view(
+                kv_cache.shape[0], block_kv, num_heads_kv, head_dim_with_sf
+            )
             logits = deep_gemm.fp8_paged_mqa_logits(
                 q_fp8,
                 kv_cache_fp8,
@@ -787,20 +817,40 @@ class IndexerKPool(MultiPlatformOp):
         )
 
         if total_k_rows > 0:
-            k_u8 = plan.ragged_k_u8
-            k_scale = plan.ragged_k_scale
-            assert k_u8 is not None and k_scale is not None
             pool = _token_pool_from_batch(forward_batch)
-            gather_index_k_scale_prefix_into(
-                pool=pool,
-                buf=self._get_index_k_read_buffer(pool, layer_id),
-                page_indices=plan.ragged_concat_page_table,
-                seq_len=total_k_rows,
-                k_out=k_u8,
-                scale_out=k_scale,
-            )
-            k_fp8 = k_u8.view(torch.float8_e4m3fn)
-            if self._should_use_eager_logits(q_fp8):
+            if getattr(pool, "index_cache_is_bf16", False):
+                from sglang.srt.layers.attention.nsa.kpool_fp8_index import (
+                    gather_index_k_bf16_prefix_into,
+                )
+
+                k_bf16 = plan.ragged_k_bf16
+                assert k_bf16 is not None
+                gather_index_k_bf16_prefix_into(
+                    pool=pool,
+                    buf=self._get_index_k_read_buffer(pool, layer_id),
+                    page_indices=plan.ragged_concat_page_table,
+                    seq_len=total_k_rows,
+                    k_out=k_bf16,
+                )
+                index_k = k_bf16
+                k_scale = None
+            else:
+                k_u8 = plan.ragged_k_u8
+                k_scale = plan.ragged_k_scale
+                assert k_u8 is not None and k_scale is not None
+                gather_index_k_scale_prefix_into(
+                    pool=pool,
+                    buf=self._get_index_k_read_buffer(pool, layer_id),
+                    page_indices=plan.ragged_concat_page_table,
+                    seq_len=total_k_rows,
+                    k_out=k_u8,
+                    scale_out=k_scale,
+                )
+                index_k = k_u8.view(torch.float8_e4m3fn)
+
+            if self._should_use_eager_logits(q_fp8) or self._should_use_triton_logits(
+                q_fp8
+            ):
                 topk_method = getattr(metadata, "topk_transform_method", None)
                 attn_metadata = getattr(metadata, "attn_metadata", None)
                 page_table_all = None
@@ -817,9 +867,10 @@ class IndexerKPool(MultiPlatformOp):
                             attn_metadata, "topk_indices_offset", None
                         )
 
-                return self._topk_from_glm5_next_eager_logits_rows(
+                return self._topk_from_glm5_next_model_local_logits_rows(
                     q_fp8[:n_real].contiguous(),
-                    (k_fp8.contiguous(), k_scale.contiguous()),
+                    index_k.contiguous(),
+                    None if k_scale is None else k_scale.contiguous(),
                     weights[:n_real].contiguous(),
                     pool_lens,
                     seq_lens_expanded,
@@ -831,9 +882,10 @@ class IndexerKPool(MultiPlatformOp):
                     page_table_row_index=page_table_row_index_all,
                 )
 
+            assert k_scale is not None, "DeepGEMM KPool requires scaled FP8 K"
             logits = deep_gemm.fp8_mqa_logits(
                 q_fp8[:n_real].contiguous(),
-                (k_fp8.contiguous(), k_scale.contiguous()),
+                (index_k.contiguous(), k_scale.contiguous()),
                 weights[:n_real].contiguous(),
                 ks_per_q,
                 ke_per_q,
@@ -865,10 +917,11 @@ class IndexerKPool(MultiPlatformOp):
             page_table_row_index=page_table_row_index_all,
         )
 
-    def _topk_from_glm5_next_eager_logits_rows(
+    def _topk_from_glm5_next_model_local_logits_rows(
         self,
-        q_fp8: torch.Tensor,
-        kv_fp8: tuple[torch.Tensor, torch.Tensor],
+        query: torch.Tensor,
+        index_k: torch.Tensor,
+        k_scale: Optional[torch.Tensor],
         weights: torch.Tensor,
         pool_lens: torch.Tensor,
         seq_lens: torch.Tensor,
@@ -880,13 +933,16 @@ class IndexerKPool(MultiPlatformOp):
         topk_offsets: Optional[torch.Tensor],
         page_table_row_index: Optional[torch.Tensor],
     ) -> torch.Tensor:
-        """Score/select fixed query-row chunks for exact-GLM SM120 prefill."""
+        """Score/select bounded rows with the architecture-local GLM scorer."""
 
         from sglang.srt.layers.attention.nsa.glm5_next_indexer_logits import (
             iter_glm5_next_eager_fp8_mqa_logits,
         )
+        from sglang.srt.layers.attention.nsa.glm5_next_indexer_triton import (
+            iter_glm5_next_triton_mqa_logits,
+        )
 
-        n_real = q_fp8.shape[0]
+        n_real = query.shape[0]
         if total_q < n_real:
             raise ValueError(
                 "GLM-5-Next total query rows cannot be smaller than real queries"
@@ -916,15 +972,27 @@ class IndexerKPool(MultiPlatformOp):
             (total_q, self.index_topk + self.index_kpool - 1),
             -1,
             dtype=torch.int32,
-            device=q_fp8.device,
+            device=query.device,
         )
-        logits_rows = iter_glm5_next_eager_fp8_mqa_logits(
-            q_fp8,
-            kv_fp8,
-            weights,
-            ks,
-            ke,
-        )
+        if self._should_use_triton_logits(query):
+            logits_rows = iter_glm5_next_triton_mqa_logits(
+                query,
+                index_k,
+                weights,
+                ks,
+                ke,
+                k_scale=k_scale,
+            )
+        else:
+            if k_scale is None:
+                raise RuntimeError("SM120 eager scorer requires an FP8 K scale")
+            logits_rows = iter_glm5_next_eager_fp8_mqa_logits(
+                query,
+                (index_k, k_scale),
+                weights,
+                ks,
+                ke,
+            )
         for q_start, q_end, logits_chunk in logits_rows:
             topk_offsets_chunk = (
                 None if topk_offsets is None else topk_offsets[q_start:q_end]
@@ -1058,7 +1126,14 @@ class IndexerKPool(MultiPlatformOp):
             forward_batch=forward_batch,
             precompute_compress_gate=False,
         )
-        q_fp8, q_scale = act_quant(query, self.block_size, self.scale_fmt)
+        pool = _token_pool_from_batch(forward_batch)
+        if getattr(pool, "index_cache_is_bf16", False):
+            q_fp8 = query.contiguous()
+            q_scale = torch.ones(
+                (*query.shape[:-1], 1), dtype=torch.float32, device=query.device
+            )
+        else:
+            q_fp8, q_scale = act_quant(query, self.block_size, self.scale_fmt)
         self._compress_write(
             x=x,
             key=key,

--- a/python/sglang/srt/layers/attention/nsa_backend.py
+++ b/python/sglang/srt/layers/attention/nsa_backend.py
@@ -76,6 +76,8 @@ else:
 
 # Reuse this workspace buffer across all NSA backend instances
 global_workspace_buffer = None
+_GLM5_NEXT_NATIVE_CUDA_CAPS = ((8, 6), (8, 9), (12, 0))
+_GLM5_NEXT_SCALED_FP8_CUDA_CAPS = ((8, 9), (12, 0))
 
 # Control whether to use fused metadata copy kernel (default: enabled)
 # Set SGLANG_USE_FUSED_METADATA_COPY=0 or false to disable
@@ -385,7 +387,13 @@ class NativeSparseAttnBackend(
         self.kv_cache_dtype = model_runner.kv_cache_dtype
 
         # Allocate global workspace buffer for TRT-LLM kernels (ragged attention on SM100/B200, or trtllm decode)
-        if self.device_sm_major >= 10 or self.nsa_decode_impl == "trtllm":
+        uses_glm5_native_backend = (
+            self.is_glm5_next
+            and self.device_capability in _GLM5_NEXT_NATIVE_CUDA_CAPS
+        )
+        if not uses_glm5_native_backend and (
+            self.device_sm_major >= 10 or self.nsa_decode_impl == "trtllm"
+        ):
             global global_workspace_buffer
             if global_workspace_buffer is None:
                 global_workspace_buffer = torch.empty(
@@ -443,7 +451,8 @@ class NativeSparseAttnBackend(
             # SM120 consumes the graph-safe model-local scorer and has no
             # DeepGEMM schedule.  Other Blackwell variants keep the existing
             # schedule contract.
-            build_schedule_metadata=self.device_capability != (12, 0),
+            build_schedule_metadata=self.device_capability
+            not in _GLM5_NEXT_NATIVE_CUDA_CAPS,
         )
 
     def _update_glm5_next_kpool_graph_metadata(
@@ -469,7 +478,8 @@ class NativeSparseAttnBackend(
             pool_size=self.nsa_index_kpool,
             real_page_size=self.real_page_size,
             slots_per_page=64,
-            build_schedule_metadata=self.device_capability != (12, 0),
+            build_schedule_metadata=self.device_capability
+            not in _GLM5_NEXT_NATIVE_CUDA_CAPS,
         )
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
@@ -713,7 +723,10 @@ class NativeSparseAttnBackend(
         # Compute it once per forward batch and reuse it across layers.
         if (
             is_cuda()
-            and not (self.is_glm5_next and self.device_capability == (12, 0))
+            and not (
+                self.is_glm5_next
+                and self.device_capability in _GLM5_NEXT_NATIVE_CUDA_CAPS
+            )
             and (
                 forward_batch.forward_mode.is_decode_or_idle()
                 or forward_batch.forward_mode.is_target_verify()
@@ -808,6 +821,11 @@ class NativeSparseAttnBackend(
                     topk_transform_method=topk_transform_method,
                     full_real_page_table=metadata.real_page_table,
                     full_seqlens_expanded=seqlens_expanded,
+                    index_cache_dtype=getattr(
+                        forward_batch.token_to_kv_pool,
+                        "index_cache_dtype",
+                        torch.float8_e4m3fn,
+                    ),
                 )
             elif forward_batch.forward_mode.is_decode_or_idle():
                 metadata = init_pooled_paged_mqa_metadata(
@@ -818,7 +836,8 @@ class NativeSparseAttnBackend(
                     real_page_size=self.real_page_size,
                     slots_per_page=slots_per_page,
                     build_schedule_metadata=not (
-                        self.is_glm5_next and self.device_capability == (12, 0)
+                        self.is_glm5_next
+                        and self.device_capability in _GLM5_NEXT_NATIVE_CUDA_CAPS
                     ),
                 )
         self.forward_metadata = metadata
@@ -1056,7 +1075,10 @@ class NativeSparseAttnBackend(
         paged_mqa_schedule_metadata = None
         if (
             is_cuda()
-            and not (self.is_glm5_next and self.device_capability == (12, 0))
+            and not (
+                self.is_glm5_next
+                and self.device_capability in _GLM5_NEXT_NATIVE_CUDA_CAPS
+            )
             and (
                 forward_mode.is_decode_or_idle()
                 or forward_mode.is_target_verify()
@@ -1236,7 +1258,10 @@ class NativeSparseAttnBackend(
         # Update DeepGEMM paged MQA schedule metadata outside the captured graph.
         if (
             is_cuda()
-            and not (self.is_glm5_next and self.device_capability == (12, 0))
+            and not (
+                self.is_glm5_next
+                and self.device_capability in _GLM5_NEXT_NATIVE_CUDA_CAPS
+            )
             and (
                 forward_mode.is_decode_or_idle()
                 or forward_mode.is_target_verify()
@@ -2073,8 +2098,6 @@ class NativeSparseAttnBackend(
         is_prefill: bool = False,
     ) -> torch.Tensor:
         """Forward using TRT-LLM sparse MLA kernel."""
-        import flashinfer.decode
-
         metadata = self.forward_metadata
 
         merge_query = q_rope is not None and self.qk_rope_head_dim > 0
@@ -2083,7 +2106,7 @@ class NativeSparseAttnBackend(
         glm5_current_chunk_locs = None
         use_glm5_scaled_fp8 = (
             self.is_glm5_next
-            and self.device_capability == (12, 0)
+            and self.device_capability in _GLM5_NEXT_SCALED_FP8_CUDA_CAPS
             and self.kv_cache_dtype == torch.float8_e4m3fn
         )
         use_glm5_current_chunk_bf16 = (
@@ -2215,7 +2238,10 @@ class NativeSparseAttnBackend(
             )
             bmm1_scale = q_scale * k_scale * layer.scaling
 
-        if self.is_glm5_next and self.device_capability == (12, 0):
+        if (
+            self.is_glm5_next
+            and self.device_capability in _GLM5_NEXT_NATIVE_CUDA_CAPS
+        ):
             latent_scale = (
                 forward_batch.token_to_kv_pool.get_latent_scale_buffer(layer.layer_id)
                 if use_glm5_scaled_fp8
@@ -2236,6 +2262,12 @@ class NativeSparseAttnBackend(
                 current_chunk_kv=glm5_current_chunk_kv,
                 current_chunk_locs=glm5_current_chunk_locs,
             )
+
+        # The GLM-native path above deliberately has no FlashInfer ABI
+        # dependency: consumer GPUs can execute it even when the installed
+        # TRTLLM-GEN kernels do not contain their architecture.  Import only
+        # after that dispatch, for the shared DeepSeek implementation below.
+        import flashinfer.decode
 
         # Padding to a multiple of four belongs to FlashInfer's TRTLLM ABI.
         # The exact GLM kernel above consumes its native 2048+3 width and must

--- a/python/sglang/srt/layers/moe/kt_ep_wrapper.py
+++ b/python/sglang/srt/layers/moe/kt_ep_wrapper.py
@@ -25,6 +25,11 @@ Diagnostic / escape-hatch environment variables (KT-DEBUG-ONLY; not for prod):
         Force GPU-experts apply() to a zero return; routed expert output
         comes purely from the CPU side. "Plan-C" fallback for diagnosing
         whether a regression sits in the GPU MoE path or the merge math.
+
+    SGLANG_KT_GLM5_NEXT_FP8_TRANSPORT=auto|native|legacy
+        Select the exact GLM-5-Next TP4 block-FP8 layer transport. ``auto``
+        uses the native batch API when present and otherwise falls back before
+        the first load; a native runtime failure never falls back.
 """
 
 import bisect
@@ -36,6 +41,7 @@ import logging
 import os
 import time
 import uuid
+from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass, replace
 from multiprocessing import shared_memory
 from pathlib import Path
@@ -76,6 +82,45 @@ logger = logging.getLogger(__name__)
 
 # Global cache for GPU experts masks (initialized once per session)
 _KT_GPU_EXPERTS_MASKS: Optional[torch.Tensor] = None
+
+_GLM5_NEXT_FP8_TRANSPORT_ENV = "SGLANG_KT_GLM5_NEXT_FP8_TRANSPORT"
+_GLM5_NEXT_FP8_TRANSPORT_MODES = frozenset(("auto", "native", "legacy"))
+_GLM5_NEXT_FP8_CONTROL_BYTES = 4096
+_GLM5_NEXT_FP8_TRANSPORT_TIMEOUT_MS = 60_000
+_GLM5_NEXT_FP8_MOE_LAYER_INDICES = tuple(range(3, 45))
+
+
+def _glm5_next_fp8_transport_mode() -> str:
+    """Return the requested GLM transport without silently accepting typos."""
+
+    mode = os.environ.get(_GLM5_NEXT_FP8_TRANSPORT_ENV, "auto").strip().lower()
+    if mode not in _GLM5_NEXT_FP8_TRANSPORT_MODES:
+        raise ValueError(
+            f"{_GLM5_NEXT_FP8_TRANSPORT_ENV} must be one of "
+            f"{sorted(_GLM5_NEXT_FP8_TRANSPORT_MODES)}, got {mode!r}"
+        )
+    return mode
+
+
+def _load_glm5_next_fp8_native_transport_api():
+    """Feature-probe the optional native transport before allocating resources."""
+
+    try:
+        from kt_kernel import kt_kernel_ext
+    except ImportError as exc:
+        return None, f"kt_kernel_ext import failed: {exc}"
+
+    missing = [
+        name
+        for name in (
+            "initialize_fp8_layerwise_control",
+            "FP8LayerwiseTransport",
+        )
+        if not hasattr(kt_kernel_ext, name)
+    ]
+    if missing:
+        return None, "kt_kernel_ext is missing " + ", ".join(missing)
+    return kt_kernel_ext, None
 
 
 @dataclass
@@ -293,6 +338,11 @@ _SHARED_STAGING_BUFFER = None  # Global shared staging buffer for all MoE layers
 _MXFP4_PREFILL_LAYER_REGISTRY = {}
 _MXFP4_LAYERWISE_MANAGERS = {}
 _MXFP4_LAYERWISE_DISABLED_REASONS = {}
+# Exact GLM-5-Next block-FP8 has a deliberately separate registry/control
+# plane.  Registration is harmless for ``legacy`` transport, while manager
+# construction is hard-gated on the native TP4/gpu_experts=0 runtime below.
+_GLM5_NEXT_FP8_NATIVE_PREFETCH_LAYER_REGISTRY = {}
+_GLM5_NEXT_FP8_NATIVE_PREFETCH_MANAGERS = {}
 
 
 class SharedStagingBuffer:
@@ -787,6 +837,8 @@ class SharedFullContext:
     def _cleanup_cpu_buffers_after_failure(self) -> None:
         """Best-effort symmetric cleanup for a failed SHM setup phase."""
 
+        self._close_glm5_next_fp8_transport()
+
         if torch.cuda.is_available():
             for tensor in getattr(self, "_registered_host_buffers", []):
                 try:
@@ -818,6 +870,18 @@ class SharedFullContext:
             except Exception:
                 pass
         self.shm_handles = {}
+
+    def close(self) -> None:
+        """Stop native workers before releasing their Host-buffer mappings."""
+
+        self._cleanup_cpu_buffers_after_failure()
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            # Interpreter shutdown can tear down torch and logging first.
+            pass
 
     def _commit_cpu_buffer_phase(
         self, local_error: Optional[Exception], phase: str
@@ -1162,8 +1226,301 @@ class SharedFullContext:
         w13_p.set_(w13_p.view(num_experts, w13_k // 16, w13_n * (num_bits // 2)))
         w2_p.set_(w2_p.view(num_experts, w2_k // 16, w2_n * (num_bits // 2)))
 
-    def _initialize_glm5_next_fp8_transport(self) -> None:
-        """Create the exact-GLM transport resources once per shared context."""
+    def _close_glm5_next_fp8_transport(self) -> None:
+        """Best-effort teardown; native workers must stop before SHM closes."""
+
+        # A successor task may be blocked in an event fence or native
+        # join/run/wait.  It owns the last possible access to both the Host
+        # slots and transport handle, so join it before closing either.
+        prefetch_manager = getattr(
+            self, "_glm5_next_fp8_native_prefetch_manager", None
+        )
+        self._glm5_next_fp8_native_prefetch_manager = None
+        if prefetch_manager is not None:
+            try:
+                prefetch_manager.close()
+            except Exception:
+                pass
+
+        transport = getattr(self, "_glm5_next_fp8_native_transport", None)
+        self._glm5_next_fp8_native_transport = None
+        if transport is not None:
+            try:
+                transport.close()
+            except Exception:
+                pass
+
+        if getattr(self, "_glm5_next_fp8_transport_backend", None) == "legacy":
+            copy_stream = getattr(self, "_glm5_next_fp8_copy_stream", None)
+            if copy_stream is not None:
+                try:
+                    copy_stream.synchronize()
+                except Exception:
+                    pass
+
+        control_shm = getattr(self, "_glm5_next_fp8_control_shm", None)
+        self._glm5_next_fp8_control_shm = None
+        if control_shm is not None:
+            if getattr(self, "_glm5_next_fp8_control_owner", False):
+                try:
+                    control_shm.unlink()
+                except FileNotFoundError:
+                    pass
+                except Exception:
+                    pass
+            try:
+                control_shm.close()
+            except Exception:
+                pass
+
+        self._glm5_next_fp8_transport_initialized = False
+        self._glm5_next_fp8_transport_backend = None
+
+    @staticmethod
+    def _tp_all_gather_object(value):
+        if (
+            not dist.is_initialized()
+            or get_tensor_model_parallel_world_size() == 1
+        ):
+            return [value]
+        values = [None] * get_tensor_model_parallel_world_size()
+        dist.all_gather_object(
+            values, value, group=get_tp_group().cpu_group
+        )
+        return values
+
+    def _glm5_next_fp8_pointer_layout(self):
+        """Build the ABI-ordered raw pointer arrays consumed by native code."""
+
+        names = tuple(self.WEIGHT_NAMES_FP8)
+        tp_rank = get_tensor_model_parallel_rank()
+        tp_size = get_tensor_model_parallel_world_size()
+        expert_nbytes = [
+            self.cpu_buffers[name].numel()
+            // 2
+            * self.cpu_buffers[name].element_size()
+            for name in names
+        ]
+        local_host_ptrs = [
+            int(self.cpu_buffers[name].data_ptr() + slot * expert_nbytes[index])
+            for slot in range(2)
+            for index, name in enumerate(names)
+        ]
+        gpu_tensors = [getattr(self.gpu_layer, name) for name in names]
+        for index, (name, tensor) in enumerate(zip(names, gpu_tensors)):
+            if not tensor.is_contiguous():
+                raise RuntimeError(
+                    "GLM-5-Next native transport requires expert-major "
+                    f"contiguous GPU tensor {name}, got stride={tensor.stride()}"
+                )
+            if tensor.shape[0] != self.gpu_layer.num_experts:
+                raise RuntimeError(
+                    "GLM-5-Next native transport GPU tensor has an invalid "
+                    f"expert axis: {name} shape={tuple(tensor.shape)}"
+                )
+            expected_nbytes = expert_nbytes[index]
+            actual_nbytes = tensor.numel() // tensor.shape[0] * tensor.element_size()
+            if actual_nbytes != expected_nbytes:
+                raise RuntimeError(
+                    "GLM-5-Next native transport Host/GPU expert stride "
+                    f"mismatch for {name}: host={expected_nbytes}, gpu={actual_nbytes}"
+                )
+        local_gpu_ptrs = [int(tensor.data_ptr()) for tensor in gpu_tensors]
+        all_rank_host_ptrs = []
+        if tp_rank == 0:
+            all_rank_host_ptrs = [
+                int(
+                    self.all_rank_buffer_ptrs[name][rank]
+                    + slot * expert_nbytes[index]
+                )
+                for slot in range(2)
+                for rank in range(tp_size)
+                for index, name in enumerate(names)
+            ]
+
+        if len(local_host_ptrs) != 8 or len(local_gpu_ptrs) != 4:
+            raise RuntimeError("invalid GLM-5-Next native pointer layout")
+        if tp_rank == 0 and len(all_rank_host_ptrs) != 2 * tp_size * 4:
+            raise RuntimeError("invalid GLM-5-Next all-rank Host pointer layout")
+        if any(pointer <= 0 for pointer in local_host_ptrs + local_gpu_ptrs):
+            raise RuntimeError("GLM-5-Next native transport received a null pointer")
+        if tp_rank == 0 and any(pointer <= 0 for pointer in all_rank_host_ptrs):
+            raise RuntimeError(
+                "GLM-5-Next native transport could not map every TP Host slot"
+            )
+        return (
+            local_host_ptrs,
+            local_gpu_ptrs,
+            all_rank_host_ptrs,
+            expert_nbytes,
+        )
+
+    def _initialize_glm5_next_fp8_native_transport(self, kt_kernel_ext) -> None:
+        tp_rank = get_tensor_model_parallel_rank()
+        tp_size = get_tensor_model_parallel_world_size()
+        control_name = f"kt_glm5_next_fp8_ctrl_{self.shm_unique_id}"
+        self._glm5_next_fp8_control_shm = None
+        self._glm5_next_fp8_control_owner = tp_rank == 0
+        self._glm5_next_fp8_native_transport = None
+
+        create_error = None
+        if tp_rank == 0:
+            try:
+                control_shm = shared_memory.SharedMemory(
+                    name=control_name,
+                    create=True,
+                    size=_GLM5_NEXT_FP8_CONTROL_BYTES,
+                )
+                self._glm5_next_fp8_control_shm = control_shm
+                control_ptr = ctypes.addressof(
+                    ctypes.c_char.from_buffer(control_shm.buf)
+                )
+                kt_kernel_ext.initialize_fp8_layerwise_control(
+                    control_ptr,
+                    _GLM5_NEXT_FP8_CONTROL_BYTES,
+                    tp_size,
+                )
+            except Exception as exc:
+                create_error = exc
+        self._commit_cpu_buffer_phase(create_error, "native control creation")
+
+        map_error = None
+        if tp_rank != 0:
+            try:
+                self._glm5_next_fp8_control_shm = shared_memory.SharedMemory(
+                    name=control_name,
+                    create=False,
+                )
+            except Exception as exc:
+                map_error = exc
+        self._commit_cpu_buffer_phase(map_error, "native control mapping")
+
+        handle_error = None
+        try:
+            control_shm = self._glm5_next_fp8_control_shm
+            if control_shm is None:
+                raise RuntimeError("native control SHM is not mapped")
+            control_ptr = ctypes.addressof(
+                ctypes.c_char.from_buffer(control_shm.buf)
+            )
+            (
+                local_host_ptrs,
+                local_gpu_ptrs,
+                all_rank_host_ptrs,
+                expert_nbytes,
+            ) = self._glm5_next_fp8_pointer_layout()
+            device = self.gpu_layer.w13_weight.device
+            cuda_device = (
+                device.index
+                if device.index is not None
+                else torch.cuda.current_device()
+            )
+            self._glm5_next_fp8_native_transport = (
+                kt_kernel_ext.FP8LayerwiseTransport(
+                    control_ptr,
+                    _GLM5_NEXT_FP8_CONTROL_BYTES,
+                    tp_rank,
+                    tp_size,
+                    cuda_device,
+                    local_host_ptrs,
+                    local_gpu_ptrs,
+                    all_rank_host_ptrs,
+                    expert_nbytes,
+                    self.gpu_layer.num_experts,
+                    _GLM5_NEXT_FP8_TRANSPORT_TIMEOUT_MS,
+                )
+            )
+            # The native handle stores these destination addresses for its
+            # lifetime.  Exact-native loads reject any later rebind instead
+            # of silently writing an obsolete allocation.
+            self._glm5_next_fp8_native_gpu_ptrs = tuple(local_gpu_ptrs)
+        except Exception as exc:
+            handle_error = exc
+        self._commit_cpu_buffer_phase(handle_error, "native handle creation")
+
+        # Every process now owns a mapping. Remove the name immediately so a
+        # crashed server cannot strand a persistent control object in /dev/shm.
+        if tp_rank == 0:
+            try:
+                self._glm5_next_fp8_control_shm.unlink()
+            except FileNotFoundError:
+                pass
+        self._glm5_next_fp8_transport_epoch = 0
+        self._glm5_next_fp8_transport_poisoned = False
+        self._glm5_next_fp8_transport_backend = "native"
+        self._glm5_next_fp8_transport_initialized = True
+
+    def _initialize_glm5_next_fp8_transport(
+        self, wrapper=None, num_gpu_experts: int = 0
+    ) -> None:
+        """Select and initialize the exact-GLM transport once per context."""
+
+        if getattr(self, "_glm5_next_fp8_transport_initialized", False):
+            return
+        if get_tensor_model_parallel_world_size() != 4:
+            raise RuntimeError(
+                "GLM-5-Next layerwise prefill transport requires TP=4"
+            )
+        gpu_expert_counts = self._tp_all_gather_object(int(num_gpu_experts))
+        if any(count != gpu_expert_counts[0] for count in gpu_expert_counts):
+            raise RuntimeError(
+                "GLM-5-Next gpu_experts differs across TP ranks: "
+                f"{gpu_expert_counts}"
+            )
+        if gpu_expert_counts[0] != 0:
+            raise RuntimeError(
+                "GLM-5-Next layerwise prefill transport requires "
+                "gpu_experts=0"
+            )
+
+        raw_mode = os.environ.get(
+            _GLM5_NEXT_FP8_TRANSPORT_ENV, "auto"
+        ).strip().lower()
+        requested_modes = self._tp_all_gather_object(raw_mode)
+        if any(mode != requested_modes[0] for mode in requested_modes):
+            raise RuntimeError(
+                f"{_GLM5_NEXT_FP8_TRANSPORT_ENV} differs across TP ranks: "
+                f"{requested_modes}"
+            )
+        requested_mode = _glm5_next_fp8_transport_mode()
+
+        if requested_mode == "legacy":
+            self._initialize_glm5_next_fp8_legacy_transport()
+            return
+
+        kt_kernel_ext, missing_reason = (
+            _load_glm5_next_fp8_native_transport_api()
+        )
+        tp_rank = get_tensor_model_parallel_rank()
+        if tp_rank == 0 and not callable(
+            getattr(getattr(wrapper, "moe", None), "run_layerwise_fp8_batch", None)
+        ):
+            missing_reason = (
+                "KT FP8 writer is missing the direct native "
+                "moe.run_layerwise_fp8_batch API"
+            )
+        missing_reasons = self._tp_all_gather_object(missing_reason)
+        missing_reasons = [reason for reason in missing_reasons if reason]
+        if missing_reasons:
+            details = "; ".join(dict.fromkeys(missing_reasons))
+            if requested_mode == "native":
+                raise RuntimeError(
+                    "GLM-5-Next native FP8 transport was forced but is "
+                    f"unavailable: {details}"
+                )
+            if tp_rank == 0:
+                logger.warning(
+                    "KT GLM-5-Next native FP8 transport API is unavailable; "
+                    "falling back to legacy before the first layer load: %s",
+                    details,
+                )
+            self._initialize_glm5_next_fp8_legacy_transport()
+            return
+
+        self._initialize_glm5_next_fp8_native_transport(kt_kernel_ext)
+
+    def _initialize_glm5_next_fp8_legacy_transport(self) -> None:
+        """Create the legacy Python per-expert transport resources."""
 
         if getattr(self, "_glm5_next_fp8_transport_initialized", False):
             return
@@ -1179,10 +1536,12 @@ class SharedFullContext:
             if dist.is_initialized()
             else None
         )
+        self._glm5_next_fp8_transport_backend = "legacy"
+        self._glm5_next_fp8_transport_poisoned = False
         self._glm5_next_fp8_transport_initialized = True
 
-    def _prepare_weight_fp8_glm5_next(self, wrapper) -> None:
-        """Load one GLM layer with 2 Host expert slots and 1 GPU layer slot."""
+    def _prepare_weight_fp8_glm5_next_legacy(self, wrapper) -> None:
+        """Legacy Python per-expert writer/copy loop retained for A/B tests."""
 
         if not getattr(self, "_glm5_next_fp8_transport_initialized", False):
             raise RuntimeError(
@@ -1314,8 +1673,178 @@ class SharedFullContext:
 
         torch.cuda.current_stream(device).wait_stream(copy_stream)
 
-    def _prepare_weight_fp8(self, wrapper, original_layer=None, gpu_experts_mask=None,
-                            logical_to_gpu_index=None):
+    def _prepare_weight_fp8_glm5_next_native(
+        self, wrapper, layer_idx: int
+    ) -> None:
+        """Run one complete layer transport without a Python expert loop."""
+
+        if getattr(self, "_glm5_next_fp8_transport_poisoned", False):
+            raise RuntimeError(
+                "GLM-5-Next native FP8 transport is poisoned; restart the "
+                "server before retrying"
+            )
+        transport = getattr(self, "_glm5_next_fp8_native_transport", None)
+        if transport is None:
+            raise RuntimeError(
+                "GLM-5-Next native FP8 transport was not initialized"
+            )
+
+        tp_rank = get_tensor_model_parallel_rank()
+        expert_count = int(self.gpu_layer.num_experts)
+        epoch = int(self._glm5_next_fp8_transport_epoch) + 1
+        self._glm5_next_fp8_transport_epoch = epoch
+        try:
+            transport.join(epoch, int(layer_idx), expert_count)
+            if tp_rank == 0:
+                # The public NativeMoEWrapper helper drains the process-wide
+                # CPUInfer pool on every invocation.  The exact-native manager
+                # establishes that drain once before its first prime and then
+                # serializes all layer writers in one worker.  Calling the
+                # bound C++ MoE directly here therefore preserves the same
+                # non-reentrancy invariant without putting a process-wide
+                # CPUInfer drain back into every successor's hot path.
+                run_batch = getattr(
+                    getattr(wrapper, "moe", None),
+                    "run_layerwise_fp8_batch",
+                    None,
+                )
+                if not callable(run_batch):
+                    raise RuntimeError(
+                        "KT FP8 writer lost direct "
+                        "moe.run_layerwise_fp8_batch after native transport "
+                        "initialization"
+                    )
+                run_batch(transport, epoch, int(layer_idx), expert_count)
+            stats = dict(transport.wait(epoch) or {})
+
+            expected = {
+                "epoch": epoch,
+                "layer_id": int(layer_idx),
+                "expert_count": expert_count,
+            }
+            for name, value in expected.items():
+                if name in stats and int(stats[name]) != value:
+                    raise RuntimeError(
+                        f"native transport returned stale {name}: "
+                        f"expected={value}, got={stats[name]}"
+                    )
+            if bool(stats.get("poisoned", False)) or int(
+                stats.get("error_code", 0)
+            ) != 0:
+                raise RuntimeError(
+                    "native transport reported an error: "
+                    f"code={stats.get('error_code', 0)} "
+                    f"rank={stats.get('error_rank', -1)}"
+                )
+        except Exception as exc:
+            self._glm5_next_fp8_transport_poisoned = True
+            try:
+                transport.close()
+            except Exception:
+                pass
+            self._glm5_next_fp8_native_transport = None
+            raise RuntimeError(
+                "GLM-5-Next native FP8 layer transport failed for "
+                f"epoch={epoch}, layer={layer_idx}; runtime fallback is disabled"
+            ) from exc
+
+        logger.debug(
+            "KT GLM-5-Next native FP8 transport: epoch=%d layer=%d rank=%d "
+            "experts=%d writer=%.2f ms slot_wait=%.2f ms h2d=%.2f ms "
+            "transport=%.2f ms bytes=%d",
+            epoch,
+            layer_idx,
+            tp_rank,
+            expert_count,
+            float(stats.get("writer_ms", 0.0)),
+            float(stats.get("slot_wait_ms", 0.0)),
+            float(stats.get("h2d_ms", 0.0)),
+            float(stats.get("total_ms", 0.0)),
+            int(stats.get("bytes", 0)),
+        )
+
+    def _validate_glm5_next_fp8_native_gpu_slot(self) -> None:
+        """Keep the native pointer ABI bound to exactly one GPU layer slot."""
+
+        expected = getattr(self, "_glm5_next_fp8_native_gpu_ptrs", None)
+        actual = tuple(
+            int(getattr(self.gpu_layer, name).data_ptr())
+            for name in self.WEIGHT_NAMES_FP8
+        )
+        if expected is None or actual != tuple(expected):
+            raise RuntimeError(
+                "GLM-5-Next native FP8 full-layer GPU slot was rebound; "
+                "restart the server instead of writing stale native pointers"
+            )
+
+    def load_glm5_next_fp8_native(
+        self,
+        *,
+        layer_idx: int,
+        wrapper,
+        consumed_event=None,
+    ) -> None:
+        """Load one exact-GLM layer without a device-wide synchronization.
+
+        ``consumed_event`` is recorded immediately after the previous MoE's
+        GPU apply is enqueued.  Waiting for that single event fences the only
+        full-layer destination slot while still allowing the successor H2D
+        transport to overlap later attention kernels on the main stream.
+        The native wait returns only after its private H2D stream has finished,
+        so the acquiring main thread can safely enqueue the next MoE.
+        """
+
+        if getattr(self, "_glm5_next_fp8_transport_backend", None) != "native":
+            raise RuntimeError(
+                "exact-native GLM load requires the native FP8 transport"
+            )
+        if getattr(self, "_glm5_next_fp8_transport_poisoned", False):
+            raise RuntimeError(
+                "GLM-5-Next native FP8 transport is poisoned; runtime "
+                "fallback is disabled"
+            )
+
+        fence_error = None
+        if consumed_event is not None:
+            try:
+                consumed_event.synchronize()
+            except Exception as exc:
+                fence_error = exc
+            if fence_error is not None:
+                self._glm5_next_fp8_transport_poisoned = True
+                raise RuntimeError(
+                    "GLM-5-Next native FP8 local consumed-event fence failed; "
+                    "runtime fallback is disabled"
+                ) from fence_error
+
+        try:
+            self._validate_glm5_next_fp8_native_gpu_slot()
+            self._prepare_weight_fp8_glm5_next_native(wrapper, layer_idx)
+            self._validate_glm5_next_fp8_native_gpu_slot()
+        except Exception:
+            self._glm5_next_fp8_transport_poisoned = True
+            raise
+
+    def _prepare_weight_fp8_glm5_next(self, wrapper, layer_idx: int) -> None:
+        backend = getattr(self, "_glm5_next_fp8_transport_backend", None)
+        if backend == "native":
+            self._prepare_weight_fp8_glm5_next_native(wrapper, layer_idx)
+            return
+        if backend == "legacy":
+            self._prepare_weight_fp8_glm5_next_legacy(wrapper)
+            return
+        raise RuntimeError(
+            "GLM-5-Next FP8 transport resources were not initialized"
+        )
+
+    def _prepare_weight_fp8(
+        self,
+        wrapper,
+        original_layer=None,
+        gpu_experts_mask=None,
+        logical_to_gpu_index=None,
+        layer_idx: Optional[int] = None,
+    ):
         """Prepare FP8 block quant weights by writing from KT and copying to GPU.
 
         Pipeline: write(e+1) || copy(e) || postprocess(e-1)
@@ -1342,7 +1871,11 @@ class SharedFullContext:
                 False,
             )
         ):
-            self._prepare_weight_fp8_glm5_next(wrapper)
+            if layer_idx is None:
+                raise RuntimeError(
+                    "GLM-5-Next FP8 transport requires the logical layer index"
+                )
+            self._prepare_weight_fp8_glm5_next(wrapper, layer_idx)
             return
 
         # Bind Python thread to specific CPU core (last cores for each rank)
@@ -1949,8 +2482,13 @@ class SharedFullContext:
             # When the inference layer is Marlin-repacked (int32), the
             # raw fp8 context layer can't share GPU→GPU copies.
             # Disable Phase 1 shortcut by passing original_layer=None.
-            self._prepare_weight_fp8(wrapper, None, gpu_experts_mask,
-                                     logical_to_gpu_index)
+            self._prepare_weight_fp8(
+                wrapper,
+                None,
+                gpu_experts_mask,
+                logical_to_gpu_index,
+                layer_idx=layer_idx,
+            )
         elif self._is_fp8_channel_quant:
             self._prepare_weight_fp8_channel(wrapper, None, gpu_experts_mask,
                                              logical_to_gpu_index)
@@ -2963,18 +3501,38 @@ def _validate_glm5_next_fp8_shared_full_context(
             "GLM-5-Next layerwise prefill requires runtime TP=4; "
             f"got TP={tp_size}"
         )
-    slot_events = getattr(
-        context, "_glm5_next_fp8_host_slot_events", None
-    )
-    if (
-        not getattr(context, "_glm5_next_fp8_transport_initialized", False)
-        or slot_events is None
-        or len(slot_events) != 2
-        or getattr(context, "_glm5_next_fp8_copy_stream", None) is None
-    ):
+    if not getattr(context, "_glm5_next_fp8_transport_initialized", False):
         raise RuntimeError(
-            "GLM-5-Next layerwise prefill requires one persistent H2D "
-            "stream and exactly two Host-slot completion events"
+            "GLM-5-Next layerwise prefill transport is not initialized"
+        )
+    transport_backend = getattr(
+        context, "_glm5_next_fp8_transport_backend", "legacy"
+    )
+    if transport_backend == "native":
+        if (
+            getattr(context, "_glm5_next_fp8_native_transport", None) is None
+            or getattr(context, "_glm5_next_fp8_control_shm", None) is None
+        ):
+            raise RuntimeError(
+                "GLM-5-Next native layerwise prefill requires a persistent "
+                "native handle and mapped control SHM"
+            )
+    elif transport_backend == "legacy":
+        slot_events = getattr(
+            context, "_glm5_next_fp8_host_slot_events", None
+        )
+        if (
+            slot_events is None
+            or len(slot_events) != 2
+            or getattr(context, "_glm5_next_fp8_copy_stream", None) is None
+        ):
+            raise RuntimeError(
+                "GLM-5-Next legacy layerwise prefill requires one persistent "
+                "H2D stream and exactly two Host-slot completion events"
+            )
+    else:
+        raise RuntimeError(
+            f"unknown GLM-5-Next transport backend {transport_backend!r}"
         )
     layer = context.gpu_layer
     runner_config = getattr(layer, "moe_runner_config", None)
@@ -3061,6 +3619,477 @@ def _validate_glm5_next_fp8_shared_full_context(
 def _glm5_next_forward_mode_name(mode) -> str:
     name = getattr(mode, "name", None)
     return str(name if name is not None else mode).upper()
+
+
+def _glm5_next_fp8_native_prefetch_signature(method, layer) -> tuple:
+    device = next(layer.parameters()).device
+    return (
+        str(device),
+        method.kt_config.weight_path,
+        method.kt_config.num_layers,
+        method.global_num_experts,
+        method._full_init_args,
+    )
+
+
+def _register_glm5_next_fp8_native_prefetch_layer(method, layer) -> None:
+    """Register exact-GLM MoE order during model construction."""
+
+    if not _glm5_next_fp8_pipeline_requested(method):
+        return
+    signature = _glm5_next_fp8_native_prefetch_signature(method, layer)
+    method._glm5_next_fp8_native_prefetch_signature = signature
+    registry = _GLM5_NEXT_FP8_NATIVE_PREFETCH_LAYER_REGISTRY.setdefault(
+        signature, {}
+    )
+    layer_idx = int(method.kt_config.layer_idx)
+    existing = registry.get(layer_idx)
+    if existing is not None and (
+        existing[0] is not method or existing[1] is not layer
+    ):
+        raise RuntimeError(
+            "duplicate exact GLM-5-Next native prefetch registration for "
+            f"layer {layer_idx}"
+        )
+    registry[layer_idx] = (method, layer)
+
+
+def _glm5_next_fp8_native_prefetch_runtime_supported(
+    method, context: SharedFullContext
+) -> bool:
+    """Hard-gate the successor worker without changing legacy behavior."""
+
+    if not _glm5_next_fp8_pipeline_requested(method):
+        return False
+    if getattr(context, "_glm5_next_fp8_transport_backend", None) != "native":
+        return False
+    tp_size = get_tensor_model_parallel_world_size()
+    if tp_size != 4:
+        raise RuntimeError(
+            "exact GLM-5-Next native successor prefetch requires TP=4; "
+            f"got TP={tp_size}"
+        )
+    if int(method.num_gpu_experts) != 0:
+        raise RuntimeError(
+            "exact GLM-5-Next native successor prefetch requires "
+            "gpu_experts=0"
+        )
+    return True
+
+
+class _Glm5NextFp8NativeSingleSlotPrefetchManager:
+    """Overlap successor transport with attention using one GPU weight slot.
+
+    The manager deliberately owns no weight tensor.  ``context.gpu_layer`` is
+    the sole full-layer destination, protected by one consumed event.  A
+    single Python worker per TP rank executes only layer-granularity control;
+    the expert writer/H2D hot loop remains in the native transport.
+    """
+
+    def __init__(self, context: SharedFullContext, signature: tuple, registry):
+        self.context = context
+        self.signature = signature
+        self.registry = registry
+        self.layer_indices = tuple(sorted(registry))
+        if self.layer_indices != _GLM5_NEXT_FP8_MOE_LAYER_INDICES:
+            raise RuntimeError(
+                "exact GLM-5-Next native prefetch requires the complete MoE "
+                "registry for layers 3..44 before its first prime; got "
+                f"{self.layer_indices}"
+            )
+        for layer_idx, (method, _layer) in registry.items():
+            config = method.kt_config
+            if (
+                int(config.layer_idx) != layer_idx
+                or int(config.num_layers or 0) != 45
+                or not bool(config.is_glm5_next)
+                or (config.method or "").upper() != "FP8"
+            ):
+                raise RuntimeError(
+                    "exact GLM-5-Next native prefetch registry contains an "
+                    f"invalid layer entry for layer {layer_idx}"
+                )
+        self.first_layer_idx = self.layer_indices[0]
+        self.last_layer_idx = self.layer_indices[-1]
+        self._successors = {
+            layer_idx: (
+                self.layer_indices[index + 1]
+                if index + 1 < len(self.layer_indices)
+                else None
+            )
+            for index, layer_idx in enumerate(self.layer_indices)
+        }
+        self.device = context.gpu_layer.w13_weight.device
+        self.consumed_event = torch.cuda.Event()
+        self.executor = ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix=(
+                f"kt-glm5-fp8-prefetch-r{get_tensor_model_parallel_rank()}"
+            ),
+        )
+        self.future: Optional[Future] = None
+        self.future_layer_idx: Optional[int] = None
+        self.loaded_layer_idx: Optional[int] = None
+        self.last_acquired_layer_idx: Optional[int] = None
+        self.round_id = 0
+        self._cpu_infer_drained = False
+        self._poison_error: Optional[BaseException] = None
+        self._closed = False
+
+    def _mark_poisoned(self, error: BaseException) -> None:
+        if self._poison_error is None:
+            self._poison_error = error
+        self.context._glm5_next_fp8_transport_poisoned = True
+
+    def _raise_if_unusable(self) -> None:
+        if self._closed:
+            raise RuntimeError(
+                "GLM-5-Next native successor prefetch manager is closed"
+            )
+        if self._poison_error is not None or getattr(
+            self.context, "_glm5_next_fp8_transport_poisoned", False
+        ):
+            raise RuntimeError(
+                "GLM-5-Next native successor prefetch is poisoned; "
+                "runtime fallback is disabled"
+            ) from self._poison_error
+
+    def _commit_rank_local_error(
+        self, local_error: Optional[BaseException], phase: str
+    ) -> None:
+        if _all_tp_ranks_succeeded(local_error is None):
+            return
+        error = RuntimeError(
+            "GLM-5-Next native successor prefetch "
+            f"{phase} failed on at least one TP rank; runtime fallback is disabled"
+        )
+        self._mark_poisoned(error)
+        if local_error is not None:
+            raise error from local_error
+        raise error
+
+    def _drain_cpu_infer_once(self, method) -> None:
+        """Establish a clean writer boundary once, before the first epoch."""
+
+        if self._cpu_infer_drained:
+            return
+        local_error = None
+        if method.tp_rank == 0:
+            try:
+                cpu_infer = getattr(method.wrapper, "cpu_infer", None)
+                sync = getattr(cpu_infer, "sync", None)
+                if not callable(sync):
+                    raise RuntimeError(
+                        "exact GLM-5-Next native prime requires "
+                        "wrapper.cpu_infer.sync"
+                    )
+                sync()
+            except Exception as exc:
+                local_error = exc
+        self._commit_rank_local_error(local_error, "initial CPUInfer drain")
+        self._cpu_infer_drained = True
+
+    def _load_layer(
+        self, layer_idx: int, method, consumed_event
+    ) -> int:
+        self.context.load_glm5_next_fp8_native(
+            layer_idx=layer_idx,
+            wrapper=method.wrapper,
+            consumed_event=consumed_event,
+        )
+        return layer_idx
+
+    def _prime(self, layer_idx: int, method, consumed_event) -> None:
+        self._drain_cpu_infer_once(method)
+        self._load_layer(layer_idx, method, consumed_event)
+        self.loaded_layer_idx = layer_idx
+
+    def _finish_future(self, expected_layer_idx: int) -> None:
+        future = self.future
+        actual_expected = self.future_layer_idx
+        loaded_layer_idx = None
+        local_error = None
+        if future is None or actual_expected != expected_layer_idx:
+            local_error = RuntimeError(
+                "GLM-5-Next native successor prefetch acquired an invalid "
+                f"future: wanted layer={expected_layer_idx}, "
+                f"pending={actual_expected}"
+            )
+        else:
+            try:
+                loaded_layer_idx = int(future.result())
+            except Exception as exc:
+                local_error = exc
+        try:
+            if (
+                local_error is None
+                and loaded_layer_idx != expected_layer_idx
+            ):
+                local_error = RuntimeError(
+                    "GLM-5-Next native successor prefetch returned stale "
+                    f"weights: wanted layer={expected_layer_idx}, "
+                    f"got={loaded_layer_idx}"
+                )
+        finally:
+            self.future = None
+            self.future_layer_idx = None
+        # This consensus deliberately runs on the acquiring main thread, not
+        # inside the background worker.  It keeps torch.distributed control
+        # flow ordered with the model thread while propagating any rank-local
+        # event/native task failure before another successor is launched.
+        try:
+            self._commit_rank_local_error(
+                local_error, f"successor acquire for layer {expected_layer_idx}"
+            )
+        except Exception as exc:
+            self._mark_poisoned(exc)
+            raise
+        self.loaded_layer_idx = loaded_layer_idx
+
+    def _drain_interrupted_round(self) -> None:
+        if self.future is None:
+            return
+        expected = self.future_layer_idx
+        if expected is None:
+            error = RuntimeError(
+                "GLM-5-Next native successor prefetch lost its pending layer"
+            )
+            self._mark_poisoned(error)
+            raise error
+        # A canceled/short request can wrap before consuming the prefetched
+        # layer.  Finish that one writer first; one GPU slot cannot be
+        # overwritten by a second producer concurrently.
+        self._finish_future(expected)
+
+    def _acquire(self, method, layer) -> bool:
+        self._raise_if_unusable()
+        layer_idx = int(method.kt_config.layer_idx)
+        registered = self.registry.get(layer_idx)
+        if registered is None or registered[0] is not method or registered[1] is not layer:
+            error = RuntimeError(
+                "GLM-5-Next native successor prefetch received an "
+                f"unregistered layer {layer_idx}"
+            )
+            self._mark_poisoned(error)
+            raise error
+
+        is_wrap = (
+            self.last_acquired_layer_idx is not None
+            and layer_idx == self.first_layer_idx
+        )
+        if self.last_acquired_layer_idx is None:
+            if layer_idx != self.first_layer_idx:
+                error = RuntimeError(
+                    "GLM-5-Next native prefetch round must start at layer "
+                    f"{self.first_layer_idx}, got layer {layer_idx}"
+                )
+                self._mark_poisoned(error)
+                raise error
+            self.round_id = 1
+            self._prime(layer_idx, method, consumed_event=None)
+            prefetch_hit = False
+        elif is_wrap:
+            self._drain_interrupted_round()
+            self.round_id += 1
+            self.loaded_layer_idx = None
+            # The previous round's last (or last actually executed) MoE
+            # recorded this event.  Fence it before re-prime overwrites the
+            # sole layer slot; later attention remains free to overlap.
+            self._prime(layer_idx, method, self.consumed_event)
+            prefetch_hit = False
+        else:
+            expected = self._successors.get(self.last_acquired_layer_idx)
+            if expected != layer_idx:
+                error = RuntimeError(
+                    "GLM-5-Next native prefetch observed an out-of-order MoE: "
+                    f"after layer {self.last_acquired_layer_idx}, expected "
+                    f"{expected}, got {layer_idx}"
+                )
+                self._mark_poisoned(error)
+                raise error
+            self._finish_future(layer_idx)
+            prefetch_hit = True
+
+        if self.loaded_layer_idx != layer_idx:
+            error = RuntimeError(
+                "GLM-5-Next native prefetch did not acquire the requested "
+                f"layer: requested={layer_idx}, loaded={self.loaded_layer_idx}"
+            )
+            self._mark_poisoned(error)
+            raise error
+        self.last_acquired_layer_idx = layer_idx
+        return prefetch_hit
+
+    def _prefetch_successor(self, layer_idx: int) -> None:
+        successor_idx = self._successors[layer_idx]
+        if successor_idx is None:
+            # There is intentionally no speculative first-layer load here.
+            # The next chunk/request synchronously re-primes only after the
+            # last layer's consumed event has completed.
+            self.future = None
+            self.future_layer_idx = None
+            return
+        if self.future is not None:
+            error = RuntimeError(
+                "GLM-5-Next native successor prefetch already has a task in flight"
+            )
+            self._mark_poisoned(error)
+            raise error
+        successor_method, _ = self.registry[successor_idx]
+        self.future_layer_idx = successor_idx
+        try:
+            self.future = self.executor.submit(
+                self._load_layer,
+                successor_idx,
+                successor_method,
+                self.consumed_event,
+            )
+        except Exception as exc:
+            self.future_layer_idx = None
+            self._mark_poisoned(exc)
+            raise RuntimeError(
+                "GLM-5-Next native successor worker submission failed; "
+                "runtime fallback is disabled"
+            ) from exc
+
+    def apply(self, method, layer, dispatch_output):
+        layer_idx = int(method.kt_config.layer_idx)
+        prefetch_hit = self._acquire(method, layer)
+        main_stream = torch.cuda.current_stream(self.device)
+        result = None
+        compute_error = None
+        try:
+            process = getattr(
+                self.context.gpu_method, "process_weights_after_loading", None
+            )
+            if callable(process):
+                process(self.context.gpu_layer)
+            self.context._validate_glm5_next_fp8_native_gpu_slot()
+            result = self.context.gpu_method.apply(
+                self.context.gpu_layer, dispatch_output
+            )
+        except Exception as exc:
+            compute_error = exc
+        finally:
+            try:
+                # This event is the only overwrite fence for the one GPU slot.
+                # It is recorded after all weight-reading MoE work is enqueued,
+                # before the caller continues with postprocess/attention.
+                self.consumed_event.record(main_stream)
+            except Exception as exc:
+                if compute_error is None:
+                    compute_error = exc
+
+        try:
+            self._commit_rank_local_error(compute_error, "compute enqueue")
+        except Exception as exc:
+            self._mark_poisoned(exc)
+            raise
+        if compute_error is not None:
+            self._mark_poisoned(compute_error)
+            raise RuntimeError(
+                "GLM-5-Next native MoE compute enqueue failed; runtime "
+                "fallback is disabled"
+            ) from compute_error
+
+        # Submit only after every rank has published its consumed fence.  The
+        # main thread returns immediately; the single worker waits that event
+        # and runs native join/run/wait for the successor.
+        self._prefetch_successor(layer_idx)
+        if method.tp_rank == 0:
+            logger.debug(
+                "KT GLM-5-Next native single-slot prefetch: layer=%d "
+                "round=%d %s successor=%s",
+                layer_idx,
+                self.round_id,
+                "prefetch-hit" if prefetch_hit else "prime",
+                self._successors[layer_idx],
+            )
+        return result
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            if self.future is not None:
+                try:
+                    self.future.result()
+                except Exception as exc:
+                    self._mark_poisoned(exc)
+                finally:
+                    self.future = None
+                    self.future_layer_idx = None
+        finally:
+            self.executor.shutdown(wait=True, cancel_futures=False)
+            if (
+                _GLM5_NEXT_FP8_NATIVE_PREFETCH_MANAGERS.get(self.signature)
+                is self
+            ):
+                _GLM5_NEXT_FP8_NATIVE_PREFETCH_MANAGERS.pop(self.signature, None)
+
+
+def _get_or_initialize_glm5_next_fp8_native_prefetch_manager(
+    method, layer, context: SharedFullContext
+) -> _Glm5NextFp8NativeSingleSlotPrefetchManager:
+    if getattr(context, "_glm5_next_fp8_transport_poisoned", False):
+        raise RuntimeError(
+            "exact GLM-5-Next native prefetch context is poisoned; runtime "
+            "fallback is disabled"
+        )
+    signature = getattr(
+        method, "_glm5_next_fp8_native_prefetch_signature", None
+    )
+    if signature is None:
+        context._glm5_next_fp8_transport_poisoned = True
+        raise RuntimeError(
+            "exact GLM-5-Next native prefetch layer was not registered during "
+            "create_weights"
+        )
+    registry = _GLM5_NEXT_FP8_NATIVE_PREFETCH_LAYER_REGISTRY.get(signature)
+    if registry is None or registry.get(int(method.kt_config.layer_idx)) != (
+        method,
+        layer,
+    ):
+        context._glm5_next_fp8_transport_poisoned = True
+        raise RuntimeError(
+            "exact GLM-5-Next native prefetch registry is incomplete"
+        )
+
+    manager = _GLM5_NEXT_FP8_NATIVE_PREFETCH_MANAGERS.get(signature)
+    if manager is not None:
+        if manager.context is not context:
+            context._glm5_next_fp8_transport_poisoned = True
+            raise RuntimeError(
+                "exact GLM-5-Next native prefetch signature reused with a "
+                "different full-layer context"
+            )
+        return manager
+
+    manager = None
+    local_error = None
+    try:
+        manager = _Glm5NextFp8NativeSingleSlotPrefetchManager(
+            context, signature, registry
+        )
+    except Exception as exc:
+        local_error = exc
+    if not _all_tp_ranks_succeeded(local_error is None):
+        context._glm5_next_fp8_transport_poisoned = True
+        if manager is not None:
+            manager.close()
+        raise RuntimeError(
+            "exact GLM-5-Next native single-slot prefetch setup failed on at "
+            "least one TP rank"
+        ) from local_error
+    if manager is None:
+        context._glm5_next_fp8_transport_poisoned = True
+        raise RuntimeError(
+            "exact GLM-5-Next native single-slot prefetch setup returned no manager"
+        )
+    _GLM5_NEXT_FP8_NATIVE_PREFETCH_MANAGERS[signature] = manager
+    context._glm5_next_fp8_native_prefetch_manager = manager
+    return manager
 
 
 def generate_front_loading_masks(
@@ -4038,6 +5067,7 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
         # Registration happens during model construction, not on the first
         # request, so layer N can identify and prepare N+1 immediately.
         _register_mxfp4_prefill_layer(self, layer)
+        _register_glm5_next_fp8_native_prefetch_layer(self, layer)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         """Process weights after loading from checkpoint.
@@ -4438,6 +5468,14 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
             # serialized full-GPU fallback.
             ctx = self._build_full_context(layer)
 
+            if _glm5_next_fp8_native_prefetch_runtime_supported(self, ctx):
+                manager = (
+                    _get_or_initialize_glm5_next_fp8_native_prefetch_manager(
+                        self, layer, ctx
+                    )
+                )
+                return manager.apply(self, layer, dispatch_output)
+
             # Re-run quant post-processing on the full-expert gpu_layer
             # if supported (e.g. Marlin repack for Fp8MarlinMoEMethod).
             # The ctx.load() call writes raw fp8 weights; downstream apply()
@@ -4793,8 +5831,8 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
     def _build_full_context(self, layer: torch.nn.Module) -> "SharedFullContext":
         global _SHARED_FULL_CONTEXT
 
+        is_glm5_next_fp8 = _glm5_next_fp8_pipeline_requested(self)
         if _SHARED_FULL_CONTEXT is None:
-            is_glm5_next_fp8 = _glm5_next_fp8_pipeline_requested(self)
             if is_glm5_next_fp8:
                 # GPU tensors are allocated independently on each TP rank.
                 # Do not let a successful peer enter the Host-SHM collectives
@@ -4855,7 +5893,10 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
                 validation_result = None
                 validation_error = None
                 try:
-                    context._initialize_glm5_next_fp8_transport()
+                    context._initialize_glm5_next_fp8_transport(
+                        wrapper=self.wrapper,
+                        num_gpu_experts=self.num_gpu_experts,
+                    )
                     validation_result = (
                         _validate_glm5_next_fp8_shared_full_context(context)
                     )
@@ -4890,21 +5931,34 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
                     logger.info(
                         "KT GLM-5-Next FP8 layerwise prefill lazily allocated "
                         "generic SharedFullContext: gpu_full_layer_slots=1 "
-                        "host_expert_slots=2 gpu_slot_bytes=%d "
+                        "host_expert_slots=2 transport=%s gpu_slot_bytes=%d "
                         "host_buffer_bytes=%d device=%s",
+                        context._glm5_next_fp8_transport_backend,
                         gpu_slot_bytes,
                         host_buffer_bytes,
                         context.gpu_layer.w13_weight.device,
                     )
             _SHARED_FULL_CONTEXT = context
 
-        _SHARED_FULL_CONTEXT.load(
-            layer_idx=self.kt_config.layer_idx,
-            wrapper=self.wrapper,
-            original_layer=layer,
-            gpu_experts_mask=self.gpu_experts_mask,
-            logical_to_gpu_index=self.logical_to_gpu_index,
-        )
+        # Native exact GLM is loaded by its single-slot manager: synchronous
+        # prime for the first MoE, then event-fenced successor tasks.  Keeping
+        # it out of generic load() avoids both device-wide synchronizations.
+        if not (
+            is_glm5_next_fp8
+            and getattr(
+                _SHARED_FULL_CONTEXT,
+                "_glm5_next_fp8_transport_backend",
+                None,
+            )
+            == "native"
+        ):
+            _SHARED_FULL_CONTEXT.load(
+                layer_idx=self.kt_config.layer_idx,
+                wrapper=self.wrapper,
+                original_layer=layer,
+                gpu_experts_mask=self.gpu_experts_mask,
+                logical_to_gpu_index=self.logical_to_gpu_index,
+            )
         return _SHARED_FULL_CONTEXT
 
 

--- a/python/sglang/srt/layers/moe/kt_ep_wrapper.py
+++ b/python/sglang/srt/layers/moe/kt_ep_wrapper.py
@@ -31,11 +31,9 @@ import bisect
 import copy
 import ctypes
 import gc
-import hashlib
 import json
 import logging
 import os
-import socket
 import time
 import uuid
 from dataclasses import dataclass, replace
@@ -295,12 +293,6 @@ _SHARED_STAGING_BUFFER = None  # Global shared staging buffer for all MoE layers
 _MXFP4_PREFILL_LAYER_REGISTRY = {}
 _MXFP4_LAYERWISE_MANAGERS = {}
 _MXFP4_LAYERWISE_DISABLED_REASONS = {}
-# GLM-5-Next block-FP8 uses its own registry and manager.  Do not merge this
-# state with the generic full-GPU fallback or MXFP4: the GLM path is required
-# (fail-closed), has no format conversion, and is eagerly allocated before KV
-# cache profiling.
-_GLM5_NEXT_FP8_PREFILL_LAYER_REGISTRY = {}
-_GLM5_NEXT_FP8_LAYERWISE_MANAGERS = {}
 
 
 class SharedStagingBuffer:
@@ -1170,6 +1162,158 @@ class SharedFullContext:
         w13_p.set_(w13_p.view(num_experts, w13_k // 16, w13_n * (num_bits // 2)))
         w2_p.set_(w2_p.view(num_experts, w2_k // 16, w2_n * (num_bits // 2)))
 
+    def _initialize_glm5_next_fp8_transport(self) -> None:
+        """Create the exact-GLM transport resources once per shared context."""
+
+        if getattr(self, "_glm5_next_fp8_transport_initialized", False):
+            return
+        device = self.gpu_layer.w13_weight.device
+        self._glm5_next_fp8_copy_stream = torch.cuda.Stream(device=device)
+        self._glm5_next_fp8_host_slot_events = (
+            torch.cuda.Event(),
+            torch.cuda.Event(),
+        )
+        self._glm5_next_fp8_host_slot_was_used = [False, False]
+        self._glm5_next_fp8_transport_status = (
+            torch.ones((1,), dtype=torch.int32, device=device)
+            if dist.is_initialized()
+            else None
+        )
+        self._glm5_next_fp8_transport_initialized = True
+
+    def _prepare_weight_fp8_glm5_next(self, wrapper) -> None:
+        """Load one GLM layer with 2 Host expert slots and 1 GPU layer slot."""
+
+        if not getattr(self, "_glm5_next_fp8_transport_initialized", False):
+            raise RuntimeError(
+                "GLM-5-Next FP8 transport resources were not initialized"
+            )
+        layer = self.gpu_layer
+        device = layer.w13_weight.device
+        num_experts = layer.num_experts
+        tp_rank = get_tensor_model_parallel_rank()
+        tp_world_size = get_tensor_model_parallel_world_size()
+        do_write = tp_rank == 0 and wrapper is not None
+        copy_stream = self._glm5_next_fp8_copy_stream
+        slot_events = self._glm5_next_fp8_host_slot_events
+        # load() globally synchronizes before entering this helper, so no
+        # event from the previous layer remains in flight.  Reset only the
+        # logical occupancy while retaining the two persistent CUDA events.
+        slot_was_used = [False, False]
+        self._glm5_next_fp8_host_slot_was_used = slot_was_used
+        transport_status = self._glm5_next_fp8_transport_status
+
+        weight_infos = [
+            (self.cpu_buffers[name], getattr(layer, name))
+            for name in self.WEIGHT_NAMES_FP8
+        ]
+        expert_nbytes = {
+            name: self.cpu_buffers[name].numel()
+            // 2
+            * self.cpu_buffers[name].element_size()
+            for name in self.WEIGHT_NAMES_FP8
+        }
+
+        def submit_write_expert(expert_id: int, slot: int) -> None:
+            pointers = {
+                name: [
+                    pointer + slot * expert_nbytes[name]
+                    for pointer in self.all_rank_buffer_ptrs[name]
+                ]
+                for name in self.WEIGHT_NAMES_FP8
+            }
+            wrapper.submit_write_weight_scale_to_buffer(
+                tp_world_size,
+                expert_id,
+                pointers["w13_weight"],
+                pointers["w13_weight_scale_inv"],
+                pointers["w2_weight"],
+                pointers["w2_weight_scale_inv"],
+            )
+
+        def all_ranks_succeeded(local_error: Optional[Exception]) -> bool:
+            if transport_status is None:
+                return local_error is None
+            transport_status.fill_(int(local_error is None))
+            dist.all_reduce(
+                transport_status,
+                op=dist.ReduceOp.MIN,
+                group=get_tp_group().device_group,
+            )
+            return bool(transport_status.item())
+
+        pending_error = (
+            RuntimeError(
+                "GLM-5-Next FP8 Host-slot transport has no KT writer on TP0"
+            )
+            if tp_rank == 0 and wrapper is None
+            else None
+        )
+        if do_write:
+            try:
+                submit_write_expert(0, 0)
+            except Exception as exc:
+                pending_error = exc
+
+        for expert_id in range(num_experts):
+            slot = expert_id % 2
+            local_error = pending_error
+            if do_write and local_error is None:
+                try:
+                    wrapper.sync_write_weight_scale_to_buffer()
+                except Exception as exc:
+                    local_error = exc
+
+            has_next = expert_id + 1 < num_experts
+            next_slot = (expert_id + 1) % 2
+            if has_next and slot_was_used[next_slot]:
+                try:
+                    slot_events[next_slot].synchronize()
+                except Exception as exc:
+                    if local_error is None:
+                        local_error = exc
+
+            if not all_ranks_succeeded(local_error):
+                raise RuntimeError(
+                    "GLM-5-Next FP8 Host-slot transport failed on at least "
+                    "one TP rank"
+                ) from local_error
+
+            pending_error = None
+            if do_write and has_next:
+                try:
+                    submit_write_expert(expert_id + 1, next_slot)
+                except Exception as exc:
+                    # Publish this TP0-only failure at the next expert's
+                    # status collective while peers finish copy(current).
+                    pending_error = exc
+
+            try:
+                with torch.cuda.stream(copy_stream):
+                    for cpu_buffer, gpu_tensor in weight_infos:
+                        gpu_tensor[expert_id].copy_(
+                            cpu_buffer[slot], non_blocking=True
+                        )
+                    slot_events[slot].record(copy_stream)
+                slot_was_used[slot] = True
+            except Exception as exc:
+                if pending_error is None:
+                    pending_error = exc
+
+        final_error = pending_error
+        try:
+            copy_stream.synchronize()
+        except Exception as exc:
+            if final_error is None:
+                final_error = exc
+        if not all_ranks_succeeded(final_error):
+            raise RuntimeError(
+                "GLM-5-Next FP8 final Host-to-GPU copy failed on at least "
+                "one TP rank"
+            ) from final_error
+
+        torch.cuda.current_stream(device).wait_stream(copy_stream)
+
     def _prepare_weight_fp8(self, wrapper, original_layer=None, gpu_experts_mask=None,
                             logical_to_gpu_index=None):
         """Prepare FP8 block quant weights by writing from KT and copying to GPU.
@@ -1190,13 +1334,23 @@ class SharedFullContext:
         already on GPU are copied directly (fast GPU-to-GPU), while CPU experts
         use the KT wrapper pipeline.
         """
+        layer = self.gpu_layer
+        if bool(
+            getattr(
+                getattr(layer, "moe_runner_config", None),
+                "glm5_next_hf_two_round_swiglu",
+                False,
+            )
+        ):
+            self._prepare_weight_fp8_glm5_next(wrapper)
+            return
+
         # Bind Python thread to specific CPU core (last cores for each rank)
         tp_rank = get_tensor_model_parallel_rank()
         num_cpus = os.cpu_count()
         target_cpu = num_cpus - 1 - tp_rank
         os.sched_setaffinity(0, {target_cpu})
 
-        layer = self.gpu_layer
         num_experts = layer.num_experts
         device = layer.w13_weight.device
 
@@ -2782,1173 +2936,6 @@ def _get_or_initialize_mxfp4_layerwise_manager(
     return _MXFP4_LAYERWISE_MANAGERS.get(signature)
 
 
-class _Glm5NextFp8PrefillSlot:
-    """One raw block-FP8 GLM-5-Next MoE layer image.
-
-    Unlike MXFP4 there is no prepared/repacked representation.  The Triton
-    runner consumes these E4M3 weights and FP32 block scales directly.
-    """
-
-    RAW_NAMES = (
-        "w13_weight",
-        "w13_weight_scale_inv",
-        "w2_weight",
-        "w2_weight_scale_inv",
-    )
-
-    def __init__(self, index: int, raw_tensors: Dict[str, torch.Tensor]):
-        self.index = index
-        for name in self.RAW_NAMES:
-            setattr(self, name, raw_tensors[name])
-
-        self.state = "EMPTY"
-        self.layer_idx: Optional[int] = None
-        self.epoch = -1
-        self.has_consumed_event = False
-        self.reuse_guard = None
-        self.ready_event = torch.cuda.Event()
-        self.consumed_event = torch.cuda.Event()
-        self.num_experts = self.w13_weight.shape[0]
-
-    def invalidate(self) -> None:
-        # Keep both the tensor storage and its last overwrite fence alive.
-        self.state = "EMPTY"
-        self.layer_idx = None
-        self.epoch = -1
-
-
-class _Glm5NextFp8LayerwisePrefillManager:
-    """Required two-slot raw block-FP8 scheduler for exact GLM-5-Next.
-
-    A positive ``--kt-gpu-prefill-token-threshold`` selects this path for
-    every plain EXTEND forward, including a final chunk smaller than the
-    configured value.  There is deliberately no hybrid/serialized fallback:
-    a transport, ordering, allocation, or coverage failure is fatal.
-    """
-
-    _CONTROL_CACHELINE_BYTES = 64
-    _CONTROL_TIMEOUT_SECONDS = 300.0
-    _ATOMIC_ACQUIRE = 2
-    _ATOMIC_RELEASE = 3
-    _SLOT_STATE_CODES = {"EMPTY": 0, "LOADING": 1, "READY": 2, "IN_USE": 3}
-    _REUSE_GUARD_CODES = {
-        None: 0,
-        "loading": 1,
-        "ready": 2,
-        "consumed": 3,
-        "synchronized": 4,
-        "poisoned": 5,
-    }
-
-    def __init__(
-        self,
-        context: SharedFullContext,
-        signature: tuple,
-        slot1_raw_tensors: Dict[str, torch.Tensor],
-    ):
-        self.context = context
-        self.signature = signature
-        self.device = context.gpu_layer.w13_weight.device
-        slot0_raw = {
-            name: getattr(context.gpu_layer, name)
-            for name in _Glm5NextFp8PrefillSlot.RAW_NAMES
-        }
-        self.slots = (
-            _Glm5NextFp8PrefillSlot(0, slot0_raw),
-            _Glm5NextFp8PrefillSlot(1, slot1_raw_tensors),
-        )
-        self.transfer_stream = torch.cuda.Stream(device=self.device)
-        self.host_slot_free_events = (torch.cuda.Event(), torch.cuda.Event())
-        self.host_slot_was_used = [False, False]
-        self.host_slot_generations = [0, 0]
-        self.host_write_status = torch.ones((1,), dtype=torch.int32, device="cpu")
-
-        # Initialized only after every TP rank has successfully allocated both
-        # GPU slots and its pinned weight SHM.  Each control word occupies its
-        # own cache line and is accessed through libatomic acquire/release
-        # operations; ordinary Python/torch SHM stores are not a publication
-        # primitive across processes.
-        self._atomic_lib = None
-        self._atomic_load_u64 = None
-        self._atomic_store_u64 = None
-        self._transport_control_shm = None
-        self._transport_control_anchor = None
-        self._transport_control_address = None
-        self._control_offsets = None
-        self.transport_generation = 0
-        self.transport_abandoned = False
-        self.contract_digest = None
-
-        self.epoch = -1
-        self.last_layer_position: Optional[int] = None
-        self.current_slot_index: Optional[int] = None
-        self.round_active = False
-        self.failure_reason: Optional[str] = None
-        self.visited_layer_indices: List[int] = []
-
-        # Acceptance counters.  fallback_count intentionally never changes;
-        # it is exported in logs to prove a 500K run did not silently fall
-        # through to hybrid or serialized prefill.
-        self.apply_count = 0
-        self.prime_count = 0
-        self.prefetch_hit_count = 0
-        self.completed_round_count = 0
-        self.fallback_count = 0
-        self.expert_layouts = {}
-        for layer_idx, (method, _layer) in self.registry.items():
-            gpu_ids = tuple(
-                expert_id
-                for expert_id in range(self.slots[0].num_experts)
-                if method.gpu_experts_mask[expert_id].item()
-            )
-            gpu_id_set = set(gpu_ids)
-            cpu_ids = tuple(
-                expert_id
-                for expert_id in range(self.slots[0].num_experts)
-                if expert_id not in gpu_id_set
-            )
-            self.expert_layouts[layer_idx] = (gpu_ids, cpu_ids)
-
-    @property
-    def registry(self):
-        return _GLM5_NEXT_FP8_PREFILL_LAYER_REGISTRY.get(self.signature, {})
-
-    @property
-    def layer_order(self) -> List[int]:
-        return sorted(self.registry)
-
-    @property
-    def allocated_bytes(self) -> int:
-        return sum(
-            getattr(slot, name).numel() * getattr(slot, name).element_size()
-            for slot in self.slots
-            for name in _Glm5NextFp8PrefillSlot.RAW_NAMES
-        )
-
-    @classmethod
-    def _build_control_offsets(cls, tp_size: int):
-        cursor = 0
-        offsets = {}
-
-        def allocate(name: str, count: int) -> None:
-            nonlocal cursor
-            offsets[name] = tuple(
-                (cursor + index) * cls._CONTROL_CACHELINE_BYTES
-                for index in range(count)
-            )
-            cursor += count
-
-        allocate("global_error", 1)
-        allocate("ready_generation", 2)
-        allocate("writer_ok", 2)
-        allocate("writer_layer", 2)
-        allocate("writer_expert", 2)
-        allocate("rank_error", tp_size)
-        allocate("free_generation", tp_size * 2)
-        return offsets, cursor * cls._CONTROL_CACHELINE_BYTES
-
-    def _configure_atomic_access(self, handle, tp_size: int) -> None:
-        atomic_lib = ctypes.CDLL("libatomic.so.1")
-        atomic_load = getattr(atomic_lib, "__atomic_load_8")
-        atomic_load.argtypes = [ctypes.c_void_p, ctypes.c_int]
-        atomic_load.restype = ctypes.c_uint64
-        atomic_store = getattr(atomic_lib, "__atomic_store_8")
-        atomic_store.argtypes = [
-            ctypes.c_void_p,
-            ctypes.c_uint64,
-            ctypes.c_int,
-        ]
-        atomic_store.restype = None
-        atomic_is_lock_free = getattr(atomic_lib, "__atomic_is_lock_free")
-        atomic_is_lock_free.argtypes = [ctypes.c_size_t, ctypes.c_void_p]
-        atomic_is_lock_free.restype = ctypes.c_bool
-
-        anchor = ctypes.c_char.from_buffer(handle.buf)
-        address = ctypes.addressof(anchor)
-        if address % self._CONTROL_CACHELINE_BYTES != 0:
-            raise RuntimeError(
-                "GLM-5-Next FP8 transport control is not cache-line aligned"
-            )
-        if not atomic_is_lock_free(8, ctypes.c_void_p(address)):
-            raise RuntimeError(
-                "GLM-5-Next FP8 transport requires lock-free shared uint64 atomics"
-            )
-
-        offsets, _ = self._build_control_offsets(tp_size)
-        self._atomic_lib = atomic_lib
-        self._atomic_load_u64 = atomic_load
-        self._atomic_store_u64 = atomic_store
-        self._transport_control_anchor = anchor
-        self._transport_control_address = address
-        self._control_offsets = offsets
-
-    def _atomic_load(self, offset: int) -> int:
-        return int(
-            self._atomic_load_u64(
-                ctypes.c_void_p(self._transport_control_address + offset),
-                self._ATOMIC_ACQUIRE,
-            )
-        )
-
-    def _atomic_store(self, offset: int, value: int) -> None:
-        if value < 0 or value >= 2**64:
-            raise OverflowError(f"invalid uint64 control value {value}")
-        self._atomic_store_u64(
-            ctypes.c_void_p(self._transport_control_address + offset),
-            ctypes.c_uint64(value),
-            self._ATOMIC_RELEASE,
-        )
-
-    def _control_offset(self, name: str, index: int = 0) -> int:
-        return self._control_offsets[name][index]
-
-    @staticmethod
-    def _open_transport_shared_memory(**kwargs):
-        """Open untracked control SHM when the Python runtime supports it.
-
-        Every TP rank keeps its own file descriptor and mmap alive for the
-        manager lifetime.  TP0 unlinks the name only after every rank has
-        opened and configured that mapping.  Disabling ``resource_tracker``
-        registration prevents an unrelated rank's tracker from attempting a
-        second unlink at process shutdown.  Python before 3.13 has no
-        ``track`` argument; immediate TP0 unlink still makes that fallback
-        safe because all mappings are already open.
-        """
-
-        try:
-            return shared_memory.SharedMemory(**kwargs, track=False)
-        except TypeError:
-            return shared_memory.SharedMemory(**kwargs)
-
-    def initialize_transport_control(self) -> None:
-        """Create a same-node acquire/release control plane for hot transport."""
-
-        tp_rank = get_tensor_model_parallel_rank()
-        tp_size = get_tensor_model_parallel_world_size()
-        _, control_nbytes = self._build_control_offsets(tp_size)
-        name_holder = [None]
-        local_error = None
-        handle = None
-        try:
-            if tp_rank == 0:
-                name_holder[0] = f"kt_glm5_fp8_ctrl_{uuid.uuid4().hex[:12]}"
-                handle = self._open_transport_shared_memory(
-                    name=name_holder[0],
-                    create=True,
-                    size=control_nbytes,
-                )
-                handle.buf[:] = bytes(control_nbytes)
-        except Exception as exc:
-            local_error = exc
-
-        if dist.is_initialized():
-            dist.broadcast_object_list(
-                name_holder,
-                src=get_tp_group().first_rank,
-                group=get_tp_group().cpu_group,
-            )
-
-        if tp_rank != 0 and local_error is None:
-            try:
-                if name_holder[0] is None:
-                    raise RuntimeError("TP0 did not publish a transport SHM name")
-                handle = self._open_transport_shared_memory(
-                    name=name_holder[0], create=False
-                )
-            except Exception as exc:
-                local_error = exc
-
-        if handle is not None and local_error is None:
-            try:
-                self._configure_atomic_access(handle, tp_size)
-            except Exception as exc:
-                local_error = exc
-
-        if not _all_tp_ranks_succeeded(local_error is None):
-            self._transport_control_anchor = None
-            if handle is not None:
-                try:
-                    handle.close()
-                except Exception:
-                    pass
-            if tp_rank == 0 and handle is not None:
-                try:
-                    handle.unlink()
-                except Exception:
-                    pass
-            message = (
-                "GLM-5-Next FP8 transport control SHM initialization failed "
-                "on at least one TP rank"
-            )
-            if local_error is not None:
-                raise RuntimeError(message) from local_error
-            raise RuntimeError(message)
-        if local_error is not None:
-            raise local_error
-        assert handle is not None
-
-        self._transport_control_shm = handle
-        if tp_rank == 0:
-            try:
-                handle.unlink()
-            except FileNotFoundError:
-                pass
-
-    def _mark_local_transport_failure(self) -> None:
-        if self._control_offsets is None:
-            return
-        try:
-            tp_rank = get_tensor_model_parallel_rank()
-            self._atomic_store(self._control_offset("rank_error", tp_rank), 1)
-            self._atomic_store(self._control_offset("global_error"), 1)
-        except Exception:
-            # Error publication is best-effort once the atomic control plane
-            # itself is broken.  Do not let it make one rank skip the fixed
-            # expert loop / layer-end consensus; the process-group watchdog
-            # remains the final guard for an unusable mapping or dead rank.
-            self.transport_abandoned = True
-
-    def _shared_transport_failed(self) -> bool:
-        return bool(
-            self._control_offsets is not None
-            and self._atomic_load(self._control_offset("global_error"))
-        )
-
-    def _wait_for_exact_control_value(
-        self, offset: int, expected: int, phase: str
-    ) -> None:
-        if self.transport_abandoned:
-            raise RuntimeError(
-                "GLM-5-Next FP8 transport control was abandoned after a "
-                "protocol failure"
-            )
-        deadline = time.monotonic() + self._CONTROL_TIMEOUT_SECONDS
-        while True:
-            observed = self._atomic_load(offset)
-            if observed == expected:
-                return
-            if observed > expected:
-                self.transport_abandoned = True
-                self._mark_local_transport_failure()
-                raise RuntimeError(
-                    "GLM-5-Next FP8 transport generation drift while waiting "
-                    f"for {phase}: expected {expected}, observed {observed}"
-                )
-            if self._shared_transport_failed():
-                self.transport_abandoned = True
-                raise RuntimeError(
-                    "GLM-5-Next FP8 atomic transport was aborted by another "
-                    f"TP rank while waiting for {phase}"
-                )
-            if time.monotonic() >= deadline:
-                self.transport_abandoned = True
-                self._mark_local_transport_failure()
-                raise RuntimeError(
-                    "GLM-5-Next FP8 atomic transport timed out while waiting "
-                    f"for {phase}"
-                )
-            time.sleep(0)
-
-    def _wait_until_all_ranks_release(
-        self, host_slot: int, generation: int
-    ) -> bool:
-        if generation == 0:
-            return not self._shared_transport_failed()
-        tp_size = get_tensor_model_parallel_world_size()
-        deadline = time.monotonic() + self._CONTROL_TIMEOUT_SECONDS
-        for rank in range(tp_size):
-            offset = self._control_offset("free_generation", rank * 2 + host_slot)
-            while True:
-                observed = self._atomic_load(offset)
-                if observed == generation:
-                    break
-                if observed > generation:
-                    self.transport_abandoned = True
-                    self._mark_local_transport_failure()
-                    raise RuntimeError(
-                        "GLM-5-Next FP8 host-slot release generation drift: "
-                        f"rank={rank} slot={host_slot} expected={generation} "
-                        f"observed={observed}"
-                    )
-                if self._shared_transport_failed():
-                    return False
-                if time.monotonic() >= deadline:
-                    self.transport_abandoned = True
-                    self._mark_local_transport_failure()
-                    raise RuntimeError(
-                        "GLM-5-Next FP8 timed out waiting for host-slot "
-                        f"{host_slot} generation {generation} release from "
-                        f"rank {rank}"
-                    )
-                time.sleep(0)
-        return not self._shared_transport_failed()
-
-    def _publish_writer_generation(
-        self,
-        host_slot: int,
-        generation: int,
-        layer_idx: int,
-        expert_id: int,
-        writer_ok: bool,
-    ) -> None:
-        self._atomic_store(
-            self._control_offset("writer_layer", host_slot), layer_idx
-        )
-        self._atomic_store(
-            self._control_offset("writer_expert", host_slot), expert_id
-        )
-        self._atomic_store(
-            self._control_offset("writer_ok", host_slot), int(writer_ok)
-        )
-        # Release-publish ready last.  Readers acquire-load it before reading
-        # the descriptor or the payload written by KT.
-        self._atomic_store(
-            self._control_offset("ready_generation", host_slot), generation
-        )
-
-    def _consume_writer_generation(
-        self,
-        host_slot: int,
-        generation: int,
-        layer_idx: int,
-        expert_id: int,
-    ) -> bool:
-        self._wait_for_exact_control_value(
-            self._control_offset("ready_generation", host_slot),
-            generation,
-            f"writer generation {generation}",
-        )
-        observed_layer = self._atomic_load(
-            self._control_offset("writer_layer", host_slot)
-        )
-        observed_expert = self._atomic_load(
-            self._control_offset("writer_expert", host_slot)
-        )
-        if observed_layer != layer_idx or observed_expert != expert_id:
-            self.transport_abandoned = True
-            self._mark_local_transport_failure()
-            raise RuntimeError(
-                "GLM-5-Next FP8 writer descriptor mismatch: expected "
-                f"layer={layer_idx}/expert={expert_id}, observed "
-                f"layer={observed_layer}/expert={observed_expert}"
-            )
-        return bool(
-            self._atomic_load(self._control_offset("writer_ok", host_slot))
-        )
-
-    def _publish_local_host_release(
-        self, host_slot: int, generation: int
-    ) -> None:
-        rank = get_tensor_model_parallel_rank()
-        self._atomic_store(
-            self._control_offset("free_generation", rank * 2 + host_slot),
-            generation,
-        )
-
-    def _entry_state_values(self, layer_idx: int) -> tuple:
-        values = (
-            layer_idx,
-            self.epoch,
-            -1 if self.last_layer_position is None else self.last_layer_position,
-            -1 if self.current_slot_index is None else self.current_slot_index,
-            int(self.round_active),
-            int(self.failure_reason is not None),
-            tuple(self.visited_layer_indices),
-            self.transport_generation,
-            tuple(self.host_slot_generations),
-        )
-        slots = []
-        for slot in self.slots:
-            slots.append(
-                (
-                    self._SLOT_STATE_CODES.get(slot.state, -1),
-                    -1 if slot.layer_idx is None else slot.layer_idx,
-                    slot.epoch,
-                    self._REUSE_GUARD_CODES.get(slot.reuse_guard, -1),
-                )
-            )
-        return values + (tuple(slots),)
-
-    def _synchronize_layer_entry(self, layer_idx: int) -> None:
-        """Fail every local TP rank before any rank chooses ready vs load."""
-
-        if not dist.is_initialized() or get_tensor_model_parallel_world_size() == 1:
-            return
-        local_error = None
-        state = None
-        try:
-            state = self._entry_state_values(layer_idx)
-        except Exception as exc:
-            local_error = exc
-        gathered = [None] * get_tensor_model_parallel_world_size()
-        dist.all_gather_object(
-            gathered,
-            (state, None if local_error is None else repr(local_error)),
-            group=get_tp_group().cpu_group,
-        )
-        if any(peer[1] is not None for peer in gathered) or any(
-            peer[0] != gathered[0][0] for peer in gathered[1:]
-        ):
-            message = (
-                "GLM-5-Next FP8 layerwise TP state diverged before transport "
-                f"for layer {layer_idx}: {gathered}"
-            )
-            if local_error is not None:
-                raise RuntimeError(message) from local_error
-            raise RuntimeError(message)
-
-    def validate_tp_contract(self) -> None:
-        """Validate all rank-invariant registry and expert layout metadata."""
-
-        local_error = None
-        digest = None
-        hostname = socket.gethostname()
-        try:
-            layers = []
-            raw_metadata = {
-                name: {
-                    "shape": list(getattr(self.slots[0], name).shape),
-                    "dtype": str(getattr(self.slots[0], name).dtype),
-                }
-                for name in _Glm5NextFp8PrefillSlot.RAW_NAMES
-            }
-            for layer_idx in self.layer_order:
-                method, original_layer = self.registry[layer_idx]
-                original_raw_metadata = {}
-                for name in _Glm5NextFp8PrefillSlot.RAW_NAMES:
-                    if not hasattr(original_layer, name):
-                        raise RuntimeError(
-                            "GLM-5-Next FP8 registered GPU layer is missing "
-                            f"raw tensor {name} at layer {layer_idx}"
-                        )
-                    tensor = getattr(original_layer, name)
-                    full_tensor = getattr(self.slots[0], name)
-                    expected_shape = (
-                        method.num_gpu_experts,
-                        *tuple(full_tensor.shape[1:]),
-                    )
-                    if tuple(tensor.shape) != expected_shape:
-                        raise RuntimeError(
-                            "GLM-5-Next FP8 registered GPU tensor shape "
-                            f"mismatch for {name} at layer {layer_idx}: "
-                            f"expected {expected_shape}, got "
-                            f"{tuple(tensor.shape)}"
-                        )
-                    if tensor.dtype != full_tensor.dtype:
-                        raise RuntimeError(
-                            "GLM-5-Next FP8 registered GPU tensor dtype "
-                            f"mismatch for {name} at layer {layer_idx}: "
-                            f"expected {full_tensor.dtype}, got {tensor.dtype}"
-                        )
-                    original_raw_metadata[name] = {
-                        "shape": list(tensor.shape),
-                        "dtype": str(tensor.dtype),
-                    }
-                layers.append(
-                    {
-                        "layer": layer_idx,
-                        "mask": method.gpu_experts_mask.to(torch.uint8).tolist(),
-                        "logical_to_gpu": method.logical_to_gpu_index.tolist(),
-                        "global_num_experts": method.global_num_experts,
-                        "full_init_args": [
-                            str(value) for value in method._full_init_args
-                        ],
-                        "weight_path": method.kt_config.weight_path,
-                        "original_raw": original_raw_metadata,
-                    }
-                )
-            contract = {
-                "kind": "glm5_next_block_fp8_layerwise_v1",
-                "tp_size": get_tensor_model_parallel_world_size(),
-                "device_type": self.device.type,
-                "layer_order": self.layer_order,
-                "raw": raw_metadata,
-                "layers": layers,
-            }
-            canonical = json.dumps(
-                contract, sort_keys=True, separators=(",", ":")
-            )
-            digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
-        except Exception as exc:
-            local_error = exc
-
-        self.contract_digest = digest
-        if not dist.is_initialized() or get_tensor_model_parallel_world_size() == 1:
-            if local_error is not None:
-                raise RuntimeError(
-                    "GLM-5-Next FP8 failed to build its TP contract"
-                ) from local_error
-            return
-
-        local = (
-            hostname,
-            digest,
-            self.device.type,
-            None if local_error is None else repr(local_error),
-        )
-        gathered = [None] * get_tensor_model_parallel_world_size()
-        dist.all_gather_object(
-            gathered, local, group=get_tp_group().cpu_group
-        )
-        if any(item[3] is not None for item in gathered):
-            message = (
-                "GLM-5-Next FP8 TP contract construction failed on at least "
-                f"one rank: {gathered}"
-            )
-            if local_error is not None:
-                raise RuntimeError(message) from local_error
-            raise RuntimeError(message)
-        if len({item[0] for item in gathered}) != 1:
-            raise RuntimeError(
-                "GLM-5-Next FP8 atomic host transport requires every TP rank "
-                f"on one host; got {gathered}"
-            )
-        if any(item[1:3] != gathered[0][1:3] for item in gathered[1:]):
-            raise RuntimeError(
-                "GLM-5-Next FP8 TP registry/mask/layout contract mismatch: "
-                f"{gathered}"
-            )
-
-    def _ensure_healthy(self) -> None:
-        if self.failure_reason is not None:
-            raise RuntimeError(
-                "GLM-5-Next FP8 layerwise prefill manager is poisoned after "
-                f"a required-path failure: {self.failure_reason}"
-            )
-
-    def _poison(self, exc: BaseException) -> None:
-        if self.failure_reason is None:
-            self.failure_reason = f"{type(exc).__name__}: {exc}"
-
-    def successor_layer_idx(self, layer_idx: int) -> Optional[int]:
-        order = self.layer_order
-        pos = bisect.bisect_right(order, layer_idx)
-        return order[pos] if pos < len(order) else None
-
-    def _advance_round(self, layer_idx: int) -> None:
-        self._ensure_healthy()
-        order = self.layer_order
-        pos = bisect.bisect_left(order, layer_idx)
-        if pos >= len(order) or order[pos] != layer_idx:
-            raise RuntimeError(
-                f"GLM-5-Next FP8 layerwise layer {layer_idx} is not "
-                f"registered; registered layers are {order}"
-            )
-
-        if not self.round_active:
-            if pos != 0:
-                raise RuntimeError(
-                    "GLM-5-Next FP8 layerwise EXTEND must start at MoE "
-                    f"layer {order[0]}, got layer {layer_idx}"
-                )
-            self.epoch += 1
-            self.round_active = True
-            self.last_layer_position = None
-            self.current_slot_index = None
-            self.visited_layer_indices = []
-            for slot in self.slots:
-                slot.invalidate()
-        elif self.last_layer_position is not None and pos != self.last_layer_position + 1:
-            raise RuntimeError(
-                "GLM-5-Next FP8 layerwise layer order mismatch in epoch "
-                f"{self.epoch}: expected {order[self.last_layer_position + 1]}, "
-                f"got {layer_idx}"
-            )
-        self.last_layer_position = pos
-
-    def _finish_round_if_complete(self, layer_idx: int) -> None:
-        order = self.layer_order
-        if layer_idx != order[-1]:
-            return
-        if self.visited_layer_indices != order:
-            raise RuntimeError(
-                "GLM-5-Next FP8 layerwise coverage mismatch in epoch "
-                f"{self.epoch}: expected {order}, got "
-                f"{self.visited_layer_indices}"
-            )
-        self.completed_round_count += 1
-        self.round_active = False
-        self.last_layer_position = None
-        self.current_slot_index = None
-
-    def _find_ready_slot(
-        self, layer_idx: int
-    ) -> Optional[_Glm5NextFp8PrefillSlot]:
-        for slot in self.slots:
-            if (
-                slot.state == "READY"
-                and slot.layer_idx == layer_idx
-                and slot.epoch == self.epoch
-            ):
-                return slot
-        return None
-
-    @staticmethod
-    def _record_raw_backing_on_stream(
-        slot: _Glm5NextFp8PrefillSlot, stream: torch.cuda.Stream
-    ) -> None:
-        for name in _Glm5NextFp8PrefillSlot.RAW_NAMES:
-            getattr(slot, name).record_stream(stream)
-
-    def _bind_slot(self, slot: _Glm5NextFp8PrefillSlot) -> None:
-        layer = self.context.gpu_layer
-        for name in _Glm5NextFp8PrefillSlot.RAW_NAMES:
-            # Slot tensors are stable Parameters.  Rebinding selects a slot;
-            # no tensor allocation or format conversion occurs in apply().
-            setattr(layer, name, getattr(slot, name))
-
-    def _tp_phase_succeeded(self, local_success: bool) -> bool:
-        if not dist.is_initialized() or get_tensor_model_parallel_world_size() == 1:
-            return local_success
-        try:
-            self.host_write_status.fill_(int(local_success))
-            dist.all_reduce(
-                self.host_write_status,
-                op=dist.ReduceOp.MIN,
-                group=get_tp_group().cpu_group,
-            )
-            return bool(self.host_write_status.item())
-        except Exception:
-            # This process can no longer prove that peers reached the same
-            # phase.  Poison the atomic transport before re-raising; an
-            # external process-group watchdog owns peer/rank death handling.
-            self.transport_abandoned = True
-            self._mark_local_transport_failure()
-            raise
-
-    def _commit_tp_runtime_phase(
-        self, local_error: Optional[BaseException], phase: str
-    ) -> None:
-        if self._tp_phase_succeeded(local_error is None):
-            return
-        message = f"GLM-5-Next FP8 {phase} failed on at least one TP rank"
-        if local_error is not None:
-            raise RuntimeError(message) from local_error
-        raise RuntimeError(message)
-
-    def _submit_host_write(self, method, expert_id: int, host_slot: int) -> None:
-        buffers = self.context.cpu_buffers
-        pointers = self.context.all_rank_buffer_ptrs
-
-        def expert_nbytes(name: str) -> int:
-            tensor = buffers[name]
-            return tensor.numel() // 2 * tensor.element_size()
-
-        offsets = {
-            name: host_slot * expert_nbytes(name)
-            for name in _Glm5NextFp8PrefillSlot.RAW_NAMES
-        }
-
-        def rank_pointers(name: str) -> List[int]:
-            return [ptr + offsets[name] for ptr in pointers[name]]
-
-        # Existing KT FP8 ABI writes raw E4M3 weights plus FP32 inverse
-        # scales.  No new C++ writer or conversion ABI is needed.
-        method.wrapper.submit_write_weight_scale_to_buffer(
-            get_tensor_model_parallel_world_size(),
-            expert_id,
-            rank_pointers("w13_weight"),
-            rank_pointers("w13_weight_scale_inv"),
-            rank_pointers("w2_weight"),
-            rank_pointers("w2_weight_scale_inv"),
-        )
-        method.wrapper.sync_write_weight_scale_to_buffer()
-
-    def _load_slot(
-        self,
-        slot: _Glm5NextFp8PrefillSlot,
-        layer_idx: int,
-        method,
-        original_layer: torch.nn.Module,
-    ) -> None:
-        if getattr(slot, "reuse_guard", None) == "poisoned":
-            raise RuntimeError(
-                f"GLM-5-Next FP8 slot {slot.index} cannot be reused after "
-                "its transfer stream failed to synchronize"
-            )
-        if slot.state == "LOADING":
-            raise RuntimeError(
-                f"GLM-5-Next FP8 slot {slot.index} is already loading "
-                f"layer {slot.layer_idx}"
-            )
-
-        reuse_guard = getattr(slot, "reuse_guard", None)
-        if reuse_guard is None and slot.has_consumed_event:
-            reuse_guard = "consumed"
-        slot.reuse_guard = "loading"
-        slot.state = "LOADING"
-        slot.layer_idx = layer_idx
-        slot.epoch = self.epoch
-
-        saved_affinity = None
-        local_error: Optional[BaseException] = None
-
-        def remember_error(exc: BaseException) -> None:
-            nonlocal local_error
-            if local_error is None:
-                local_error = exc
-            self._mark_local_transport_failure()
-
-        try:
-            try:
-                weight_infos = [
-                    (name, self.context.cpu_buffers[name], getattr(slot, name))
-                    for name in _Glm5NextFp8PrefillSlot.RAW_NAMES
-                ]
-                gpu_expert_ids, cpu_expert_ids = self.expert_layouts[layer_idx]
-
-                if hasattr(os, "sched_getaffinity"):
-                    saved_affinity = os.sched_getaffinity(0)
-                    available_cpus = sorted(saved_affinity)
-                    if available_cpus:
-                        target = available_cpus[
-                            -1 - (method.tp_rank % len(available_cpus))
-                        ]
-                        os.sched_setaffinity(0, {target})
-            except Exception as exc:
-                weight_infos = []
-                gpu_expert_ids, cpu_expert_ids = self.expert_layouts.get(
-                    layer_idx, ((), tuple(range(slot.num_experts)))
-                )
-                remember_error(exc)
-
-            try:
-                with torch.cuda.stream(self.transfer_stream):
-                    if reuse_guard == "consumed":
-                        self.transfer_stream.wait_event(slot.consumed_event)
-                    elif reuse_guard == "ready":
-                        self.transfer_stream.wait_event(slot.ready_event)
-                    if local_error is None:
-                        for expert_id in gpu_expert_ids:
-                            gpu_index = method.logical_to_gpu_index[
-                                expert_id
-                            ].item()
-                            for name, _, destination in weight_infos:
-                                source = getattr(original_layer, name)
-                                destination[expert_id].copy_(
-                                    source[gpu_index], non_blocking=True
-                                )
-            except Exception as exc:
-                remember_error(exc)
-
-            for position, expert_id in enumerate(cpu_expert_ids):
-                host_slot = position % 2
-                self.transport_generation += 1
-                generation = self.transport_generation
-                previous_generation = self.host_slot_generations[host_slot]
-
-                if self.host_slot_was_used[host_slot]:
-                    try:
-                        self.host_slot_free_events[host_slot].synchronize()
-                        self.host_slot_was_used[host_slot] = False
-                        self._publish_local_host_release(
-                            host_slot, previous_generation
-                        )
-                    except Exception as exc:
-                        remember_error(exc)
-
-                if method.tp_rank == 0:
-                    writer_ok = False
-                    try:
-                        can_write = self._wait_until_all_ranks_release(
-                            host_slot, previous_generation
-                        )
-                        if can_write and local_error is None:
-                            if method.wrapper is None:
-                                raise RuntimeError(
-                                    "GLM-5-Next FP8 TP0 has no KT wrapper for "
-                                    "host weight transport"
-                                )
-                            self._submit_host_write(method, expert_id, host_slot)
-                            writer_ok = True
-                    except Exception as exc:
-                        remember_error(exc)
-                    finally:
-                        try:
-                            self._publish_writer_generation(
-                                host_slot,
-                                generation,
-                                layer_idx,
-                                expert_id,
-                                writer_ok
-                                and not self._shared_transport_failed(),
-                            )
-                        except Exception as exc:
-                            # Continue the fixed expert loop.  Peers observe
-                            # global_error and abort their generation wait;
-                            # watchdog handles a fully broken atomic mapping.
-                            remember_error(exc)
-
-                writer_ok = False
-                try:
-                    writer_ok = self._consume_writer_generation(
-                        host_slot,
-                        generation,
-                        layer_idx,
-                        expert_id,
-                    )
-                except Exception as exc:
-                    remember_error(exc)
-                self.host_slot_generations[host_slot] = generation
-
-                if not writer_ok and local_error is None:
-                    remember_error(
-                        RuntimeError(
-                            "GLM-5-Next FP8 TP0 writer failed for "
-                            f"layer {layer_idx}, expert {expert_id}"
-                        )
-                    )
-
-                copied = False
-                transport_failed = True
-                try:
-                    transport_failed = self._shared_transport_failed()
-                except Exception as exc:
-                    remember_error(exc)
-                if writer_ok and local_error is None and not transport_failed:
-                    event_recorded = False
-                    try:
-                        with torch.cuda.stream(self.transfer_stream):
-                            try:
-                                for _, cpu_buffer, destination in weight_infos:
-                                    destination[expert_id].copy_(
-                                        cpu_buffer[host_slot], non_blocking=True
-                                    )
-                            finally:
-                                self.host_slot_free_events[host_slot].record(
-                                    self.transfer_stream
-                                )
-                                event_recorded = True
-                        self.host_slot_was_used[host_slot] = True
-                        copied = True
-                    except Exception as exc:
-                        remember_error(exc)
-                        if event_recorded:
-                            self.host_slot_was_used[host_slot] = True
-                        else:
-                            try:
-                                self.transfer_stream.synchronize()
-                                self.host_slot_was_used[host_slot] = False
-                            except Exception as fence_exc:
-                                remember_error(fence_exc)
-
-                if not copied and not self.host_slot_was_used[host_slot]:
-                    # This rank enqueued no DMA for the generation, so release
-                    # it immediately.  A rank with an unfenced prior DMA never
-                    # enters this branch and consequently cannot authorize an
-                    # overwrite after failure.
-                    try:
-                        self._publish_local_host_release(host_slot, generation)
-                    except Exception as exc:
-                        remember_error(exc)
-
-            fence_complete = False
-            try:
-                with torch.cuda.stream(self.transfer_stream):
-                    slot.ready_event.record(self.transfer_stream)
-                slot.ready_event.synchronize()
-                slot.reuse_guard = "ready"
-                fence_complete = True
-            except Exception as exc:
-                remember_error(exc)
-                try:
-                    self.transfer_stream.synchronize()
-                    slot.reuse_guard = "synchronized"
-                    fence_complete = True
-                except Exception as fence_exc:
-                    slot.reuse_guard = "poisoned"
-                    remember_error(fence_exc)
-
-            if fence_complete:
-                for host_slot in range(2):
-                    if self.host_slot_was_used[host_slot]:
-                        self.host_slot_was_used[host_slot] = False
-                        try:
-                            self._publish_local_host_release(
-                                host_slot,
-                                self.host_slot_generations[host_slot],
-                            )
-                        except Exception as exc:
-                            remember_error(exc)
-
-            if local_error is None:
-                try:
-                    if self._shared_transport_failed():
-                        local_error = RuntimeError(
-                            "another TP rank reported an atomic transport "
-                            "failure"
-                        )
-                except Exception as exc:
-                    remember_error(exc)
-            self._commit_tp_runtime_phase(
-                local_error, f"transport for layer {layer_idx}"
-            )
-            slot.state = "READY"
-        except Exception:
-            fence_error = None
-            if slot.reuse_guard not in ("ready", "synchronized", "poisoned"):
-                try:
-                    with torch.cuda.stream(self.transfer_stream):
-                        if reuse_guard == "consumed":
-                            self.transfer_stream.wait_event(slot.consumed_event)
-                        elif reuse_guard == "ready":
-                            self.transfer_stream.wait_event(slot.ready_event)
-                        slot.ready_event.record(self.transfer_stream)
-                    slot.reuse_guard = "ready"
-                except Exception:
-                    try:
-                        self.transfer_stream.synchronize()
-                        slot.reuse_guard = "synchronized"
-                    except Exception as exc:
-                        slot.reuse_guard = "poisoned"
-                        fence_error = exc
-            slot.invalidate()
-            if fence_error is not None:
-                raise RuntimeError(
-                    f"GLM-5-Next FP8 failed to fence slot {slot.index} "
-                    "after a transport error"
-                ) from fence_error
-            raise
-        finally:
-            if saved_affinity is not None:
-                try:
-                    os.sched_setaffinity(0, saved_affinity)
-                except Exception:
-                    logger.warning(
-                        "Failed to restore CPU affinity after GLM-5-Next "
-                        "FP8 transport",
-                        exc_info=True,
-                    )
-
-    def _acquire(self, layer_idx: int, method, layer: torch.nn.Module):
-        self._synchronize_layer_entry(layer_idx)
-        self._advance_round(layer_idx)
-        ready = self._find_ready_slot(layer_idx)
-        if ready is not None:
-            return ready, True
-
-        slot = (
-            self.slots[0]
-            if self.current_slot_index is None
-            else self.slots[1 - self.current_slot_index]
-        )
-        self._load_slot(slot, layer_idx, method, layer)
-        return slot, False
-
-    def _prefetch_successor(self, current: _Glm5NextFp8PrefillSlot) -> None:
-        successor_idx = self.successor_layer_idx(current.layer_idx)
-        if successor_idx is None:
-            return
-        entry = self.registry.get(successor_idx)
-        if entry is None:
-            raise RuntimeError(
-                f"GLM-5-Next FP8 successor layer {successor_idx} "
-                "disappeared from registry"
-            )
-        next_method, next_layer = entry
-        target = self.slots[1 - current.index]
-        if (
-            target.state == "READY"
-            and target.layer_idx == successor_idx
-            and target.epoch == self.epoch
-        ):
-            return
-        self._load_slot(target, successor_idx, next_method, next_layer)
-
-    def apply(self, method, layer, dispatch_output):
-        layer_idx = method.kt_config.layer_idx
-        try:
-            slot, prefetch_hit = self._acquire(layer_idx, method, layer)
-            if slot.layer_idx != layer_idx or slot.epoch != self.epoch:
-                raise RuntimeError(
-                    "GLM-5-Next FP8 layerwise acquired stale weights: "
-                    f"wanted layer={layer_idx}/epoch={self.epoch}, got "
-                    f"layer={slot.layer_idx}/epoch={slot.epoch}"
-                )
-
-            main_stream = None
-            result = None
-            compute_error = None
-            try:
-                main_stream = torch.cuda.current_stream(self.device)
-                main_stream.wait_event(slot.ready_event)
-                self._bind_slot(slot)
-                self._record_raw_backing_on_stream(slot, main_stream)
-                result = self.context.gpu_method.apply(
-                    self.context.gpu_layer, dispatch_output
-                )
-            except Exception as exc:
-                compute_error = exc
-            finally:
-                if main_stream is not None:
-                    try:
-                        slot.consumed_event.record(main_stream)
-                        slot.has_consumed_event = True
-                        slot.reuse_guard = "consumed"
-                        slot.state = "IN_USE"
-                        self.current_slot_index = slot.index
-                    except Exception as exc:
-                        if compute_error is None:
-                            compute_error = exc
-                        try:
-                            main_stream.synchronize()
-                            slot.reuse_guard = "synchronized"
-                            slot.state = "IN_USE"
-                            self.current_slot_index = slot.index
-                        except Exception:
-                            pass
-
-            self._commit_tp_runtime_phase(
-                compute_error, f"compute launch for layer {layer_idx}"
-            )
-            self.apply_count += 1
-            if prefetch_hit:
-                self.prefetch_hit_count += 1
-            else:
-                self.prime_count += 1
-            self.visited_layer_indices.append(layer_idx)
-
-            # Compute is already enqueued; prepare N+1 while it runs.
-            self._prefetch_successor(slot)
-            coverage_error = None
-            try:
-                self._finish_round_if_complete(layer_idx)
-            except Exception as exc:
-                coverage_error = exc
-            if layer_idx == self.layer_order[-1]:
-                # No rank may leave the final MoE layer after a rank-local
-                # coverage failure while peers proceed to later collectives.
-                self._commit_tp_runtime_phase(
-                    coverage_error, f"coverage for epoch {self.epoch}"
-                )
-            elif coverage_error is not None:
-                raise coverage_error
-            if method.tp_rank == 0:
-                log = (
-                    logger.info
-                    if layer_idx == self.layer_order[-1]
-                    else logger.debug
-                )
-                log(
-                    "KT GLM-5-Next FP8 layerwise prefill: layer=%d epoch=%d "
-                    "slot=%d %s apply_count=%d prime_count=%d "
-                    "prefetch_hit_count=%d completed_rounds=%d fallback_count=%d",
-                    layer_idx,
-                    self.epoch,
-                    slot.index,
-                    "prefetch-hit" if prefetch_hit else "prime",
-                    self.apply_count,
-                    self.prime_count,
-                    self.prefetch_hit_count,
-                    self.completed_round_count,
-                    self.fallback_count,
-                )
-            return result
-        except Exception as exc:
-            self._poison(exc)
-            raise
-
-
 def _glm5_next_fp8_pipeline_requested(method) -> bool:
     return (
         bool(getattr(method.kt_config, "is_glm5_next", False))
@@ -3957,145 +2944,60 @@ def _glm5_next_fp8_pipeline_requested(method) -> bool:
     )
 
 
-def _glm5_next_fp8_pipeline_signature(method, layer: torch.nn.Module) -> tuple:
-    device = next(layer.parameters()).device
-    return (
-        "glm5_next_block_fp8",
-        str(device),
-        method.kt_config.weight_path,
-        method.kt_config.num_layers,
-        method.global_num_experts,
-        method._full_init_args,
-    )
+_GLM5_NEXT_FP8_RAW_WEIGHT_NAMES = (
+    "w13_weight",
+    "w13_weight_scale_inv",
+    "w2_weight",
+    "w2_weight_scale_inv",
+)
 
 
-def _register_glm5_next_fp8_prefill_layer(method, layer: torch.nn.Module) -> None:
-    if not _glm5_next_fp8_pipeline_requested(method):
-        return
-    if method.kt_config.kt_enable_dynamic_expert_update:
-        raise ValueError(
-            "GLM-5-Next required FP8 layerwise prefill is incompatible with "
-            "--kt-enable-dynamic-expert-update"
+def _validate_glm5_next_fp8_shared_full_context(
+    context: SharedFullContext,
+) -> Tuple[int, int]:
+    """Validate the lazy generic context and return GPU/host storage bytes."""
+
+    tp_size = get_tensor_model_parallel_world_size()
+    if tp_size != 4:
+        raise RuntimeError(
+            "GLM-5-Next layerwise prefill requires runtime TP=4; "
+            f"got TP={tp_size}"
         )
-    signature = _glm5_next_fp8_pipeline_signature(method, layer)
-    method._glm5_next_fp8_pipeline_signature = signature
-    registry = _GLM5_NEXT_FP8_PREFILL_LAYER_REGISTRY.setdefault(signature, {})
-    layer_idx = method.kt_config.layer_idx
-    existing = registry.get(layer_idx)
-    if existing is not None and (
-        existing[0] is not method or existing[1] is not layer
+    slot_events = getattr(
+        context, "_glm5_next_fp8_host_slot_events", None
+    )
+    if (
+        not getattr(context, "_glm5_next_fp8_transport_initialized", False)
+        or slot_events is None
+        or len(slot_events) != 2
+        or getattr(context, "_glm5_next_fp8_copy_stream", None) is None
     ):
         raise RuntimeError(
-            "duplicate GLM-5-Next FP8 layerwise prefill registration for "
-            f"layer {layer_idx}"
+            "GLM-5-Next layerwise prefill requires one persistent H2D "
+            "stream and exactly two Host-slot completion events"
         )
-    registry[layer_idx] = (method, layer)
-
-
-def _validate_glm5_next_fp8_registry(signature: tuple, registry: dict) -> None:
-    order = sorted(registry)
-    expected_order = list(range(3, 45))
-    if order != expected_order:
-        raise RuntimeError(
-            "GLM-5-Next required FP8 layerwise registry must contain every "
-            f"MoE layer 3..44 exactly once; got {order}"
-        )
-    for layer_idx, (method, _layer) in registry.items():
-        if not _glm5_next_fp8_pipeline_requested(method):
-            raise RuntimeError(
-                f"GLM-5-Next FP8 registry {signature} contains an ineligible "
-                f"layer {layer_idx}"
-            )
-        if method.kt_config.num_layers != 45:
-            raise RuntimeError(
-                "GLM-5-Next FP8 layerwise requires num_layers=45; got "
-                f"{method.kt_config.num_layers} at layer {layer_idx}"
-            )
-        if method.kt_config.kt_enable_dynamic_expert_update:
-            raise RuntimeError(
-                "GLM-5-Next FP8 layerwise does not support dynamic expert update"
-            )
-        if getattr(method, "tp_rank", None) != get_tensor_model_parallel_rank():
-            raise RuntimeError(
-                "GLM-5-Next FP8 layerwise method/rank mismatch at layer "
-                f"{layer_idx}: method.tp_rank={getattr(method, 'tp_rank', None)}, "
-                f"runtime rank={get_tensor_model_parallel_rank()}"
-            )
-        if getattr(method, "global_num_experts", None) != 288:
-            raise RuntimeError(
-                "GLM-5-Next FP8 layerwise requires exactly 288 routed "
-                f"experts; got {getattr(method, 'global_num_experts', None)}"
-            )
-        full_init_args = getattr(method, "_full_init_args", ())
-        if len(full_init_args) < 2 or tuple(full_init_args[:2]) != (4096, 256):
-            raise RuntimeError(
-                "GLM-5-Next FP8 layerwise requires TP8 expert geometry "
-                "hidden=4096/intermediate_per_partition=256; got "
-                f"{full_init_args}"
-            )
-        mask = getattr(method, "gpu_experts_mask", None)
-        mapping = getattr(method, "logical_to_gpu_index", None)
-        if (
-            not isinstance(mask, torch.Tensor)
-            or mask.dtype != torch.bool
-            or tuple(mask.shape) != (288,)
-            or not isinstance(mapping, torch.Tensor)
-            or tuple(mapping.shape) != (288,)
-        ):
-            raise RuntimeError(
-                "GLM-5-Next FP8 layerwise requires [288] bool mask and "
-                f"logical mapping at layer {layer_idx}"
-            )
-        # Both tensors are model state and therefore normally live on the TP
-        # rank's CUDA device.  Build the invariant on that same device: a CPU
-        # reference here makes torch.equal fail during the required startup
-        # preflight before the layerwise slots can be allocated.
-        mapping_int32 = mapping.to(dtype=torch.int32)
-        mask_on_mapping_device = mask.to(device=mapping.device)
-        expected_mapping = torch.full(
-            (288,), -1, dtype=torch.int32, device=mapping.device
-        )
-        gpu_ids = torch.where(mask_on_mapping_device)[0]
-        expected_mapping[gpu_ids] = torch.arange(
-            gpu_ids.numel(), dtype=torch.int32, device=mapping.device
-        )
-        if not torch.equal(mapping_int32, expected_mapping):
-            raise RuntimeError(
-                "GLM-5-Next FP8 logical_to_gpu_index does not match its "
-                f"static mask at layer {layer_idx}"
-            )
-        if getattr(method, "num_gpu_experts", None) != gpu_ids.numel():
-            raise RuntimeError(
-                "GLM-5-Next FP8 num_gpu_experts does not match its static "
-                f"mask at layer {layer_idx}"
-            )
-
-
-def _validate_glm5_next_fp8_context(context: SharedFullContext) -> None:
-    runner_config = getattr(context.gpu_layer, "moe_runner_config", None)
+    layer = context.gpu_layer
+    runner_config = getattr(layer, "moe_runner_config", None)
     if not bool(
         getattr(runner_config, "glm5_next_hf_two_round_swiglu", False)
     ):
         raise RuntimeError(
-            "GLM-5-Next layerwise requires the private HF two-round "
+            "GLM-5-Next layerwise prefill requires the private HF two-round "
             "BF16 SwiGLU runner"
         )
     if not getattr(context, "_is_fp8_quant", False):
         raise RuntimeError(
-            "GLM-5-Next layerwise built a non-block-FP8 full context"
+            "GLM-5-Next layerwise prefill built a non-block-FP8 full context"
         )
     base_method = context._get_base_quant_method()
-    if not getattr(base_method, "block_quant", False):
+    if (
+        not getattr(base_method, "block_quant", False)
+        or getattr(base_method, "use_mxfp8", False)
+        or tuple(getattr(base_method, "weight_block_size", ())) != (128, 128)
+    ):
         raise RuntimeError(
-            "GLM-5-Next layerwise requires a block-quantized FP8 MoE method"
-        )
-    if getattr(base_method, "use_mxfp8", False):
-        raise RuntimeError(
-            "GLM-5-Next layerwise requires raw E4M3+FP32 block FP8, not MXFP8"
-        )
-    if tuple(getattr(base_method, "weight_block_size", ())) != (128, 128):
-        raise RuntimeError(
-            "GLM-5-Next layerwise requires FP8 weight_block_size=[128, 128]"
+            "GLM-5-Next layerwise prefill requires raw E4M3+FP32 "
+            "block-FP8 weights with weight_block_size=[128, 128]"
         )
     runner_backend = getattr(
         getattr(base_method, "runner", None), "runner_backend", None
@@ -4106,15 +3008,15 @@ def _validate_glm5_next_fp8_context(context: SharedFullContext) -> None:
         or not runner_backend.is_triton()
     ):
         raise RuntimeError(
-            "GLM-5-Next layerwise requires the raw block-FP8 Triton MoE runner"
+            "GLM-5-Next layerwise prefill requires the raw block-FP8 "
+            "Triton MoE runner"
         )
 
-    layer = context.gpu_layer
     expected_shapes = {
-        "w13_weight": (288, 512, 4096),
-        "w13_weight_scale_inv": (288, 4, 32),
-        "w2_weight": (288, 4096, 256),
-        "w2_weight_scale_inv": (288, 32, 2),
+        "w13_weight": (288, 1024, 4096),
+        "w13_weight_scale_inv": (288, 8, 32),
+        "w2_weight": (288, 4096, 512),
+        "w2_weight_scale_inv": (288, 32, 4),
     }
     expected_dtypes = {
         "w13_weight": getattr(torch, "float8_e4m3fn", None),
@@ -4122,245 +3024,38 @@ def _validate_glm5_next_fp8_context(context: SharedFullContext) -> None:
         "w2_weight": getattr(torch, "float8_e4m3fn", None),
         "w2_weight_scale_inv": torch.float32,
     }
-    for name in _Glm5NextFp8PrefillSlot.RAW_NAMES:
-        if not hasattr(layer, name):
+    gpu_slot_bytes = 0
+    host_buffer_bytes = 0
+    for name in _GLM5_NEXT_FP8_RAW_WEIGHT_NAMES:
+        gpu_tensor = getattr(layer, name, None)
+        if gpu_tensor is None or gpu_tensor.dtype != expected_dtypes[name]:
             raise RuntimeError(
-                f"GLM-5-Next FP8 full context is missing raw tensor {name}"
+                "GLM-5-Next generic full context has an invalid raw tensor "
+                f"{name}: expected dtype={expected_dtypes[name]}, "
+                f"got {getattr(gpu_tensor, 'dtype', None)}"
             )
-        tensor = getattr(layer, name)
-        if tuple(tensor.shape) != expected_shapes[name]:
+        if tuple(gpu_tensor.shape) != expected_shapes[name]:
             raise RuntimeError(
-                f"GLM-5-Next FP8 {name} shape mismatch: expected "
-                f"{expected_shapes[name]}, got {tuple(tensor.shape)}"
+                "GLM-5-Next TP4 generic full context has an invalid shape "
+                f"for {name}: expected={expected_shapes[name]}, "
+                f"got={tuple(gpu_tensor.shape)}"
             )
-        if tensor.dtype != expected_dtypes[name]:
+        gpu_slot_bytes += gpu_tensor.numel() * gpu_tensor.element_size()
+
+        host_buffer = context.cpu_buffers.get(name)
+        if host_buffer is None or host_buffer.shape[0] != 2:
             raise RuntimeError(
-                f"GLM-5-Next FP8 {name} dtype mismatch: expected "
-                f"{expected_dtypes[name]}, got {tensor.dtype}"
+                "GLM-5-Next generic layerwise prefill requires exactly two "
+                f"expert Host slots for {name}"
             )
-
-
-def _validate_glm5_next_fp8_writer_abi(registry: dict) -> None:
-    """Fail startup if TP0's installed KT binary lacks the FP8 writer ABI."""
-
-    if get_tensor_model_parallel_rank() != 0:
-        return
-    for layer_idx, (method, _layer) in registry.items():
-        wrapper = getattr(method, "wrapper", None)
-        if wrapper is None:
+        if tuple(host_buffer.shape[1:]) != tuple(gpu_tensor.shape[1:]):
             raise RuntimeError(
-                f"GLM-5-Next FP8 layer {layer_idx} has no TP0 KT wrapper"
+                f"GLM-5-Next Host/GPU expert shape mismatch for {name}: "
+                f"host={tuple(host_buffer.shape)}, gpu={tuple(gpu_tensor.shape)}"
             )
-        for name in (
-            "submit_write_weight_scale_to_buffer",
-            "sync_write_weight_scale_to_buffer",
-        ):
-            if not callable(getattr(wrapper, name, None)):
-                raise RuntimeError(
-                    "GLM-5-Next FP8 requires the installed KT writer ABI; "
-                    f"layer {layer_idx} is missing {name}"
-                )
-        moe = getattr(wrapper, "moe", None)
-        if moe is None or not hasattr(moe, "write_weight_scale_to_buffer_task"):
-            raise RuntimeError(
-                "GLM-5-Next FP8 requires a kt-kernel binary exposing "
-                "write_weight_scale_to_buffer_task; missing at layer "
-                f"{layer_idx}"
-            )
+        host_buffer_bytes += host_buffer.numel() * host_buffer.element_size()
 
-
-def _glm5_next_fp8_raw_slot_storage_nbytes(
-    *, num_experts: int, hidden_size: int, intermediate_size: int
-) -> int:
-    """Bytes in one raw E4M3 + FP32 [128, 128] full-expert slot."""
-
-    fp8_size = torch.tensor([], dtype=torch.float8_e4m3fn).element_size()
-    fp32_size = torch.tensor([], dtype=torch.float32).element_size()
-    hidden_blocks = (hidden_size + 127) // 128
-    intermediate_blocks = (intermediate_size + 127) // 128
-    return (
-        num_experts
-        * (2 * intermediate_size * hidden_size + hidden_size * intermediate_size)
-        * fp8_size
-        + num_experts
-        * (
-            2 * intermediate_blocks * hidden_blocks
-            + hidden_blocks * intermediate_blocks
-        )
-        * fp32_size
-    )
-
-
-def _allocate_glm5_next_fp8_slot_storage(
-    context: SharedFullContext,
-) -> Dict[str, torch.Tensor]:
-    return {
-        name: torch.nn.Parameter(
-            torch.empty_like(getattr(context.gpu_layer, name).data),
-            requires_grad=False,
-        )
-        for name in _Glm5NextFp8PrefillSlot.RAW_NAMES
-    }
-
-
-def _initialize_glm5_next_fp8_layerwise_pipeline(
-    signature: tuple, registry: dict
-) -> _Glm5NextFp8LayerwisePrefillManager:
-    existing = _GLM5_NEXT_FP8_LAYERWISE_MANAGERS.get(signature)
-    if existing is not None:
-        return existing
-
-    preflight_error = None
-    try:
-        _validate_glm5_next_fp8_registry(signature, registry)
-        if not torch.cuda.is_available():
-            raise RuntimeError(
-                "GLM-5-Next required FP8 layerwise prefill requires CUDA"
-            )
-        if get_tensor_model_parallel_world_size() != 8:
-            raise RuntimeError(
-                "GLM-5-Next required FP8 layerwise prefill is accepted only "
-                "for the TP=8 production topology"
-            )
-    except Exception as exc:
-        preflight_error = exc
-    if not _all_tp_ranks_succeeded(preflight_error is None):
-        message = (
-            "GLM-5-Next required FP8 layerwise preflight failed on at least "
-            "one TP rank"
-        )
-        if preflight_error is not None:
-            raise RuntimeError(message) from preflight_error
-        raise RuntimeError(message)
-    if preflight_error is not None:
-        raise preflight_error
-
-    first_layer_idx = min(registry)
-    method, layer = registry[first_layer_idx]
-    context = None
-    slot1_raw = None
-    manager = None
-    local_error = None
-    try:
-        context = SharedFullContext(
-            layer=layer,
-            init_args=method._full_init_args,
-            global_num_experts=method.global_num_experts,
-            moe_runner_config=method.moe_runner_config,
-            defer_cpu_buffers=True,
-        )
-        _validate_glm5_next_fp8_context(context)
-        slot1_raw = _allocate_glm5_next_fp8_slot_storage(context)
-        manager = _Glm5NextFp8LayerwisePrefillManager(
-            context, signature, slot1_raw
-        )
-        _validate_glm5_next_fp8_writer_abi(registry)
-    except Exception as exc:
-        local_error = exc
-
-    if not _all_tp_ranks_succeeded(local_error is None):
-        manager = None
-        slot1_raw = None
-        context = None
-        gc.collect()
-        if torch.cuda.is_available():
-            torch.cuda.empty_cache()
-        message = (
-            "GLM-5-Next required FP8 two-slot allocation failed on at least "
-            "one TP rank; refusing hybrid/serialized fallback"
-        )
-        if local_error is not None:
-            raise RuntimeError(message) from local_error
-        raise RuntimeError(message)
-    if local_error is not None:
-        raise local_error
-    assert context is not None and manager is not None
-
-    shm_error = None
-    try:
-        # The digest excludes rank-local CUDA indices, but covers the complete
-        # registry, raw tensor metadata, masks, and logical mappings.  Validate
-        # it before TP0 receives pointers into peer processes.
-        manager.validate_tp_contract()
-        # Allocate host transport only after both GPU slots exist on every TP
-        # rank, preventing an OOM peer from stranding SHM collectives.
-        context.initialize_cpu_buffers()
-        manager.initialize_transport_control()
-    except Exception as exc:
-        shm_error = exc
-    if not _all_tp_ranks_succeeded(shm_error is None):
-        message = (
-            "GLM-5-Next required FP8 host transport initialization failed "
-            "on at least one TP rank"
-        )
-        if shm_error is not None:
-            raise RuntimeError(message) from shm_error
-        raise RuntimeError(message)
-    if shm_error is not None:
-        raise shm_error
-
-    _GLM5_NEXT_FP8_LAYERWISE_MANAGERS[signature] = manager
-    if method.tp_rank == 0:
-        logger.info(
-            "KT GLM-5-Next FP8 layerwise prefill eagerly allocated two raw "
-            "E4M3+FP32 full-layer slots on %s before KV profiling "
-            "(total=%.2f GiB, contract=%s, fallback_count=0)",
-            manager.device,
-            manager.allocated_bytes / 1024**3,
-            manager.contract_digest,
-        )
-    return manager
-
-
-def initialize_glm5_next_fp8_layerwise_prefill() -> int:
-    """Eagerly allocate all required GLM managers before KV profiling.
-
-    Called only for the exact-model gate.  Returning allocated bytes makes the
-    startup reservation auditable; the memory profiler must not subtract it a
-    second time because the tensors are already resident.
-    """
-
-    registry_error = None
-    registry_count = len(_GLM5_NEXT_FP8_PREFILL_LAYER_REGISTRY)
-    if registry_count != 1:
-        registry_error = RuntimeError(
-            "GLM-5-Next required FP8 layerwise prefill needs exactly one "
-            "device-local MoE registry; got "
-            f"{registry_count}"
-        )
-    if not _all_tp_ranks_succeeded(registry_error is None):
-        message = (
-            "GLM-5-Next required FP8 layerwise registry count differs or is "
-            "invalid on at least one TP rank"
-        )
-        if registry_error is not None:
-            raise RuntimeError(message) from registry_error
-        raise RuntimeError(message)
-    if registry_error is not None:
-        raise registry_error
-
-    signature, registry = next(
-        iter(_GLM5_NEXT_FP8_PREFILL_LAYER_REGISTRY.items())
-    )
-    manager = _initialize_glm5_next_fp8_layerwise_pipeline(signature, registry)
-    return manager.allocated_bytes
-
-
-def _get_glm5_next_fp8_layerwise_manager(
-    method,
-) -> _Glm5NextFp8LayerwisePrefillManager:
-    signature = getattr(method, "_glm5_next_fp8_pipeline_signature", None)
-    if signature is None:
-        raise RuntimeError(
-            "GLM-5-Next required FP8 layerwise layer was not registered"
-        )
-    manager = _GLM5_NEXT_FP8_LAYERWISE_MANAGERS.get(signature)
-    if manager is None:
-        raise RuntimeError(
-            "GLM-5-Next required FP8 layerwise manager was not initialized "
-            "before KV-cache profiling; refusing fallback"
-        )
-    return manager
+    return gpu_slot_bytes, host_buffer_bytes
 
 
 def _glm5_next_forward_mode_name(mode) -> str:
@@ -5343,7 +4038,6 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
         # Registration happens during model construction, not on the first
         # request, so layer N can identify and prepare N+1 immediately.
         _register_mxfp4_prefill_layer(self, layer)
-        _register_glm5_next_fp8_prefill_layer(self, layer)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         """Process weights after loading from checkpoint.
@@ -5590,6 +4284,7 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
         topk_output = dispatch_output.topk_output
         num_tokens = int(x.shape[0]) if x.dim() > 0 else 0
         _glm5_next_fp8_required = _glm5_next_fp8_pipeline_requested(self)
+        _glm5_next_full_gpu_allowed = not _glm5_next_fp8_required
         if _glm5_next_fp8_required:
             forward_mode = getattr(self, "_glm5_next_forward_mode", None)
             if forward_mode is None:
@@ -5598,13 +4293,18 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
                     "ForwardMode metadata"
                 )
             forward_mode_name = _glm5_next_forward_mode_name(forward_mode)
+            if forward_mode_name not in ("EXTEND", "DECODE", "IDLE"):
+                raise RuntimeError(
+                    "GLM-5-Next FP8 layerwise prefill supports only plain "
+                    "EXTEND (text layerwise or image hybrid) and bypasses "
+                    "only DECODE/IDLE; got "
+                    f"ForwardMode.{forward_mode_name}"
+                )
             if forward_mode_name == "EXTEND":
                 if bool(getattr(self, "_glm5_next_has_image_inputs", False)):
-                    # Session D keeps the complete image EXTEND batch on the
-                    # already accepted CPU/hybrid expert route.  Keep
-                    # _glm5_next_fp8_required true so the generic full-GPU
-                    # threshold fallback below cannot accidentally select a
-                    # different image-prefill implementation.
+                    # Keep the complete image EXTEND batch on the accepted
+                    # CPU/hybrid route; multimodal batches must not enter the
+                    # text-only generic full-layer loader.
                     self._glm5_next_mm_hybrid_extend_count = (
                         getattr(self, "_glm5_next_mm_hybrid_extend_count", 0) + 1
                     )
@@ -5615,32 +4315,21 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
                             self.kt_config.layer_idx,
                             self._glm5_next_mm_hybrid_extend_count,
                         )
-                else:
-                    # The threshold is an enable switch for exact GLM, not a
-                    # per-chunk size cutoff.  This includes the final short
-                    # chunk of every pure-text EXTEND.
+                elif num_tokens >= self.gpu_prefill_token_threshold:
+                    # Exact GLM uses the same serialized SharedFullContext
+                    # loader as the generic block-FP8 path.  Short final
+                    # chunks remain hybrid instead of forcing another layer
+                    # image transfer.
+                    _glm5_next_full_gpu_allowed = True
                     self._glm5_next_layerwise_extend_count = (
                         getattr(self, "_glm5_next_layerwise_extend_count", 0) + 1
                     )
-                    return _get_glm5_next_fp8_layerwise_manager(self).apply(
-                        self, layer, dispatch_output
-                    )
-            if forward_mode_name not in ("EXTEND", "DECODE", "IDLE"):
-                raise RuntimeError(
-                    "GLM-5-Next required FP8 layerwise prefill supports only "
-                    "plain EXTEND (text layerwise or image hybrid) and bypasses "
-                    "only DECODE/IDLE; got "
-                    f"ForwardMode.{forward_mode_name}"
-                )
 
         from sglang.srt.eplb.expert_distribution import (
             get_global_expert_distribution_recorder,
         )
         from sglang.srt.layers.moe.token_dispatcher import StandardCombineInput
 
-        # The required exact-GLM EXTEND route above must happen before this
-        # TP0-only recorder.  A recorder exception on rank 0 must never leave
-        # peers entering layerwise transport collectives.
         if self.tp_rank == 0:
             recorder = get_global_expert_distribution_recorder()
             recorder.on_gpu_expert_mask(
@@ -5675,8 +4364,17 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
             or hasattr(layer, "w13_weight_packed")
             or getattr(layer, "_v4_tk_path", False)
         )
+        if (
+            _glm5_next_fp8_required
+            and _glm5_next_full_gpu_allowed
+            and not _full_gpu_fallback_supported
+        ):
+            raise RuntimeError(
+                "GLM-5-Next FP8 layerwise prefill requires raw block-FP8 "
+                "weight attributes for the generic SharedFullContext loader"
+            )
         _full_gpu_gate = (
-            not _glm5_next_fp8_required
+            _glm5_next_full_gpu_allowed
             and self.gpu_prefill_token_threshold > 0
             and num_tokens >= self.gpu_prefill_token_threshold
             and _full_gpu_fallback_supported
@@ -6096,12 +4794,109 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
         global _SHARED_FULL_CONTEXT
 
         if _SHARED_FULL_CONTEXT is None:
-            _SHARED_FULL_CONTEXT = SharedFullContext(
-                layer=layer,
-                init_args=self._full_init_args,
-                global_num_experts=self.global_num_experts,
-                moe_runner_config=self.moe_runner_config,
-            )
+            is_glm5_next_fp8 = _glm5_next_fp8_pipeline_requested(self)
+            if is_glm5_next_fp8:
+                # GPU tensors are allocated independently on each TP rank.
+                # Do not let a successful peer enter the Host-SHM collectives
+                # until every rank has finished that allocation: otherwise a
+                # single-rank OOM can strand the remaining ranks forever.
+                context = None
+                context_error = None
+                try:
+                    context = SharedFullContext(
+                        layer=layer,
+                        init_args=self._full_init_args,
+                        global_num_experts=self.global_num_experts,
+                        moe_runner_config=self.moe_runner_config,
+                        defer_cpu_buffers=True,
+                    )
+                except Exception as exc:
+                    context_error = exc
+
+                if not _all_tp_ranks_succeeded(context_error is None):
+                    any_oom = _any_tp_rank_true(
+                        isinstance(context_error, torch.cuda.OutOfMemoryError)
+                    )
+                    any_fatal = _any_tp_rank_true(
+                        context_error is not None
+                        and not isinstance(
+                            context_error, torch.cuda.OutOfMemoryError
+                        )
+                    )
+                    context = None
+                    gc.collect()
+                    if torch.cuda.is_available():
+                        torch.cuda.empty_cache()
+                    if any_fatal:
+                        message = (
+                            "GLM-5-Next full-layer GPU slot initialization "
+                            "failed on at least one TP rank"
+                        )
+                    elif any_oom:
+                        message = (
+                            "GLM-5-Next full-layer GPU slot CUDA out of memory "
+                            "on at least one TP rank"
+                        )
+                    else:
+                        message = (
+                            "GLM-5-Next full-layer GPU slot initialization "
+                            "failed without a rank-local exception"
+                        )
+                    raise RuntimeError(message) from context_error
+
+                if context is None:
+                    raise RuntimeError(
+                        "GLM-5-Next full-layer GPU slot initialization returned "
+                        "no context"
+                    )
+                # _create_cpu_buffers has phase-level TP consensus and cleanup.
+                context.initialize_cpu_buffers()
+
+                validation_result = None
+                validation_error = None
+                try:
+                    context._initialize_glm5_next_fp8_transport()
+                    validation_result = (
+                        _validate_glm5_next_fp8_shared_full_context(context)
+                    )
+                except Exception as exc:
+                    validation_error = exc
+                if not _all_tp_ranks_succeeded(validation_error is None):
+                    context._cleanup_cpu_buffers_after_failure()
+                    context = None
+                    gc.collect()
+                    if torch.cuda.is_available():
+                        torch.cuda.empty_cache()
+                    raise RuntimeError(
+                        "GLM-5-Next single-slot transport setup or context "
+                        "validation failed on at least one TP rank"
+                    ) from validation_error
+
+                if validation_result is None:
+                    raise RuntimeError(
+                        "GLM-5-Next single-slot validation returned no result"
+                    )
+                gpu_slot_bytes, host_buffer_bytes = validation_result
+            else:
+                context = SharedFullContext(
+                    layer=layer,
+                    init_args=self._full_init_args,
+                    global_num_experts=self.global_num_experts,
+                    moe_runner_config=self.moe_runner_config,
+                )
+
+            if is_glm5_next_fp8:
+                if self.tp_rank == 0:
+                    logger.info(
+                        "KT GLM-5-Next FP8 layerwise prefill lazily allocated "
+                        "generic SharedFullContext: gpu_full_layer_slots=1 "
+                        "host_expert_slots=2 gpu_slot_bytes=%d "
+                        "host_buffer_bytes=%d device=%s",
+                        gpu_slot_bytes,
+                        host_buffer_bytes,
+                        context.gpu_layer.w13_weight.device,
+                    )
+            _SHARED_FULL_CONTEXT = context
 
         _SHARED_FULL_CONTEXT.load(
             layer_idx=self.kt_config.layer_idx,

--- a/python/sglang/srt/mem_cache/glm5_next_memory_pool.py
+++ b/python/sglang/srt/mem_cache/glm5_next_memory_pool.py
@@ -124,6 +124,9 @@ class Glm5NextNSATokenToKVPool(NSATokenToKVPool):
             kv_cache_dim=kv_cache_dim,
             start_layer=start_layer,
             end_layer=end_layer,
+            index_cache_dtype=(
+                torch.bfloat16 if dtype == torch.bfloat16 else torch.float8_e4m3fn
+            ),
         )
 
         # The shared NSA pool selects its scaled FP8 layout when
@@ -134,6 +137,11 @@ class Glm5NextNSATokenToKVPool(NSATokenToKVPool):
         if dtype == torch.float8_e4m3fn:
             assert not self.nsa_kv_cache_store_fp8
             assert self.kv_cache_dim == kv_lora_rank
+        elif dtype != torch.bfloat16:
+            raise ValueError(
+                "GLM-5-Next consumer cache supports only BF16 or FP8 E4M3, "
+                f"got {dtype}"
+            )
 
         self.index_kpool = index_kpool
         self.index_kpool_compress = index_kpool_compress
@@ -413,6 +421,14 @@ class Glm5NextHybridKVPool(HybridLinearKVPool):
     @property
     def quant_block_size(self) -> int:
         return self.full_kv_pool.quant_block_size
+
+    @property
+    def index_cache_dtype(self) -> torch.dtype:
+        return self.full_kv_pool.index_cache_dtype
+
+    @property
+    def index_cache_is_bf16(self) -> bool:
+        return self.full_kv_pool.index_cache_is_bf16
 
     @property
     def index_kpool(self) -> int:

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -1746,6 +1746,7 @@ class NSATokenToKVPool(MLATokenToKVPool):
         kv_cache_dim: int,
         start_layer: Optional[int] = None,
         end_layer: Optional[int] = None,
+        index_cache_dtype: Optional[torch.dtype] = None,
     ):
 
         override_dim = (
@@ -1769,6 +1770,13 @@ class NSATokenToKVPool(MLATokenToKVPool):
         # self.index_k_dtype = torch.float8_e4m3fn
         # self.index_k_scale_dtype = torch.float32
         self.index_head_dim = index_head_dim
+        self.index_cache_dtype = index_cache_dtype or torch.float8_e4m3fn
+        if self.index_cache_dtype not in (torch.float8_e4m3fn, torch.bfloat16):
+            raise ValueError(
+                "NSA index cache supports only FP8 E4M3 or BF16, got "
+                f"{self.index_cache_dtype}"
+            )
+        self.index_cache_is_bf16 = self.index_cache_dtype == torch.bfloat16
         # num head == 1 and head dim == 128 for index_k in NSA
         assert index_head_dim == 128
 
@@ -1793,10 +1801,17 @@ class NSATokenToKVPool(MLATokenToKVPool):
                         (size + page_size + 1) // self.page_size,
                         self.page_size
                         * (
-                            index_head_dim + index_head_dim // self.quant_block_size * 4
+                            index_head_dim
+                            if self.index_cache_is_bf16
+                            else index_head_dim
+                            + index_head_dim // self.quant_block_size * 4
                         ),
                     ),
-                    dtype=self.index_k_with_scale_buffer_dtype,
+                    dtype=(
+                        torch.bfloat16
+                        if self.index_cache_is_bf16
+                        else self.index_k_with_scale_buffer_dtype
+                    ),
                     device=device,
                 )
                 for _ in range(layer_num)
@@ -1815,6 +1830,10 @@ class NSATokenToKVPool(MLATokenToKVPool):
         page_indices: torch.Tensor,
     ):
         buf = self.index_k_with_scale_buffer[layer_id - self.start_layer]
+        if self.index_cache_is_bf16:
+            num_pages = (seq_len + self.page_size - 1) // self.page_size
+            pages = buf.index_select(0, page_indices[:num_pages].to(torch.int64))
+            return pages.view(-1, self.index_head_dim)[:seq_len]
         return index_buf_accessor.GetK.execute(
             self, buf, seq_len=seq_len, page_indices=page_indices
         )
@@ -1826,6 +1845,8 @@ class NSATokenToKVPool(MLATokenToKVPool):
         page_indices: torch.Tensor,
     ):
         buf = self.index_k_with_scale_buffer[layer_id - self.start_layer]
+        if self.index_cache_is_bf16:
+            return torch.ones((seq_len,), dtype=torch.float32, device=buf.device)
         return index_buf_accessor.GetS.execute(
             self, buf, seq_len=seq_len, page_indices=page_indices
         )
@@ -1848,6 +1869,11 @@ class NSATokenToKVPool(MLATokenToKVPool):
                  k_scale: (seq_len, 4), uint8
         """
         buf = self.index_k_with_scale_buffer[layer_id - self.start_layer]
+        if self.index_cache_is_bf16:
+            return (
+                self.get_index_k_continuous(layer_id, seq_len, page_indices),
+                torch.ones((seq_len,), dtype=torch.float32, device=buf.device),
+            )
         return index_buf_accessor.GetKAndS.execute(
             self, buf, seq_len=seq_len, page_indices=page_indices
         )
@@ -1860,6 +1886,18 @@ class NSATokenToKVPool(MLATokenToKVPool):
         index_k_scale: torch.Tensor,
     ) -> None:
         buf = self.index_k_with_scale_buffer[layer_id - self.start_layer]
+        if self.index_cache_is_bf16:
+            if index_k.shape != (loc.numel(), self.index_head_dim):
+                raise ValueError(
+                    "BF16 NSA index K must have shape "
+                    f"{(loc.numel(), self.index_head_dim)}, got {tuple(index_k.shape)}"
+                )
+            pages = torch.div(loc, self.page_size, rounding_mode="floor").to(torch.long)
+            offsets = torch.remainder(loc, self.page_size).to(torch.long)
+            buf.view(-1, self.page_size, self.index_head_dim)[pages, offsets] = (
+                index_k.to(torch.bfloat16)
+            )
+            return
         index_buf_accessor.SetKAndS.execute(
             pool=self, buf=buf, loc=loc, index_k=index_k, index_k_scale=index_k_scale
         )

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -590,25 +590,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         # Deduce KV cache dtype
         self.configure_kv_cache_dtype()
 
-        # Exact GLM-5-Next treats a positive threshold as a required
-        # layerwise-prefill enable switch.  Materialize its two raw block-FP8
-        # slots before KV profiling so the profiler observes the real reserved
-        # VRAM and a startup OOM fails closed rather than surfacing on the first
-        # long request.
-        self.glm5_next_fp8_layerwise_prefill_allocated_bytes = 0
-        if (
-            getattr(server_args, "_glm5_next_session_ab_active", False)
-            and (server_args.kt_method or "").upper() == "FP8"
-            and (server_args.kt_gpu_prefill_token_threshold or 0) > 0
-        ):
-            from sglang.srt.layers.moe.kt_ep_wrapper import (
-                initialize_glm5_next_fp8_layerwise_prefill,
-            )
-
-            self.glm5_next_fp8_layerwise_prefill_allocated_bytes = (
-                initialize_glm5_next_fp8_layerwise_prefill()
-            )
-
         # Do not allocate the MXFP4 layerwise slots at startup.  Still account
         # for their future capacity before KV-cache profiling, otherwise the
         # pool can consume the VRAM needed by the first long prefill request.

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -145,13 +145,17 @@ class ModelRunnerKVCacheMixin:
                     if getattr(self.model_config, "is_glm5_next", False)
                     else get_nsa_index_head_dim(self.model_config.hf_config)
                 )
-                indexer_size_per_token = (
-                    index_head_dim
-                    + index_head_dim // NSATokenToKVPool.quant_block_size * 4
-                )
-                element_size = torch._utils._element_size(
-                    NSATokenToKVPool.index_k_with_scale_buffer_dtype
-                )
+                if is_glm5_next_kpool and self.kv_cache_dtype == torch.bfloat16:
+                    indexer_size_per_token = index_head_dim
+                    element_size = torch.bfloat16.itemsize
+                else:
+                    indexer_size_per_token = (
+                        index_head_dim
+                        + index_head_dim // NSATokenToKVPool.quant_block_size * 4
+                    )
+                    element_size = torch._utils._element_size(
+                        NSATokenToKVPool.index_k_with_scale_buffer_dtype
+                    )
                 cell_size += indexer_size_per_token * num_layers * element_size
         else:
             if self.model_config.is_hybrid_swa:

--- a/python/sglang/srt/multimodal/processors/glm5_next.py
+++ b/python/sglang/srt/multimodal/processors/glm5_next.py
@@ -200,7 +200,7 @@ class Glm5NextProcessor(Glm46VProcessor):
 
 
 class Glm5NextSGLangProcessor(Glm4vImageProcessor):
-    """Strict one-image request adapter registered only for GLM-5-Next."""
+    """Strict image-only request adapter registered only for GLM-5-Next."""
 
     models = [Glm5NextForConditionalGeneration]
 
@@ -286,22 +286,23 @@ class Glm5NextSGLangProcessor(Glm4vImageProcessor):
             raise ValueError("GLM-5-Next Session D does not support audio input.")
         if getattr(request_obj, "video_data", None):
             raise ValueError("GLM-5-Next Session D does not support video input.")
-        if not isinstance(image_data, list) or len(image_data) != 1:
+        if not isinstance(image_data, list) or not image_data:
             count = len(image_data) if isinstance(image_data, list) else 0
             raise ValueError(
-                "GLM-5-Next Session D requires exactly one image per request; "
+                "GLM-5-Next requires at least one image per image request; "
                 f"got {count}."
             )
-        if isinstance(image_data[0], dict):
+        image_count = len(image_data)
+        if any(isinstance(image, dict) for image in image_data):
             raise ValueError(
-                "GLM-5-Next Session D does not accept processor_output or "
+                "GLM-5-Next does not accept processor_output or "
                 "precomputed_embedding image inputs."
             )
         placeholder_count = self._count_image_placeholders(input_text)
-        if placeholder_count != 1:
+        if placeholder_count != image_count:
             raise ValueError(
-                "GLM-5-Next Session D requires exactly one image placeholder; "
-                f"got {placeholder_count}."
+                "GLM-5-Next image count/placeholder count mismatch: "
+                f"images={image_count}, placeholders={placeholder_count}."
             )
 
         # load_mm_data is synchronous: it submits image I/O to the processor's
@@ -313,9 +314,14 @@ class Glm5NextSGLangProcessor(Glm4vImageProcessor):
             video_data=None,
             multimodal_tokens=self.mm_tokens,
         )
-        if len(base_output.images) != 1 or base_output.videos or base_output.audios:
+        if (
+            len(base_output.images) != image_count
+            or base_output.videos
+            or base_output.audios
+        ):
             raise ValueError(
-                "GLM-5-Next image loading must produce exactly one still image."
+                "GLM-5-Next image loading changed the request cardinality: "
+                f"expected={image_count}, loaded={len(base_output.images)}."
             )
 
         mm_items, input_ids, ret = self.process_and_combine_mm_data(
@@ -324,26 +330,95 @@ class Glm5NextSGLangProcessor(Glm4vImageProcessor):
         image_grid_thw = getattr(ret, "image_grid_thw", None)
         if image_grid_thw is None and isinstance(ret, dict):
             image_grid_thw = ret.get("image_grid_thw")
-        if image_grid_thw is None or tuple(image_grid_thw.shape) != (1, 3):
+        expected_grid_shape = (image_count, 3)
+        if image_grid_thw is None or tuple(image_grid_thw.shape) != expected_grid_shape:
+            actual_grid_shape = (
+                None if image_grid_thw is None else tuple(image_grid_thw.shape)
+            )
             raise RuntimeError(
-                "GLM-5-Next processor must return image_grid_thw with shape (1, 3)."
+                "GLM-5-Next processor returned an invalid image_grid_thw shape: "
+                f"expected={expected_grid_shape}, got={actual_grid_shape}."
             )
         if len(mm_items) != 1 or not mm_items[0].is_image():
             raise RuntimeError(
-                "GLM-5-Next processor must return exactly one image item."
+                "GLM-5-Next processor must return one bundled image item."
             )
-        expected_tokens = int(image_grid_thw[0].prod().item()) // (
-            self.spatial_merge_size**2
-        )
+
+        merge_area = self.spatial_merge_size**2
+        patch_counts = [int(grid.prod().item()) for grid in image_grid_thw]
+        if any(patch_count % merge_area for patch_count in patch_counts):
+            raise RuntimeError(
+                "GLM-5-Next image patch counts must be divisible by the spatial "
+                f"merge area {merge_area}; got {patch_counts}."
+            )
+        expected_tokens_per_image = [
+            patch_count // merge_area for patch_count in patch_counts
+        ]
+        expected_tokens = sum(expected_tokens_per_image)
         actual_tokens = int((input_ids == self.IM_TOKEN_ID).sum().item())
         if actual_tokens != expected_tokens:
             raise RuntimeError(
                 "GLM-5-Next image placeholder/feature mismatch: "
                 f"expected {expected_tokens} image tokens, got {actual_tokens}."
             )
-        if len(mm_items[0].offsets) != 1:
+
+        source_offsets = mm_items[0].offsets or []
+        covered_positions = []
+        for start, end in source_offsets:
+            start, end = int(start), int(end)
+            if end < start:
+                raise RuntimeError(
+                    "GLM-5-Next processor returned an inverted image offset: "
+                    f"start={start}, end={end}."
+                )
+            covered_positions.extend(range(start, end + 1))
+        image_token_positions = (
+            (input_ids == self.IM_TOKEN_ID).nonzero(as_tuple=True)[0].tolist()
+        )
+        if covered_positions != image_token_positions:
             raise RuntimeError(
-                "GLM-5-Next processor must return one contiguous image offset."
+                "GLM-5-Next processor image offsets do not cover exactly the "
+                "expanded image tokens."
+            )
+
+        # Adjacent placeholders form one token run in the generic processor.
+        # Split by the per-image grid sizes so the scheduler still receives one
+        # ordered offset per source image.
+        normalized_offsets = []
+        token_cursor = 0
+        for image_index, expected_tokens_for_image in enumerate(
+            expected_tokens_per_image
+        ):
+            positions = image_token_positions[
+                token_cursor : token_cursor + expected_tokens_for_image
+            ]
+            token_cursor += expected_tokens_for_image
+            is_contiguous = len(positions) == expected_tokens_for_image and all(
+                right == left + 1 for left, right in zip(positions, positions[1:])
+            )
+            if not is_contiguous:
+                raise RuntimeError(
+                    "GLM-5-Next image offset/token mismatch at image "
+                    f"{image_index}: expected={expected_tokens_for_image}, "
+                    f"positions={positions}."
+                )
+            normalized_offsets.append((positions[0], positions[-1]))
+        mm_items[0].offsets = normalized_offsets
+
+        feature = mm_items[0].feature
+        feature_shape = getattr(feature, "shape", None)
+        if feature_shape is None:
+            feature_shape = getattr(getattr(feature, "info_data", None), "shape", None)
+        expected_feature_rows = sum(patch_counts)
+        if (
+            feature_shape is None
+            or len(feature_shape) == 0
+            or int(feature_shape[0]) != expected_feature_rows
+        ):
+            raise RuntimeError(
+                "GLM-5-Next image feature/grid mismatch: "
+                f"expected_rows={expected_feature_rows}, "
+                f"feature_shape={None if feature_shape is None else tuple(feature_shape)}."
             )
 
         attention_mask = getattr(ret, "attention_mask", None)

--- a/python/sglang/srt/multimodal/processors/glm5_next.py
+++ b/python/sglang/srt/multimodal/processors/glm5_next.py
@@ -1,4 +1,4 @@
-"""Self-contained single-image processor for GLM-5-Next.
+"""Self-contained image processor for GLM-5-Next.
 
 The pinned transformers-kt wheel has the reusable GLM-4.6V tokenizer and
 patchifier, but it does not register the checkpoint's Glmga image processor.
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import torch
 from transformers.image_transforms import group_images_by_shape, reorder_images
 from transformers.image_utils import SizeDict
 from transformers.models.glm46v.image_processing_glm46v import (
@@ -272,6 +273,148 @@ class Glm5NextSGLangProcessor(Glm4vImageProcessor):
             return input_text.count(self.IM_TOKEN_ID)
         raise TypeError("GLM-5-Next multimodal prompt must be text or token ids.")
 
+    def _get_multi_image_mrope(
+        self,
+        input_ids,
+        image_grid_thw,
+        image_offsets,
+        attention_mask,
+    ):
+        """Build GLM MRoPE positions while preserving adjacent image boundaries.
+
+        The shared GLM4V helper discovers modality segments by grouping adjacent
+        image-token IDs.  Two adjacent source placeholders therefore look like
+        one image and consume only the first grid.  The request adapter already
+        has one validated offset and one grid per source image, so use those
+        explicit boundaries for the multi-image case.
+        """
+
+        if input_ids.ndim != 1:
+            raise RuntimeError(
+                "GLM-5-Next multi-image MRoPE expects one token sequence; "
+                f"got shape={tuple(input_ids.shape)}."
+            )
+        sequence_length = int(input_ids.shape[0])
+        if attention_mask is None:
+            active_mask = torch.ones_like(input_ids, dtype=torch.bool)
+        else:
+            active_mask = attention_mask.reshape(-1).to(
+                device=input_ids.device, dtype=torch.bool
+            )
+            if active_mask.numel() != sequence_length:
+                raise RuntimeError(
+                    "GLM-5-Next multi-image attention mask length changed: "
+                    f"tokens={sequence_length}, mask={active_mask.numel()}."
+                )
+
+        active_indices = active_mask.nonzero(as_tuple=True)[0]
+        position_pieces = []
+        assignment_pieces = []
+        next_position = 0
+        token_cursor = 0
+
+        def append_text(indices):
+            nonlocal next_position
+            text_length = int(indices.numel())
+            if text_length == 0:
+                return
+            text_positions = torch.arange(
+                text_length, device=input_ids.device, dtype=input_ids.dtype
+            )
+            text_positions = text_positions.view(1, -1).expand(3, -1)
+            text_positions = text_positions + next_position
+            position_pieces.append(text_positions)
+            assignment_pieces.append(indices)
+            next_position = int(text_positions.max().item()) + 1
+
+        for image_index, ((start, end), grid) in enumerate(
+            zip(image_offsets, image_grid_thw)
+        ):
+            start, end = int(start), int(end)
+            if start < token_cursor or end < start or end >= sequence_length:
+                raise RuntimeError(
+                    "GLM-5-Next multi-image offsets are not ordered in bounds at "
+                    f"image {image_index}: start={start}, end={end}, "
+                    f"cursor={token_cursor}, sequence_length={sequence_length}."
+                )
+
+            text_indices = active_indices[
+                (active_indices >= token_cursor) & (active_indices < start)
+            ]
+            append_text(text_indices)
+
+            image_indices = active_indices[
+                (active_indices >= start) & (active_indices <= end)
+            ]
+            t, h, w = (int(value) for value in grid)
+            merge_size = int(self.spatial_merge_size)
+            if h % merge_size or w % merge_size:
+                raise RuntimeError(
+                    "GLM-5-Next image grid is not divisible by the spatial "
+                    f"merge size at image {image_index}: grid={(t, h, w)}, "
+                    f"merge_size={merge_size}."
+                )
+            grid_h, grid_w = h // merge_size, w // merge_size
+            image_token_count = t * grid_h * grid_w
+            if int(image_indices.numel()) != image_token_count:
+                raise RuntimeError(
+                    "GLM-5-Next multi-image offset/grid mismatch at image "
+                    f"{image_index}: offset_tokens={image_indices.numel()}, "
+                    f"grid_tokens={image_token_count}."
+                )
+
+            t_index = (
+                torch.arange(t, device=input_ids.device, dtype=input_ids.dtype)
+                .view(-1, 1)
+                .expand(t, grid_h * grid_w)
+                .reshape(-1)
+            )
+            h_index = (
+                torch.arange(grid_h, device=input_ids.device, dtype=input_ids.dtype)
+                .view(1, -1, 1)
+                .expand(t, grid_h, grid_w)
+                .reshape(-1)
+            )
+            w_index = (
+                torch.arange(grid_w, device=input_ids.device, dtype=input_ids.dtype)
+                .view(1, 1, -1)
+                .expand(t, grid_h, grid_w)
+                .reshape(-1)
+            )
+            image_positions = torch.stack((t_index, h_index, w_index)) + next_position
+            position_pieces.append(image_positions)
+            assignment_pieces.append(image_indices)
+            next_position = int(image_positions.max().item()) + 1
+            token_cursor = end + 1
+
+        append_text(active_indices[active_indices >= token_cursor])
+        assigned_indices = torch.cat(assignment_pieces)
+        if not torch.equal(assigned_indices, active_indices):
+            raise RuntimeError(
+                "GLM-5-Next multi-image MRoPE segments do not cover exactly the "
+                "active token sequence."
+            )
+        active_positions = torch.cat(position_pieces, dim=1)
+        if active_positions.shape[1] != active_indices.numel():
+            raise RuntimeError(
+                "GLM-5-Next multi-image MRoPE position length changed: "
+                f"positions={active_positions.shape[1]}, "
+                f"active_tokens={active_indices.numel()}."
+            )
+
+        position_ids = torch.ones(
+            (3, sequence_length),
+            dtype=input_ids.dtype,
+            device=input_ids.device,
+        )
+        position_ids[:, active_indices] = active_positions
+        position_delta = torch.tensor(
+            [[next_position - sequence_length]],
+            dtype=input_ids.dtype,
+            device=input_ids.device,
+        )
+        return position_ids, position_delta
+
     async def process_mm_data_async(
         self,
         image_data,
@@ -424,14 +567,24 @@ class Glm5NextSGLangProcessor(Glm4vImageProcessor):
         attention_mask = getattr(ret, "attention_mask", None)
         if attention_mask is None and isinstance(ret, dict):
             attention_mask = ret.get("attention_mask")
-        mrope_positions, mrope_position_delta = MRotaryEmbedding.get_rope_index_glm4v(
-            input_ids=input_ids.unsqueeze(0),
-            hf_config=self.hf_config,
-            image_grid_thw=image_grid_thw,
-            video_grid_thw=None,
-            attention_mask=attention_mask,
-        )
-        mrope_positions = mrope_positions.squeeze(1)
+        if image_count == 1:
+            mrope_positions, mrope_position_delta = (
+                MRotaryEmbedding.get_rope_index_glm4v(
+                    input_ids=input_ids.unsqueeze(0),
+                    hf_config=self.hf_config,
+                    image_grid_thw=image_grid_thw,
+                    video_grid_thw=None,
+                    attention_mask=attention_mask,
+                )
+            )
+            mrope_positions = mrope_positions.squeeze(1)
+        else:
+            mrope_positions, mrope_position_delta = self._get_multi_image_mrope(
+                input_ids=input_ids,
+                image_grid_thw=image_grid_thw,
+                image_offsets=normalized_offsets,
+                attention_mask=attention_mask,
+            )
         if mrope_positions.ndim != 2 or mrope_positions.shape[0] != 3:
             raise RuntimeError(
                 "GLM-5-Next MRoPE positions must have shape (3, sequence_length)."

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1393,15 +1393,13 @@ class ServerArgs:
                 f"FP8 weight format; got quantization={self.quantization!r}."
             )
 
-        # Session AB accepts TP=1 for structural/component validation and TP=8
-        # for the pinned production checkpoint.  Intermediate TP widths and
-        # alternate PP/DP/CP/EP topologies have no acceptance evidence, and
-        # the mHC communicator intentionally rejects the scattered states
-        # produced by A2A MoE and dense fully-DP modes.
-        if self.tp_size not in (1, 8):
+        # Session AB accepts only the TP=4 runtime layout.  Other TP widths and
+        # alternate PP/DP/CP/EP topologies are deliberately outside the
+        # released boundary.  The mHC communicator intentionally rejects the
+        # scattered states produced by A2A MoE and dense fully-DP modes.
+        if self.tp_size != 4:
             raise ValueError(
-                "GLM-5-Next Session AB accepts only TP=1 structural validation "
-                "or the TP=8 production topology; "
+                "GLM-5-Next Session AB accepts only TP=4; "
                 f"got tp_size={self.tp_size}."
             )
 
@@ -1485,19 +1483,17 @@ class ServerArgs:
                 )
 
             # The positive threshold enables GLM's layerwise full-GPU prefill
-            # route.  Its two-slot FP8 pipeline is accepted only for the TP=8
-            # production layout.  Dynamic expert replacement mutates the
-            # resident set behind those slots and is deliberately excluded.
+            # route.  It is supported only by the TP=4 runtime layout.
+            # Dynamic expert replacement mutates the resident set behind the
+            # shared context and is deliberately excluded.
             prefill_threshold = getattr(
                 self, "kt_gpu_prefill_token_threshold", None
             )
             if prefill_threshold is not None and prefill_threshold > 0:
-                if self.tp_size != 8:
+                if self.tp_size != 4:
                     raise ValueError(
                         "GLM-5-Next KT layerwise prefill "
-                        "(--kt-gpu-prefill-token-threshold > 0) requires TP=8; "
-                        "TP=1 is structural-test-only and must keep the "
-                        "threshold unset or <= 0."
+                        "(--kt-gpu-prefill-token-threshold > 0) requires TP=4."
                     )
                 if getattr(self, "kt_enable_dynamic_expert_update", False):
                     raise ValueError(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1523,19 +1523,22 @@ class ServerArgs:
         # revalidate without loading or inspecting configs for other models.
         self._glm5_next_session_ab_active = True
 
-    def _configure_glm5_next_session_ab_nsa(self, major: int) -> None:
-        if major < 10:
+    def _configure_glm5_next_session_ab_nsa(
+        self, capability: tuple[int, int]
+    ) -> None:
+        from sglang.srt.configs.glm5_next import get_glm5_next_gpu_profile
+
+        profile = get_glm5_next_gpu_profile(capability)
+        if self.kv_cache_dtype == "auto":
+            self.kv_cache_dtype = profile.kv_cache_dtype
+        elif self.kv_cache_dtype == "bf16":
+            self.kv_cache_dtype = "bfloat16"
+
+        if self.kv_cache_dtype != profile.kv_cache_dtype:
             raise ValueError(
-                "GLM-5-Next Session AB requires an NVIDIA Blackwell GPU "
-                "(compute capability major >= 10) for the validated FP8 "
-                "KPool4 path; "
-                f"got compute capability major {major}."
-            )
-        if self.kv_cache_dtype != "fp8_e4m3":
-            raise ValueError(
-                "GLM-5-Next Session AB requires --kv-cache-dtype=fp8_e4m3; "
-                f"got {self.kv_cache_dtype!r}. BF16 and other KV-cache "
-                "precisions are outside the accepted boundary."
+                f"GLM-5-Next {profile.value} requires "
+                f"--kv-cache-dtype={profile.kv_cache_dtype}; got "
+                f"{self.kv_cache_dtype!r}."
             )
 
         if self.nsa_prefill_backend is None:
@@ -1547,17 +1550,40 @@ class ServerArgs:
             or self.nsa_decode_backend != "trtllm"
         ):
             raise ValueError(
-                "GLM-5-Next Session AB FP8 KPool4 requires trtllm for both "
+                "GLM-5-Next KPool4 requires the model-local trtllm dispatcher "
+                "for both "
                 "NSA prefill and decode; got "
                 f"prefill={self.nsa_prefill_backend!r}, "
                 f"decode={self.nsa_decode_backend!r}."
             )
 
         logger.warning(
-            "Set GLM-5-Next KPool4 NSA dispatcher paths to trtllm for FP8 KV "
-            "cache on Blackwell; Session C uses the model-local graph-safe "
-            "SM120 indexer and sparse-MLA kernels."
+            "Set GLM-5-Next GPU profile=%s, KV cache=%s, KPool cache=%s, "
+            "NSA dispatcher=trtllm; the dispatcher selects model-local "
+            "graph-safe kernels on SM86/SM89/SM120.",
+            profile.value,
+            profile.kv_cache_dtype,
+            profile.index_cache_dtype,
         )
+
+        prefill_threshold = getattr(self, "kt_gpu_prefill_token_threshold", None)
+        if (
+            profile.is_consumer_gpu
+            and prefill_threshold is not None
+            and prefill_threshold > 0
+        ):
+            raise ValueError(
+                "GLM-5-Next layerwise prefill is not adapted for SM86/SM89; "
+                "set --kt-gpu-prefill-token-threshold=0."
+            )
+
+        if profile.is_consumer_gpu and bool(
+            getattr(self, "enable_multimodal", False)
+        ):
+            raise ValueError(
+                "GLM-5-Next SM86/SM89 acceptance covers text inference only; "
+                "--enable-multimodal must remain disabled."
+            )
 
     def _set_default_nsa_kv_cache_dtype(self, major: int) -> str:
         user_set_prefill = self.nsa_prefill_backend is not None
@@ -1780,11 +1806,12 @@ class ServerArgs:
 
                     import torch
 
-                    major, _ = torch.cuda.get_device_capability()
-                    self._set_default_nsa_kv_cache_dtype(major)
+                    capability = torch.cuda.get_device_capability()
+                    major, _ = capability
                     if is_glm5_next:
-                        self._configure_glm5_next_session_ab_nsa(major)
+                        self._configure_glm5_next_session_ab_nsa(capability)
                     else:
+                        self._set_default_nsa_kv_cache_dtype(major)
                         self._set_default_nsa_backends(self.kv_cache_dtype, major)
 
                 if self.enable_nsa_prefill_context_parallel:

--- a/scripts/glm5_next_consumer_gpu_compile.py
+++ b/scripts/glm5_next_consumer_gpu_compile.py
@@ -1,0 +1,636 @@
+#!/usr/bin/env python3
+"""Offline-compile GLM-5-Next's SM86/SM89 Triton kernel matrix.
+
+This does not require a GPU.  It validates that the installed Triton toolchain
+can lower every model-local consumer-GPU kernel to the requested CUDA target.
+It is intentionally separate from numerical and end-to-end acceptance, which
+must run on real hardware.  Pass ``--resource-report`` to force recompilation
+and expose ptxas register, stack, and spill counts for static-config review.
+
+After this passes, run the consumer-GPU unit file on the target host, then use
+``glm5_next_session_c_benchmark.py collect --decode-input 32768
+--decode-output 256`` against a CUDA-Graph-enabled server.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import triton
+from triton.backends.compiler import GPUTarget
+from triton.compiler import ASTSource
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load(name: str, relative_path: str) -> ModuleType:
+    path = ROOT / relative_path
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _compile(
+    *,
+    label: str,
+    capability: int,
+    kernel: Any,
+    signature: dict[str, str],
+    constants: dict[str, Any],
+    num_warps: int,
+    num_stages: int,
+) -> None:
+    target = GPUTarget("cuda", capability, 32)
+    backend = triton.compiler.make_backend(target)
+    options = backend.parse_options({"num_warps": num_warps, "num_stages": num_stages})
+    triton.compile(
+        ASTSource(kernel, signature, constants),
+        target=target,
+        options=options.__dict__,
+    )
+    print(f"PASS {label}")
+
+
+def _compile_indexer(indexer: ModuleType, capability: int) -> None:
+    is_sm86 = capability == 86
+    value_type = "*bf16" if is_sm86 else "*fp8e4nv"
+    block_k, num_warps, num_stages = indexer.glm5_next_indexer_launch_config(
+        (capability // 10, capability % 10)
+    )
+    flat_signature = {
+        "q_ptr": value_type,
+        "k_ptr": value_type,
+        "k_scale_ptr": "*fp32",
+        "weights_ptr": "*fp32",
+        "ks_ptr": "*i32",
+        "ke_ptr": "*i32",
+        "logits_ptr": "*fp32",
+        "num_keys": "i32",
+    }
+    flat_constants = {
+        "stride_q_row": 4096,
+        "stride_q_head": 128,
+        "stride_q_dim": 1,
+        "stride_k_row": 128,
+        "stride_k_dim": 1,
+        "stride_weights_row": 32,
+        "stride_weights_head": 1,
+        "stride_logits_row": 32768,
+        "NUM_HEADS": 32,
+        "HEAD_DIM": 128,
+        "USE_K_SCALE": not is_sm86,
+        "BLOCK_K": block_k,
+    }
+    _compile(
+        label=f"indexer-flat-sm{capability}",
+        capability=capability,
+        kernel=indexer._glm5_next_flat_mqa_logits_kernel,
+        signature=flat_signature,
+        constants=flat_constants,
+        num_warps=num_warps,
+        num_stages=num_stages,
+    )
+
+    paged_signature = {
+        "q_ptr": value_type,
+        "cache_ptr": value_type,
+        "cache_scale_ptr": "*bf16" if is_sm86 else "*fp32",
+        "weights_ptr": "*fp32",
+        "seq_lens_ptr": "*i32",
+        "page_table_ptr": "*i32",
+        "logits_ptr": "*fp32",
+        "max_seq_len": "i32",
+        "num_cache_pages": "i32",
+    }
+    paged_constants = {
+        "stride_q_row": 4096,
+        "stride_q_head": 128,
+        "stride_q_dim": 1,
+        "stride_cache_page": 8192 if is_sm86 else 8448,
+        "stride_weights_row": 32,
+        "stride_weights_head": 1,
+        "stride_page_table_row": 4096,
+        "stride_page_table_col": 1,
+        "stride_logits_row": 262144,
+        "SCALE_OFFSET": 0 if is_sm86 else 2048,
+        "SCALE_PAGE_STRIDE": 0 if is_sm86 else 2112,
+        "NUM_HEADS": 32,
+        "HEAD_DIM": 128,
+        "PAGE_SIZE": 64,
+        "USE_K_SCALE": not is_sm86,
+        "BLOCK_K": block_k,
+    }
+    _compile(
+        label=f"indexer-paged-sm{capability}",
+        capability=capability,
+        kernel=indexer._glm5_next_paged_mqa_logits_kernel,
+        signature=paged_signature,
+        constants=paged_constants,
+        num_warps=num_warps,
+        num_stages=num_stages,
+    )
+
+
+def _compile_sparse_mla(sparse: ModuleType, capability: int) -> None:
+    is_sm86 = capability == 86
+    block_t, num_warps, num_stages = sparse.glm5_next_sparse_mla_launch_config(
+        (capability // 10, capability % 10)
+    )
+    signature = {
+        "query_ptr": "*bf16",
+        "kv_ptr": "*bf16" if is_sm86 else "*fp8e4nv",
+        "kv_scale_ptr": "*bf16" if is_sm86 else "*fp32",
+        "indices_ptr": "*i32",
+        "output_ptr": "*bf16",
+        "sm_scale": "fp32",
+        "num_kv_tokens": "i64",
+        "topk": "i32",
+    }
+    constants = {
+        "stride_query_row": 16384,
+        "stride_query_head": 512,
+        "stride_query_dim": 1,
+        "stride_kv_row": 512,
+        "stride_kv_dim": 1,
+        "stride_kv_scale_row": 512 if is_sm86 else 4,
+        "stride_kv_scale_group": 1,
+        "stride_indices_row": 2051,
+        "stride_indices_col": 1,
+        "stride_output_row": 16384,
+        "stride_output_head": 512,
+        "stride_output_dim": 1,
+        "HEAD_DIM": 512,
+        "SCALE_GROUP_SIZE": 128,
+        "USE_KV_SCALE": not is_sm86,
+        "BLOCK_T": block_t,
+    }
+    _compile(
+        label=f"sparse-mla-sm{capability}",
+        capability=capability,
+        kernel=sparse._glm5_next_sparse_mla_decode_kernel,
+        signature=signature,
+        constants=constants,
+        num_warps=num_warps,
+        num_stages=num_stages,
+    )
+
+
+def _compile_kda(kda: ModuleType, capability: int) -> None:
+    capability_tuple = (capability // 10, capability % 10)
+    gate_config, decode_config = kda.glm5_next_kda_launch_config(capability_tuple)
+    gate_block_t, gate_warps, gate_stages = gate_config
+    decode_warps, decode_stages = decode_config
+    _compile(
+        label=f"kda-gate-sm{capability}",
+        capability=capability,
+        kernel=kda._glm5_next_safe_gate_kernel,
+        signature={
+            "raw_gate": "*bf16",
+            "A_log": "*fp32",
+            "output": "*fp32",
+            "dt_bias": "*bf16",
+            "lower_bound": "fp32",
+            "T": "i32",
+            "H": "i32",
+        },
+        constants={
+            "D": 128,
+            "BT": gate_block_t,
+            "BD": 128,
+            "HAS_BIAS": True,
+        },
+        num_warps=gate_warps,
+        num_stages=gate_stages,
+    )
+    _compile(
+        label=f"kda-decode-sm{capability}",
+        capability=capability,
+        kernel=kda._glm5_next_safe_decode_kernel,
+        signature={
+            "A_log": "*fp32",
+            "raw_gate": "*bf16",
+            "dt_bias": "*bf16",
+            "lower_bound": "fp32",
+            "q": "*bf16",
+            "k": "*bf16",
+            "v": "*bf16",
+            "raw_beta": "*bf16",
+            "output": "*bf16",
+            "state_source": "*fp32",
+            "state_indices": "*i32",
+            "query_start_loc": "*i32",
+            "scale": "fp32",
+            "T": "i32",
+        },
+        constants={
+            "B": 1,
+            "H": 16,
+            "HV": 64,
+            "K": 128,
+            "V": 128,
+            "BK": 128,
+            "BV": 32,
+            "USE_INITIAL_STATE": True,
+            "USE_QK_L2NORM_IN_KERNEL": True,
+            "IS_VARLEN": True,
+            "SPLIT_N_HV_GRID": False,
+        },
+        num_warps=decode_warps,
+        num_stages=decode_stages,
+    )
+
+
+def _runtime_stride_signature(prefixes: tuple[str, ...]) -> dict[str, str]:
+    return {name: "i32" for name in prefixes}
+
+
+def _compile_kpool_sm86(kpool: ModuleType) -> None:
+    capability = 86
+    _compile(
+        label="kpool-gather-sm86",
+        capability=capability,
+        kernel=kpool._gather_index_k_bf16_prefix_into_kernel,
+        signature={
+            "buf_ptr": "*bf16",
+            "page_indices_ptr": "*i32",
+            "k_out_ptr": "*bf16",
+        },
+        constants={
+            "PAGE_SIZE": 64,
+            "BUF_NUMEL_PER_PAGE": 8192,
+            "HEAD_DIM": 128,
+            "BLOCK_D": 128,
+        },
+        num_warps=4,
+        num_stages=2,
+    )
+    writer_signature = {
+        "buf_ptr": "*bf16",
+        "slot_k_ptr": "*bf16",
+        "slot_score_ptr": "*bf16",
+        "ape_ptr": "*fp32",
+        "loc_ptr": "*i64",
+        "write_mask_ptr": "*i1",
+        "compressed_k_ptr": "*bf16",
+        "compressed_scale_ptr": "*bf16",
+        **_runtime_stride_signature(
+            (
+                "slot_k_stride_0",
+                "slot_k_stride_1",
+                "slot_score_stride_0",
+                "slot_score_stride_1",
+                "ape_stride_0",
+            )
+        ),
+    }
+    _compile(
+        label="kpool-writer-sm86",
+        capability=capability,
+        kernel=kpool._kpool_softmax_rotate_write_cache_bf16_kernel,
+        signature=writer_signature,
+        constants={
+            "PAGE_SIZE": 64,
+            "BUF_NUMEL_PER_PAGE": 8192,
+            "POOL_SIZE": 4,
+            "HEAD_DIM": 128,
+            "HAS_WRITE_MASK": False,
+            "RETURN_COMPRESSED": False,
+            "WRITE_CACHE": True,
+            "BLOCK_D": 128,
+        },
+        num_warps=4,
+        num_stages=2,
+    )
+    _compile(
+        label="kpool-writer-return-sm86",
+        capability=capability,
+        kernel=kpool._kpool_softmax_rotate_write_cache_bf16_kernel,
+        signature={**writer_signature, "compressed_scale_ptr": "*fp32"},
+        constants={
+            "PAGE_SIZE": 64,
+            "BUF_NUMEL_PER_PAGE": 8192,
+            "POOL_SIZE": 4,
+            "HEAD_DIM": 128,
+            "HAS_WRITE_MASK": False,
+            "RETURN_COMPRESSED": True,
+            "WRITE_CACHE": False,
+            "BLOCK_D": 128,
+        },
+        num_warps=4,
+        num_stages=2,
+    )
+    _compile(
+        label="kpool-writer-write-return-sm86",
+        capability=capability,
+        kernel=kpool._kpool_softmax_rotate_write_cache_bf16_kernel,
+        signature={**writer_signature, "compressed_scale_ptr": "*fp32"},
+        constants={
+            "PAGE_SIZE": 64,
+            "BUF_NUMEL_PER_PAGE": 8192,
+            "POOL_SIZE": 4,
+            "HEAD_DIM": 128,
+            "HAS_WRITE_MASK": False,
+            "RETURN_COMPRESSED": True,
+            "WRITE_CACHE": True,
+            "BLOCK_D": 128,
+        },
+        num_warps=4,
+        num_stages=2,
+    )
+    common_decode_signature = {
+        "buf_ptr": "*bf16",
+        "tail_k_ptr": "*bf16",
+        "tail_score_ptr": "*bf16",
+        "key_ptr": "*bf16",
+        "slot_score_ptr": "*bf16",
+        "ape_ptr": "*fp32",
+        "block_tables_ptr": "*i32",
+        "req_pool_indices_ptr": "*i32",
+        "positions_ptr": "*i64",
+        "seq_lens_ptr": "*i32",
+        "out_cache_loc_ptr": "*i64",
+        **_runtime_stride_signature(
+            (
+                "tail_k_stride_0",
+                "tail_k_stride_1",
+                "tail_score_stride_0",
+                "tail_score_stride_1",
+                "key_stride_0",
+                "slot_score_stride_0",
+                "ape_stride_0",
+                "block_tables_stride_0",
+                "block_tables_stride_1",
+            )
+        ),
+    }
+    _compile(
+        label="kpool-decode-sm86",
+        capability=capability,
+        kernel=kpool._kpool_decode_update_and_maybe_write_cache_bf16_kernel,
+        signature=common_decode_signature,
+        constants={
+            "REQ_POOL_SIZE": 2048,
+            "BUF_NUMEL_PER_PAGE": 8192,
+            "POOL_SIZE": 4,
+            "TAIL_SIZE": 4,
+            "HEAD_DIM": 128,
+            "BLOCK_TABLE_COLS": 16384,
+            "BLOCK_D": 128,
+            "SLOTS_PER_PAGE": 64,
+        },
+        num_warps=4,
+        num_stages=2,
+    )
+    _compile(
+        label="kpool-assemble-sm86",
+        capability=capability,
+        kernel=kpool._kpool_assemble_softmax_rotate_write_cache_bf16_kernel,
+        signature={
+            "buf_ptr": "*bf16",
+            "chunk_k_ptr": "*bf16",
+            "chunk_score_ptr": "*bf16",
+            "tail_k_ptr": "*bf16",
+            "tail_score_ptr": "*bf16",
+            "req_pool_idx_ptr": "*i32",
+            "n_from_tail_ptr": "*i32",
+            "chunk_src_start_ptr": "*i64",
+            "tail_logical_base_ptr": "*i64",
+            "ape_ptr": "*fp32",
+            "loc_ptr": "*i64",
+            "write_mask_ptr": "*i1",
+            **_runtime_stride_signature(
+                (
+                    "chunk_stride_0",
+                    "tail_stride_0",
+                    "tail_stride_1",
+                    "ape_stride_0",
+                )
+            ),
+        },
+        constants={
+            "BUF_NUMEL_PER_PAGE": 8192,
+            "POOL_SIZE": 4,
+            "TAIL_SIZE": 4,
+            "HEAD_DIM": 128,
+            "HAS_WRITE_MASK": True,
+            "BLOCK_D": 128,
+            "SLOTS_PER_PAGE": 64,
+        },
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+def _compile_kpool_sm89(kpool: ModuleType) -> None:
+    capability = 89
+    _compile(
+        label="kpool-gather-sm89",
+        capability=capability,
+        kernel=kpool._gather_index_k_scale_prefix_into_kernel,
+        signature={
+            "buf_u8_ptr": "*u8",
+            "buf_fp32_ptr": "*fp32",
+            "page_indices_ptr": "*i32",
+            "k_out_ptr": "*u8",
+            "scale_out_ptr": "*fp32",
+        },
+        constants={
+            "PAGE_SIZE": 64,
+            "BUF_NUMEL_PER_PAGE": 8448,
+            "HEAD_DIM": 128,
+            "S_OFFSET_NBYTES_IN_PAGE": 8192,
+            "BLOCK_D": 128,
+        },
+        num_warps=4,
+        num_stages=3,
+    )
+    writer_signature = {
+        "buf_fp8_ptr": "*fp8e4nv",
+        "buf_fp32_ptr": "*fp32",
+        "slot_k_ptr": "*bf16",
+        "slot_score_ptr": "*bf16",
+        "ape_ptr": "*fp32",
+        "loc_ptr": "*i64",
+        "write_mask_ptr": "*i1",
+        "compressed_k_ptr": "*fp8e4nv",
+        "compressed_scale_ptr": "*fp32",
+        **_runtime_stride_signature(
+            (
+                "slot_k_stride_0",
+                "slot_k_stride_1",
+                "slot_score_stride_0",
+                "slot_score_stride_1",
+                "ape_stride_0",
+            )
+        ),
+    }
+    _compile(
+        label="kpool-writer-sm89",
+        capability=capability,
+        kernel=kpool._kpool_softmax_rotate_write_cache_kernel,
+        signature=writer_signature,
+        constants={
+            "PAGE_SIZE": 64,
+            "BUF_NUMEL_PER_PAGE": 8448,
+            "POOL_SIZE": 4,
+            "HEAD_DIM": 128,
+            "S_OFFSET_NBYTES_IN_PAGE": 8192,
+            "ROUND_SCALE": False,
+            "HAS_WRITE_MASK": False,
+            "RETURN_COMPRESSED": False,
+            "WRITE_CACHE": True,
+            "BLOCK_D": 128,
+        },
+        num_warps=4,
+        num_stages=3,
+    )
+    decode_signature = {
+        "buf_fp8_ptr": "*fp8e4nv",
+        "buf_fp32_ptr": "*fp32",
+        "tail_k_ptr": "*bf16",
+        "tail_score_ptr": "*bf16",
+        "key_ptr": "*bf16",
+        "slot_score_ptr": "*bf16",
+        "ape_ptr": "*fp32",
+        "block_tables_ptr": "*i32",
+        "req_pool_indices_ptr": "*i32",
+        "positions_ptr": "*i64",
+        "seq_lens_ptr": "*i32",
+        "out_cache_loc_ptr": "*i64",
+        **_runtime_stride_signature(
+            (
+                "tail_k_stride_0",
+                "tail_k_stride_1",
+                "tail_score_stride_0",
+                "tail_score_stride_1",
+                "key_stride_0",
+                "slot_score_stride_0",
+                "ape_stride_0",
+                "block_tables_stride_0",
+                "block_tables_stride_1",
+            )
+        ),
+    }
+    _compile(
+        label="kpool-decode-sm89",
+        capability=capability,
+        kernel=kpool._kpool_decode_update_and_maybe_write_cache_kernel,
+        signature=decode_signature,
+        constants={
+            "REQ_POOL_SIZE": 2048,
+            "PAGE_SIZE": 64,
+            "BUF_NUMEL_PER_PAGE": 8448,
+            "POOL_SIZE": 4,
+            "TAIL_SIZE": 4,
+            "HEAD_DIM": 128,
+            "BLOCK_TABLE_COLS": 16384,
+            "S_OFFSET_NBYTES_IN_PAGE": 8192,
+            "ROUND_SCALE": False,
+            "BLOCK_D": 128,
+            "SLOTS_PER_PAGE": 64,
+        },
+        num_warps=4,
+        num_stages=3,
+    )
+    _compile(
+        label="kpool-assemble-sm89",
+        capability=capability,
+        kernel=kpool._kpool_assemble_softmax_rotate_write_cache_kernel,
+        signature={
+            "buf_fp8_ptr": "*fp8e4nv",
+            "buf_fp32_ptr": "*fp32",
+            "chunk_k_ptr": "*bf16",
+            "chunk_score_ptr": "*bf16",
+            "tail_k_ptr": "*bf16",
+            "tail_score_ptr": "*bf16",
+            "req_pool_idx_ptr": "*i32",
+            "n_from_tail_ptr": "*i32",
+            "chunk_src_start_ptr": "*i64",
+            "tail_logical_base_ptr": "*i64",
+            "ape_ptr": "*fp32",
+            "loc_ptr": "*i64",
+            "write_mask_ptr": "*i1",
+            **_runtime_stride_signature(
+                (
+                    "chunk_stride_0",
+                    "tail_stride_0",
+                    "tail_stride_1",
+                    "ape_stride_0",
+                )
+            ),
+        },
+        constants={
+            "BUF_NUMEL_PER_PAGE": 8448,
+            "POOL_SIZE": 4,
+            "TAIL_SIZE": 4,
+            "HEAD_DIM": 128,
+            "S_OFFSET_NBYTES_IN_PAGE": 8192,
+            "ROUND_SCALE": False,
+            "HAS_WRITE_MASK": True,
+            "BLOCK_D": 128,
+            "SLOTS_PER_PAGE": 64,
+        },
+        num_warps=4,
+        num_stages=3,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--targets",
+        nargs="+",
+        choices=("86", "89"),
+        default=("86", "89"),
+    )
+    parser.add_argument(
+        "--resource-report",
+        action="store_true",
+        help="force recompilation and print ptxas register/spill usage",
+    )
+    args = parser.parse_args()
+
+    if args.resource_report:
+        from triton import knobs
+
+        knobs.compilation.always_compile = True
+        knobs.nvidia.dump_ptxas_log = True
+
+    indexer = _load(
+        "_glm5_next_indexer_compile",
+        "python/sglang/srt/layers/attention/nsa/glm5_next_indexer_triton.py",
+    )
+    sparse = _load(
+        "_glm5_next_sparse_compile",
+        "python/sglang/srt/layers/attention/nsa/glm5_next_sparse_attention.py",
+    )
+    kda = _load(
+        "_glm5_next_kda_compile",
+        "python/sglang/srt/layers/attention/linear/kernels/glm5_next_kda_ops.py",
+    )
+    kpool = _load(
+        "_glm5_next_kpool_compile",
+        "python/sglang/srt/layers/attention/nsa/kpool_fp8_index.py",
+    )
+
+    for target in args.targets:
+        capability = int(target)
+        _compile_indexer(indexer, capability)
+        _compile_sparse_mla(sparse, capability)
+        _compile_kda(kda, capability)
+        if capability == 86:
+            _compile_kpool_sm86(kpool)
+        else:
+            _compile_kpool_sm89(kpool)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/glm5_next_session_c_final_acceptance.py
+++ b/scripts/glm5_next_session_c_final_acceptance.py
@@ -6,14 +6,15 @@ which the ordinary correctness oracle and performance benchmark deliberately
 do not prove:
 
 * exact layerwise-prefill chunk boundaries (128/4096/4097/8193);
-* threshold-0 ordinary prefill versus threshold-1 layerwise parity;
+* threshold-0 ordinary prefill versus threshold-1024 layerwise parity;
 * the final 500000-input + 1024-output integrated request;
 * real decode CUDA Graph counter movement; and
 * exact batch-size 1/2/4 graph replay for the Qwen regression.
 
 The layerwise and long modes require access to the server log.  They snapshot
-the log immediately before each request and accept only complete 42-layer
-rounds with the expected cumulative counters and ``fallback_count=0``.
+the log immediately before each request and accept only complete generic
+``SharedFullContext`` 42-layer compute rounds.  The GLM-specific storage
+contract is one lazily allocated full-layer GPU slot and two host expert slots.
 """
 
 from __future__ import annotations
@@ -44,11 +45,12 @@ DEFAULT_VOCAB_SIZE = 154880
 LAYERWISE_LENGTHS = (128, 4096, 4097, 8193)
 LAYERWISE_CHUNK_SIZE = 4096
 LAYERWISE_MOE_LAYERS = 42
-LAYERWISE_PREFETCH_HITS_PER_ROUND = LAYERWISE_MOE_LAYERS - 1
-LAYERWISE_FINAL_SLOT = (LAYERWISE_MOE_LAYERS - 1) % 2
+LAYERWISE_FIRST_LAYER = 3
+LAYERWISE_LAST_LAYER = 44
+LAYERWISE_TOKEN_THRESHOLD = 1024
 DEFAULT_BOUNDARY_OUTPUT = 16
 LAYERWISE_FIXTURE_SEED = 20260811
-REQUIRED_TP_SIZE = 8
+REQUIRED_TP_SIZE = 4
 PREFILL_PARITY_COLLECTION_TOP_K = 256
 PREFILL_PARITY_COMPARISON_TOP_K = 64
 PREFILL_PARITY_LOGPROB_ATOL = 5e-2
@@ -60,22 +62,23 @@ BUCKET_OUTPUT_TOKENS = 8
 BUCKET_TOP_K = 64
 
 LAYERWISE_PATTERN = re.compile(
-    r"KT GLM-5-Next FP8 layerwise prefill: "
-    r"layer=(?P<layer>\d+) epoch=(?P<epoch>\d+) "
-    r"slot=(?P<slot>\d+) (?P<load_kind>prefetch-hit|prime) "
-    r"apply_count=(?P<apply_count>\d+) "
-    r"prime_count=(?P<prime_count>\d+) "
-    r"prefetch_hit_count=(?P<prefetch_hit_count>\d+) "
-    r"completed_rounds=(?P<completed_rounds>\d+) "
-    r"fallback_count=(?P<fallback_count>\d+)"
+    r"KT layerwise prefill: layer (?P<layer>\d+) "
+    r"compute = (?P<compute_ms>[-+0-9.eE]+) ms"
+    r"(?:, expert update = (?P<expert_update_ms>[-+0-9.eE]+) ms)?"
 )
 
 LAYERWISE_STARTUP_PATTERN = re.compile(
-    r"KT GLM-5-Next FP8 layerwise prefill eagerly allocated two raw "
-    r"E4M3\+FP32 full-layer slots on (?P<device>\S+) before KV profiling "
-    r"\(total=(?P<total_gib>[0-9]+(?:\.[0-9]+)?) GiB, "
-    r"contract=(?P<contract>[0-9a-f]{64}), "
-    r"fallback_count=(?P<fallback_count>\d+)\)"
+    r"KT GLM-5-Next FP8 layerwise prefill lazily allocated generic "
+    r"SharedFullContext: gpu_full_layer_slots=(?P<gpu_slots>\d+) "
+    r"host_expert_slots=(?P<host_slots>\d+) "
+    r"gpu_slot_bytes=(?P<gpu_slot_bytes>\d+) "
+    r"host_buffer_bytes=(?P<host_buffer_bytes>\d+) "
+    r"device=(?P<device>\S+)"
+)
+
+LEGACY_LAYERWISE_PATTERNS = (
+    re.compile(r"eagerly allocated two raw E4M3\+FP32 full-layer slots"),
+    re.compile(r"KT GLM-5-Next FP8 layerwise prefill: .*prefetch-hit"),
 )
 
 SERVER_ARGS_PATTERN = re.compile(r"server_args=ServerArgs\((?P<body>[^\n]+)\)")
@@ -286,33 +289,53 @@ def validate_graph_counter_progress(
 
 
 def parse_layerwise_summaries(text: str) -> list[dict[str, Any]]:
-    """Return one completion summary per full 42-layer prefill round."""
-    summaries: list[dict[str, Any]] = []
-    for match in LAYERWISE_PATTERN.finditer(text):
-        item: dict[str, Any] = {
-            key: int(value) if key != "load_kind" else value
-            for key, value in match.groupdict().items()
+    """Group generic layerwise compute events into ordered 42-layer rounds.
+
+    Partial and malformed groups are deliberately retained so the validator
+    can fail closed instead of silently discarding evidence from a stalled or
+    out-of-order loader.
+    """
+    events = [
+        {
+            "layer": int(match.group("layer")),
+            "compute_ms": float(match.group("compute_ms")),
+            "expert_update_ms": (
+                float(match.group("expert_update_ms"))
+                if match.group("expert_update_ms") is not None
+                else None
+            ),
         }
-        # Production logs every MoE layer so operators can diagnose a stalled
-        # prefetch.  Only layer 44 completes a round and advances
-        # completed_rounds; accepting all 42 events as summaries makes every
-        # healthy request fail the exact-round gate.
-        if item["layer"] == 44:
-            summaries.append(item)
+        for match in LAYERWISE_PATTERN.finditer(text)
+    ]
+    summaries: list[dict[str, Any]] = []
+    for start in range(0, len(events), LAYERWISE_MOE_LAYERS):
+        group = events[start : start + LAYERWISE_MOE_LAYERS]
+        summaries.append(
+            {
+                "round_index": len(summaries),
+                "layers": [event["layer"] for event in group],
+                "compute_ms": [event["compute_ms"] for event in group],
+                "expert_update_ms": [
+                    event["expert_update_ms"] for event in group
+                ],
+                "complete": len(group) == LAYERWISE_MOE_LAYERS,
+            }
+        )
     return summaries
 
 
-def _zero_layerwise_summary() -> dict[str, int]:
-    return {
-        "layer": 44,
-        "epoch": -1,
-        "slot": -1,
-        "apply_count": 0,
-        "prime_count": 0,
-        "prefetch_hit_count": 0,
-        "completed_rounds": 0,
-        "fallback_count": 0,
-    }
+def expected_layerwise_rounds(
+    input_tokens: int,
+    chunk_size: int,
+    *,
+    threshold: int = LAYERWISE_TOKEN_THRESHOLD,
+) -> int:
+    """Count chunks large enough to enter the generic full-layer route."""
+    if threshold <= 0:
+        return 0
+    full_chunks, tail = divmod(input_tokens, chunk_size)
+    qualifying_full_chunks = full_chunks if chunk_size >= threshold else 0
+    return qualifying_full_chunks + int(tail >= threshold)
 
 
 def validate_layerwise_progress(
@@ -322,93 +345,102 @@ def validate_layerwise_progress(
     expected_rounds: int,
 ) -> list[str]:
     failures: list[str] = []
-    prior = dict(previous or _zero_layerwise_summary())
     if len(current) != expected_rounds:
         failures.append(
             f"expected {expected_rounds} completed layerwise rounds, "
             f"observed {len(current)}"
         )
+    expected_layers = list(range(LAYERWISE_FIRST_LAYER, LAYERWISE_LAST_LAYER + 1))
     for index, summary in enumerate(current):
-        expected = {
-            "layer": 44,
-            "epoch": int(prior["epoch"]) + 1,
-            "slot": LAYERWISE_FINAL_SLOT,
-            "load_kind": "prefetch-hit",
-            "apply_count": int(prior["apply_count"]) + LAYERWISE_MOE_LAYERS,
-            "prime_count": int(prior["prime_count"]) + 1,
-            "prefetch_hit_count": int(prior["prefetch_hit_count"])
-            + LAYERWISE_PREFETCH_HITS_PER_ROUND,
-            "completed_rounds": int(prior["completed_rounds"]) + 1,
-            "fallback_count": 0,
-        }
-        for key, expected_value in expected.items():
-            if summary.get(key) != expected_value:
-                failures.append(
-                    f"round {index} {key}: expected {expected_value}, "
-                    f"observed {summary.get(key)}"
-                )
-        if summary.get("apply_count") != summary.get("prime_count", 0) + summary.get(
-            "prefetch_hit_count", 0
-        ):
+        if summary.get("round_index") != index:
             failures.append(
-                f"round {index}: apply_count does not equal prime+prefetch_hit"
+                f"round {index}: round_index is {summary.get('round_index')!r}"
             )
-        prior = summary
+        if summary.get("complete") is not True:
+            failures.append(f"round {index}: generic compute sequence is incomplete")
+        if summary.get("layers") != expected_layers:
+            failures.append(
+                f"round {index}: expected ordered layers "
+                f"{LAYERWISE_FIRST_LAYER}..{LAYERWISE_LAST_LAYER}, "
+                f"observed {summary.get('layers')!r}"
+            )
+        timings = summary.get("compute_ms")
+        if (
+            not isinstance(timings, list)
+            or len(timings) != LAYERWISE_MOE_LAYERS
+            or any(not math.isfinite(value) or value < 0 for value in timings)
+        ):
+            failures.append(f"round {index}: compute timings are invalid")
     return failures
 
 
-def validate_layerwise_startup(text: str) -> dict[str, Any]:
-    """Prove that the required two GPU slots were allocated before KV pools."""
+def validate_layerwise_startup(
+    text: str, *, require_allocation: bool = True
+) -> dict[str, Any]:
+    """Validate the lazy generic SharedFullContext allocation contract."""
     failures: list[str] = []
     matches = list(LAYERWISE_STARTUP_PATTERN.finditer(text))
-    if len(matches) != 1:
+    if len(matches) > 1 or (require_allocation and len(matches) != 1):
         failures.append(
-            "expected exactly one GLM-5-Next FP8 two-slot allocation marker, "
+            "expected exactly one GLM-5-Next lazy SharedFullContext allocation "
+            "marker, "
             f"observed {len(matches)}"
         )
     allocation: dict[str, Any] | None = None
     if matches:
         match = matches[0]
-        total_gib = float(match.group("total_gib"))
-        fallback_count = int(match.group("fallback_count"))
+        gpu_slots = int(match.group("gpu_slots"))
+        host_slots = int(match.group("host_slots"))
+        gpu_slot_bytes = int(match.group("gpu_slot_bytes"))
+        host_buffer_bytes = int(match.group("host_buffer_bytes"))
         allocation = {
             "offset": match.start(),
             "device": match.group("device"),
-            "total_gib": total_gib,
-            "contract_sha256": match.group("contract"),
-            "fallback_count": fallback_count,
+            "gpu_full_layer_slots": gpu_slots,
+            "host_expert_slots": host_slots,
+            "gpu_slot_bytes": gpu_slot_bytes,
+            "host_buffer_bytes": host_buffer_bytes,
         }
-        if total_gib <= 0:
-            failures.append("layerwise two-slot allocation size is not positive")
-        if fallback_count != 0:
+        if gpu_slots != 1:
             failures.append(
-                f"startup layerwise fallback_count is {fallback_count}, expected 0"
+                f"gpu_full_layer_slots is {gpu_slots}, expected exactly 1"
             )
+        if host_slots != 2:
+            failures.append(f"host_expert_slots is {host_slots}, expected exactly 2")
+        if gpu_slot_bytes <= 0 or host_buffer_bytes <= 0:
+            failures.append("lazy layerwise allocation byte counts must be positive")
 
         memory_pool_offsets = [
             match.start() for match in re.finditer(r"Memory pool end\.", text)
         ]
         if not memory_pool_offsets:
             failures.append("server log has no completed KV memory-pool marker")
-        elif match.start() >= min(memory_pool_offsets):
+        elif match.start() <= max(memory_pool_offsets):
             failures.append(
-                "layerwise two-slot allocation marker does not precede KV memory pool"
+                "layerwise allocation is not lazy: marker must follow KV memory pool"
             )
 
         ready_offset = text.find("The server is fired up and ready to roll!")
         if ready_offset < 0:
             failures.append("server-ready marker is missing")
-        elif match.start() >= ready_offset:
+        elif match.start() <= ready_offset:
             failures.append(
-                "layerwise two-slot allocation marker does not precede server ready"
+                "layerwise allocation is not lazy: marker must follow server ready"
             )
         first_round = LAYERWISE_PATTERN.search(text)
         if first_round is not None and match.start() >= first_round.start():
-            failures.append("layerwise execution appears before startup allocation")
+            failures.append("generic layerwise execution appears before lazy allocation")
+
+    if text.count("The server is fired up and ready to roll!") != 1:
+        failures.append("server log must contain exactly one server-ready marker")
+    for legacy_pattern in LEGACY_LAYERWISE_PATTERNS:
+        if legacy_pattern.search(text) is not None:
+            failures.append("server log contains a legacy eager/two-slot protocol marker")
 
     return {
         "allocation": allocation,
         "allocation_marker_count": len(matches),
+        "allocation_required": require_allocation,
         "failures": failures,
         "pass": not failures,
     }
@@ -420,7 +452,7 @@ def _server_arg_value(body: str, name: str) -> str | None:
 
 
 def validate_prefill_parity_server_log(text: str, *, threshold: int) -> dict[str, Any]:
-    """Bind a parity collection to the exact TP8 threshold-0/1 server."""
+    """Bind a parity collection to the exact TP4 threshold-0/1024 server."""
     failures: list[str] = []
     server_args_matches = list(SERVER_ARGS_PATTERN.finditer(text))
     fields: dict[str, str | None] = {}
@@ -455,14 +487,18 @@ def validate_prefill_parity_server_log(text: str, *, threshold: int) -> dict[str
     if text.count("The server is fired up and ready to roll!") != 1:
         failures.append("server log must contain exactly one server-ready marker")
 
-    startup = validate_layerwise_startup(text) if threshold == 1 else None
+    startup = (
+        validate_layerwise_startup(text, require_allocation=False)
+        if threshold == LAYERWISE_TOKEN_THRESHOLD
+        else None
+    )
     if startup is not None:
         failures.extend(startup["failures"])
     else:
         if LAYERWISE_STARTUP_PATTERN.search(text) is not None:
-            failures.append("threshold-0 server allocated the layerwise manager")
+            failures.append("threshold-0 server allocated SharedFullContext")
         if LAYERWISE_PATTERN.search(text) is not None:
-            failures.append("threshold-0 server executed the layerwise manager")
+            failures.append("threshold-0 server executed generic layerwise prefill")
 
     return {
         "threshold": threshold,
@@ -492,8 +528,9 @@ def _log_before(path: Path) -> tuple[int, dict[str, Any] | None]:
     if not path.is_file():
         raise FileNotFoundError(path)
     size = path.stat().st_size
-    summaries = parse_layerwise_summaries(_read_tail(path))
-    return size, summaries[-1] if summaries else None
+    # Generic SharedFullContext logs have no global epoch/counter.  Every
+    # request is validated from its exact append-only log window instead.
+    return size, None
 
 
 def _log_after(path: Path, offset: int) -> tuple[int, str]:
@@ -571,7 +608,7 @@ def _capture_request_evidence(
     counters_after = cuda_graph_counters_by_rank(metrics_after_text)
 
     summaries = parse_layerwise_summaries(log_segment)
-    expected_rounds = math.ceil(len(input_ids) / chunk_size)
+    expected_rounds = expected_layerwise_rounds(len(input_ids), chunk_size)
     failures.extend(
         validate_layerwise_progress(
             previous_summary,
@@ -646,13 +683,15 @@ def run_layerwise(args: argparse.Namespace) -> int:
         failures.append(
             "layerwise matrix must use lengths 128/4096/4097/8193, "
             "chunk size 4096, exactly 16 output tokens, seed 20260811, "
-            "TP=8, and vocab size 154880"
+            "TP=4, and vocab size 154880"
         )
 
     server_log = Path(args.server_log)
     try:
         startup_text = server_log.read_text(encoding="utf-8", errors="replace")
-        startup_evidence = validate_layerwise_startup(startup_text)
+        startup_evidence = validate_prefill_parity_server_log(
+            startup_text, threshold=LAYERWISE_TOKEN_THRESHOLD
+        )
     except Exception as error:
         startup_evidence = {
             "failures": [f"{type(error).__name__}: {error}"],
@@ -696,6 +735,20 @@ def run_layerwise(args: argparse.Namespace) -> int:
         if not evidence["pass"] and args.stop_on_failure:
             break
 
+    try:
+        final_log = server_log.read_text(encoding="utf-8", errors="replace")
+        allocation_evidence = validate_layerwise_startup(
+            final_log, require_allocation=True
+        )
+    except Exception as error:
+        allocation_evidence = {
+            "failures": [f"{type(error).__name__}: {error}"],
+            "pass": False,
+        }
+    failures.extend(
+        f"allocation: {failure}" for failure in allocation_evidence["failures"]
+    )
+
     payload = {
         "schema_version": SCHEMA_VERSION,
         "kind": "glm5_next_session_c_layerwise_boundaries",
@@ -707,17 +760,22 @@ def run_layerwise(args: argparse.Namespace) -> int:
             "chunk_size": args.chunk_size,
             "output_tokens": args.output_length,
             "expected_rounds": {
-                str(length): math.ceil(length / args.chunk_size) for length in lengths
+                str(length): expected_layerwise_rounds(length, args.chunk_size)
+                for length in lengths
             },
             "require_decode_cuda_graph": True,
-            "require_layerwise_fallback_zero": True,
-            "require_startup_two_slot_allocation_before_kv_pool": True,
+            "layerwise_token_threshold": LAYERWISE_TOKEN_THRESHOLD,
+            "require_generic_complete_layer_rounds": True,
+            "require_lazy_shared_full_context": True,
+            "gpu_full_layer_slots": 1,
+            "host_expert_slots": 2,
             "fixture_seed": args.fixture_seed,
             "vocab_size": args.vocab_size,
             "tp_size": args.tp_size,
             "compliant": contract_compliant,
         },
         "startup_evidence": startup_evidence,
+        "allocation_evidence": allocation_evidence,
         "cases": cases,
         "failures": failures,
         "pass": not failures,
@@ -747,7 +805,7 @@ def run_long(args: argparse.Namespace) -> int:
     if not contract_compliant:
         failures.append(
             "final long request requires exactly 500000 input, 1024 output, "
-            "layerwise chunk size 4096, seed 20260812, TP=8, and vocab 154880"
+            "layerwise chunk size 4096, seed 20260812, TP=4, and vocab 154880"
         )
     try:
         if not contract_compliant:
@@ -771,6 +829,19 @@ def run_long(args: argparse.Namespace) -> int:
             "pass": False,
         }
     failures.extend(evidence["failures"])
+    try:
+        allocation_evidence = validate_layerwise_startup(
+            Path(args.server_log).read_text(encoding="utf-8", errors="replace"),
+            require_allocation=True,
+        )
+    except Exception as error:
+        allocation_evidence = {
+            "failures": [f"{type(error).__name__}: {error}"],
+            "pass": False,
+        }
+    failures.extend(
+        f"allocation: {failure}" for failure in allocation_evidence["failures"]
+    )
     payload = {
         "schema_version": SCHEMA_VERSION,
         "kind": "glm5_next_session_c_final_long_context",
@@ -782,9 +853,15 @@ def run_long(args: argparse.Namespace) -> int:
             "input_tokens": MIN_LONG_INPUT,
             "output_tokens": MIN_LONG_OUTPUT,
             "chunk_size": args.chunk_size,
-            "expected_layerwise_rounds": math.ceil(args.input_length / args.chunk_size),
+            "expected_layerwise_rounds": expected_layerwise_rounds(
+                args.input_length, args.chunk_size
+            ),
             "require_decode_cuda_graph": True,
-            "require_layerwise_fallback_zero": True,
+            "layerwise_token_threshold": LAYERWISE_TOKEN_THRESHOLD,
+            "require_generic_complete_layer_rounds": True,
+            "require_lazy_shared_full_context": True,
+            "gpu_full_layer_slots": 1,
+            "host_expert_slots": 2,
             "throughput_gate": None,
             "fixture_seed": args.fixture_seed,
             "vocab_size": args.vocab_size,
@@ -793,6 +870,7 @@ def run_long(args: argparse.Namespace) -> int:
         },
         "fixture": fixture,
         "evidence": evidence,
+        "allocation_evidence": allocation_evidence,
         "failures": failures,
         "pass": not failures,
     }
@@ -983,8 +1061,8 @@ def _collect_prefill_parity_case(
     after_offset, log_segment = _log_after(server_log, before_offset)
     summaries = parse_layerwise_summaries(log_segment)
     failures: list[str] = []
-    expected_rounds = math.ceil(length / args.chunk_size)
-    if args.threshold == 1:
+    expected_rounds = expected_layerwise_rounds(length, args.chunk_size)
+    if args.threshold == LAYERWISE_TOKEN_THRESHOLD:
         failures.extend(
             validate_layerwise_progress(
                 previous_summary,
@@ -1012,7 +1090,11 @@ def _collect_prefill_parity_case(
         "prompt_tokens": meta.get("prompt_tokens"),
         "completion_tokens": meta.get("completion_tokens"),
         "top_logprobs": top_logprobs,
-        "expected_layerwise_rounds": expected_rounds if args.threshold == 1 else 0,
+        "expected_layerwise_rounds": (
+            expected_rounds
+            if args.threshold == LAYERWISE_TOKEN_THRESHOLD
+            else 0
+        ),
         "previous_layerwise_summary": previous_summary,
         "layerwise_summaries": summaries,
         "server_log_window": {
@@ -1030,7 +1112,7 @@ def _collect_prefill_parity_case(
 def run_prefill_parity(args: argparse.Namespace) -> int:
     lengths = tuple(args.lengths)
     contract_compliant = (
-        args.threshold in (0, 1)
+        args.threshold in (0, LAYERWISE_TOKEN_THRESHOLD)
         and lengths == LAYERWISE_LENGTHS
         and args.output_length == DEFAULT_BOUNDARY_OUTPUT
         and args.chunk_size == LAYERWISE_CHUNK_SIZE
@@ -1042,9 +1124,9 @@ def run_prefill_parity(args: argparse.Namespace) -> int:
     failures: list[str] = []
     if not contract_compliant:
         failures.append(
-            "prefill parity requires threshold 0/1, lengths "
+            "prefill parity requires threshold 0/1024, lengths "
             "128/4096/4097/8193, output 16, chunk 4096, seed 20260811, "
-            "TP=8, vocab 154880, and collected top-k 256"
+            "TP=4, vocab 154880, and collected top-k 256"
         )
 
     server_log = Path(args.server_log)
@@ -1081,6 +1163,39 @@ def run_prefill_parity(args: argparse.Namespace) -> int:
         failures.extend(f"length {length}: {failure}" for failure in case["failures"])
         if not case["pass"] and args.stop_on_failure:
             break
+
+    try:
+        final_log = server_log.read_text(encoding="utf-8", errors="replace")
+        final_server_evidence = validate_prefill_parity_server_log(
+            final_log, threshold=args.threshold
+        )
+        if args.threshold == LAYERWISE_TOKEN_THRESHOLD:
+            allocation_evidence = validate_layerwise_startup(
+                final_log, require_allocation=True
+            )
+            final_server_evidence["layerwise_startup"] = allocation_evidence
+            final_server_evidence["failures"] = list(
+                dict.fromkeys(
+                    final_server_evidence["failures"]
+                    + allocation_evidence["failures"]
+                )
+            )
+            final_server_evidence["pass"] = not final_server_evidence["failures"]
+        server_evidence = final_server_evidence | {
+            "path": str(server_log.resolve()),
+            "initial_size": server_evidence.get("initial_size"),
+            "initial_sha256": server_evidence.get("initial_sha256"),
+        }
+    except Exception as error:
+        server_evidence = {
+            **server_evidence,
+            "failures": server_evidence.get("failures", [])
+            + [f"{type(error).__name__}: {error}"],
+            "pass": False,
+        }
+    failures.extend(
+        f"final server: {failure}" for failure in server_evidence["failures"]
+    )
 
     payload = {
         "schema_version": SCHEMA_VERSION,
@@ -1142,10 +1257,24 @@ def _validate_prefill_collection(
         ):
             failures.append(f"{role}: server_args evidence is invalid")
         startup = server_evidence.get("layerwise_startup")
-        if expected_threshold == 1 and (
+        if expected_threshold == LAYERWISE_TOKEN_THRESHOLD and (
             not isinstance(startup, dict) or startup.get("pass") is not True
         ):
             failures.append(f"{role}: layerwise startup evidence is invalid")
+        elif expected_threshold == LAYERWISE_TOKEN_THRESHOLD:
+            allocation = startup.get("allocation")
+            if (
+                not isinstance(allocation, dict)
+                or allocation.get("gpu_full_layer_slots") != 1
+                or allocation.get("host_expert_slots") != 2
+                or not isinstance(allocation.get("gpu_slot_bytes"), int)
+                or allocation["gpu_slot_bytes"] <= 0
+                or not isinstance(allocation.get("host_buffer_bytes"), int)
+                or allocation["host_buffer_bytes"] <= 0
+            ):
+                failures.append(
+                    f"{role}: lazy SharedFullContext slot evidence is invalid"
+                )
         if expected_threshold == 0 and startup is not None:
             failures.append(f"{role}: threshold-0 startup evidence is not null")
         if not isinstance(server_evidence.get("path"), str):
@@ -1242,8 +1371,10 @@ def _validate_prefill_collection(
             failures.append(f"{role} length {length}: completion token count differs")
 
         summaries = case.get("layerwise_summaries")
-        expected_rounds = math.ceil(length / LAYERWISE_CHUNK_SIZE)
-        if expected_threshold == 1:
+        expected_rounds = expected_layerwise_rounds(
+            length, LAYERWISE_CHUNK_SIZE
+        )
+        if expected_threshold == LAYERWISE_TOKEN_THRESHOLD:
             if not isinstance(summaries, list):
                 failures.append(
                     f"{role} length {length}: layerwise summaries are missing"
@@ -1361,7 +1492,9 @@ def compare_prefill_parity_payloads(
         baseline, role="threshold-0", expected_threshold=0
     )
     candidate_failures, candidate_cases = _validate_prefill_collection(
-        candidate, role="threshold-1", expected_threshold=1
+        candidate,
+        role="threshold-1024",
+        expected_threshold=LAYERWISE_TOKEN_THRESHOLD,
     )
     failures.extend(candidate_failures)
     diagnostics: list[dict[str, Any]] = []
@@ -1434,7 +1567,7 @@ def compare_prefill_parity_payloads(
             if missing:
                 failures.append(
                     f"length {length} step {step_index}: {len(missing)} "
-                    "threshold-0 top-64 IDs are absent from threshold-1 top-256"
+                    "threshold-0 top-64 IDs are absent from threshold-1024 top-256"
                 )
             if numerical_failures:
                 failures.append(
@@ -1447,7 +1580,7 @@ def compare_prefill_parity_payloads(
         "created_unix": time.time(),
         "contract": {
             "baseline_threshold": 0,
-            "candidate_threshold": 1,
+            "candidate_threshold": LAYERWISE_TOKEN_THRESHOLD,
             "lengths": list(LAYERWISE_LENGTHS),
             "output_tokens": DEFAULT_BOUNDARY_OUTPUT,
             "fixture_seed": LAYERWISE_FIXTURE_SEED,
@@ -1467,13 +1600,13 @@ def compare_prefill_parity_payloads(
 
 def run_compare_prefill_parity(args: argparse.Namespace) -> int:
     baseline_path = Path(args.threshold_0)
-    candidate_path = Path(args.threshold_1)
+    candidate_path = Path(args.threshold_1024)
     baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
     candidate = json.loads(candidate_path.read_text(encoding="utf-8"))
     payload = compare_prefill_parity_payloads(baseline, candidate)
     payload["inputs"] = {
         "threshold_0": str(baseline_path.resolve()),
-        "threshold_1": str(candidate_path.resolve()),
+        "threshold_1024": str(candidate_path.resolve()),
     }
     _atomic_write_json(Path(args.output), payload)
     print(json.dumps({"output": args.output, "pass": payload["pass"]}, indent=2))
@@ -1709,7 +1842,7 @@ def _add_common_request_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--fixture-seed", type=int, default=FIXTURE_SEED)
     parser.add_argument("--request-timeout", type=float, default=86_400.0)
     parser.add_argument("--no-flush-cache", action="store_true")
-    parser.add_argument("--tp-size", type=int, default=8)
+    parser.add_argument("--tp-size", type=int, default=REQUIRED_TP_SIZE)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -1738,7 +1871,12 @@ def build_parser() -> argparse.ArgumentParser:
     )
     _add_common_request_args(prefill_parity)
     prefill_parity.add_argument("--server-log", required=True)
-    prefill_parity.add_argument("--threshold", type=int, choices=(0, 1), required=True)
+    prefill_parity.add_argument(
+        "--threshold",
+        type=int,
+        choices=(0, LAYERWISE_TOKEN_THRESHOLD),
+        required=True,
+    )
     prefill_parity.add_argument(
         "--lengths", type=int, nargs="+", default=list(LAYERWISE_LENGTHS)
     )
@@ -1757,10 +1895,10 @@ def build_parser() -> argparse.ArgumentParser:
 
     compare_prefill = subparsers.add_parser(
         "compare-prefill-parity",
-        help="compare frozen threshold-0 and threshold-1 prefill collections",
+        help="compare frozen threshold-0 and threshold-1024 prefill collections",
     )
     compare_prefill.add_argument("--threshold-0", required=True)
-    compare_prefill.add_argument("--threshold-1", required=True)
+    compare_prefill.add_argument("--threshold-1024", required=True)
     compare_prefill.add_argument("--output", required=True)
     compare_prefill.set_defaults(func=run_compare_prefill_parity)
 

--- a/scripts/glm5_next_session_c_graph_acceptance.py
+++ b/scripts/glm5_next_session_c_graph_acceptance.py
@@ -1132,7 +1132,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--eager-json")
     parser.add_argument("--vocab-size", type=int, default=DEFAULT_VOCAB_SIZE)
     parser.add_argument("--top-k", type=int, default=DEFAULT_TOP_K)
-    parser.add_argument("--tp-size", type=int, default=8)
+    parser.add_argument("--tp-size", type=int, default=4)
     parser.add_argument("--request-timeout", type=float, default=7200)
     parser.add_argument("--no-flush-cache", action="store_true")
     return parser

--- a/scripts/glm5_next_session_c_qa_gsm_graph_acceptance.py
+++ b/scripts/glm5_next_session_c_qa_gsm_graph_acceptance.py
@@ -12,14 +12,14 @@ Examples::
 
     python scripts/glm5_next_session_c_qa_gsm_graph_acceptance.py qa \
       --base-url http://127.0.0.1:30100 --model /mnt/models/GLM-5-Next-0808 \
-      --output /mnt/artifacts/qa.json --tp-size 8
+      --output /mnt/artifacts/qa.json --tp-size 4
 
     python scripts/glm5_next_session_c_qa_gsm_graph_acceptance.py gsm8k \
       --base-url http://127.0.0.1:30100 --data-path /mnt/data/test.jsonl \
       --result-file /mnt/artifacts/gsm/result.jsonl \
       --raw-result-file /mnt/artifacts/gsm/raw.jsonl \
       --work-dir /mnt/artifacts/gsm/work \
-      --output /mnt/artifacts/gsm/acceptance.json --tp-size 8
+      --output /mnt/artifacts/gsm/acceptance.json --tp-size 4
 """
 
 from __future__ import annotations
@@ -1250,7 +1250,7 @@ def _sha256(value: str) -> str:
 def _common_parser(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--base-url", required=True)
     parser.add_argument("--output", required=True, type=Path)
-    parser.add_argument("--tp-size", type=_positive_int, default=8)
+    parser.add_argument("--tp-size", type=_positive_int, default=4)
     parser.add_argument(
         "--minimum-graph-delta-per-rank", type=_positive_float, default=1.0
     )

--- a/test/registered/unit/test_glm5_next_consumer_gpu_kernels.py
+++ b/test/registered/unit/test_glm5_next_consumer_gpu_kernels.py
@@ -1,0 +1,549 @@
+"""Static contracts for the GLM-5-Next SM86/SM89 kernel boundary."""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import math
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+INDEXER_PATH = (
+    REPO_ROOT / "python/sglang/srt/layers/attention/nsa/glm5_next_indexer_triton.py"
+)
+INDEXER_CALLER_PATH = (
+    REPO_ROOT / "python/sglang/srt/layers/attention/nsa/nsa_indexer_kpool.py"
+)
+KPOOL_PATH = REPO_ROOT / "python/sglang/srt/layers/attention/nsa/kpool_fp8_index.py"
+SPARSE_PATH = (
+    REPO_ROOT / "python/sglang/srt/layers/attention/nsa/glm5_next_sparse_attention.py"
+)
+BACKEND_PATH = REPO_ROOT / "python/sglang/srt/layers/attention/nsa_backend.py"
+CONFIG_PATH = REPO_ROOT / "python/sglang/srt/configs/glm5_next.py"
+
+
+def _load_indexer_module():
+    spec = importlib.util.spec_from_file_location(
+        "_glm5_next_consumer_indexer_test", INDEXER_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _function_source(path: Path, name: str) -> str:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    function = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == name
+    )
+    return ast.unparse(function)
+
+
+def _consumer_capability() -> tuple[int, int] | None:
+    if not torch.cuda.is_available():
+        return None
+    capability = torch.cuda.get_device_capability()
+    return capability if capability in ((8, 6), (8, 9)) else None
+
+
+def _expected_logits(query, keys, weights, starts, ends, scales=None):
+    scores = torch.bmm(
+        keys.to(torch.bfloat16).unsqueeze(0).expand(query.shape[0], -1, -1),
+        query.to(torch.bfloat16).transpose(1, 2),
+    )
+    logits = (torch.relu(scores).float() * weights.float().unsqueeze(1)).sum(2)
+    if scales is not None:
+        logits *= scales.float().unsqueeze(0)
+    positions = torch.arange(keys.shape[0], device=query.device).unsqueeze(0)
+    valid = (positions >= starts.unsqueeze(1)) & (positions < ends.unsqueeze(1))
+    return logits.masked_fill(~valid, float("-inf"))
+
+
+def _hadamard128_reference(values: torch.Tensor) -> torch.Tensor:
+    output = values.float()
+    stride = 1
+    while stride < 128:
+        view = output.reshape(*output.shape[:-1], -1, 2, stride)
+        left = view[..., 0, :].clone()
+        right = view[..., 1, :].clone()
+        output = torch.stack((left + right, left - right), dim=-2).reshape_as(output)
+        stride *= 2
+    return output * (1.0 / math.sqrt(128.0))
+
+
+def _compressed_bf16_reference(slot_k, slot_score, ape):
+    probabilities = torch.softmax(slot_score.float() + ape.unsqueeze(0), dim=1)
+    pooled = (probabilities * slot_k.float()).sum(1).to(torch.bfloat16).float()
+    return _hadamard128_reference(pooled).to(torch.bfloat16)
+
+
+class TestGlm5NextConsumerGPUKernels(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.indexer = _load_indexer_module()
+
+    def test_indexer_has_exact_static_configs(self):
+        self.assertEqual(
+            self.indexer.glm5_next_indexer_launch_config((8, 6)), (32, 4, 2)
+        )
+        self.assertEqual(
+            self.indexer.glm5_next_indexer_launch_config((8, 9)), (64, 4, 3)
+        )
+        for capability in ((8, 0), (9, 0), (12, 0)):
+            with self.subTest(capability=capability):
+                with self.assertRaisesRegex(ValueError, "unsupported"):
+                    self.indexer.glm5_next_indexer_launch_config(capability)
+
+    def test_indexer_cpu_route_is_disabled(self):
+        self.assertFalse(self.indexer.use_glm5_next_triton_indexer(torch.device("cpu")))
+
+    def test_indexer_kernels_keep_exact_score_contract(self):
+        flat = _function_source(INDEXER_PATH, "_glm5_next_flat_mqa_logits_kernel")
+        paged = _function_source(INDEXER_PATH, "_glm5_next_paged_mqa_logits_kernel")
+        for source in (flat, paged):
+            self.assertIn("tl.dot", source)
+            self.assertIn("tl.maximum(head_scores, 0.0)", source)
+            self.assertIn("tl.sum(head_scores * weights[None, :], axis=1)", source)
+            self.assertIn("if USE_K_SCALE", source)
+            for host_sync in (".item()", ".cpu()", ".tolist()"):
+                self.assertNotIn(host_sync, source)
+        self.assertIn("page_table_ptr", paged)
+        self.assertIn("key_offsets < seq_len", paged)
+
+    def test_dispatch_preserves_sm120_and_generic_nsa_paths(self):
+        paged = _function_source(INDEXER_CALLER_PATH, "_get_topk_paged")
+        ragged = _function_source(INDEXER_CALLER_PATH, "_get_topk_ragged_kpool_plan")
+        forward = _function_source(INDEXER_CALLER_PATH, "forward_cuda")
+
+        self.assertLess(
+            paged.index("if use_triton_logits"), paged.index("elif use_eager_logits")
+        )
+        self.assertIn("deep_gemm.fp8_paged_mqa_logits", paged)
+        self.assertIn("gather_index_k_bf16_prefix_into", ragged)
+        self.assertIn("deep_gemm.fp8_mqa_logits", ragged)
+        self.assertIn("if getattr(pool, 'index_cache_is_bf16', False)", forward)
+        self.assertIn("q_fp8, q_scale = act_quant", forward)
+
+    def test_sm86_kpool_has_isolated_bf16_transport_kernels(self):
+        source = KPOOL_PATH.read_text(encoding="utf-8")
+        for name in (
+            "_gather_index_k_bf16_prefix_into_kernel",
+            "_kpool_softmax_rotate_write_cache_bf16_kernel",
+            "_kpool_decode_update_and_maybe_write_cache_bf16_kernel",
+            "_kpool_assemble_softmax_rotate_write_cache_bf16_kernel",
+        ):
+            self.assertIn(f"def {name}(", source)
+        self.assertIn("if buf.dtype == torch.bfloat16", source)
+
+    def test_capability_matrix_and_flashinfer_boundary_fail_closed(self):
+        config = CONFIG_PATH.read_text(encoding="utf-8")
+        self.assertIn("if capability == (8, 6)", config)
+        self.assertIn("if capability == (8, 9)", config)
+        self.assertIn("if capability[0] >= 10", config)
+
+        forward = _function_source(BACKEND_PATH, "_forward_trtllm")
+        native_dispatch = forward.index("glm5_next_sparse_mla_reference")
+        flashinfer_import = forward.index("import flashinfer.decode")
+        self.assertLess(native_dispatch, flashinfer_import)
+
+    @unittest.skipUnless(
+        _consumer_capability() is not None,
+        "an SM86 or SM89 GPU is required",
+    )
+    def test_flat_indexer_matches_bf16_formula(self):
+        capability = _consumer_capability()
+        assert capability is not None
+        torch.manual_seed(20260817)
+        device = torch.device("cuda")
+        query_bf16 = (torch.randn(5, 32, 128, device=device) * 0.1).to(torch.bfloat16)
+        keys_bf16 = (torch.randn(137, 128, device=device) * 0.1).to(torch.bfloat16)
+        weights = torch.randn(5, 32, dtype=torch.float32, device=device)
+        starts = torch.tensor([0, 1, 17, 64, 137], dtype=torch.int32, device=device)
+        ends = torch.tensor([137, 80, 101, 137, 137], dtype=torch.int32, device=device)
+
+        if capability == (8, 6):
+            query, keys, scales = query_bf16, keys_bf16, None
+        else:
+            query = query_bf16.to(torch.float8_e4m3fn)
+            keys = keys_bf16.to(torch.float8_e4m3fn)
+            scales = torch.linspace(0.5, 1.5, keys.shape[0], device=device)
+
+        chunks = list(
+            self.indexer.iter_glm5_next_triton_mqa_logits(
+                query,
+                keys,
+                weights,
+                starts,
+                ends,
+                k_scale=scales,
+                query_chunk_size=2,
+            )
+        )
+        actual = torch.cat([chunk for _, _, chunk in chunks])
+        expected = _expected_logits(query, keys, weights, starts, ends, scales)
+        self.assertTrue(torch.equal(torch.isneginf(actual), torch.isneginf(expected)))
+        finite = torch.isfinite(expected)
+        torch.testing.assert_close(
+            actual[finite], expected[finite], rtol=2e-2, atol=2e-2
+        )
+
+    @unittest.skipUnless(
+        _consumer_capability() is not None,
+        "an SM86 or SM89 GPU is required",
+    )
+    def test_paged_indexer_matches_formula_and_replays_cuda_graph(self):
+        capability = _consumer_capability()
+        assert capability is not None
+        torch.manual_seed(20260818)
+        device = torch.device("cuda")
+        pages = 4
+        keys_bf16 = (torch.randn(pages, 64, 128, device=device) * 0.1).to(
+            torch.bfloat16
+        )
+        query_bf16 = (torch.randn(2, 32, 128, device=device) * 0.1).to(torch.bfloat16)
+        weights = torch.randn(2, 32, dtype=torch.float32, device=device)
+        page_table = torch.tensor([[2, 0], [3, 1]], dtype=torch.int32, device=device)
+        seq_lens = torch.tensor([70, 9], dtype=torch.int32, device=device)
+
+        if capability == (8, 6):
+            query = query_bf16
+            cache = keys_bf16.reshape(pages, -1).contiguous()
+            page_scales = None
+            use_scale = False
+        else:
+            query = query_bf16.to(torch.float8_e4m3fn)
+            keys = keys_bf16.to(torch.float8_e4m3fn)
+            page_scales = torch.linspace(
+                0.5, 1.5, pages * 64, dtype=torch.float32, device=device
+            ).reshape(pages, 64)
+            cache = torch.empty(
+                (pages, 64 * 128 + 64 * 4), dtype=torch.uint8, device=device
+            )
+            cache[:, : 64 * 128] = keys.reshape(pages, -1).view(torch.uint8)
+            cache[:, 64 * 128 :] = page_scales.view(torch.uint8).reshape(pages, -1)
+            use_scale = True
+
+        def expected_for_lengths(lengths):
+            rows = []
+            for row in range(2):
+                ordered_keys = keys_bf16.index_select(
+                    0, page_table[row].to(torch.int64)
+                ).reshape(-1, 128)
+                if capability == (8, 9):
+                    ordered_keys = ordered_keys.to(torch.float8_e4m3fn)
+                    ordered_scales = page_scales.index_select(
+                        0, page_table[row].to(torch.int64)
+                    ).reshape(-1)
+                else:
+                    ordered_scales = None
+                rows.append(
+                    _expected_logits(
+                        query[row : row + 1],
+                        ordered_keys,
+                        weights[row : row + 1],
+                        torch.zeros(1, dtype=torch.int32, device=device),
+                        lengths[row : row + 1],
+                        ordered_scales,
+                    )[0]
+                )
+            return torch.stack(rows)
+
+        self.indexer.glm5_next_triton_paged_mqa_logits(
+            query, cache, weights, seq_lens, page_table, 128, use_k_scale=use_scale
+        )
+        torch.cuda.synchronize()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            actual = self.indexer.glm5_next_triton_paged_mqa_logits(
+                query,
+                cache,
+                weights,
+                seq_lens,
+                page_table,
+                128,
+                use_k_scale=use_scale,
+            )
+        graph.replay()
+        torch.cuda.synchronize()
+        expected = expected_for_lengths(seq_lens)
+        self.assertTrue(torch.equal(torch.isneginf(actual), torch.isneginf(expected)))
+        finite = torch.isfinite(expected)
+        torch.testing.assert_close(
+            actual[finite], expected[finite], rtol=2e-2, atol=2e-2
+        )
+
+        seq_lens.copy_(torch.tensor([3, 127], dtype=torch.int32, device=device))
+        graph.replay()
+        torch.cuda.synchronize()
+        expected = expected_for_lengths(seq_lens)
+        self.assertTrue(torch.equal(torch.isneginf(actual), torch.isneginf(expected)))
+        finite = torch.isfinite(expected)
+        torch.testing.assert_close(
+            actual[finite], expected[finite], rtol=2e-2, atol=2e-2
+        )
+
+    @unittest.skipUnless(
+        _consumer_capability() is not None,
+        "an SM86 or SM89 GPU is required",
+    )
+    def test_consumer_sparse_mla_matches_oracle_and_replays_cuda_graph(self):
+        capability = _consumer_capability()
+        assert capability is not None
+        spec = importlib.util.spec_from_file_location(
+            "_glm5_next_sparse_consumer_test", SPARSE_PATH
+        )
+        assert spec is not None and spec.loader is not None
+        sparse = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(sparse)
+
+        torch.manual_seed(20260822)
+        query_cpu = (torch.randn(1, 2, 512) * 0.1).to(torch.bfloat16)
+        kv_bf16 = (torch.randn(16, 512) * 0.1).to(torch.bfloat16)
+        first_indices_cpu = torch.tensor(
+            [[0, 3, 5, 9, -1, -1, -1, -1]], dtype=torch.int32
+        )
+        second_indices_cpu = torch.tensor(
+            [[1, 2, 7, 12, 15, -1, -1, -1]], dtype=torch.int32
+        )
+        scale = 512**-0.5
+        if capability == (8, 6):
+            kv_cpu = kv_bf16
+            kv_scale_cpu = None
+        else:
+            blocks = kv_bf16.float().view(-1, 4, 128)
+            kv_scale_cpu = blocks.abs().amax(-1).clamp_min(1e-4) / 448.0
+            kv_cpu = (
+                (blocks / kv_scale_cpu.unsqueeze(-1))
+                .to(torch.float8_e4m3fn)
+                .view_as(kv_bf16)
+            )
+
+        expected = sparse.glm5_next_sparse_mla_reference(
+            query_cpu,
+            kv_cpu,
+            first_indices_cpu,
+            sm_scale=scale,
+            kv_scale=kv_scale_cpu,
+        )
+        query = query_cpu.cuda()
+        kv = kv_cpu.cuda()
+        indices = first_indices_cpu.cuda()
+        kv_scale = None if kv_scale_cpu is None else kv_scale_cpu.cuda()
+        actual = sparse.glm5_next_sparse_mla_reference(
+            query,
+            kv,
+            indices,
+            sm_scale=scale,
+            kv_scale=kv_scale,
+        )
+        torch.cuda.synchronize()
+        torch.testing.assert_close(actual.cpu(), expected, rtol=2e-2, atol=2e-2)
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            actual = sparse.glm5_next_sparse_mla_reference(
+                query,
+                kv,
+                indices,
+                sm_scale=scale,
+                kv_scale=kv_scale,
+            )
+        indices.copy_(second_indices_cpu)
+        graph.replay()
+        torch.cuda.synchronize()
+        expected = sparse.glm5_next_sparse_mla_reference(
+            query_cpu,
+            kv_cpu,
+            second_indices_cpu,
+            sm_scale=scale,
+            kv_scale=kv_scale_cpu,
+        )
+        torch.testing.assert_close(actual.cpu(), expected, rtol=2e-2, atol=2e-2)
+
+    @unittest.skipUnless(
+        _consumer_capability() == (8, 6),
+        "an SM86 GPU is required",
+    )
+    def test_sm86_bf16_kpool_writer_matches_reference(self):
+        spec = importlib.util.spec_from_file_location(
+            "_glm5_next_kpool_sm86_test", KPOOL_PATH
+        )
+        assert spec is not None and spec.loader is not None
+        kpool = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(kpool)
+
+        torch.manual_seed(20260819)
+        device = torch.device("cuda")
+        slot_k = torch.randn(2, 4, 128, dtype=torch.bfloat16, device=device)
+        slot_score = torch.randn(2, 4, 128, dtype=torch.bfloat16, device=device)
+        ape = torch.randn(4, 128, dtype=torch.float32, device=device)
+        loc = torch.tensor([0, 65], dtype=torch.int64, device=device)
+        cache = torch.zeros((2, 64 * 128), dtype=torch.bfloat16, device=device)
+        pool = SimpleNamespace(page_size=64, index_head_dim=128)
+
+        compressed, scales = kpool.kpool_softmax_rotate_write_cache(
+            pool,
+            cache,
+            slot_k,
+            slot_score,
+            ape,
+            loc,
+            return_compressed=True,
+        )
+        expected = _compressed_bf16_reference(slot_k, slot_score, ape)
+
+        torch.testing.assert_close(compressed, expected, rtol=2e-2, atol=2e-2)
+        torch.testing.assert_close(scales, torch.ones_like(scales), rtol=0, atol=0)
+        torch.testing.assert_close(cache[0, :128], expected[0], rtol=2e-2, atol=2e-2)
+        torch.testing.assert_close(cache[1, 128:256], expected[1], rtol=2e-2, atol=2e-2)
+
+    @unittest.skipUnless(
+        _consumer_capability() == (8, 6),
+        "an SM86 GPU is required",
+    )
+    def test_sm86_bf16_gather_and_extend_assemble_match_reference(self):
+        spec = importlib.util.spec_from_file_location(
+            "_glm5_next_kpool_sm86_extend_test", KPOOL_PATH
+        )
+        assert spec is not None and spec.loader is not None
+        kpool = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(kpool)
+
+        torch.manual_seed(20260820)
+        device = torch.device("cuda")
+        pool = SimpleNamespace(
+            page_size=64,
+            index_head_dim=128,
+            index_kpool=4,
+            tail_extra_slots=0,
+            slots_per_page=64,
+        )
+        cache = torch.randn(3, 64 * 128, dtype=torch.bfloat16, device=device)
+        page_indices = torch.tensor([2, 0], dtype=torch.int32, device=device)
+        gathered = torch.empty(70, 128, dtype=torch.bfloat16, device=device)
+        kpool.gather_index_k_bf16_prefix_into(pool, cache, page_indices, 70, gathered)
+        expected_gather = cache.index_select(0, page_indices.long()).view(-1, 128)[:70]
+        self.assertTrue(torch.equal(gathered, expected_gather))
+
+        cache.zero_()
+        chunk_k = torch.randn(4, 128, dtype=torch.bfloat16, device=device)
+        chunk_score = torch.randn(4, 128, dtype=torch.bfloat16, device=device)
+        tail_k = torch.randn(2, 4, 128, dtype=torch.bfloat16, device=device)
+        tail_score = torch.randn(2, 4, 128, dtype=torch.bfloat16, device=device)
+        ape = torch.randn(4, 128, dtype=torch.float32, device=device)
+        request = torch.tensor([1], dtype=torch.int32, device=device)
+        n_from_tail = torch.tensor([2], dtype=torch.int32, device=device)
+        chunk_start = torch.tensor([1], dtype=torch.int64, device=device)
+        tail_base = torch.tensor([3], dtype=torch.int64, device=device)
+        loc = torch.tensor([65], dtype=torch.int64, device=device)
+        kpool.kpool_assemble_softmax_rotate_write_cache(
+            pool,
+            cache,
+            chunk_k,
+            chunk_score,
+            tail_k,
+            tail_score,
+            request,
+            n_from_tail,
+            chunk_start,
+            tail_base,
+            ape,
+            loc,
+        )
+        selected_k = torch.stack(
+            (tail_k[1, 3], tail_k[1, 0], chunk_k[1], chunk_k[2])
+        ).unsqueeze(0)
+        selected_score = torch.stack(
+            (tail_score[1, 3], tail_score[1, 0], chunk_score[1], chunk_score[2])
+        ).unsqueeze(0)
+        expected = _compressed_bf16_reference(selected_k, selected_score, ape)[0]
+        torch.testing.assert_close(cache[1, 128:256], expected, rtol=2e-2, atol=2e-2)
+
+    @unittest.skipUnless(
+        _consumer_capability() == (8, 6),
+        "an SM86 GPU is required",
+    )
+    def test_sm86_bf16_decode_writer_replays_cuda_graph(self):
+        spec = importlib.util.spec_from_file_location(
+            "_glm5_next_kpool_sm86_decode_test", KPOOL_PATH
+        )
+        assert spec is not None and spec.loader is not None
+        kpool = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(kpool)
+
+        torch.manual_seed(20260821)
+        device = torch.device("cuda")
+        pool = SimpleNamespace(
+            page_size=64,
+            index_head_dim=128,
+            index_kpool=4,
+            tail_extra_slots=0,
+            slots_per_page=64,
+        )
+        cache = torch.zeros(2, 64 * 128, dtype=torch.bfloat16, device=device)
+        tail_seed = torch.randn(2, 4, 128, dtype=torch.bfloat16, device=device)
+        score_seed = torch.randn(2, 4, 128, dtype=torch.bfloat16, device=device)
+        tail_k = tail_seed.clone()
+        tail_score = score_seed.clone()
+        key = torch.randn(1, 128, dtype=torch.bfloat16, device=device)
+        score = torch.randn(1, 128, dtype=torch.bfloat16, device=device)
+        ape = torch.randn(4, 128, dtype=torch.float32, device=device)
+        block_tables = torch.zeros(1, 8, dtype=torch.int32, device=device)
+        block_tables[0, 0] = 1
+        request = torch.tensor([1], dtype=torch.int32, device=device)
+        positions = torch.tensor([3], dtype=torch.int64, device=device)
+        seq_lens = torch.tensor([4], dtype=torch.int32, device=device)
+        cache_locs = torch.tensor([1], dtype=torch.int64, device=device)
+
+        def write_decode():
+            kpool.kpool_decode_update_and_maybe_write_cache(
+                pool,
+                cache,
+                tail_k,
+                tail_score,
+                key,
+                score,
+                ape,
+                block_tables,
+                request,
+                positions,
+                seq_lens,
+                cache_locs,
+            )
+
+        write_decode()
+        torch.cuda.synchronize()
+        graph = torch.cuda.CUDAGraph()
+        tail_k.copy_(tail_seed)
+        tail_score.copy_(score_seed)
+        cache.zero_()
+        with torch.cuda.graph(graph):
+            write_decode()
+        tail_k.copy_(tail_seed)
+        tail_score.copy_(score_seed)
+        cache.zero_()
+        graph.replay()
+        torch.cuda.synchronize()
+
+        selected_k = torch.stack(
+            (tail_seed[1, 0], tail_seed[1, 1], tail_seed[1, 2], key[0])
+        ).unsqueeze(0)
+        selected_score = torch.stack(
+            (score_seed[1, 0], score_seed[1, 1], score_seed[1, 2], score[0])
+        ).unsqueeze(0)
+        expected = _compressed_bf16_reference(selected_k, selected_score, ape)[0]
+        torch.testing.assert_close(cache[1, :128], expected, rtol=2e-2, atol=2e-2)
+        self.assertTrue(torch.equal(tail_k[1, 3], key[0]))
+        self.assertTrue(torch.equal(tail_score[1, 3], score[0]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/test_glm5_next_kda.py
+++ b/test/registered/unit/test_glm5_next_kda.py
@@ -626,12 +626,14 @@ class TestGlm5NextKDAIsolation(unittest.TestCase):
         self.assertNotIn("beta.float().sigmoid()", source)
         self.assertIn("glm5_next_safe_gate", source)
 
-    def test_safe_gate_uses_one_deterministic_launch_configuration(self):
+    def test_safe_gate_uses_architecture_static_launch_configurations(self):
         source = OPS_PATH.read_text(encoding="utf-8")
+        ops = _load_ops()
         self.assertNotIn("@triton.autotune", source)
-        self.assertIn("_SAFE_GATE_BLOCK_T = 32", source)
-        self.assertIn("_SAFE_GATE_NUM_WARPS = 8", source)
-        self.assertIn("_SAFE_GATE_NUM_STAGES = 3", source)
+        self.assertIn("def glm5_next_kda_launch_config(", source)
+        self.assertIn("if capability == (8, 6):", source)
+        self.assertIn("if capability == (8, 9):", source)
+        self.assertIn("return (32, 8, 3), (1, 3)", source)
         self.assertIn(
             "@triton.jit\ndef _glm5_next_safe_gate_kernel(",
             source,
@@ -640,6 +642,14 @@ class TestGlm5NextKDAIsolation(unittest.TestCase):
             '@triton.jit(do_not_specialize=["T"])\n'
             "def _glm5_next_safe_gate_kernel(",
             source,
+        )
+        self.assertEqual(
+            ops.glm5_next_kda_launch_config((8, 6)),
+            ((16, 4, 2), (4, 1)),
+        )
+        self.assertEqual(
+            ops.glm5_next_kda_launch_config((8, 9)),
+            ((32, 4, 3), (4, 1)),
         )
 
     def test_kimi_kernel_launch_autotune_tf32_and_padding_are_untouched(self):

--- a/test/registered/unit/test_glm5_next_kpool_pool_lifecycle.py
+++ b/test/registered/unit/test_glm5_next_kpool_pool_lifecycle.py
@@ -48,9 +48,17 @@ class _FakeNSATokenToKVPool:
         )
         self.kv_cache_dim = kwargs["kv_cache_dim"]
         self.index_head_dim = kwargs["index_head_dim"]
+        self.index_cache_dtype = kwargs.get(
+            "index_cache_dtype", torch.float8_e4m3fn
+        )
+        self.index_cache_is_bf16 = self.index_cache_dtype == torch.bfloat16
         self.mem_usage = 0
         self.index_k_with_scale_buffer = [
-            torch.zeros((1, 132), dtype=torch.uint8) for _ in range(self.layer_num)
+            torch.zeros(
+                (1, 128 if self.index_cache_is_bf16 else 132),
+                dtype=torch.bfloat16 if self.index_cache_is_bf16 else torch.uint8,
+            )
+            for _ in range(self.layer_num)
         ]
 
     def get_kv_size_bytes(self):
@@ -168,10 +176,10 @@ def _load_sources():
 ) = _load_sources()
 
 
-def _make_hybrid_pool(req_pool_size=6):
+def _make_hybrid_pool(req_pool_size=6, dtype=torch.float8_e4m3fn):
     return POOL.Glm5NextHybridKVPool(
         size=128,
-        dtype=torch.float8_e4m3fn,
+        dtype=dtype,
         page_size=64,
         head_num=1,
         head_dim=256,
@@ -243,6 +251,21 @@ class TestGlm5NextKPoolMemoryPool(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             pool.get_latent_scale_buffer(0)
+
+    def test_sm86_bf16_cache_omits_all_fp8_scale_sidecars(self):
+        pool = _make_hybrid_pool(dtype=torch.bfloat16)
+        self.assertTrue(pool.index_cache_is_bf16)
+        self.assertEqual(pool.index_cache_dtype, torch.bfloat16)
+        self.assertEqual(
+            pool.get_index_k_with_scale_buffer(3).dtype, torch.bfloat16
+        )
+        self.assertIsNone(pool.get_latent_scale_buffer(3))
+        with self.assertRaisesRegex(RuntimeError, "only for GLM FP8 KV cache"):
+            pool.set_latent_scale_buffer(
+                3,
+                torch.tensor([1], dtype=torch.long),
+                torch.ones((1, 4), dtype=torch.float32),
+            )
 
     def test_speculative_cache_move_fails_closed(self):
         pool = _make_hybrid_pool()

--- a/test/registered/unit/test_glm5_next_regression_guards.py
+++ b/test/registered/unit/test_glm5_next_regression_guards.py
@@ -1020,8 +1020,8 @@ class TestKPoolBatchOwnedPool(unittest.TestCase):
     def test_kpool_ragged_row_chunks_slice_all_metadata_and_keep_padding(self):
         iterator_calls = []
 
-        def fake_logits_rows(q_fp8, kv_fp8, weights, ks, ke):
-            iterator_calls.append((q_fp8, kv_fp8, weights, ks, ke))
+        def fake_logits_rows(query, index_k, weights, ks, ke, *, k_scale=None):
+            iterator_calls.append((query, index_k, k_scale, weights, ks, ke))
             for start, end in ((0, 2), (2, 4), (4, 5)):
                 yield start, end, torch.full((end - start, 7), float(start))
 
@@ -1035,11 +1035,11 @@ class TestKPoolBatchOwnedPool(unittest.TestCase):
 
         method = _compile_function(
             self._SOURCE,
-            "_topk_from_glm5_next_eager_logits_rows",
+            "_topk_from_glm5_next_model_local_logits_rows",
             class_name="IndexerKPool",
             globals_={
                 "torch": torch,
-                "iter_glm5_next_eager_fp8_mqa_logits": fake_logits_rows,
+                "iter_glm5_next_triton_mqa_logits": fake_logits_rows,
             },
         )
         q = torch.zeros((5, 3, 128), dtype=torch.float32)
@@ -1057,12 +1057,14 @@ class TestKPoolBatchOwnedPool(unittest.TestCase):
             index_topk=8,
             index_kpool=4,
             _topk_from_kpool_logits=select,
+            _should_use_triton_logits=lambda _query: True,
         )
 
         result = method(
             runner,
             q,
-            (k, scale),
+            k,
+            scale,
             weights,
             pool_lens,
             seq_lens,

--- a/test/registered/unit/test_glm5_next_server_args_boundary.py
+++ b/test/registered/unit/test_glm5_next_server_args_boundary.py
@@ -11,6 +11,7 @@ from types import SimpleNamespace
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 SERVER_ARGS_PATH = REPO_ROOT / "python/sglang/srt/server_args.py"
+MODEL_RUNNER_PATH = REPO_ROOT / "python/sglang/srt/model_executor/model_runner.py"
 NSA_BACKEND_PATH = REPO_ROOT / "python/sglang/srt/layers/attention/nsa_backend.py"
 
 
@@ -98,7 +99,7 @@ def _boundary_args(**overrides):
         dllm_algorithm=None,
         dllm_algorithm_config=None,
         quantization="fp8",
-        tp_size=1,
+        tp_size=4,
         pp_size=1,
         dp_size=1,
         moe_dp_size=1,
@@ -247,16 +248,14 @@ class TestGlm5NextSessionABOptions(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, message):
                     self.validate(_boundary_args(**overrides))
 
-    def test_only_tp1_structural_and_tp8_production_widths_are_accepted(self):
-        for tp_size in (1, 8):
-            with self.subTest(tp_size=tp_size):
-                args = _boundary_args(tp_size=tp_size)
-                self.validate(args)
-                self.assertEqual(args.tp_size, tp_size)
+    def test_only_tp4_width_is_accepted(self):
+        args = _boundary_args(tp_size=4)
+        self.validate(args)
+        self.assertEqual(args.tp_size, 4)
 
-        for tp_size in (2, 4, 16):
+        for tp_size in (1, 2, 8, 16):
             with self.subTest(tp_size=tp_size):
-                with self.assertRaisesRegex(ValueError, "TP=8 production"):
+                with self.assertRaisesRegex(ValueError, "only TP=4"):
                     self.validate(_boundary_args(tp_size=tp_size))
 
     def test_only_tensor_parallel_topology_is_accepted(self):
@@ -317,29 +316,19 @@ class TestGlm5NextSessionABOptions(unittest.TestCase):
                         )
                     )
 
-    def test_layerwise_prefill_requires_tp8_and_static_experts(self):
+    def test_layerwise_prefill_requires_tp4_and_static_experts(self):
         accepted = _boundary_args(
-            tp_size=8,
+            tp_size=4,
             kt_weight_path="stub/experts",
             kt_method="fp8",
             kt_gpu_prefill_token_threshold=4096,
         )
         self.validate(accepted)
 
-        with self.assertRaisesRegex(ValueError, "requires TP=8"):
-            self.validate(
-                _boundary_args(
-                    tp_size=1,
-                    kt_weight_path="stub/experts",
-                    kt_method="fp8",
-                    kt_gpu_prefill_token_threshold=4096,
-                )
-            )
-
         with self.assertRaisesRegex(ValueError, "dynamic-expert-update"):
             self.validate(
                 _boundary_args(
-                    tp_size=8,
+                    tp_size=4,
                     kt_weight_path="stub/experts",
                     kt_method="fp8",
                     kt_gpu_prefill_token_threshold=4096,
@@ -347,13 +336,11 @@ class TestGlm5NextSessionABOptions(unittest.TestCase):
                 )
             )
 
-        structural = _boundary_args(
-            tp_size=1,
-            kt_weight_path="stub/experts",
-            kt_method="fp8",
-            kt_gpu_prefill_token_threshold=0,
-        )
-        self.validate(structural)
+    def test_glm_layerwise_context_is_not_eagerly_initialized_by_model_runner(self):
+        source = MODEL_RUNNER_PATH.read_text(encoding="utf-8")
+
+        self.assertNotIn("initialize_glm5_next_fp8_layerwise_prefill", source)
+        self.assertNotIn("glm5_next_fp8_layerwise_prefill_allocated_bytes", source)
 
 
 class TestGlm5NextSessionABNSA(unittest.TestCase):
@@ -540,7 +527,7 @@ class TestGlm5NextBoundaryIsolation(unittest.TestCase):
             args = _boundary_args(moe_runner_backend="triton" if exact_glm else backend)
             args.quantization = "fp8"
             args.ep_size = 1
-            args.tp_size = 1
+            args.tp_size = 4 if exact_glm else 1
             args._validate_glm5_next_session_ab_boundary = lambda: validate(args)
             if exact_glm:
                 validate(args)

--- a/test/registered/unit/test_glm5_next_server_args_boundary.py
+++ b/test/registered/unit/test_glm5_next_server_args_boundary.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import ast
 import copy
+import sys
 import unittest
 from pathlib import Path
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
+from unittest import mock
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -346,11 +348,49 @@ class TestGlm5NextSessionABOptions(unittest.TestCase):
 class TestGlm5NextSessionABNSA(unittest.TestCase):
     @staticmethod
     def _configure():
-        return _compile_function(
+        def get_glm5_next_gpu_profile(capability):
+            if capability == (8, 6):
+                return SimpleNamespace(
+                    value="sm86_bf16",
+                    kv_cache_dtype="bfloat16",
+                    index_cache_dtype="bfloat16",
+                    is_consumer_gpu=True,
+                )
+            if capability == (8, 9):
+                return SimpleNamespace(
+                    value="sm89_fp8",
+                    kv_cache_dtype="fp8_e4m3",
+                    index_cache_dtype="fp8_e4m3",
+                    is_consumer_gpu=True,
+                )
+            if capability[0] >= 10:
+                return SimpleNamespace(
+                    value="blackwell_fp8",
+                    kv_cache_dtype="fp8_e4m3",
+                    index_cache_dtype="fp8_e4m3",
+                    is_consumer_gpu=False,
+                )
+            raise ValueError("GLM-5-Next supports NVIDIA SM86, SM89, or Blackwell")
+
+        configure = _compile_function(
             "_configure_glm5_next_session_ab_nsa",
             class_name="ServerArgs",
             globals_={"logger": _LoggerStub()},
         )
+        glm5_next_config = ModuleType("sglang.srt.configs.glm5_next")
+        glm5_next_config.get_glm5_next_gpu_profile = get_glm5_next_gpu_profile
+        package_modules = {
+            "sglang": ModuleType("sglang"),
+            "sglang.srt": ModuleType("sglang.srt"),
+            "sglang.srt.configs": ModuleType("sglang.srt.configs"),
+            "sglang.srt.configs.glm5_next": glm5_next_config,
+        }
+
+        def invoke(self, capability):
+            with mock.patch.dict(sys.modules, package_modules):
+                return configure(self, capability)
+
+        return invoke
 
     @staticmethod
     def _args(**overrides):
@@ -358,6 +398,8 @@ class TestGlm5NextSessionABNSA(unittest.TestCase):
             kv_cache_dtype="fp8_e4m3",
             nsa_prefill_backend=None,
             nsa_decode_backend=None,
+            kt_gpu_prefill_token_threshold=0,
+            enable_multimodal=False,
         )
         values.update(overrides)
         return SimpleNamespace(**values)
@@ -366,23 +408,60 @@ class TestGlm5NextSessionABNSA(unittest.TestCase):
         configure = self._configure()
         args = self._args()
 
-        configure(args, 12)
+        configure(args, (12, 0))
 
         self.assertEqual(args.nsa_prefill_backend, "trtllm")
         self.assertEqual(args.nsa_decode_backend, "trtllm")
 
-    def test_bf16_and_pre_blackwell_are_rejected(self):
+    def test_architecture_specific_cache_dtype_policy(self):
+        sm86 = self._args(kv_cache_dtype="auto")
+        self._configure()(sm86, (8, 6))
+        self.assertEqual(sm86.kv_cache_dtype, "bfloat16")
+
+        sm89 = self._args(kv_cache_dtype="auto")
+        self._configure()(sm89, (8, 9))
+        self.assertEqual(sm89.kv_cache_dtype, "fp8_e4m3")
+
         for dtype in ("bf16", "bfloat16"):
             with self.subTest(dtype=dtype):
                 with self.assertRaisesRegex(ValueError, "fp8_e4m3"):
-                    self._configure()(self._args(kv_cache_dtype=dtype), 12)
+                    self._configure()(self._args(kv_cache_dtype=dtype), (8, 9))
 
-        with self.assertRaisesRegex(ValueError, "Blackwell"):
-            self._configure()(self._args(), 9)
+        with self.assertRaisesRegex(ValueError, "bfloat16"):
+            self._configure()(self._args(kv_cache_dtype="fp8_e4m3"), (8, 6))
+
+        with self.assertRaisesRegex(ValueError, "SM86, SM89, or Blackwell"):
+            self._configure()(self._args(), (9, 0))
+
+    def test_consumer_gpu_rejects_layerwise_prefill(self):
+        with self.assertRaisesRegex(ValueError, "not adapted for SM86/SM89"):
+            self._configure()(
+                self._args(
+                    kv_cache_dtype="bfloat16",
+                    kt_gpu_prefill_token_threshold=4096,
+                ),
+                (8, 6),
+            )
+
+    def test_consumer_gpu_rejects_multimodal_but_blackwell_is_unchanged(self):
+        with self.assertRaisesRegex(ValueError, "text inference only"):
+            self._configure()(
+                self._args(
+                    kv_cache_dtype="bfloat16",
+                    enable_multimodal=True,
+                ),
+                (8, 6),
+            )
+
+        blackwell = self._args(enable_multimodal=True)
+        self._configure()(blackwell, (12, 0))
+        self.assertTrue(blackwell.enable_multimodal)
 
     def test_non_trtllm_sparse_backend_is_rejected(self):
         with self.assertRaisesRegex(ValueError, "both NSA prefill and decode"):
-            self._configure()(self._args(nsa_prefill_backend="flashmla_sparse"), 12)
+            self._configure()(
+                self._args(nsa_prefill_backend="flashmla_sparse"), (12, 0)
+            )
 
     def test_startup_does_not_require_new_flashinfer_abi(self):
         configure = _find_function(

--- a/test/registered/unit/test_glm5_next_session_c_final_acceptance.py
+++ b/test/registered/unit/test_glm5_next_session_c_final_acceptance.py
@@ -15,102 +15,55 @@ assert SPEC.loader is not None
 SPEC.loader.exec_module(ACCEPTANCE)
 
 
-def _summary(
-    *,
-    epoch,
-    apply_count,
-    prime_count,
-    prefetch_hit_count,
-    completed_rounds,
-    fallback_count=0,
-    slot=1,
-    load_kind="prefetch-hit",
-):
+def _round(*, round_index=0, layers=None, compute_ms=None):
+    layers = list(range(3, 45)) if layers is None else layers
+    compute_ms = [1.0] * len(layers) if compute_ms is None else compute_ms
     return {
-        "layer": 44,
-        "epoch": epoch,
-        "slot": slot,
-        "load_kind": load_kind,
-        "apply_count": apply_count,
-        "prime_count": prime_count,
-        "prefetch_hit_count": prefetch_hit_count,
-        "completed_rounds": completed_rounds,
-        "fallback_count": fallback_count,
+        "round_index": round_index,
+        "layers": layers,
+        "compute_ms": compute_ms,
+        "expert_update_ms": [None] * len(layers),
+        "complete": len(layers) == 42,
     }
 
 
 def test_layerwise_log_parser_and_progress_gate_accept_exact_rounds():
     text = "\n".join(
-        [
-            "noise",
-            "KT GLM-5-Next FP8 layerwise prefill: layer=44 epoch=3 slot=1 "
-            "prefetch-hit apply_count=168 prime_count=4 "
-            "prefetch_hit_count=164 completed_rounds=4 fallback_count=0",
-            "KT GLM-5-Next FP8 layerwise prefill: layer=44 epoch=4 slot=1 "
-            "prefetch-hit apply_count=210 prime_count=5 "
-            "prefetch_hit_count=205 completed_rounds=5 fallback_count=0",
+        ["noise"]
+        + [
+            "KT layerwise prefill: "
+            f"layer {layer} compute = {round_index + layer / 100:.2f} ms"
+            for round_index in range(2)
+            for layer in range(3, 45)
         ]
     )
     current = ACCEPTANCE.parse_layerwise_summaries(text)
-    previous = _summary(
-        epoch=2,
-        apply_count=126,
-        prime_count=3,
-        prefetch_hit_count=123,
-        completed_rounds=3,
-    )
 
     assert len(current) == 2
     assert not ACCEPTANCE.validate_layerwise_progress(
-        previous, current, expected_rounds=2
+        None, current, expected_rounds=2
     )
 
 
-def test_layerwise_log_parser_ignores_per_layer_diagnostics():
-    lines = []
-    for epoch in range(2):
-        for layer in range(3, 45):
-            offset = layer - 3
-            lines.append(
-                "KT GLM-5-Next FP8 layerwise prefill: "
-                f"layer={layer} epoch={epoch} slot={offset % 2} "
-                f"{'prime' if layer == 3 else 'prefetch-hit'} "
-                f"apply_count={epoch * 42 + offset + 1} "
-                f"prime_count={epoch + 1} "
-                f"prefetch_hit_count={epoch * 41 + offset} "
-                f"completed_rounds={epoch + (layer == 44)} fallback_count=0"
-            )
-
-    summaries = ACCEPTANCE.parse_layerwise_summaries("\n".join(lines))
-
-    assert summaries == [
-        _summary(
-            epoch=0,
-            apply_count=42,
-            prime_count=1,
-            prefetch_hit_count=41,
-            completed_rounds=1,
-        ),
-        _summary(
-            epoch=1,
-            apply_count=84,
-            prime_count=2,
-            prefetch_hit_count=82,
-            completed_rounds=2,
-        ),
-    ]
-    assert not ACCEPTANCE.validate_layerwise_progress(
-        None, summaries, expected_rounds=2
-    )
-
-
-def test_layerwise_partial_round_does_not_become_a_summary():
+def test_layerwise_log_parser_accepts_optional_expert_update_timing():
     text = "\n".join(
-        "KT GLM-5-Next FP8 layerwise prefill: "
-        f"layer={layer} epoch=0 slot={(layer - 3) % 2} "
-        f"{'prime' if layer == 3 else 'prefetch-hit'} "
-        f"apply_count={layer - 2} prime_count=1 "
-        f"prefetch_hit_count={layer - 3} completed_rounds=0 fallback_count=0"
+        "KT layerwise prefill: "
+        f"layer {layer} compute = 1.25 ms, expert update = 0.50 ms"
+        for layer in range(3, 45)
+    )
+
+    summaries = ACCEPTANCE.parse_layerwise_summaries(text)
+
+    assert len(summaries) == 1
+    assert summaries[0]["expert_update_ms"] == [0.5] * 42
+    assert not ACCEPTANCE.validate_layerwise_progress(
+        None, summaries, expected_rounds=1
+    )
+
+
+def test_layerwise_partial_round_is_retained_and_rejected():
+    text = "\n".join(
+        f"KT layerwise prefill: layer {layer} compute = 1.00 ms"
         for layer in range(3, 44)
     )
 
@@ -119,62 +72,28 @@ def test_layerwise_partial_round_does_not_become_a_summary():
         None, summaries, expected_rounds=1
     )
 
-    assert summaries == []
-    assert any("expected 1" in failure for failure in failures)
+    assert len(summaries) == 1
+    assert summaries[0]["complete"] is False
+    assert any("incomplete" in failure for failure in failures)
 
 
-def test_layerwise_progress_fails_closed_on_missing_round_or_fallback():
-    previous = _summary(
-        epoch=0,
-        apply_count=42,
-        prime_count=1,
-        prefetch_hit_count=41,
-        completed_rounds=1,
-    )
-    bad = _summary(
-        epoch=1,
-        apply_count=84,
-        prime_count=2,
-        prefetch_hit_count=82,
-        completed_rounds=2,
-        fallback_count=1,
-    )
-
+def test_layerwise_progress_fails_closed_on_missing_or_out_of_order_round():
+    bad = _round(layers=[3, 5, 4, *range(6, 45)])
     failures = ACCEPTANCE.validate_layerwise_progress(
-        previous, [bad], expected_rounds=2
+        None, [bad], expected_rounds=2
     )
 
     assert any("expected 2" in failure for failure in failures)
-    assert any("fallback_count" in failure for failure in failures)
+    assert any("ordered layers" in failure for failure in failures)
 
 
-def test_layerwise_progress_rejects_wrong_final_slot_or_load_kind():
-    wrong_slot = _summary(
-        epoch=0,
-        apply_count=42,
-        prime_count=1,
-        prefetch_hit_count=41,
-        completed_rounds=1,
-        slot=0,
-    )
-    wrong_kind = _summary(
-        epoch=0,
-        apply_count=42,
-        prime_count=1,
-        prefetch_hit_count=41,
-        completed_rounds=1,
-        load_kind="prime",
-    )
-
-    slot_failures = ACCEPTANCE.validate_layerwise_progress(
-        None, [wrong_slot], expected_rounds=1
-    )
-    kind_failures = ACCEPTANCE.validate_layerwise_progress(
-        None, [wrong_kind], expected_rounds=1
-    )
-
-    assert any("slot" in failure for failure in slot_failures)
-    assert any("load_kind" in failure for failure in kind_failures)
+def test_expected_layerwise_rounds_keeps_subthreshold_tail_hybrid():
+    assert ACCEPTANCE.expected_layerwise_rounds(128, 4096) == 0
+    assert ACCEPTANCE.expected_layerwise_rounds(4096, 4096) == 1
+    assert ACCEPTANCE.expected_layerwise_rounds(4097, 4096) == 1
+    assert ACCEPTANCE.expected_layerwise_rounds(8193, 4096) == 2
+    assert ACCEPTANCE.expected_layerwise_rounds(500_000, 4096) == 122
+    assert ACCEPTANCE.expected_layerwise_rounds(4096, 512) == 0
 
 
 def test_prometheus_graph_counter_sums_matching_modes_only():
@@ -379,7 +298,7 @@ def test_bucket_contract_defaults_are_exact():
     assert args.input_length == 128
     assert args.output_length == 8
     assert args.top_k == 64
-    assert args.tp_size == 8
+    assert args.tp_size == 4
 
 
 def test_final_long_contract_is_exact_not_a_minimum(monkeypatch, tmp_path):
@@ -422,53 +341,79 @@ def test_fatal_log_scan_ignores_info_but_rejects_runtime_failures():
     assert len(failures) == 3
 
 
-def _startup_log(*, threshold=1, allocation_first=True):
+def _startup_log(*, threshold=1024, lazy=True, include_allocation=True):
     server_args = (
-        "server_args=ServerArgs(tp_size=8, chunked_prefill_size=4096, "
+        "server_args=ServerArgs(tp_size=4, chunked_prefill_size=4096, "
         "kt_method='FP8', kt_gpu_prefill_token_threshold="
         f"{threshold})"
     )
     allocation = (
-        "KT GLM-5-Next FP8 layerwise prefill eagerly allocated two raw "
-        "E4M3+FP32 full-layer slots on cuda:0 before KV profiling "
-        f"(total=1.69 GiB, contract={'a' * 64}, fallback_count=0)"
+        "KT GLM-5-Next FP8 layerwise prefill lazily allocated generic "
+        "SharedFullContext: gpu_full_layer_slots=1 host_expert_slots=2 "
+        "gpu_slot_bytes=1812381696 host_buffer_bytes=12582912 device=cuda:0"
     )
     memory_pool = "Memory pool end. avail mem=12.34 GB"
-    ordered = (
-        [allocation, memory_pool] if allocation_first else [memory_pool, allocation]
-    )
-    return "\n".join(
-        [server_args, *ordered, "The server is fired up and ready to roll!"]
-    )
+    ready = "The server is fired up and ready to roll!"
+    ordered = [memory_pool, ready]
+    if include_allocation:
+        ordered = [*ordered, allocation] if lazy else [allocation, *ordered]
+    return "\n".join([server_args, *ordered])
 
 
-def test_layerwise_startup_requires_one_allocation_before_kv_pool_and_ready():
+def test_layerwise_startup_requires_one_lazy_single_gpu_two_host_allocation():
     result = ACCEPTANCE.validate_layerwise_startup(_startup_log())
 
     assert result["pass"]
-    assert result["allocation"]["total_gib"] == 1.69
-    assert result["allocation"]["fallback_count"] == 0
+    assert result["allocation"]["gpu_full_layer_slots"] == 1
+    assert result["allocation"]["host_expert_slots"] == 2
+    assert result["allocation"]["gpu_slot_bytes"] == 1812381696
 
-    wrong_order = ACCEPTANCE.validate_layerwise_startup(
-        _startup_log(allocation_first=False)
-    )
+    eager = ACCEPTANCE.validate_layerwise_startup(_startup_log(lazy=False))
     duplicate = ACCEPTANCE.validate_layerwise_startup(
-        _startup_log() + "\n" + _startup_log().splitlines()[1]
+        _startup_log() + "\n" + _startup_log().splitlines()[-1]
     )
-    assert not wrong_order["pass"]
-    assert any("does not precede" in failure for failure in wrong_order["failures"])
+    missing = ACCEPTANCE.validate_layerwise_startup(
+        _startup_log(include_allocation=False)
+    )
+    pending = ACCEPTANCE.validate_layerwise_startup(
+        _startup_log(include_allocation=False), require_allocation=False
+    )
+    assert not eager["pass"]
+    assert any("not lazy" in failure for failure in eager["failures"])
     assert not duplicate["pass"]
     assert any("exactly one" in failure for failure in duplicate["failures"])
+    assert not missing["pass"]
+    assert pending["pass"]
 
 
-def test_prefill_server_log_binds_explicit_threshold_and_tp8():
-    threshold_1 = ACCEPTANCE.validate_prefill_parity_server_log(
-        _startup_log(threshold=1), threshold=1
+def test_layerwise_startup_rejects_wrong_slots_and_legacy_protocol():
+    wrong_slots = _startup_log().replace(
+        "gpu_full_layer_slots=1 host_expert_slots=2",
+        "gpu_full_layer_slots=2 host_expert_slots=1",
+    )
+    legacy = _startup_log() + "\n" + (
+        "KT GLM-5-Next FP8 layerwise prefill eagerly allocated two raw "
+        "E4M3+FP32 full-layer slots"
+    )
+
+    slots_result = ACCEPTANCE.validate_layerwise_startup(wrong_slots)
+    legacy_result = ACCEPTANCE.validate_layerwise_startup(legacy)
+
+    assert not slots_result["pass"]
+    assert any("gpu_full_layer_slots" in item for item in slots_result["failures"])
+    assert any("host_expert_slots" in item for item in slots_result["failures"])
+    assert not legacy_result["pass"]
+    assert any("legacy" in item for item in legacy_result["failures"])
+
+
+def test_prefill_server_log_binds_explicit_threshold_and_tp4():
+    threshold_1024 = ACCEPTANCE.validate_prefill_parity_server_log(
+        _startup_log(threshold=1024), threshold=1024
     )
     threshold_0_log = "\n".join(
         [
             (
-                "server_args=ServerArgs(tp_size=8, chunked_prefill_size=4096, "
+                "server_args=ServerArgs(tp_size=4, chunked_prefill_size=4096, "
                 "kt_method='FP8', kt_gpu_prefill_token_threshold=0)"
             ),
             "The server is fired up and ready to roll!",
@@ -478,10 +423,10 @@ def test_prefill_server_log_binds_explicit_threshold_and_tp8():
         threshold_0_log, threshold=0
     )
 
-    assert threshold_1["pass"]
+    assert threshold_1024["pass"]
     assert threshold_0["pass"]
     wrong_threshold = ACCEPTANCE.validate_prefill_parity_server_log(
-        threshold_0_log, threshold=1
+        threshold_0_log, threshold=1024
     )
     assert not wrong_threshold["pass"]
     assert any(
@@ -494,14 +439,12 @@ def test_threshold_zero_rejects_nonfinal_layerwise_event():
     threshold_0_log = "\n".join(
         [
             (
-                "server_args=ServerArgs(tp_size=8, chunked_prefill_size=4096, "
+                "server_args=ServerArgs(tp_size=4, chunked_prefill_size=4096, "
                 "kt_method='FP8', kt_gpu_prefill_token_threshold=0)"
             ),
             "The server is fired up and ready to roll!",
             (
-                "KT GLM-5-Next FP8 layerwise prefill: layer=3 epoch=0 slot=0 "
-                "prime apply_count=1 prime_count=1 prefetch_hit_count=0 "
-                "completed_rounds=0 fallback_count=0"
+                "KT layerwise prefill: layer 3 compute = 1.25 ms"
             ),
         ]
     )
@@ -536,8 +479,6 @@ def test_completed_request_requires_length_finish_and_in_range_tokens():
 
 def _prefill_parity_payload(threshold):
     cases = []
-    previous = None
-    completed_rounds = 0
     for length in ACCEPTANCE.LAYERWISE_LENGTHS:
         fixture = ACCEPTANCE.build_fixture(
             length,
@@ -559,18 +500,9 @@ def _prefill_parity_payload(threshold):
                 ]
             )
         summaries = []
-        case_previous = copy.deepcopy(previous)
-        if threshold == 1:
-            for _ in range((length + 4095) // 4096):
-                completed_rounds += 1
-                previous = _summary(
-                    epoch=completed_rounds - 1,
-                    apply_count=completed_rounds * 42,
-                    prime_count=completed_rounds,
-                    prefetch_hit_count=completed_rounds * 41,
-                    completed_rounds=completed_rounds,
-                )
-                summaries.append(copy.deepcopy(previous))
+        expected_rounds = ACCEPTANCE.expected_layerwise_rounds(length, 4096)
+        if threshold == ACCEPTANCE.LAYERWISE_TOKEN_THRESHOLD:
+            summaries = [_round(round_index=index) for index in range(expected_rounds)]
         cases.append(
             {
                 "input_tokens": length,
@@ -582,9 +514,11 @@ def _prefill_parity_payload(threshold):
                 "completion_tokens": 16,
                 "top_logprobs": top_logprobs,
                 "expected_layerwise_rounds": (
-                    (length + 4095) // 4096 if threshold == 1 else 0
+                    expected_rounds
+                    if threshold == ACCEPTANCE.LAYERWISE_TOKEN_THRESHOLD
+                    else 0
                 ),
-                "previous_layerwise_summary": case_previous,
+                "previous_layerwise_summary": None,
                 "layerwise_summaries": summaries,
                 "server_log_window": {
                     "path": "/tmp/server.log",
@@ -598,7 +532,7 @@ def _prefill_parity_payload(threshold):
             }
         )
     server_args = {
-        "tp_size": "8",
+        "tp_size": "4",
         "chunked_prefill_size": "4096",
         "kt_method": "'FP8'",
         "kt_gpu_prefill_token_threshold": str(threshold),
@@ -613,7 +547,7 @@ def _prefill_parity_payload(threshold):
             "output_tokens": 16,
             "chunk_size": 4096,
             "fixture_seed": 20260811,
-            "tp_size": 8,
+            "tp_size": 4,
             "vocab_size": 154880,
             "collection_top_k": 256,
             "comparison_top_k": 64,
@@ -626,7 +560,11 @@ def _prefill_parity_payload(threshold):
         "server_evidence": {
             "threshold": threshold,
             "server_args": server_args,
-            "layerwise_startup": {"pass": True} if threshold == 1 else None,
+            "layerwise_startup": (
+                ACCEPTANCE.validate_layerwise_startup(_startup_log())
+                if threshold == ACCEPTANCE.LAYERWISE_TOKEN_THRESHOLD
+                else None
+            ),
             "path": "/tmp/server.log",
             "initial_size": 1024,
             "initial_sha256": "a" * 64,
@@ -639,7 +577,7 @@ def _prefill_parity_payload(threshold):
 
 def test_prefill_parity_comparison_accepts_exact_tokens_and_bounded_toplogprobs():
     baseline = _prefill_parity_payload(0)
-    candidate = _prefill_parity_payload(1)
+    candidate = _prefill_parity_payload(1024)
     for case in candidate["cases"]:
         for step in case["top_logprobs"]:
             for item in step:
@@ -653,7 +591,7 @@ def test_prefill_parity_comparison_accepts_exact_tokens_and_bounded_toplogprobs(
 
 def test_prefill_parity_comparison_rejects_token_or_toplogprob_drift():
     baseline = _prefill_parity_payload(0)
-    token_candidate = _prefill_parity_payload(1)
+    token_candidate = _prefill_parity_payload(1024)
     token_case = token_candidate["cases"][0]
     token_case["output_ids"][0] = 150000
     token_case["top_logprobs"][0][0]["token_id"] = 150000
@@ -664,7 +602,7 @@ def test_prefill_parity_comparison_rejects_token_or_toplogprob_drift():
     assert not token_result["pass"]
     assert any("greedy output token" in failure for failure in token_result["failures"])
 
-    logprob_candidate = _prefill_parity_payload(1)
+    logprob_candidate = _prefill_parity_payload(1024)
     logprob_candidate["cases"][0]["top_logprobs"][0][0]["logprob"] = -0.5
     logprob_result = ACCEPTANCE.compare_prefill_parity_payloads(
         baseline, logprob_candidate
@@ -677,7 +615,7 @@ def test_prefill_parity_comparison_rejects_token_or_toplogprob_drift():
 
 def test_prefill_parity_comparison_fails_closed_on_missing_top_evidence():
     baseline = _prefill_parity_payload(0)
-    candidate = _prefill_parity_payload(1)
+    candidate = _prefill_parity_payload(1024)
     candidate["cases"][0]["top_logprobs"][0].pop()
 
     result = ACCEPTANCE.compare_prefill_parity_payloads(baseline, candidate)
@@ -693,19 +631,19 @@ def test_prefill_parity_parser_defaults_freeze_matrix_seed_and_tp():
         [
             "prefill-parity",
             "--label",
-            "threshold-1",
+            "threshold-1024",
             "--output",
             "/tmp/prefill.json",
             "--server-log",
             "/tmp/server.log",
             "--threshold",
-            "1",
+            "1024",
         ]
     )
 
     assert args.lengths == [128, 4096, 4097, 8193]
     assert args.output_length == 16
     assert args.fixture_seed == 20260811
-    assert args.tp_size == 8
+    assert args.tp_size == 4
     assert args.vocab_size == 154880
     assert args.top_k == 256

--- a/test/registered/unit/test_glm5_next_session_c_graph_acceptance.py
+++ b/test/registered/unit/test_glm5_next_session_c_graph_acceptance.py
@@ -48,7 +48,7 @@ class _FakeSGLang:
             return b"# graph counter deliberately absent\nsglang:running_requests 0\n"
         value = 10 if self.metrics_calls == 1 else 73
         lines = ["# TYPE sglang:cuda_graph_passes_total counter"]
-        for rank in range(8):
+        for rank in range(4):
             lines.append(
                 "sglang:cuda_graph_passes_total"
                 f'{{mode="decode_cuda_graph",tp_rank="{rank}"}} {value}'
@@ -141,6 +141,7 @@ def _collect(tmp_path, *, mode="graph", expose_graph_counter=True):
 
 
 def test_fixtures_are_stable_distinct_and_exact_graph_buckets():
+    assert _args(Path("/tmp")).tp_size == 4
     first = ACCEPTANCE.build_fixtures(154880)
     second = ACCEPTANCE.build_fixtures(154880)
 
@@ -276,7 +277,7 @@ def test_mocked_http_graph_acceptance_covers_exact_a_poison_a_contract(tmp_path)
 
     gate = payload["metrics"]["decode_cuda_graph_gate"]
     assert gate["pass"]
-    assert gate["delta"] == 504
+    assert gate["delta"] == 252
     assert all(item["graph_delta"] == 63 for item in gate["per_rank"].values())
     assert all(item["decode_none_delta"] == 0 for item in gate["per_rank"].values())
     assert gate["source"] == "HTTP /metrics only"

--- a/test/registered/unit/test_glm5_next_session_c_qa_gsm_graph_acceptance.py
+++ b/test/registered/unit/test_glm5_next_session_c_qa_gsm_graph_acceptance.py
@@ -187,17 +187,17 @@ def test_metrics_allow_decode_none_counter_disappearance_but_not_increase():
     assert comparison["per_rank"]["1"]["decode_none_delta"] == -4
 
 
-def test_metrics_require_positive_cuda_graph_delta_on_all_eight_ranks():
-    before = acceptance.analyze_metrics(_metrics(graph=[10] * 8))
-    after = acceptance.analyze_metrics(_metrics(graph=[11] * 7 + [10]))
+def test_metrics_require_positive_cuda_graph_delta_on_all_four_ranks():
+    before = acceptance.analyze_metrics(_metrics(graph=[10] * 4))
+    after = acceptance.analyze_metrics(_metrics(graph=[11] * 3 + [10]))
 
     comparison = acceptance.compare_metrics(
-        before, after, tp_size=8, minimum_graph_delta_per_rank=1
+        before, after, tp_size=4, minimum_graph_delta_per_rank=1
     )
 
     assert comparison["pass"] is False
-    assert comparison["per_rank"]["7"]["pass"] is False
-    assert any("TP rank 7" in failure for failure in comparison["failures"])
+    assert comparison["per_rank"]["3"]["pass"] is False
+    assert any("TP rank 3" in failure for failure in comparison["failures"])
 
 
 def test_qa_requires_choice_content_usage_and_stop_finish():
@@ -340,6 +340,7 @@ def test_gsm_command_freezes_session_c_parameters(tmp_path: Path):
 
     command = acceptance.build_gsm_command(args)
 
+    assert args.tp_size == 4
     assert command[0] == args.python
     assert command[1] == "-c"
     assert command[2] == acceptance.GSM_BENCHMARK_WORKER

--- a/test/registered/unit/test_glm5_next_session_d_contract.py
+++ b/test/registered/unit/test_glm5_next_session_d_contract.py
@@ -16,6 +16,7 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 STAGE3_TEST_PATH = REPO_ROOT / "test/registered/unit/test_glm5_next_stage3.py"
 MODEL_CONFIG_PATH = REPO_ROOT / "python/sglang/srt/configs/model_config.py"
 PROCESSOR_PATH = REPO_ROOT / "python/sglang/srt/multimodal/processors/glm5_next.py"
+CHAT_TEMPLATE_PATH = REPO_ROOT / "examples/chat_template/glm5_next_multimodal.jinja"
 GLM_OCR_MODEL_PATH = REPO_ROOT / "python/sglang/srt/models/glm_ocr.py"
 GLM5_MODEL_PATH = REPO_ROOT / "python/sglang/srt/models/glm5_next.py"
 
@@ -200,7 +201,11 @@ def _compile_multi_image_request_harness(mrope_embedding):
         for node in tree.body
         if isinstance(node, ast.ClassDef) and node.name == "Glm5NextSGLangProcessor"
     )
-    method_names = {"_count_image_placeholders", "process_mm_data_async"}
+    method_names = {
+        "_count_image_placeholders",
+        "_get_multi_image_mrope",
+        "process_mm_data_async",
+    }
     methods = [
         copy.deepcopy(node)
         for node in processor.body
@@ -211,7 +216,10 @@ def _compile_multi_image_request_harness(mrope_embedding):
     for method in methods:
         method.decorator_list = []
     module = ast.fix_missing_locations(ast.Module(body=methods, type_ignores=[]))
-    namespace = {"MRotaryEmbedding": mrope_embedding}
+    namespace = {
+        "MRotaryEmbedding": mrope_embedding,
+        "torch": pytest.importorskip("torch"),
+    }
     exec(compile(module, str(PROCESSOR_PATH), "exec"), namespace)
     return type(
         "_Glm5NextMultiImageRequestHarness",
@@ -420,6 +428,49 @@ def test_processor_and_shared_glm_ocr_changes_remain_isolated():
     )
 
 
+def test_glm5_multimodal_chat_template_preserves_image_order():
+    jinja2 = pytest.importorskip("jinja2")
+    source = CHAT_TEMPLATE_PATH.read_text(encoding="utf-8")
+
+    def raise_exception(message):
+        raise ValueError(message)
+
+    template = jinja2.Environment().from_string(source)
+    rendered = template.render(
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image"},
+                    {"type": "image"},
+                    {"type": "text", "text": "compare in order"},
+                ],
+            }
+        ],
+        add_generation_prompt=True,
+        raise_exception=raise_exception,
+    )
+    assert rendered == (
+        "[gMASK]<sop><|user|>\n<|image|><|image|>compare in order<|assistant|>\n"
+    )
+
+    text_only = template.render(
+        messages=[{"role": "user", "content": "hello"}],
+        add_generation_prompt=True,
+        raise_exception=raise_exception,
+    )
+    assert text_only == "[gMASK]<sop><|user|>\nhello<|assistant|>\n"
+
+    with pytest.raises(ValueError, match="only text and image"):
+        template.render(
+            messages=[
+                {"role": "user", "content": [{"type": "video"}]},
+            ],
+            add_generation_prompt=True,
+            raise_exception=raise_exception,
+        )
+
+
 def test_multi_image_request_cardinality_offsets_and_feature_contract():
     torch = pytest.importorskip("torch")
 
@@ -535,6 +586,13 @@ def test_multi_image_request_cardinality_offsets_and_feature_contract():
 
     adjacent_result = run_request([[1, 8, 20], [1, 4, 12]], adjacent_placeholders=True)
     assert adjacent_result["mm_items"][0].offsets == [(1, 40), (41, 52)]
+    assert adjacent_result["mrope_positions"][:, 0].tolist() == [0, 0, 0]
+    assert adjacent_result["mrope_positions"][:, 1].tolist() == [1, 1, 1]
+    assert adjacent_result["mrope_positions"][:, 40].tolist() == [1, 4, 10]
+    assert adjacent_result["mrope_positions"][:, 41].tolist() == [11, 11, 11]
+    assert adjacent_result["mrope_positions"][:, 52].tolist() == [11, 12, 16]
+    assert adjacent_result["mrope_positions"][:, 53].tolist() == [17, 17, 17]
+    assert adjacent_result["mrope_position_delta"].tolist() == [[-36]]
 
     two_grids = [[1, 8, 20], [1, 4, 12]]
     with pytest.raises(ValueError, match="at least one image"):

--- a/test/registered/unit/test_glm5_next_session_d_contract.py
+++ b/test/registered/unit/test_glm5_next_session_d_contract.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import ast
 import copy
 import importlib.util
@@ -188,6 +189,35 @@ def _compile_checkpoint_image_config_parser():
     }
     exec(compile(module, str(PROCESSOR_PATH), "exec"), namespace)
     return namespace["from_checkpoint_config"], expected_values
+
+
+def _compile_multi_image_request_harness(mrope_embedding):
+    tree = ast.parse(
+        PROCESSOR_PATH.read_text(encoding="utf-8"), filename=str(PROCESSOR_PATH)
+    )
+    processor = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "Glm5NextSGLangProcessor"
+    )
+    method_names = {"_count_image_placeholders", "process_mm_data_async"}
+    methods = [
+        copy.deepcopy(node)
+        for node in processor.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name in method_names
+    ]
+    assert {method.name for method in methods} == method_names
+    for method in methods:
+        method.decorator_list = []
+    module = ast.fix_missing_locations(ast.Module(body=methods, type_ignores=[]))
+    namespace = {"MRotaryEmbedding": mrope_embedding}
+    exec(compile(module, str(PROCESSOR_PATH), "exec"), namespace)
+    return type(
+        "_Glm5NextMultiImageRequestHarness",
+        (),
+        {method_name: namespace[method_name] for method_name in method_names},
+    )
 
 
 def test_exact_checkpoint_token_ids_and_vision_defaults():
@@ -388,3 +418,138 @@ def test_processor_and_shared_glm_ocr_changes_remain_isolated():
     assert "merger_context_dim=self.vision_config.projection_intermediate_size" in (
         glm5_source
     )
+
+
+def test_multi_image_request_cardinality_offsets_and_feature_contract():
+    torch = pytest.importorskip("torch")
+
+    class _MRotaryEmbedding:
+        @staticmethod
+        def get_rope_index_glm4v(input_ids, **kwargs):
+            del kwargs
+            seq_len = input_ids.shape[-1]
+            return (
+                torch.zeros((3, 1, seq_len), dtype=torch.long),
+                torch.zeros((1, 1), dtype=torch.long),
+            )
+
+    harness = _compile_multi_image_request_harness(_MRotaryEmbedding)
+
+    def run_request(
+        grids,
+        *,
+        image_data=None,
+        prompt_count=None,
+        loaded_count=None,
+        offsets_override=None,
+        feature_rows=None,
+        video_data=None,
+        audio_data=None,
+        adjacent_placeholders=False,
+    ):
+        image_count = len(grids)
+        image_data = (
+            [f"image-{index}" for index in range(image_count)]
+            if image_data is None
+            else image_data
+        )
+        prompt_count = len(image_data) if prompt_count is None else prompt_count
+        loaded_count = len(image_data) if loaded_count is None else loaded_count
+        grid_tensor = torch.tensor(grids, dtype=torch.long)
+        patch_counts = [int(grid.prod().item()) for grid in grid_tensor]
+        token_counts = [patch_count // 4 for patch_count in patch_counts]
+
+        input_ids = [101]
+        offsets = []
+        for index, token_count in enumerate(token_counts):
+            start = len(input_ids)
+            input_ids.extend([7] * token_count)
+            offsets.append((start, len(input_ids) - 1))
+            if not adjacent_placeholders:
+                input_ids.append(102 + index)
+        if adjacent_placeholders:
+            offsets = [(1, len(input_ids) - 1)]
+            input_ids.append(102)
+        input_ids = torch.tensor(input_ids, dtype=torch.long)
+        if offsets_override is not None:
+            offsets = offsets_override
+
+        expected_feature_rows = sum(patch_counts)
+        feature_rows = expected_feature_rows if feature_rows is None else feature_rows
+        item = SimpleNamespace(
+            feature=torch.zeros((feature_rows, 1176), dtype=torch.float32),
+            offsets=offsets,
+            is_image=lambda: True,
+        )
+        ret = SimpleNamespace(
+            image_grid_thw=grid_tensor,
+            attention_mask=torch.ones_like(input_ids).unsqueeze(0),
+        )
+
+        processor = harness()
+        processor.VIDEO_TOKEN = "<|video|>"
+        processor.VIDEO_TOKEN_ID = 8
+        processor.IMAGE_TOKEN = "<|image|>"
+        processor.IM_TOKEN_ID = 7
+        processor.IMAGE_START_TOKEN_ID = 9
+        processor.IMAGE_END_TOKEN_ID = 10
+        processor.spatial_merge_size = 2
+        processor.hf_config = SimpleNamespace()
+        processor.mm_tokens = object()
+        processor.load_mm_data = lambda **kwargs: SimpleNamespace(
+            images=[object()] * loaded_count,
+            videos=[],
+            audios=[],
+        )
+        processor.process_and_combine_mm_data = lambda *args, **kwargs: (
+            [item],
+            input_ids,
+            ret,
+        )
+        prompt_separator = "" if adjacent_placeholders else " compare "
+        prompt = prompt_separator.join(["<|image|>"] * prompt_count)
+        request = SimpleNamespace(video_data=video_data)
+        result = asyncio.run(
+            processor.process_mm_data_async(
+                image_data,
+                [] if audio_data is None else audio_data,
+                prompt,
+                request,
+            )
+        )
+        return result
+
+    cases = (
+        [[1, 8, 20]],
+        [[1, 8, 20], [1, 4, 12]],
+        [[1, 4, 4]] * 4,
+        [[1, 4, 4]] * 8,
+    )
+    for grids in cases:
+        result = run_request(grids)
+        assert len(result["mm_items"][0].offsets) == len(grids)
+        assert tuple(result["mrope_positions"].shape) == (
+            3,
+            len(result["input_ids"]),
+        )
+
+    adjacent_result = run_request([[1, 8, 20], [1, 4, 12]], adjacent_placeholders=True)
+    assert adjacent_result["mm_items"][0].offsets == [(1, 40), (41, 52)]
+
+    two_grids = [[1, 8, 20], [1, 4, 12]]
+    with pytest.raises(ValueError, match="at least one image"):
+        run_request(two_grids, image_data=[], prompt_count=0)
+    with pytest.raises(ValueError, match="count/placeholder count mismatch"):
+        run_request(two_grids, prompt_count=1)
+    with pytest.raises(ValueError, match="processor_output"):
+        run_request(two_grids, image_data=["image-0", {"format": "processor_output"}])
+    with pytest.raises(ValueError, match="does not support video"):
+        run_request(two_grids, video_data=["video-0"])
+    with pytest.raises(ValueError, match="does not support audio"):
+        run_request(two_grids, audio_data=["audio-0"])
+    with pytest.raises(ValueError, match="changed the request cardinality"):
+        run_request(two_grids, loaded_count=1)
+    with pytest.raises(RuntimeError, match="offsets do not cover"):
+        run_request(two_grids, offsets_override=[(1, 40), (42, 54)])
+    with pytest.raises(RuntimeError, match="feature/grid mismatch"):
+        run_request(two_grids, feature_rows=207)

--- a/test/registered/unit/test_glm5_next_session_d_processor_subprocess.py
+++ b/test/registered/unit/test_glm5_next_session_d_processor_subprocess.py
@@ -171,6 +171,18 @@ def _assert_image_output(output, tokenizer, torch):
     assert int((output.mm_token_type_ids == 1).sum().item()) == 40
 
 
+def _assert_multi_image_output(output, tokenizer, torch, image_count):
+    image_token_id = tokenizer.convert_tokens_to_ids("<|image|>")
+    assert tuple(output.image_grid_thw.shape) == (image_count, 3)
+    patch_counts = [int(grid.prod().item()) for grid in output.image_grid_thw]
+    expected_tokens = sum(patch_count // 4 for patch_count in patch_counts)
+    assert tuple(output.pixel_values.shape) == (sum(patch_counts), 1176)
+    assert output.pixel_values.dtype == torch.float32
+    assert bool(output.pixel_values.isfinite().all())
+    assert int((output.input_ids == image_token_id).sum().item()) == expected_tokens
+    assert int((output.mm_token_type_ids == 1).sum().item()) == expected_tokens
+
+
 def _run_image_and_processor_parity(glm5_module, dependencies):
     np, torch, Image, hf_image_module, Glm46VVideoProcessor = dependencies
 
@@ -208,6 +220,17 @@ def _run_image_and_processor_parity(glm5_module, dependencies):
         return_mm_token_type_ids=True,
     )
     _assert_image_output(output, tokenizer, torch)
+    second_image = Image.fromarray(
+        np.arange(211 * 97 * 3, dtype=np.uint8).reshape(211, 97, 3),
+        "RGB",
+    )
+    multi_output = processor(
+        images=[image, second_image],
+        text=["<|image|> describe <|image|>"],
+        return_tensors="pt",
+        return_mm_token_type_ids=True,
+    )
+    _assert_multi_image_output(multi_output, tokenizer, torch, 2)
 
     reference_config = copy.deepcopy(CHECKPOINT_IMAGE_CONFIG)
     reference_config.pop("image_processor_type")
@@ -241,11 +264,18 @@ def _run_image_and_processor_parity(glm5_module, dependencies):
     hf_image_module.smart_resize = _expanded_smart_resize
     try:
         reference_output = reference(images=[image], return_tensors="pt")
+        reference_multi_output = reference(
+            images=[image, second_image], return_tensors="pt"
+        )
     finally:
         hf_image_module.smart_resize = original_smart_resize
 
     assert torch.equal(output.image_grid_thw, reference_output.image_grid_thw)
     assert torch.equal(output.pixel_values, reference_output.pixel_values)
+    assert torch.equal(
+        multi_output.image_grid_thw, reference_multi_output.image_grid_thw
+    )
+    assert torch.equal(multi_output.pixel_values, reference_multi_output.pixel_values)
 
     _assert_raises(
         ValueError,
@@ -256,7 +286,7 @@ def _run_image_and_processor_parity(glm5_module, dependencies):
         ),
         "does not support video input",
     )
-    return image, tokenizer, output
+    return [image, second_image], tokenizer, output
 
 
 def _install_hf_utils_stubs(PretrainedConfig):
@@ -384,7 +414,7 @@ def _write_processor_config(path: Path, processor_config: dict):
 
 def _run_get_processor_smoke(
     glm5_module,
-    image,
+    images,
     tokenizer,
     torch,
     PretrainedConfig,
@@ -455,18 +485,25 @@ def _run_get_processor_smoke(
         assert processor.image_processor.patch_expand_factor == 2
 
         output = processor(
-            images=[image],
+            images=[images[0]],
             text=["<|image|> describe"],
             return_tensors="pt",
             return_mm_token_type_ids=True,
         )
         _assert_image_output(output, processor.tokenizer, torch)
+        multi_output = processor(
+            images=images,
+            text=["<|image|> describe <|image|>"],
+            return_tensors="pt",
+            return_mm_token_type_ids=True,
+        )
+        _assert_multi_image_output(multi_output, processor.tokenizer, torch, 2)
         _assert_raises(
             ValueError,
             lambda: processor(
-                images=[image],
+                images=[images[0]],
                 text=["<|image|> describe"],
-                videos=[image],
+                videos=[images[0]],
             ),
             "does not support video input",
         )
@@ -510,12 +547,12 @@ def _child_main() -> int:
         hf_image_module,
         Glm46VVideoProcessor,
     )
-    image, tokenizer, _output = _run_image_and_processor_parity(
+    images, tokenizer, _output = _run_image_and_processor_parity(
         glm5_module, dependencies
     )
     _run_get_processor_smoke(
         glm5_module,
-        image,
+        images,
         tokenizer,
         torch,
         PretrainedConfig,
@@ -525,7 +562,8 @@ def _child_main() -> int:
     )
     print(
         f"{SUCCESS_MARKER}: transformers-kt={installed_version}; "
-        "resize=112x280; grid=[1,8,20]; patches=160; tokens=40"
+        "single_and_multi_image_parity=pass; resize=112x280; "
+        "grid=[1,8,20]; patches=160; tokens=40"
     )
     return 0
 

--- a/test/registered/unit/test_glm5_next_sparse_attention.py
+++ b/test/registered/unit/test_glm5_next_sparse_attention.py
@@ -326,7 +326,13 @@ class TestGlm5NextSparseAttention(unittest.TestCase):
         )
         source = ast.unparse(forward)
         self.assertIn("if self.is_glm5_next", source)
-        self.assertIn("self.is_glm5_next and self.device_capability == (12, 0)", source)
+        self.assertIn(
+            "self.is_glm5_next and self.device_capability in _GLM5_NEXT_NATIVE_CUDA_CAPS",
+            source,
+        )
+        self.assertIn(
+            "self.device_capability in _GLM5_NEXT_SCALED_FP8_CUDA_CAPS", source
+        )
         self.assertIn("glm5_next_sparse_mla_reference", source)
         self.assertIn("use_cuda_decode_kernel=not is_prefill", source)
         self.assertIn("forward_batch.forward_mode.is_extend_without_speculative()", source)
@@ -365,6 +371,10 @@ class TestGlm5NextSparseAttention(unittest.TestCase):
 
     @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required")
     def test_raw_fp8_cuda_kernel_matches_cpu_oracle_and_replays_graph(self):
+        if torch.cuda.get_device_capability() < (8, 9):
+            self.skipTest("this legacy route requires native FP8")
+        if torch.cuda.get_device_capability() == (8, 9):
+            self.skipTest("consumer profiles use BF16 or scaled FP8 cache")
         torch.manual_seed(20260812)
         query_cpu = (torch.randn(1, 2, 512) * 0.1).to(torch.float8_e4m3fn)
         kv_cpu = (torch.randn(16, 512) * 0.1).to(torch.float8_e4m3fn)
@@ -412,6 +422,8 @@ class TestGlm5NextSparseAttention(unittest.TestCase):
 
     @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required")
     def test_scaled_fp8_cuda_kernel_matches_oracle_and_replays_graph(self):
+        if torch.cuda.get_device_capability() < (8, 9):
+            self.skipTest("pre-SM89 GPUs use an unscaled BF16 latent cache")
         torch.manual_seed(20260815)
         query_bf16 = (torch.randn(1, 2, 512) * 0.02).to(torch.bfloat16)
         kv_bf16 = (torch.randn(16, 512) * 0.02).to(torch.bfloat16)

--- a/test/registered/unit/test_glm5_next_stage3.py
+++ b/test/registered/unit/test_glm5_next_stage3.py
@@ -429,6 +429,26 @@ class TestGlm5NextConfig(unittest.TestCase):
             self.config_module.Glm5NextCapabilities(False, False, False, False, False),
         )
 
+    def test_consumer_gpu_profiles_select_exact_cache_precision(self):
+        sm86 = self.config_module.get_glm5_next_gpu_profile((8, 6))
+        self.assertEqual(sm86.value, "sm86_bf16")
+        self.assertEqual(sm86.kv_cache_dtype, "bfloat16")
+        self.assertEqual(sm86.index_cache_dtype, "bfloat16")
+        self.assertTrue(sm86.is_consumer_gpu)
+
+        sm89 = self.config_module.get_glm5_next_gpu_profile((8, 9))
+        self.assertEqual(sm89.value, "sm89_fp8")
+        self.assertEqual(sm89.kv_cache_dtype, "fp8_e4m3")
+        self.assertEqual(sm89.index_cache_dtype, "fp8_e4m3")
+        self.assertTrue(sm89.is_consumer_gpu)
+
+        blackwell = self.config_module.get_glm5_next_gpu_profile((12, 0))
+        self.assertEqual(blackwell.value, "blackwell_fp8")
+        self.assertFalse(blackwell.is_consumer_gpu)
+
+        with self.assertRaisesRegex(ValueError, "SM86, SM89, or Blackwell"):
+            self.config_module.get_glm5_next_gpu_profile((9, 0))
+
     def test_nested_vision_config_is_data_only(self):
         root = self.config_module.Glm5NextConfig(
             vision_config={"depth": 24, "hidden_size": 1536}

--- a/test/unit/test_glm5_next_fp8_layerwise_prefill.py
+++ b/test/unit/test_glm5_next_fp8_layerwise_prefill.py
@@ -1,14 +1,12 @@
-"""CPU-only contracts for exact GLM-5-Next block-FP8 layerwise prefill."""
+"""CPU-only contracts for GLM-5-Next's generic FP8 prefill path."""
 
-import ast
+import contextlib
 import importlib.util
-import inspect
-import subprocess
+import math
 import sys
 import types
 import unittest
 from collections import namedtuple
-from multiprocessing import shared_memory
 from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
@@ -41,7 +39,9 @@ def _load_test_target():
         "sglang.srt": _package("sglang.srt"),
         "sglang.srt.layers": _package("sglang.srt.layers"),
         "sglang.srt.layers.moe": _package("sglang.srt.layers.moe"),
-        "sglang.srt.layers.quantization": _package("sglang.srt.layers.quantization"),
+        "sglang.srt.layers.quantization": _package(
+            "sglang.srt.layers.quantization"
+        ),
         "sglang.srt.distributed": _module(
             "sglang.srt.distributed",
             get_tensor_model_parallel_rank=lambda: 0,
@@ -94,44 +94,6 @@ def _load_test_target():
 kt_ep_wrapper = _load_test_target()
 
 
-class _RecordingEvent:
-    def __init__(self, name, log):
-        self.name = name
-        self.log = log
-
-    def record(self, stream=None):
-        self.log.append(("record", self.name, getattr(stream, "name", stream)))
-
-
-class _RecordingStream:
-    def __init__(self, name, log):
-        self.name = name
-        self.log = log
-
-    def wait_event(self, event):
-        self.log.append(("wait_event", self.name, event.name))
-
-    def synchronize(self):
-        self.log.append(("synchronize", self.name))
-
-
-class _StateSlot:
-    def __init__(self, index, log):
-        self.index = index
-        self.state = "EMPTY"
-        self.layer_idx = None
-        self.epoch = -1
-        self.has_consumed_event = False
-        self.reuse_guard = None
-        self.ready_event = _RecordingEvent(f"ready{index}", log)
-        self.consumed_event = _RecordingEvent(f"consumed{index}", log)
-
-    def invalidate(self):
-        self.state = "EMPTY"
-        self.layer_idx = None
-        self.epoch = -1
-
-
 class _StandardCombineInput:
     def __init__(self, hidden_states):
         self.hidden_states = hidden_states
@@ -161,35 +123,59 @@ def _runtime_stubs():
     }
 
 
-class TestGlm5NextFp8Gates(unittest.TestCase):
+class _GpuMethod:
+    def __init__(self, fill_value):
+        self.fill_value = fill_value
+        self.calls = []
+
+    def apply(self, layer, dispatch_output):
+        self.calls.append((layer, dispatch_output))
+        return _StandardCombineInput(
+            torch.full_like(dispatch_output.hidden_states, self.fill_value)
+        )
+
+
+class TestGlm5NextFp8GenericRouting(unittest.TestCase):
     def setUp(self):
-        kt_ep_wrapper._GLM5_NEXT_FP8_PREFILL_LAYER_REGISTRY.clear()
-        kt_ep_wrapper._GLM5_NEXT_FP8_LAYERWISE_MANAGERS.clear()
+        kt_ep_wrapper._SHARED_FULL_CONTEXT = None
+        kt_ep_wrapper._MXFP4_LAYERWISE_MANAGERS.clear()
+        kt_ep_wrapper._MXFP4_LAYERWISE_DISABLED_REASONS.clear()
 
     @staticmethod
-    def _wrapper(*, exact=True, method="FP8", threshold=4096, mode="EXTEND"):
+    def _wrapper(*, exact=True, threshold=1024, mode="EXTEND"):
         wrapper = object.__new__(kt_ep_wrapper.KTEPWrapperMethod)
         wrapper.tp_rank = 1
         wrapper.kt_config = SimpleNamespace(
             layer_idx=3,
-            method=method,
+            method="FP8",
             is_glm5_next=exact,
             kt_enable_dynamic_expert_update=False,
         )
         wrapper.gpu_prefill_token_threshold = threshold
-        wrapper._glm5_next_forward_mode = SimpleNamespace(name=mode)
-        wrapper._glm5_next_fp8_pipeline_signature = ("glm", "cuda:0")
+        if mode is not None:
+            wrapper._glm5_next_forward_mode = SimpleNamespace(name=mode)
+        wrapper._glm5_next_has_image_inputs = False
         wrapper.gpu_experts_mask = torch.tensor([True])
         wrapper.gpu_experts_mask_cuda = torch.tensor([True])
+        wrapper.logical_to_gpu_index = torch.tensor([0], dtype=torch.int32)
         wrapper.logical_to_gpu_index_cuda = torch.tensor([0], dtype=torch.int32)
         wrapper.num_gpu_experts = 1
         wrapper._cpu_stream = None
-        wrapper.gpu_method = SimpleNamespace(
-            apply=lambda _layer, dispatch: _StandardCombineInput(
-                torch.full_like(dispatch.hidden_states, 7)
-            )
-        )
+        wrapper.gpu_method = _GpuMethod(fill_value=7)
+        wrapper._full_init_args = (4096, 512, torch.bfloat16)
+        wrapper.global_num_experts = 288
+        wrapper.moe_runner_config = object()
+        wrapper.wrapper = object()
         return wrapper
+
+    @staticmethod
+    def _layer():
+        return SimpleNamespace(
+            w13_weight=object(),
+            w13_weight_scale_inv=object(),
+            w2_weight=object(),
+            w2_weight_scale_inv=object(),
+        )
 
     @staticmethod
     def _dispatch(num_tokens):
@@ -201,7 +187,7 @@ class TestGlm5NextFp8Gates(unittest.TestCase):
         )
         return _DispatchOutput(hidden_states=hidden, topk_output=topk)
 
-    def _apply(self, wrapper, num_tokens):
+    def _apply(self, wrapper, layer, num_tokens):
         with (
             mock.patch.dict(sys.modules, _runtime_stubs()),
             mock.patch.object(
@@ -209,674 +195,453 @@ class TestGlm5NextFp8Gates(unittest.TestCase):
                 "mask_and_remap_expert_ids",
                 side_effect=lambda ids, *_args: ids,
             ),
+            mock.patch.object(torch.cuda, "is_available", return_value=False),
         ):
-            return wrapper.apply(SimpleNamespace(), self._dispatch(num_tokens))
+            return wrapper.apply(layer, self._dispatch(num_tokens))
 
-    def test_gate_is_exact_glm_block_fp8_only(self):
-        self.assertTrue(
-            kt_ep_wrapper._glm5_next_fp8_pipeline_requested(self._wrapper())
-        )
-        self.assertFalse(
-            kt_ep_wrapper._glm5_next_fp8_pipeline_requested(self._wrapper(exact=False))
-        )
-        self.assertFalse(
-            kt_ep_wrapper._glm5_next_fp8_pipeline_requested(
-                self._wrapper(method="MXFP4")
-            )
-        )
-        self.assertFalse(
-            kt_ep_wrapper._glm5_next_fp8_pipeline_requested(self._wrapper(threshold=0))
-        )
-
-    def test_every_extend_chunk_uses_required_manager_below_threshold(self):
-        wrapper = self._wrapper(threshold=4096, mode="EXTEND")
-        manager = mock.Mock()
-        manager.apply.return_value = "required-layerwise"
-        kt_ep_wrapper._GLM5_NEXT_FP8_LAYERWISE_MANAGERS[
-            wrapper._glm5_next_fp8_pipeline_signature
-        ] = manager
-
-        result = self._apply(wrapper, num_tokens=17)
-
-        self.assertEqual(result, "required-layerwise")
-        manager.apply.assert_called_once()
-
-    def test_decode_and_idle_never_touch_manager(self):
-        for mode in ("DECODE", "IDLE"):
-            with self.subTest(mode=mode):
-                wrapper = self._wrapper(mode=mode)
-                manager = mock.Mock()
-                kt_ep_wrapper._GLM5_NEXT_FP8_LAYERWISE_MANAGERS[
-                    wrapper._glm5_next_fp8_pipeline_signature
-                ] = manager
-
-                result = self._apply(wrapper, num_tokens=1)
-
-                manager.apply.assert_not_called()
-                manager.abort_round.assert_not_called()
-                torch.testing.assert_close(
-                    result.hidden_states, torch.full((1, 2), 7.0)
-                )
-
-    def test_image_extend_bypasses_layerwise_and_uses_hybrid_path(self):
-        wrapper = self._wrapper(mode="EXTEND")
-        wrapper._glm5_next_has_image_inputs = True
-        manager = mock.Mock()
-        kt_ep_wrapper._GLM5_NEXT_FP8_LAYERWISE_MANAGERS[
-            wrapper._glm5_next_fp8_pipeline_signature
-        ] = manager
-
-        result = self._apply(wrapper, num_tokens=17)
-
-        manager.apply.assert_not_called()
-        self.assertEqual(wrapper._glm5_next_mm_hybrid_extend_count, 1)
-        torch.testing.assert_close(
-            result.hidden_states, torch.full((17, 2), 7.0)
-        )
-
-    def test_unsupported_modes_and_missing_manager_fail_closed(self):
-        for mode in ("MIXED", "TARGET_VERIFY", "SPLIT_PREFILL", "DLLM_EXTEND"):
-            with self.subTest(mode=mode):
-                with self.assertRaisesRegex(RuntimeError, "supports only plain EXTEND"):
-                    self._apply(self._wrapper(mode=mode), num_tokens=8)
-
-        with self.assertRaisesRegex(RuntimeError, "refusing fallback"):
-            self._apply(self._wrapper(mode="EXTEND"), num_tokens=8)
-
-    def test_generic_fp8_does_not_enter_glm_manager(self):
-        wrapper = self._wrapper(exact=False, mode="EXTEND")
-        manager = mock.Mock()
-        kt_ep_wrapper._GLM5_NEXT_FP8_LAYERWISE_MANAGERS[
-            wrapper._glm5_next_fp8_pipeline_signature
-        ] = manager
-
-        result = self._apply(wrapper, num_tokens=1)
-
-        manager.apply.assert_not_called()
-        torch.testing.assert_close(result.hidden_states, torch.full((1, 2), 7.0))
-
-
-class TestGlm5NextFp8Manager(unittest.TestCase):
-    def setUp(self):
-        kt_ep_wrapper._GLM5_NEXT_FP8_PREFILL_LAYER_REGISTRY.clear()
-        kt_ep_wrapper._GLM5_NEXT_FP8_LAYERWISE_MANAGERS.clear()
-
-    def _manager(self):
-        signature = ("glm", "state")
-        log = []
-        methods = {
-            layer_idx: SimpleNamespace(
-                kt_config=SimpleNamespace(layer_idx=layer_idx), tp_rank=1
-            )
-            for layer_idx in range(3, 45)
-        }
-        layers = {layer_idx: object() for layer_idx in methods}
-        kt_ep_wrapper._GLM5_NEXT_FP8_PREFILL_LAYER_REGISTRY[signature] = {
-            layer_idx: (methods[layer_idx], layers[layer_idx]) for layer_idx in methods
-        }
-        manager = object.__new__(kt_ep_wrapper._Glm5NextFp8LayerwisePrefillManager)
-        manager.signature = signature
-        manager.context = SimpleNamespace(
+    @staticmethod
+    def _generic_context(fill_value=11):
+        return SimpleNamespace(
             gpu_layer=object(),
-            gpu_method=SimpleNamespace(
-                apply=lambda _layer, dispatch: (
-                    log.append(("compute", dispatch)) or dispatch
-                )
-            ),
+            gpu_method=_GpuMethod(fill_value=fill_value),
+            load=mock.Mock(),
+            initialize_cpu_buffers=mock.Mock(),
+            _initialize_glm5_next_fp8_transport=mock.Mock(),
+            _cleanup_cpu_buffers_after_failure=mock.Mock(),
+            _is_mxfp4_quant=False,
         )
-        manager.slots = (_StateSlot(0, log), _StateSlot(1, log))
-        manager.device = torch.device("cpu")
-        manager.epoch = -1
-        manager.last_layer_position = None
-        manager.current_slot_index = None
-        manager.round_active = False
-        manager.failure_reason = None
-        manager.visited_layer_indices = []
-        manager.apply_count = 0
-        manager.prime_count = 0
-        manager.prefetch_hit_count = 0
-        manager.completed_round_count = 0
-        manager.fallback_count = 0
 
-        def load_slot(slot, layer_idx, _method, _layer):
-            log.append(("load", layer_idx, slot.index, manager.epoch))
-            slot.state = "READY"
-            slot.layer_idx = layer_idx
-            slot.epoch = manager.epoch
-            slot.reuse_guard = "ready"
+    def test_1023_is_hybrid_and_1024_lazily_builds_one_shared_context(self):
+        wrapper = self._wrapper()
+        layer = self._layer()
+        context = self._generic_context()
 
-        return manager, methods, layers, log, load_slot
-
-    def test_two_slots_cover_every_moe_layer_and_complete_epoch(self):
-        manager, methods, layers, log, load_slot = self._manager()
-        stream = _RecordingStream("main", log)
         with (
-            mock.patch.object(manager, "_load_slot", side_effect=load_slot),
             mock.patch.object(
-                manager,
-                "_bind_slot",
-                side_effect=lambda slot: log.append(("bind", slot.index)),
-            ),
-            mock.patch.object(manager, "_record_raw_backing_on_stream"),
-            mock.patch.object(manager, "_commit_tp_runtime_phase"),
-            mock.patch.object(torch.cuda, "current_stream", return_value=stream),
+                kt_ep_wrapper, "SharedFullContext", return_value=context
+            ) as context_ctor,
+            mock.patch.object(
+                kt_ep_wrapper,
+                "_validate_glm5_next_fp8_shared_full_context",
+                return_value=(1_812_381_696, 12_585_984),
+            ) as validate_context,
         ):
-            for layer_idx in range(3, 45):
-                self.assertEqual(
-                    manager.apply(
-                        methods[layer_idx], layers[layer_idx], f"layer-{layer_idx}"
-                    ),
-                    f"layer-{layer_idx}",
-                )
+            below = self._apply(wrapper, layer, 1023)
+            context_ctor.assert_not_called()
+            context.load.assert_not_called()
+            validate_context.assert_not_called()
 
-        self.assertEqual(manager.apply_count, 42)
-        self.assertEqual(manager.prime_count, 1)
-        self.assertEqual(manager.prefetch_hit_count, 41)
-        self.assertEqual(manager.completed_round_count, 1)
-        self.assertEqual(manager.fallback_count, 0)
-        self.assertFalse(manager.round_active)
+            at_threshold = self._apply(wrapper, layer, 1024)
+            second_layer = self._layer()
+            wrapper.kt_config.layer_idx = 4
+            second = self._apply(wrapper, second_layer, 1024)
+
+        torch.testing.assert_close(
+            below.hidden_states, torch.full((1023, 2), 7.0)
+        )
+        torch.testing.assert_close(
+            at_threshold.hidden_states, torch.full((1024, 2), 11.0)
+        )
+        torch.testing.assert_close(
+            second.hidden_states, torch.full((1024, 2), 11.0)
+        )
+        context_ctor.assert_called_once_with(
+            layer=layer,
+            init_args=(4096, 512, torch.bfloat16),
+            global_num_experts=288,
+            moe_runner_config=wrapper.moe_runner_config,
+            defer_cpu_buffers=True,
+        )
+        context.initialize_cpu_buffers.assert_called_once_with()
+        context._initialize_glm5_next_fp8_transport.assert_called_once_with()
+        self.assertIs(kt_ep_wrapper._SHARED_FULL_CONTEXT, context)
+        validate_context.assert_called_once_with(context)
+        self.assertEqual(context.load.call_count, 2)
         self.assertEqual(
-            [entry[2] for entry in log if entry[0] == "load"],
-            [index % 2 for index in range(42)],
-        )
-
-    def test_two_consecutive_extend_epochs_keep_monotonic_state(self):
-        manager, methods, layers, _log, load_slot = self._manager()
-        with (
-            mock.patch.object(manager, "_load_slot", side_effect=load_slot),
-            mock.patch.object(manager, "_bind_slot"),
-            mock.patch.object(manager, "_record_raw_backing_on_stream"),
-            mock.patch.object(manager, "_commit_tp_runtime_phase"),
-            mock.patch.object(
-                torch.cuda,
-                "current_stream",
-                return_value=_RecordingStream("main", []),
-            ),
-        ):
-            for _epoch in range(2):
-                for layer_idx in range(3, 45):
-                    manager.apply(
-                        methods[layer_idx], layers[layer_idx], layer_idx
-                    )
-
-        self.assertEqual(manager.epoch, 1)
-        self.assertEqual(manager.apply_count, 84)
-        self.assertEqual(manager.prime_count, 2)
-        self.assertEqual(manager.prefetch_hit_count, 82)
-        self.assertEqual(manager.completed_round_count, 2)
-        self.assertEqual(manager.fallback_count, 0)
-        self.assertFalse(manager.round_active)
-
-    def test_skip_poison_is_sticky_and_never_falls_back(self):
-        manager, methods, layers, _log, load_slot = self._manager()
-        with (
-            mock.patch.object(manager, "_load_slot", side_effect=load_slot),
-            mock.patch.object(manager, "_bind_slot"),
-            mock.patch.object(manager, "_record_raw_backing_on_stream"),
-            mock.patch.object(manager, "_commit_tp_runtime_phase"),
-            mock.patch.object(
-                torch.cuda,
-                "current_stream",
-                return_value=_RecordingStream("main", []),
-            ),
-        ):
-            manager.apply(methods[3], layers[3], object())
-            with self.assertRaisesRegex(RuntimeError, "layer order mismatch"):
-                manager.apply(methods[5], layers[5], object())
-            with self.assertRaisesRegex(RuntimeError, "manager is poisoned"):
-                manager.apply(methods[4], layers[4], object())
-
-        self.assertEqual(manager.fallback_count, 0)
-
-    def test_manager_uses_events_without_global_cuda_synchronize(self):
-        target_path = (
-            Path(__file__).resolve().parents[2]
-            / "python/sglang/srt/layers/moe/kt_ep_wrapper.py"
-        )
-        module_source = target_path.read_text(encoding="utf-8")
-        tree = ast.parse(module_source)
-        node = next(
-            node
-            for node in tree.body
-            if isinstance(node, ast.ClassDef)
-            and node.name == "_Glm5NextFp8LayerwisePrefillManager"
-        )
-        source = ast.get_source_segment(module_source, node)
-        self.assertNotIn("torch.cuda.synchronize", source)
-        self.assertIn("self.transfer_stream", source)
-        self.assertIn("__atomic_load_8", source)
-        self.assertIn("__atomic_store_8", source)
-        self.assertIn("_CONTROL_CACHELINE_BYTES = 64", source)
-        self.assertIn("slot.ready_event", source)
-        self.assertIn("slot.ready_event.synchronize()", source)
-        self.assertIn("slot.consumed_event", source)
-        self.assertNotIn("get_tp_group().device_group", source)
-        load_source = inspect.getsource(
-            kt_ep_wrapper._Glm5NextFp8LayerwisePrefillManager._load_slot
-        )
-        self.assertNotIn("dist.all_reduce", load_source)
-
-    def test_atomic_control_is_cacheline_isolated_and_process_shared(self):
-        manager_type = kt_ep_wrapper._Glm5NextFp8LayerwisePrefillManager
-        offsets, control_nbytes = manager_type._build_control_offsets(2)
-        flat_offsets = sorted(
-            offset for group in offsets.values() for offset in group
-        )
-        self.assertTrue(
-            all(
-                right - left == manager_type._CONTROL_CACHELINE_BYTES
-                for left, right in zip(flat_offsets, flat_offsets[1:])
-            )
-        )
-
-        payload_offset = control_nbytes
-        handle = shared_memory.SharedMemory(
-            create=True, size=control_nbytes + 64
-        )
-        manager = object.__new__(manager_type)
-        manager.transport_abandoned = False
-        manager._CONTROL_TIMEOUT_SECONDS = 5.0
-        try:
-            handle.buf[:] = bytes(control_nbytes + 64)
-            manager._configure_atomic_access(handle, tp_size=2)
-            ready_offset = offsets["ready_generation"][0]
-            child_code = r"""
-import ctypes
-import sys
-from multiprocessing import shared_memory
-
-try:
-    handle = shared_memory.SharedMemory(
-        name=sys.argv[1], create=False, track=False
-    )
-except TypeError:
-    from multiprocessing import resource_tracker
-
-    handle = shared_memory.SharedMemory(name=sys.argv[1], create=False)
-    resource_tracker.unregister(handle._name, "shared_memory")
-anchor = ctypes.c_char.from_buffer(handle.buf)
-address = ctypes.addressof(anchor)
-store = getattr(ctypes.CDLL("libatomic.so.1"), "__atomic_store_8")
-store.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_int]
-store.restype = None
-payload_offset = int(sys.argv[3])
-handle.buf[payload_offset : payload_offset + 9] = b"published"
-store(ctypes.c_void_p(address + int(sys.argv[2])), ctypes.c_uint64(7), 3)
-anchor = None
-handle.close()
-"""
-            process = subprocess.Popen(
-                [
-                    sys.executable,
-                    "-c",
-                    child_code,
-                    handle.name,
-                    str(ready_offset),
-                    str(payload_offset),
-                ]
-            )
-            manager._wait_for_exact_control_value(
-                ready_offset, 7, "child publication"
-            )
-            self.assertEqual(
-                bytes(handle.buf[payload_offset : payload_offset + 9]),
-                b"published",
-            )
-            self.assertEqual(process.wait(timeout=10), 0)
-        finally:
-            manager._transport_control_anchor = None
-            handle.close()
-            handle.unlink()
-
-    def test_generation_drift_is_fail_closed(self):
-        manager_type = kt_ep_wrapper._Glm5NextFp8LayerwisePrefillManager
-        offsets, control_nbytes = manager_type._build_control_offsets(1)
-        handle = shared_memory.SharedMemory(create=True, size=control_nbytes)
-        manager = object.__new__(manager_type)
-        manager.transport_abandoned = False
-        try:
-            handle.buf[:] = bytes(control_nbytes)
-            manager._configure_atomic_access(handle, tp_size=1)
-            ready_offset = offsets["ready_generation"][0]
-            manager._atomic_store(ready_offset, 4)
-            with self.assertRaisesRegex(RuntimeError, "generation drift"):
-                manager._wait_for_exact_control_value(
-                    ready_offset, 3, "stale consumer"
-                )
-            self.assertTrue(manager.transport_abandoned)
-            self.assertEqual(
-                manager._atomic_load(offsets["global_error"][0]), 1
-            )
-        finally:
-            manager._transport_control_anchor = None
-            handle.close()
-            handle.unlink()
-
-    def test_sticky_global_error_immediately_aborts_generation_wait(self):
-        manager_type = kt_ep_wrapper._Glm5NextFp8LayerwisePrefillManager
-        offsets, control_nbytes = manager_type._build_control_offsets(1)
-        handle = shared_memory.SharedMemory(create=True, size=control_nbytes)
-        manager = object.__new__(manager_type)
-        manager.transport_abandoned = False
-        manager._CONTROL_TIMEOUT_SECONDS = 60.0
-        try:
-            handle.buf[:] = bytes(control_nbytes)
-            manager._configure_atomic_access(handle, tp_size=1)
-            manager._atomic_store(offsets["global_error"][0], 1)
-            with self.assertRaisesRegex(RuntimeError, "aborted by another"):
-                manager._wait_for_exact_control_value(
-                    offsets["ready_generation"][0],
-                    1,
-                    "failed writer publication",
-                )
-            self.assertTrue(manager.transport_abandoned)
-        finally:
-            manager._transport_control_anchor = None
-            handle.close()
-            handle.unlink()
-
-    def test_writer_descriptor_mismatch_poison_is_sticky(self):
-        manager_type = kt_ep_wrapper._Glm5NextFp8LayerwisePrefillManager
-        _offsets, control_nbytes = manager_type._build_control_offsets(1)
-        handle = shared_memory.SharedMemory(create=True, size=control_nbytes)
-        manager = object.__new__(manager_type)
-        manager.transport_abandoned = False
-        try:
-            handle.buf[:] = bytes(control_nbytes)
-            manager._configure_atomic_access(handle, tp_size=1)
-            manager._publish_writer_generation(
-                host_slot=0,
-                generation=1,
-                layer_idx=3,
-                expert_id=17,
-                writer_ok=True,
-            )
-            with self.assertRaisesRegex(RuntimeError, "descriptor mismatch"):
-                manager._consume_writer_generation(
-                    host_slot=0,
-                    generation=1,
+            context.load.call_args_list,
+            [
+                mock.call(
                     layer_idx=3,
-                    expert_id=18,
+                    wrapper=wrapper.wrapper,
+                    original_layer=layer,
+                    gpu_experts_mask=wrapper.gpu_experts_mask,
+                    logical_to_gpu_index=wrapper.logical_to_gpu_index,
+                ),
+                mock.call(
+                    layer_idx=4,
+                    wrapper=wrapper.wrapper,
+                    original_layer=second_layer,
+                    gpu_experts_mask=wrapper.gpu_experts_mask,
+                    logical_to_gpu_index=wrapper.logical_to_gpu_index,
+                ),
+            ],
+        )
+
+    def test_image_extend_and_decode_idle_bypass_generic_context(self):
+        cases = (("EXTEND", True), ("DECODE", False), ("IDLE", False))
+        for mode, has_image in cases:
+            with self.subTest(mode=mode, has_image=has_image):
+                kt_ep_wrapper._SHARED_FULL_CONTEXT = None
+                wrapper = self._wrapper(mode=mode)
+                wrapper._glm5_next_has_image_inputs = has_image
+                context = self._generic_context()
+                with mock.patch.object(
+                    kt_ep_wrapper, "SharedFullContext", return_value=context
+                ) as context_ctor:
+                    result = self._apply(wrapper, self._layer(), 1024)
+
+                context_ctor.assert_not_called()
+                context.load.assert_not_called()
+                torch.testing.assert_close(
+                    result.hidden_states, torch.full((1024, 2), 7.0)
                 )
-            self.assertTrue(manager.transport_abandoned)
-            self.assertTrue(manager._shared_transport_failed())
-        finally:
-            manager._transport_control_anchor = None
-            handle.close()
-            handle.unlink()
+                if has_image:
+                    self.assertEqual(wrapper._glm5_next_mm_hybrid_extend_count, 1)
 
-    def test_tp_contract_rejects_peer_mask_or_mapping_digest_drift(self):
-        signature = ("glm", "contract")
-        original_layer = SimpleNamespace(
-            **{
-                name: torch.empty(1)
-                for name in kt_ep_wrapper._Glm5NextFp8PrefillSlot.RAW_NAMES
-            }
-        )
-        method = SimpleNamespace(
-            gpu_experts_mask=torch.tensor([True, False]),
-            logical_to_gpu_index=torch.tensor([0, -1], dtype=torch.int32),
-            num_gpu_experts=1,
-            global_num_experts=2,
-            _full_init_args=(4, 2, torch.bfloat16),
-            kt_config=SimpleNamespace(weight_path="weights"),
-        )
-        kt_ep_wrapper._GLM5_NEXT_FP8_PREFILL_LAYER_REGISTRY[signature] = {
-            3: (method, original_layer)
-        }
-        manager = object.__new__(
-            kt_ep_wrapper._Glm5NextFp8LayerwisePrefillManager
-        )
-        manager.signature = signature
-        manager.device = torch.device("cpu")
-        manager.slots = (
-            SimpleNamespace(
-                **{
-                    name: torch.empty(1)
-                    for name in kt_ep_wrapper._Glm5NextFp8PrefillSlot.RAW_NAMES
-                }
-            ),
-        )
-
-        def inject_peer_drift(gathered, local, **_kwargs):
-            gathered[:] = [
-                local,
-                (local[0], "different-digest", local[2], None),
-            ]
+    def test_single_rank_slot_oom_fails_collectively_before_host_buffers(self):
+        wrapper = self._wrapper()
+        layer = self._layer()
 
         with (
             mock.patch.object(
-                kt_ep_wrapper.dist, "is_initialized", return_value=True
+                kt_ep_wrapper,
+                "SharedFullContext",
+                side_effect=torch.cuda.OutOfMemoryError("test slot OOM"),
+            ),
+            mock.patch.object(torch.cuda, "is_available", return_value=False),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "CUDA out of memory"):
+                wrapper._build_full_context(layer)
+
+        self.assertIsNone(kt_ep_wrapper._SHARED_FULL_CONTEXT)
+
+    def test_cross_rank_validation_failure_cleans_host_buffers(self):
+        wrapper = self._wrapper()
+        context = self._generic_context()
+
+        with (
+            mock.patch.object(
+                kt_ep_wrapper, "SharedFullContext", return_value=context
+            ),
+            mock.patch.object(
+                kt_ep_wrapper,
+                "_validate_glm5_next_fp8_shared_full_context",
+                return_value=(1_812_381_696, 12_585_984),
+            ),
+            mock.patch.object(
+                kt_ep_wrapper,
+                "_all_tp_ranks_succeeded",
+                side_effect=(True, False),
+            ),
+            mock.patch.object(torch.cuda, "is_available", return_value=False),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "validation failed"):
+                wrapper._build_full_context(self._layer())
+
+        context.initialize_cpu_buffers.assert_called_once_with()
+        context._cleanup_cpu_buffers_after_failure.assert_called_once_with()
+        self.assertIsNone(kt_ep_wrapper._SHARED_FULL_CONTEXT)
+
+    def test_missing_and_unsupported_forward_modes_fail_before_allocation(self):
+        for mode, pattern in (
+            (None, "ForwardMode metadata"),
+            ("MIXED", "supports only plain EXTEND"),
+        ):
+            with self.subTest(mode=mode):
+                kt_ep_wrapper._SHARED_FULL_CONTEXT = None
+                wrapper = self._wrapper(mode=mode)
+                context = self._generic_context()
+                with mock.patch.object(
+                    kt_ep_wrapper, "SharedFullContext", return_value=context
+                ) as context_ctor:
+                    with self.assertRaisesRegex(RuntimeError, pattern):
+                        self._apply(wrapper, self._layer(), 1024)
+
+                context_ctor.assert_not_called()
+                context.load.assert_not_called()
+
+    def test_non_glm_keeps_the_existing_generic_threshold_behavior(self):
+        wrapper = self._wrapper(exact=False, mode=None)
+        layer = self._layer()
+        context = self._generic_context(fill_value=13)
+
+        with mock.patch.object(
+            kt_ep_wrapper, "SharedFullContext", return_value=context
+        ) as context_ctor:
+            below = self._apply(wrapper, layer, 1023)
+            at_threshold = self._apply(wrapper, layer, 1024)
+
+        torch.testing.assert_close(
+            below.hidden_states, torch.full((1023, 2), 7.0)
+        )
+        torch.testing.assert_close(
+            at_threshold.hidden_states, torch.full((1024, 2), 13.0)
+        )
+        context_ctor.assert_called_once()
+        context.load.assert_called_once()
+
+
+class _TensorMetadata:
+    def __init__(self, shape, dtype):
+        self.shape = torch.Size(shape)
+        self.dtype = dtype
+
+    def numel(self):
+        return math.prod(self.shape)
+
+    def element_size(self):
+        return torch.empty((), dtype=self.dtype).element_size()
+
+
+class _FakeSharedMemory:
+    instances = []
+
+    def __init__(self, *, name, create, size):
+        self.name = name
+        self.create = create
+        self.size = size
+        self.buf = bytearray(size)
+        self.unlinked = False
+        self.closed = False
+        self.instances.append(self)
+
+    def unlink(self):
+        self.unlinked = True
+
+    def close(self):
+        self.closed = True
+
+
+class _FakeCudaEvent:
+    def __init__(self):
+        self.record_count = 0
+        self.synchronize_count = 0
+
+    def record(self, _stream):
+        self.record_count += 1
+
+    def synchronize(self):
+        self.synchronize_count += 1
+
+
+class _FakeCudaStream:
+    def __init__(self):
+        self.synchronize_count = 0
+        self.waited_streams = []
+
+    def synchronize(self):
+        self.synchronize_count += 1
+
+    def wait_stream(self, stream):
+        self.waited_streams.append(stream)
+
+
+class _FakeFp8Writer:
+    def __init__(self, context):
+        self.context = context
+        self.pending = None
+        self.submitted = []
+        self.sync_count = 0
+
+    def submit_write_weight_scale_to_buffer(
+        self,
+        tp_size,
+        expert_id,
+        w13_weight_ptrs,
+        w13_scale_ptrs,
+        w2_weight_ptrs,
+        w2_scale_ptrs,
+    ):
+        self.submitted.append((tp_size, expert_id))
+        base = self.context.cpu_buffers["w13_weight"].data_ptr()
+        per_slot_bytes = (
+            self.context.cpu_buffers["w13_weight"].numel()
+            // 2
+            * self.context.cpu_buffers["w13_weight"].element_size()
+        )
+        slot = (w13_weight_ptrs[0] - base) // per_slot_bytes
+        self.pending = (expert_id, slot)
+
+    def sync_write_weight_scale_to_buffer(self):
+        expert_id, slot = self.pending
+        for offset, name in enumerate(
+            kt_ep_wrapper.SharedFullContext.WEIGHT_NAMES_FP8
+        ):
+            self.context.cpu_buffers[name][slot].fill_(expert_id + offset * 10)
+        self.sync_count += 1
+        self.pending = None
+
+
+class TestGlm5NextFp8SingleSlotLayout(unittest.TestCase):
+    def setUp(self):
+        kt_ep_wrapper._SHARED_FULL_CONTEXT = None
+        _FakeSharedMemory.instances.clear()
+
+    def test_generic_host_transport_allocates_exactly_two_expert_slots(self):
+        context = object.__new__(kt_ep_wrapper.SharedFullContext)
+        context.gpu_layer = SimpleNamespace(
+            num_experts=3,
+            w13_weight=_TensorMetadata((3, 4, 5), torch.float8_e4m3fn),
+            w13_weight_scale_inv=_TensorMetadata((3, 1, 1), torch.float32),
+            w2_weight=_TensorMetadata((3, 5, 2), torch.float8_e4m3fn),
+            w2_weight_scale_inv=_TensorMetadata((3, 1, 1), torch.float32),
+        )
+        context._is_mxfp4_quant = False
+        context._is_mxfp8_quant = False
+        context._is_fp8_quant = True
+        context._is_fp8_channel_quant = False
+        context._is_bf16_quant = False
+        context._commit_cpu_buffer_phase = mock.Mock()
+        context._collect_all_rank_buffer_pointers = mock.Mock(
+            return_value={name: [index + 1] for index, name in enumerate(
+                kt_ep_wrapper.SharedFullContext.WEIGHT_NAMES_FP8
+            )}
+        )
+        fake_numa = SimpleNamespace(
+            numa_available=lambda: 0,
+            numa_set_localalloc=lambda: None,
+        )
+
+        with (
+            mock.patch.object(kt_ep_wrapper.ctypes, "CDLL", return_value=fake_numa),
+            mock.patch.object(
+                kt_ep_wrapper.shared_memory,
+                "SharedMemory",
+                side_effect=_FakeSharedMemory,
+            ),
+            mock.patch.object(
+                kt_ep_wrapper,
+                "get_tensor_model_parallel_rank",
+                return_value=0,
             ),
             mock.patch.object(
                 kt_ep_wrapper,
                 "get_tensor_model_parallel_world_size",
-                return_value=2,
+                return_value=1,
+            ),
+            mock.patch.object(kt_ep_wrapper.dist, "is_initialized", return_value=False),
+            mock.patch.object(torch.cuda, "is_available", return_value=False),
+        ):
+            context._create_cpu_buffers()
+
+        expected_shapes = {
+            "w13_weight": (2, 4, 5),
+            "w13_weight_scale_inv": (2, 1, 1),
+            "w2_weight": (2, 5, 2),
+            "w2_weight_scale_inv": (2, 1, 1),
+        }
+        self.assertEqual(set(context.cpu_buffers), set(expected_shapes))
+        for name, expected_shape in expected_shapes.items():
+            self.assertEqual(tuple(context.cpu_buffers[name].shape), expected_shape)
+        self.assertEqual(len(_FakeSharedMemory.instances), 4)
+        self.assertTrue(all(item.unlinked for item in _FakeSharedMemory.instances))
+
+    def test_exact_glm_transport_reuses_two_persistent_host_slot_events(self):
+        context = object.__new__(kt_ep_wrapper.SharedFullContext)
+        context._glm5_next_fp8_transport_initialized = True
+        context._glm5_next_fp8_copy_stream = _FakeCudaStream()
+        context._glm5_next_fp8_host_slot_events = (
+            _FakeCudaEvent(),
+            _FakeCudaEvent(),
+        )
+        context._glm5_next_fp8_host_slot_was_used = [False, False]
+        context._glm5_next_fp8_transport_status = None
+        context.gpu_layer = SimpleNamespace(num_experts=4)
+        context.cpu_buffers = {}
+        context.all_rank_buffer_ptrs = {}
+        for name in kt_ep_wrapper.SharedFullContext.WEIGHT_NAMES_FP8:
+            cpu_buffer = torch.empty((2, 1), dtype=torch.float32)
+            gpu_tensor = torch.empty((4, 1), dtype=torch.float32)
+            context.cpu_buffers[name] = cpu_buffer
+            context.all_rank_buffer_ptrs[name] = [cpu_buffer.data_ptr()]
+            setattr(context.gpu_layer, name, gpu_tensor)
+
+        writer = _FakeFp8Writer(context)
+        current_stream = _FakeCudaStream()
+        with (
+            mock.patch.object(
+                kt_ep_wrapper,
+                "get_tensor_model_parallel_rank",
+                return_value=0,
             ),
             mock.patch.object(
-                kt_ep_wrapper.dist,
-                "all_gather_object",
-                side_effect=inject_peer_drift,
+                kt_ep_wrapper,
+                "get_tensor_model_parallel_world_size",
+                return_value=1,
+            ),
+            mock.patch.object(
+                torch.cuda,
+                "stream",
+                side_effect=lambda _stream: contextlib.nullcontext(),
+            ),
+            mock.patch.object(
+                torch.cuda,
+                "current_stream",
+                return_value=current_stream,
             ),
         ):
-            with self.assertRaisesRegex(RuntimeError, "contract mismatch"):
-                manager.validate_tp_contract()
+            context._prepare_weight_fp8_glm5_next(writer)
 
-    def test_tp_contract_rejects_processed_or_repacked_original_gpu_tensor(self):
-        signature = ("glm", "raw-original")
-        names = kt_ep_wrapper._Glm5NextFp8PrefillSlot.RAW_NAMES
-        original_layer = SimpleNamespace(
-            **{name: torch.empty(1) for name in names}
-        )
-        original_layer.w13_weight = torch.empty(1, dtype=torch.int32)
-        method = SimpleNamespace(
-            gpu_experts_mask=torch.tensor([True, False]),
-            logical_to_gpu_index=torch.tensor([0, -1], dtype=torch.int32),
-            num_gpu_experts=1,
-            global_num_experts=2,
-            _full_init_args=(4, 2, torch.bfloat16),
-            kt_config=SimpleNamespace(weight_path="weights"),
-        )
-        kt_ep_wrapper._GLM5_NEXT_FP8_PREFILL_LAYER_REGISTRY[signature] = {
-            3: (method, original_layer)
-        }
-        manager = object.__new__(
-            kt_ep_wrapper._Glm5NextFp8LayerwisePrefillManager
-        )
-        manager.signature = signature
-        manager.device = torch.device("cpu")
-        manager.slots = (
-            SimpleNamespace(**{name: torch.empty(1) for name in names}),
-        )
-
-        with self.assertRaisesRegex(RuntimeError, "failed to build") as raised:
-            manager.validate_tp_contract()
-        self.assertIn("dtype mismatch", str(raised.exception.__cause__))
-
-    def test_transport_control_disables_resource_tracking_when_supported(self):
-        opener = mock.Mock(return_value="untracked")
-        with mock.patch.object(kt_ep_wrapper.shared_memory, "SharedMemory", opener):
-            result = (
-                kt_ep_wrapper._Glm5NextFp8LayerwisePrefillManager
-                ._open_transport_shared_memory(name="control", create=False)
-            )
-
-        self.assertEqual(result, "untracked")
-        opener.assert_called_once_with(
-            name="control", create=False, track=False
-        )
-
-    def test_transport_control_tracking_fallback_is_for_old_python_only(self):
-        opener = mock.Mock(side_effect=[TypeError("no track"), "tracked"])
-        with mock.patch.object(kt_ep_wrapper.shared_memory, "SharedMemory", opener):
-            result = (
-                kt_ep_wrapper._Glm5NextFp8LayerwisePrefillManager
-                ._open_transport_shared_memory(name="control", create=False)
-            )
-
-        self.assertEqual(result, "tracked")
-        self.assertEqual(
-            opener.call_args_list,
-            [
-                mock.call(name="control", create=False, track=False),
-                mock.call(name="control", create=False),
-            ],
-        )
-
-    def test_bind_selects_only_the_four_stable_raw_tensors(self):
-        names = kt_ep_wrapper._Glm5NextFp8PrefillSlot.RAW_NAMES
-        old = {name: torch.nn.Parameter(torch.zeros(1)) for name in names}
-        new = {name: torch.nn.Parameter(torch.ones(1)) for name in names}
-        layer = SimpleNamespace(**old)
-        manager = object.__new__(kt_ep_wrapper._Glm5NextFp8LayerwisePrefillManager)
-        manager.context = SimpleNamespace(gpu_layer=layer)
-
-        manager._bind_slot(SimpleNamespace(**new))
-
-        for name in names:
-            self.assertIs(getattr(layer, name), new[name])
-        self.assertFalse(hasattr(layer, "_v4_marlin_weights"))
-
-    def test_writer_abi_uses_fp8_and_fp32_host_slot_offsets(self):
-        class HostBuffer:
-            def __init__(self, numel, element_size):
-                self._numel = numel
-                self._element_size = element_size
-
-            def numel(self):
-                return self._numel
-
-            def element_size(self):
-                return self._element_size
-
-        names = kt_ep_wrapper._Glm5NextFp8PrefillSlot.RAW_NAMES
-        buffers = {
-            names[0]: HostBuffer(200, 1),
-            names[1]: HostBuffer(80, 4),
-            names[2]: HostBuffer(120, 1),
-            names[3]: HostBuffer(40, 4),
-        }
-        pointers = {
-            name: [1000 + index * 100, 2000 + index * 100]
-            for index, name in enumerate(names)
-        }
-        manager = object.__new__(kt_ep_wrapper._Glm5NextFp8LayerwisePrefillManager)
-        manager.context = SimpleNamespace(
-            cpu_buffers=buffers, all_rank_buffer_ptrs=pointers
-        )
-        wrapper = mock.Mock()
-        method = SimpleNamespace(wrapper=wrapper)
-
-        with mock.patch.object(
-            kt_ep_wrapper, "get_tensor_model_parallel_world_size", return_value=2
+        self.assertEqual(writer.submitted, [(1, 0), (1, 1), (1, 2), (1, 3)])
+        self.assertEqual(writer.sync_count, 4)
+        for offset, name in enumerate(
+            kt_ep_wrapper.SharedFullContext.WEIGHT_NAMES_FP8
         ):
-            manager._submit_host_write(method, expert_id=17, host_slot=1)
-
-        args = wrapper.submit_write_weight_scale_to_buffer.call_args.args
-        self.assertEqual(args[:2], (2, 17))
-        for position, name in enumerate(names, 2):
-            offset = buffers[name].numel() // 2 * buffers[name].element_size()
-            self.assertEqual(
-                args[position], [pointer + offset for pointer in pointers[name]]
+            expected = torch.arange(4, dtype=torch.float32) + offset * 10
+            torch.testing.assert_close(
+                getattr(context.gpu_layer, name).flatten(), expected
             )
-        wrapper.sync_write_weight_scale_to_buffer.assert_called_once_with()
+        event0, event1 = context._glm5_next_fp8_host_slot_events
+        self.assertEqual(event0.record_count, 2)
+        self.assertEqual(event1.record_count, 2)
+        self.assertEqual(event0.synchronize_count, 1)
+        self.assertEqual(event1.synchronize_count, 1)
+        self.assertEqual(context._glm5_next_fp8_copy_stream.synchronize_count, 1)
 
+    def test_tp4_fp8_geometry_and_single_full_layer_slot_bytes(self):
+        num_experts = 288
+        hidden_size = 4096
+        global_intermediate_size = 2048
+        tp_size = 4
+        block_size = 128
+        intermediate_size = global_intermediate_size // tp_size
 
-class TestGlm5NextFp8AllocationContracts(unittest.TestCase):
-    def setUp(self):
-        kt_ep_wrapper._GLM5_NEXT_FP8_PREFILL_LAYER_REGISTRY.clear()
-        kt_ep_wrapper._GLM5_NEXT_FP8_LAYERWISE_MANAGERS.clear()
-
-    def test_exact_two_slot_capacity_is_reserved_before_kv_profile(self):
-        one_slot = kt_ep_wrapper._glm5_next_fp8_raw_slot_storage_nbytes(
-            num_experts=288,
-            hidden_size=4096,
-            intermediate_size=256,
-        )
-        self.assertEqual(one_slot, 906_190_848)
-        self.assertEqual(2 * one_slot, 1_812_381_696)
-
-        model_runner_source = (
-            Path(__file__).resolve().parents[2]
-            / "python/sglang/srt/model_executor/model_runner.py"
-        ).read_text(encoding="utf-8")
-        allocation_pos = model_runner_source.index(
-            "initialize_glm5_next_fp8_layerwise_prefill()"
-        )
-        pool_pos = model_runner_source.index("self.init_memory_pool()", allocation_pos)
-        self.assertLess(allocation_pos, pool_pos)
-
-    def test_registry_requires_all_42_exact_checkpoint_moe_layers(self):
-        mask = torch.zeros(288, dtype=torch.bool)
-        mask[:4] = True
-        mapping = torch.full((288,), -1, dtype=torch.int32)
-        mapping[:4] = torch.arange(4, dtype=torch.int32)
-        method = SimpleNamespace(
-            kt_config=SimpleNamespace(
-                is_glm5_next=True,
-                method="FP8",
-                num_layers=45,
-                kt_enable_dynamic_expert_update=False,
+        self.assertEqual(intermediate_size, 512)
+        gpu_tensors = {
+            "w13_weight": _TensorMetadata(
+                (num_experts, 2 * intermediate_size, hidden_size),
+                torch.float8_e4m3fn,
             ),
-            gpu_prefill_token_threshold=1,
-            tp_rank=0,
-            global_num_experts=288,
-            _full_init_args=(4096, 256, torch.bfloat16),
-            gpu_experts_mask=mask,
-            logical_to_gpu_index=mapping,
-            num_gpu_experts=4,
-        )
-        complete = {idx: (method, object()) for idx in range(3, 45)}
-        kt_ep_wrapper._validate_glm5_next_fp8_registry(("glm",), complete)
-
-        incomplete = dict(complete)
-        incomplete.pop(44)
-        with self.assertRaisesRegex(RuntimeError, "every MoE layer 3..44"):
-            kt_ep_wrapper._validate_glm5_next_fp8_registry(("glm",), incomplete)
-
-    @unittest.skipUnless(torch.cuda.is_available(), "requires a CUDA device")
-    def test_registry_validates_cuda_resident_mask_and_mapping(self):
-        device = torch.device("cuda", torch.cuda.current_device())
-        mask = torch.zeros(288, dtype=torch.bool, device=device)
-        mask[:4] = True
-        mapping = torch.full((288,), -1, dtype=torch.int32, device=device)
-        mapping[:4] = torch.arange(4, dtype=torch.int32, device=device)
-        method = SimpleNamespace(
-            kt_config=SimpleNamespace(
-                is_glm5_next=True,
-                method="FP8",
-                num_layers=45,
-                kt_enable_dynamic_expert_update=False,
+            "w13_weight_scale_inv": _TensorMetadata(
+                (
+                    num_experts,
+                    math.ceil(2 * intermediate_size / block_size),
+                    math.ceil(hidden_size / block_size),
+                ),
+                torch.float32,
             ),
-            gpu_prefill_token_threshold=1,
-            tp_rank=0,
-            global_num_experts=288,
-            _full_init_args=(4096, 256, torch.bfloat16),
-            gpu_experts_mask=mask,
-            logical_to_gpu_index=mapping,
-            num_gpu_experts=4,
-        )
-        complete = {idx: (method, object()) for idx in range(3, 45)}
-
-        kt_ep_wrapper._validate_glm5_next_fp8_registry(("glm",), complete)
-
-    def test_context_accepts_only_raw_e4m3_and_fp32_128_scales(self):
-        class TensorMetadata:
-            def __init__(self, shape, dtype):
-                self.shape = shape
-                self.dtype = dtype
-
-        layer = SimpleNamespace(
-            w13_weight=TensorMetadata((288, 512, 4096), torch.float8_e4m3fn),
-            w13_weight_scale_inv=TensorMetadata((288, 4, 32), torch.float32),
-            w2_weight=TensorMetadata((288, 4096, 256), torch.float8_e4m3fn),
-            w2_weight_scale_inv=TensorMetadata((288, 32, 2), torch.float32),
-            moe_runner_config=SimpleNamespace(
-                glm5_next_hf_two_round_swiglu=True
+            "w2_weight": _TensorMetadata(
+                (num_experts, hidden_size, intermediate_size),
+                torch.float8_e4m3fn,
             ),
-        )
+            "w2_weight_scale_inv": _TensorMetadata(
+                (
+                    num_experts,
+                    math.ceil(hidden_size / block_size),
+                    math.ceil(intermediate_size / block_size),
+                ),
+                torch.float32,
+            ),
+        }
+        host_buffers = {
+            name: _TensorMetadata((2, *tensor.shape[1:]), tensor.dtype)
+            for name, tensor in gpu_tensors.items()
+        }
         context = SimpleNamespace(
             _is_fp8_quant=True,
+            _glm5_next_fp8_transport_initialized=True,
+            _glm5_next_fp8_copy_stream=object(),
+            _glm5_next_fp8_host_slot_events=(object(), object()),
             _get_base_quant_method=lambda: SimpleNamespace(
                 block_quant=True,
                 use_mxfp8=False,
@@ -885,133 +650,66 @@ class TestGlm5NextFp8AllocationContracts(unittest.TestCase):
                     runner_backend=SimpleNamespace(is_triton=lambda: True)
                 ),
             ),
-            gpu_layer=layer,
-        )
-        kt_ep_wrapper._validate_glm5_next_fp8_context(context)
-
-        layer.moe_runner_config.glm5_next_hf_two_round_swiglu = False
-        with self.assertRaisesRegex(RuntimeError, "private HF two-round"):
-            kt_ep_wrapper._validate_glm5_next_fp8_context(context)
-        layer.moe_runner_config.glm5_next_hf_two_round_swiglu = True
-
-        layer.w2_weight_scale_inv.dtype = torch.bfloat16
-        with self.assertRaisesRegex(RuntimeError, "dtype mismatch"):
-            kt_ep_wrapper._validate_glm5_next_fp8_context(context)
-
-        layer.w2_weight_scale_inv.dtype = torch.float32
-        context._get_base_quant_method = lambda: SimpleNamespace(
-            block_quant=True,
-            use_mxfp8=False,
-            weight_block_size=[128, 128],
-            runner=SimpleNamespace(
-                runner_backend=SimpleNamespace(is_triton=lambda: False)
+            gpu_layer=SimpleNamespace(
+                num_experts=num_experts,
+                moe_runner_config=SimpleNamespace(
+                    glm5_next_hf_two_round_swiglu=True
+                ),
+                **gpu_tensors,
             ),
+            cpu_buffers=host_buffers,
         )
-        with self.assertRaisesRegex(RuntimeError, "Triton MoE runner"):
-            kt_ep_wrapper._validate_glm5_next_fp8_context(context)
 
-    def test_tp0_writer_abi_is_probed_before_serving(self):
-        complete_wrapper = SimpleNamespace(
-            submit_write_weight_scale_to_buffer=lambda *_args: None,
-            sync_write_weight_scale_to_buffer=lambda: None,
-            moe=SimpleNamespace(write_weight_scale_to_buffer_task=object()),
-        )
-        registry = {
-            3: (SimpleNamespace(wrapper=complete_wrapper), object())
-        }
         with mock.patch.object(
-            kt_ep_wrapper, "get_tensor_model_parallel_rank", return_value=0
+            kt_ep_wrapper,
+            "get_tensor_model_parallel_world_size",
+            return_value=4,
         ):
-            kt_ep_wrapper._validate_glm5_next_fp8_writer_abi(registry)
-
-            incomplete = {
-                3: (
-                    SimpleNamespace(
-                        wrapper=SimpleNamespace(
-                            submit_write_weight_scale_to_buffer=lambda *_args: None,
-                            sync_write_weight_scale_to_buffer=lambda: None,
-                            moe=object(),
-                        )
-                    ),
-                    object(),
+            gpu_slot_bytes, host_buffer_bytes = (
+                kt_ep_wrapper._validate_glm5_next_fp8_shared_full_context(
+                    context
                 )
-            }
-            with self.assertRaisesRegex(
-                RuntimeError, "write_weight_scale_to_buffer_task"
-            ):
-                kt_ep_wrapper._validate_glm5_next_fp8_writer_abi(incomplete)
+            )
+        self.assertEqual(gpu_slot_bytes, 1_812_381_696)
+        self.assertEqual(host_buffer_bytes, 12_585_984)
 
-        with mock.patch.object(
-            kt_ep_wrapper, "get_tensor_model_parallel_rank", return_value=1
-        ):
-            kt_ep_wrapper._validate_glm5_next_fp8_writer_abi(incomplete)
-
-    def test_startup_oom_is_fatal_and_does_not_register_manager(self):
-        signature = ("glm", "oom")
-        mask = torch.zeros(288, dtype=torch.bool)
-        mapping = torch.full((288,), -1, dtype=torch.int32)
-        method = SimpleNamespace(
-            kt_config=SimpleNamespace(
-                is_glm5_next=True,
-                method="FP8",
-                num_layers=45,
-                kt_enable_dynamic_expert_update=False,
-            ),
-            gpu_prefill_token_threshold=1,
-            _full_init_args=(4096, 256, torch.bfloat16),
-            global_num_experts=288,
-            moe_runner_config=object(),
-            tp_rank=0,
-            gpu_experts_mask=mask,
-            logical_to_gpu_index=mapping,
-            num_gpu_experts=0,
+        context.cpu_buffers["w13_weight"] = _TensorMetadata(
+            (1, *gpu_tensors["w13_weight"].shape[1:]), torch.float8_e4m3fn
         )
-        registry = {idx: (method, object()) for idx in range(3, 45)}
         with (
-            mock.patch.object(torch.cuda, "is_available", return_value=True),
             mock.patch.object(
                 kt_ep_wrapper,
                 "get_tensor_model_parallel_world_size",
-                return_value=8,
+                return_value=4,
             ),
-            mock.patch.object(
-                kt_ep_wrapper,
-                "SharedFullContext",
-                side_effect=torch.cuda.OutOfMemoryError("slot 0"),
-            ) as context_ctor,
-            mock.patch.object(torch.cuda, "empty_cache"),
+            self.assertRaisesRegex(
+                RuntimeError, "exactly two expert Host slots"
+            ),
         ):
-            with self.assertRaisesRegex(RuntimeError, "refusing.*fallback"):
-                kt_ep_wrapper._initialize_glm5_next_fp8_layerwise_pipeline(
-                    signature, registry
-                )
+            kt_ep_wrapper._validate_glm5_next_fp8_shared_full_context(context)
 
-        context_ctor.assert_called_once()
-        self.assertNotIn(signature, kt_ep_wrapper._GLM5_NEXT_FP8_LAYERWISE_MANAGERS)
+    def test_private_glm_two_slot_pipeline_symbols_are_gone(self):
+        removed_symbols = (
+            "_GLM5_NEXT_FP8_PREFILL_LAYER_REGISTRY",
+            "_GLM5_NEXT_FP8_LAYERWISE_MANAGERS",
+            "_Glm5NextFp8PrefillSlot",
+            "_Glm5NextFp8LayerwisePrefillManager",
+            "_register_glm5_next_fp8_prefill_layer",
+            "_initialize_glm5_next_fp8_layerwise_pipeline",
+            "initialize_glm5_next_fp8_layerwise_prefill",
+            "_get_glm5_next_fp8_layerwise_manager",
+        )
+        for symbol in removed_symbols:
+            with self.subTest(symbol=symbol):
+                self.assertFalse(hasattr(kt_ep_wrapper, symbol))
 
-    def test_glm_manager_and_registry_are_not_mxfp4_state(self):
-        self.assertIsNot(
-            kt_ep_wrapper._GLM5_NEXT_FP8_PREFILL_LAYER_REGISTRY,
-            kt_ep_wrapper._MXFP4_PREFILL_LAYER_REGISTRY,
+        model_runner_source = (
+            Path(__file__).resolve().parents[2]
+            / "python/sglang/srt/model_executor/model_runner.py"
+        ).read_text(encoding="utf-8")
+        self.assertNotIn(
+            "initialize_glm5_next_fp8_layerwise_prefill", model_runner_source
         )
-        self.assertIsNot(
-            kt_ep_wrapper._GLM5_NEXT_FP8_LAYERWISE_MANAGERS,
-            kt_ep_wrapper._MXFP4_LAYERWISE_MANAGERS,
-        )
-        self.assertFalse(
-            issubclass(
-                kt_ep_wrapper._Glm5NextFp8LayerwisePrefillManager,
-                kt_ep_wrapper._Mxfp4LayerwisePrefillManager,
-            )
-        )
-
-    def test_initializer_has_no_lazy_or_disabled_fallback_branch(self):
-        source = inspect.getsource(
-            kt_ep_wrapper._initialize_glm5_next_fp8_layerwise_pipeline
-        )
-        self.assertNotIn("_MXFP4", source)
-        self.assertNotIn("DISABLED_REASONS", source)
-        self.assertIn("refusing hybrid/serialized fallback", source)
 
 
 if __name__ == "__main__":

--- a/test/unit/test_glm5_next_fp8_layerwise_prefill.py
+++ b/test/unit/test_glm5_next_fp8_layerwise_prefill.py
@@ -2,8 +2,10 @@
 
 import contextlib
 import importlib.util
+import inspect
 import math
 import sys
+import threading
 import types
 import unittest
 from collections import namedtuple
@@ -140,6 +142,8 @@ class TestGlm5NextFp8GenericRouting(unittest.TestCase):
         kt_ep_wrapper._SHARED_FULL_CONTEXT = None
         kt_ep_wrapper._MXFP4_LAYERWISE_MANAGERS.clear()
         kt_ep_wrapper._MXFP4_LAYERWISE_DISABLED_REASONS.clear()
+        kt_ep_wrapper._GLM5_NEXT_FP8_NATIVE_PREFETCH_LAYER_REGISTRY.clear()
+        kt_ep_wrapper._GLM5_NEXT_FP8_NATIVE_PREFETCH_MANAGERS.clear()
 
     @staticmethod
     def _wrapper(*, exact=True, threshold=1024, mode="EXTEND"):
@@ -253,7 +257,10 @@ class TestGlm5NextFp8GenericRouting(unittest.TestCase):
             defer_cpu_buffers=True,
         )
         context.initialize_cpu_buffers.assert_called_once_with()
-        context._initialize_glm5_next_fp8_transport.assert_called_once_with()
+        context._initialize_glm5_next_fp8_transport.assert_called_once_with(
+            wrapper=wrapper.wrapper,
+            num_gpu_experts=wrapper.num_gpu_experts,
+        )
         self.assertIs(kt_ep_wrapper._SHARED_FULL_CONTEXT, context)
         validate_context.assert_called_once_with(context)
         self.assertEqual(context.load.call_count, 2)
@@ -472,10 +479,160 @@ class _FakeFp8Writer:
         self.pending = None
 
 
+class _FakeNativeTransport:
+    def __init__(self, args, calls):
+        self.args = args
+        self.calls = calls
+        self.last_join = None
+        self.close_count = 0
+
+    def join(self, epoch, layer_id, expert_count):
+        self.last_join = (epoch, layer_id, expert_count)
+        self.calls.append(("join", *self.last_join))
+
+    def wait(self, epoch):
+        self.calls.append(("wait", epoch))
+        joined_epoch, layer_id, expert_count = self.last_join
+        return {
+            "epoch": joined_epoch,
+            "layer_id": layer_id,
+            "expert_count": expert_count,
+            "rank": 0,
+            "writer_ms": 3.0,
+            "slot_wait_ms": 1.0,
+            "h2d_ms": 2.0,
+            "total_ms": 4.0,
+            "bytes": 64,
+            "poisoned": False,
+            "error_code": 0,
+            "error_rank": -1,
+        }
+
+    def close(self):
+        self.close_count += 1
+        self.calls.append(("close",))
+
+
+class _FakeNativeExtension:
+    def __init__(self, calls):
+        self.calls = calls
+        self.initialize_args = None
+        self.transport = None
+
+    def initialize_fp8_layerwise_control(self, control_ptr, control_size, tp_size):
+        self.initialize_args = (control_ptr, control_size, tp_size)
+        self.calls.append(("initialize", control_size, tp_size))
+
+    def FP8LayerwiseTransport(self, *args):
+        self.transport = _FakeNativeTransport(args, self.calls)
+        self.calls.append(("construct",))
+        return self.transport
+
+
+class _FakeNativeWriter:
+    def __init__(self, calls, fail=False):
+        self.calls = calls
+        self.fail = fail
+        self.moe = self
+        self.cpu_infer = SimpleNamespace(sync=mock.Mock())
+        self.public_run_count = 0
+
+    def run_layerwise_fp8_batch(
+        self, transport, epoch, layer_id, expert_count
+    ):
+        self.calls.append(("run", epoch, layer_id, expert_count))
+        if self.fail:
+            raise RuntimeError("injected producer failure")
+
+
+class _FakePrefetchEvent:
+    def __init__(self, calls):
+        self.calls = calls
+        self.recorded = threading.Event()
+
+    def record(self, stream):
+        self.calls.append(("consumed-record", stream))
+        self.recorded.set()
+
+    def synchronize(self):
+        self.calls.append(("consumed-wait",))
+        if not self.recorded.wait(timeout=1):
+            raise RuntimeError("consumed event was never recorded")
+
+
+class _FakePrefetchGpuMethod:
+    def __init__(self, calls):
+        self.calls = calls
+
+    def process_weights_after_loading(self, _layer):
+        self.calls.append(("process",))
+
+    def apply(self, _layer, dispatch_output):
+        layer_idx = dispatch_output.layer_idx
+        self.calls.append(("apply", layer_idx))
+        return f"result-{layer_idx}"
+
+
+class _FakePrefetchContext:
+    def __init__(self, calls, fail_layer=None, successor_release=None):
+        self.calls = calls
+        self.fail_layer = fail_layer
+        self.successor_release = successor_release
+        self.successor_entered = threading.Event()
+        self._glm5_next_fp8_transport_poisoned = False
+        self.gpu_layer = SimpleNamespace(
+            w13_weight=torch.empty((1,), dtype=torch.float32)
+        )
+        self.gpu_method = _FakePrefetchGpuMethod(calls)
+
+    def load_glm5_next_fp8_native(
+        self, *, layer_idx, wrapper, consumed_event=None
+    ):
+        self.calls.append(("load-enter", layer_idx, wrapper.name))
+        if consumed_event is not None:
+            consumed_event.synchronize()
+        if layer_idx == 4 and self.successor_release is not None:
+            self.successor_entered.set()
+            if not self.successor_release.wait(timeout=1):
+                raise RuntimeError("test successor release timed out")
+        if layer_idx == self.fail_layer:
+            raise RuntimeError(f"injected layer {layer_idx} load failure")
+        self.calls.append(("load-done", layer_idx))
+
+    def _validate_glm5_next_fp8_native_gpu_slot(self):
+        self.calls.append(("validate-slot",))
+
+
+def _fake_prefetch_method(layer_idx, calls):
+    cpu_infer = SimpleNamespace(
+        sync=mock.Mock(side_effect=lambda: calls.append(("cpu-infer-sync",)))
+    )
+    writer = SimpleNamespace(
+        name=f"writer-{layer_idx}", cpu_infer=cpu_infer, moe=object()
+    )
+    method = SimpleNamespace(
+        kt_config=SimpleNamespace(
+            layer_idx=layer_idx,
+            num_layers=45,
+            is_glm5_next=True,
+            method="FP8",
+        ),
+        tp_rank=0,
+        wrapper=writer,
+    )
+    return method
+
+
 class TestGlm5NextFp8SingleSlotLayout(unittest.TestCase):
     def setUp(self):
         kt_ep_wrapper._SHARED_FULL_CONTEXT = None
         _FakeSharedMemory.instances.clear()
+        for manager in list(
+            kt_ep_wrapper._GLM5_NEXT_FP8_NATIVE_PREFETCH_MANAGERS.values()
+        ):
+            manager.close()
+        kt_ep_wrapper._GLM5_NEXT_FP8_NATIVE_PREFETCH_LAYER_REGISTRY.clear()
+        kt_ep_wrapper._GLM5_NEXT_FP8_NATIVE_PREFETCH_MANAGERS.clear()
 
     def test_generic_host_transport_allocates_exactly_two_expert_slots(self):
         context = object.__new__(kt_ep_wrapper.SharedFullContext)
@@ -539,6 +696,7 @@ class TestGlm5NextFp8SingleSlotLayout(unittest.TestCase):
     def test_exact_glm_transport_reuses_two_persistent_host_slot_events(self):
         context = object.__new__(kt_ep_wrapper.SharedFullContext)
         context._glm5_next_fp8_transport_initialized = True
+        context._glm5_next_fp8_transport_backend = "legacy"
         context._glm5_next_fp8_copy_stream = _FakeCudaStream()
         context._glm5_next_fp8_host_slot_events = (
             _FakeCudaEvent(),
@@ -580,7 +738,7 @@ class TestGlm5NextFp8SingleSlotLayout(unittest.TestCase):
                 return_value=current_stream,
             ),
         ):
-            context._prepare_weight_fp8_glm5_next(writer)
+            context._prepare_weight_fp8_glm5_next(writer, layer_idx=3)
 
         self.assertEqual(writer.submitted, [(1, 0), (1, 1), (1, 2), (1, 3)])
         self.assertEqual(writer.sync_count, 4)
@@ -597,6 +755,428 @@ class TestGlm5NextFp8SingleSlotLayout(unittest.TestCase):
         self.assertEqual(event0.synchronize_count, 1)
         self.assertEqual(event1.synchronize_count, 1)
         self.assertEqual(context._glm5_next_fp8_copy_stream.synchronize_count, 1)
+
+    @staticmethod
+    def _native_context():
+        context = object.__new__(kt_ep_wrapper.SharedFullContext)
+        context.shm_unique_id = "native_test"
+        context._commit_cpu_buffer_phase = mock.Mock()
+        context.cpu_buffers = {}
+        context.all_rank_buffer_ptrs = {}
+        gpu_tensors = {}
+        for index, name in enumerate(
+            kt_ep_wrapper.SharedFullContext.WEIGHT_NAMES_FP8
+        ):
+            cpu_buffer = torch.empty((2, index + 1), dtype=torch.float32)
+            gpu_tensor = torch.empty((3, index + 1), dtype=torch.float32)
+            context.cpu_buffers[name] = cpu_buffer
+            context.all_rank_buffer_ptrs[name] = [
+                cpu_buffer.data_ptr() + rank * 1_000_000
+                for rank in range(4)
+            ]
+            gpu_tensors[name] = gpu_tensor
+        context.gpu_layer = SimpleNamespace(num_experts=3, **gpu_tensors)
+        return context
+
+    def test_native_transport_uses_fixed_flattened_pointer_abi(self):
+        context = self._native_context()
+        calls = []
+        extension = _FakeNativeExtension(calls)
+        writer = _FakeNativeWriter(calls)
+
+        with (
+            mock.patch.dict(
+                "os.environ",
+                {"SGLANG_KT_GLM5_NEXT_FP8_TRANSPORT": "native"},
+                clear=False,
+            ),
+            mock.patch.object(
+                kt_ep_wrapper,
+                "_load_glm5_next_fp8_native_transport_api",
+                return_value=(extension, None),
+            ),
+            mock.patch.object(
+                kt_ep_wrapper,
+                "get_tensor_model_parallel_rank",
+                return_value=0,
+            ),
+            mock.patch.object(
+                kt_ep_wrapper,
+                "get_tensor_model_parallel_world_size",
+                return_value=4,
+            ),
+            mock.patch.object(kt_ep_wrapper.dist, "is_initialized", return_value=False),
+            mock.patch.object(
+                kt_ep_wrapper.shared_memory,
+                "SharedMemory",
+                side_effect=_FakeSharedMemory,
+            ),
+            mock.patch.object(torch.cuda, "current_device", return_value=0),
+        ):
+            context._initialize_glm5_next_fp8_transport(
+                wrapper=writer, num_gpu_experts=0
+            )
+
+        self.assertEqual(
+            extension.initialize_args[1:],
+            (kt_ep_wrapper._GLM5_NEXT_FP8_CONTROL_BYTES, 4),
+        )
+        args = extension.transport.args
+        self.assertEqual(args[1:5], (4096, 0, 4, 0))
+        local_host_ptrs = args[5]
+        local_gpu_ptrs = args[6]
+        all_rank_host_ptrs = args[7]
+        expert_nbytes = args[8]
+        self.assertEqual(len(local_host_ptrs), 8)
+        self.assertEqual(len(local_gpu_ptrs), 4)
+        self.assertEqual(len(all_rank_host_ptrs), 32)
+        self.assertEqual(expert_nbytes, [4, 8, 12, 16])
+
+        expected_local = []
+        expected_all_rank = []
+        names = kt_ep_wrapper.SharedFullContext.WEIGHT_NAMES_FP8
+        for slot in range(2):
+            for index, name in enumerate(names):
+                expected_local.append(
+                    context.cpu_buffers[name].data_ptr()
+                    + slot * expert_nbytes[index]
+                )
+            for rank in range(4):
+                for index, name in enumerate(names):
+                    expected_all_rank.append(
+                        context.all_rank_buffer_ptrs[name][rank]
+                        + slot * expert_nbytes[index]
+                    )
+        self.assertEqual(local_host_ptrs, expected_local)
+        self.assertEqual(all_rank_host_ptrs, expected_all_rank)
+        self.assertEqual(
+            local_gpu_ptrs,
+            [getattr(context.gpu_layer, name).data_ptr() for name in names],
+        )
+        self.assertEqual(args[9:], (3, 60_000))
+        self.assertEqual(context._glm5_next_fp8_transport_backend, "native")
+        self.assertTrue(context._glm5_next_fp8_control_shm.unlinked)
+
+    def test_native_prepare_is_one_join_run_wait_per_layer_and_epochs_advance(self):
+        context = self._native_context()
+        calls = []
+        extension = _FakeNativeExtension(calls)
+        transport = extension.FP8LayerwiseTransport()
+        context._glm5_next_fp8_native_transport = transport
+        context._glm5_next_fp8_transport_backend = "native"
+        context._glm5_next_fp8_transport_initialized = True
+        context._glm5_next_fp8_transport_poisoned = False
+        context._glm5_next_fp8_transport_epoch = 0
+        writer = _FakeNativeWriter(calls)
+
+        with mock.patch.object(
+            kt_ep_wrapper,
+            "get_tensor_model_parallel_rank",
+            return_value=0,
+        ):
+            context._prepare_weight_fp8_glm5_next(writer, layer_idx=3)
+            context._prepare_weight_fp8_glm5_next(writer, layer_idx=4)
+
+        self.assertEqual(
+            [call for call in calls if call[0] in ("join", "run", "wait")],
+            [
+                ("join", 1, 3, 3),
+                ("run", 1, 3, 3),
+                ("wait", 1),
+                ("join", 2, 4, 3),
+                ("run", 2, 4, 3),
+                ("wait", 2),
+            ],
+        )
+        writer.cpu_infer.sync.assert_not_called()
+        source = inspect.getsource(
+            kt_ep_wrapper.SharedFullContext._prepare_weight_fp8_glm5_next_native
+        )
+        self.assertNotIn("dist.", source)
+        self.assertNotIn(".item()", source)
+        self.assertNotIn("for expert", source)
+
+    def test_native_runtime_failure_poisoned_without_legacy_fallback(self):
+        context = self._native_context()
+        calls = []
+        extension = _FakeNativeExtension(calls)
+        transport = extension.FP8LayerwiseTransport()
+        context._glm5_next_fp8_native_transport = transport
+        context._glm5_next_fp8_transport_backend = "native"
+        context._glm5_next_fp8_transport_initialized = True
+        context._glm5_next_fp8_transport_poisoned = False
+        context._glm5_next_fp8_transport_epoch = 0
+        writer = _FakeNativeWriter(calls, fail=True)
+        context._prepare_weight_fp8_glm5_next_legacy = mock.Mock()
+
+        with mock.patch.object(
+            kt_ep_wrapper,
+            "get_tensor_model_parallel_rank",
+            return_value=0,
+        ):
+            with self.assertRaisesRegex(RuntimeError, "runtime fallback is disabled"):
+                context._prepare_weight_fp8_glm5_next(writer, layer_idx=3)
+            with self.assertRaisesRegex(RuntimeError, "poisoned"):
+                context._prepare_weight_fp8_glm5_next(writer, layer_idx=4)
+
+        self.assertTrue(context._glm5_next_fp8_transport_poisoned)
+        self.assertEqual(transport.close_count, 1)
+        context._prepare_weight_fp8_glm5_next_legacy.assert_not_called()
+
+    def test_transport_mode_fallback_and_hard_gates(self):
+        context = self._native_context()
+        context._initialize_glm5_next_fp8_legacy_transport = mock.Mock()
+        writer = _FakeNativeWriter([])
+        with (
+            mock.patch.object(
+                kt_ep_wrapper,
+                "get_tensor_model_parallel_rank",
+                return_value=0,
+            ),
+            mock.patch.object(
+                kt_ep_wrapper,
+                "get_tensor_model_parallel_world_size",
+                return_value=4,
+            ),
+            mock.patch.object(
+                kt_ep_wrapper.dist, "is_initialized", return_value=False
+            ),
+            mock.patch.dict(
+                "os.environ",
+                {"SGLANG_KT_GLM5_NEXT_FP8_TRANSPORT": "auto"},
+                clear=False,
+            ),
+            mock.patch.object(
+                kt_ep_wrapper,
+                "_load_glm5_next_fp8_native_transport_api",
+                return_value=(None, "missing test API"),
+            ),
+        ):
+            context._initialize_glm5_next_fp8_transport(
+                wrapper=writer, num_gpu_experts=0
+            )
+        context._initialize_glm5_next_fp8_legacy_transport.assert_called_once_with()
+
+        context._initialize_glm5_next_fp8_legacy_transport.reset_mock()
+        with (
+            mock.patch.object(
+                kt_ep_wrapper,
+                "get_tensor_model_parallel_rank",
+                return_value=0,
+            ),
+            mock.patch.object(
+                kt_ep_wrapper,
+                "get_tensor_model_parallel_world_size",
+                return_value=4,
+            ),
+            mock.patch.object(kt_ep_wrapper.dist, "is_initialized", return_value=False),
+            mock.patch.dict(
+                "os.environ",
+                {"SGLANG_KT_GLM5_NEXT_FP8_TRANSPORT": "native"},
+                clear=False,
+            ),
+            mock.patch.object(
+                kt_ep_wrapper,
+                "_load_glm5_next_fp8_native_transport_api",
+                return_value=(None, "missing test API"),
+            ),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "was forced"):
+                context._initialize_glm5_next_fp8_transport(
+                    wrapper=writer, num_gpu_experts=0
+                )
+            with self.assertRaisesRegex(RuntimeError, "gpu_experts=0"):
+                context._initialize_glm5_next_fp8_transport(
+                    wrapper=writer, num_gpu_experts=1
+                )
+        context._initialize_glm5_next_fp8_legacy_transport.assert_not_called()
+
+    def test_native_single_slot_state_machine_prefetches_and_wraps(self):
+        calls = []
+        successor_release = threading.Event()
+        context = _FakePrefetchContext(
+            calls, successor_release=successor_release
+        )
+        method3 = _fake_prefetch_method(3, calls)
+        method4 = _fake_prefetch_method(4, calls)
+        layer3 = object()
+        layer4 = object()
+        registry = {3: (method3, layer3), 4: (method4, layer4)}
+        event = _FakePrefetchEvent(calls)
+        main_stream = object()
+
+        with (
+            mock.patch.object(torch.cuda, "Event", return_value=event),
+            mock.patch.object(
+                kt_ep_wrapper,
+                "_GLM5_NEXT_FP8_MOE_LAYER_INDICES",
+                (3, 4),
+            ),
+            mock.patch.object(
+                torch.cuda, "current_stream", return_value=main_stream
+            ),
+            mock.patch.object(
+                kt_ep_wrapper,
+                "get_tensor_model_parallel_rank",
+                return_value=0,
+            ),
+            mock.patch.object(
+                kt_ep_wrapper,
+                "_all_tp_ranks_succeeded",
+                side_effect=lambda success: success,
+            ),
+        ):
+            manager = (
+                kt_ep_wrapper._Glm5NextFp8NativeSingleSlotPrefetchManager(
+                    context, ("test",), registry
+                )
+            )
+            try:
+                first = manager.apply(
+                    method3, layer3, SimpleNamespace(layer_idx=3)
+                )
+                self.assertEqual(first, "result-3")
+                self.assertTrue(context.successor_entered.wait(timeout=1))
+                self.assertIsNotNone(manager.future)
+                self.assertFalse(manager.future.done())
+
+                # The main thread has already returned from layer 3 while its
+                # sole worker remains in successor transport.
+                successor_release.set()
+                second = manager.apply(
+                    method4, layer4, SimpleNamespace(layer_idx=4)
+                )
+                self.assertEqual(second, "result-4")
+                self.assertIsNone(manager.future)  # last layer never prefetches
+
+                # A new chunk/request wraps to the first MoE.  It synchronously
+                # fences layer 4 and re-primes the same GPU slot.
+                wrapped = manager.apply(
+                    method3, layer3, SimpleNamespace(layer_idx=3)
+                )
+                self.assertEqual(wrapped, "result-3")
+                successor = manager.apply(
+                    method4, layer4, SimpleNamespace(layer_idx=4)
+                )
+                self.assertEqual(successor, "result-4")
+            finally:
+                manager.close()
+
+        self.assertEqual(
+            [call[:2] for call in calls if call[0] == "load-enter"],
+            [
+                ("load-enter", 3),
+                ("load-enter", 4),
+                ("load-enter", 3),
+                ("load-enter", 4),
+            ],
+        )
+        self.assertEqual(calls.count(("cpu-infer-sync",)), 1)
+        method3.wrapper.cpu_infer.sync.assert_called_once_with()
+        method4.wrapper.cpu_infer.sync.assert_not_called()
+        self.assertEqual(manager.round_id, 2)
+        self.assertEqual(manager.last_acquired_layer_idx, 4)
+        self.assertFalse(manager.context._glm5_next_fp8_transport_poisoned)
+
+    def test_native_prefetch_rejects_partial_glm_registry_before_prime(self):
+        calls = []
+        context = _FakePrefetchContext(calls)
+        method3 = _fake_prefetch_method(3, calls)
+        with self.assertRaisesRegex(RuntimeError, "complete MoE registry"):
+            kt_ep_wrapper._Glm5NextFp8NativeSingleSlotPrefetchManager(
+                context, ("partial",), {3: (method3, object())}
+            )
+        self.assertNotIn(("cpu-infer-sync",), calls)
+        self.assertFalse(
+            any(call[0] == "load-enter" for call in calls if call)
+        )
+
+    def test_native_successor_failure_poisoned_without_fallback(self):
+        calls = []
+        context = _FakePrefetchContext(calls, fail_layer=4)
+        method3 = _fake_prefetch_method(3, calls)
+        method4 = _fake_prefetch_method(4, calls)
+        layer3 = object()
+        layer4 = object()
+        registry = {3: (method3, layer3), 4: (method4, layer4)}
+        event = _FakePrefetchEvent(calls)
+
+        with (
+            mock.patch.object(torch.cuda, "Event", return_value=event),
+            mock.patch.object(
+                kt_ep_wrapper,
+                "_GLM5_NEXT_FP8_MOE_LAYER_INDICES",
+                (3, 4),
+            ),
+            mock.patch.object(torch.cuda, "current_stream", return_value=object()),
+            mock.patch.object(
+                kt_ep_wrapper,
+                "get_tensor_model_parallel_rank",
+                return_value=0,
+            ),
+            mock.patch.object(
+                kt_ep_wrapper,
+                "_all_tp_ranks_succeeded",
+                side_effect=lambda success: success,
+            ),
+        ):
+            manager = (
+                kt_ep_wrapper._Glm5NextFp8NativeSingleSlotPrefetchManager(
+                    context, ("failure-test",), registry
+                )
+            )
+            try:
+                manager.apply(method3, layer3, SimpleNamespace(layer_idx=3))
+                with self.assertRaisesRegex(
+                    RuntimeError, "runtime fallback is disabled"
+                ):
+                    manager.apply(
+                        method4, layer4, SimpleNamespace(layer_idx=4)
+                    )
+                with self.assertRaisesRegex(RuntimeError, "poisoned"):
+                    manager.apply(
+                        method3, layer3, SimpleNamespace(layer_idx=3)
+                    )
+            finally:
+                manager.close()
+
+        self.assertTrue(context._glm5_next_fp8_transport_poisoned)
+        self.assertNotIn("legacy", " ".join(map(str, calls)).lower())
+
+    def test_native_prefetch_source_contracts(self):
+        exact_load_source = inspect.getsource(
+            kt_ep_wrapper.SharedFullContext.load_glm5_next_fp8_native
+        )
+        self.assertIn("consumed_event.synchronize()", exact_load_source)
+        self.assertNotIn("torch.cuda.synchronize", exact_load_source)
+        self.assertNotIn("_all_tp_ranks_succeeded", exact_load_source)
+
+        native_prepare_source = inspect.getsource(
+            kt_ep_wrapper.SharedFullContext._prepare_weight_fp8_glm5_next_native
+        )
+        self.assertIn('getattr(wrapper, "moe", None)', native_prepare_source)
+        self.assertNotIn("cpu_infer.sync", native_prepare_source)
+
+        worker_source = inspect.getsource(
+            kt_ep_wrapper._Glm5NextFp8NativeSingleSlotPrefetchManager._load_layer
+        )
+        self.assertNotIn("dist.", worker_source)
+        self.assertNotIn("_all_tp_ranks_succeeded", worker_source)
+
+        create_source = inspect.getsource(
+            kt_ep_wrapper.KTEPWrapperMethod.create_weights
+        )
+        self.assertIn(
+            "_register_glm5_next_fp8_native_prefetch_layer", create_source
+        )
+
+        close_source = inspect.getsource(
+            kt_ep_wrapper.SharedFullContext._close_glm5_next_fp8_transport
+        )
+        self.assertLess(
+            close_source.index("prefetch_manager.close()"),
+            close_source.index("transport.close()"),
+        )
 
     def test_tp4_fp8_geometry_and_single_full_layer_slot_bytes(self):
         num_experts = 288


### PR DESCRIPTION
## Summary

- add an exact GLM-5-Next FP8/TP4 single-GPU-slot prefetch controller
- synchronously prime layer 3, then load layer n+1 on one persistent per-rank worker after the current-stream consumed event
- overlap the successor native writer/H2D transport with postprocess and the next attention layer
- keep exactly two Host expert slots and one full-layer GPU slot
- fail closed on incomplete layer registry, stale ordering, pointer rebinding, rank-local failure, or poisoned transport

The path is hard-gated to exact GLM-5-Next, block-FP8, TP=4, gpu_experts=0, raw Triton MoE. Legacy transport, MXFP4, BF16, and other models retain their existing paths.

Depends on kvcache-ai/ktransformers#2160.

## Validation

- focused GLM tests: 18 passed + 13 subtests
- MXFP4 preservation tests: 27 passed
- TP4 GPUs 0-3, CUDA Graph enabled, 30K prompt:
  - chunk 8192 hot TTFT: 33.637s vs legacy 41.229s (-18.4%)
  - chunk 16384 hot TTFT: 26.652s vs legacy 33.113s (-19.5%)
- output token hashes match the corresponding legacy/native baselines exactly
- natural 29,835-token Chinese prompt remained coherent:
  - chunk 8192: 854.6 tok/s prefill
  - chunk 16384: 1112.3 tok/s prefill
- Qwen3-30B-A3B TP4 regression: 23/23 passed, including CUDA Graph batches 1/2/4 and deterministic top-256 checks

This PR is submitted for review only and must not be auto-merged.