### PR TITLE
feat(glm5-next): support GLM-5.3-flash serving

### DIFF
--- a/examples/chat_template/glm5_next_multimodal.jinja
+++ b/examples/chat_template/glm5_next_multimodal.jinja
@@ -1,28 +1,218 @@
-{%- macro render_content(content) -%}
-{%- if content is string -%}
-{{ content }}
-{%- else -%}
-{%- for item in content -%}
-{%- if item['type'] == 'text' -%}
-{{ item['text'] }}
-{%- elif item['type'] == 'image' -%}
-{{ '<|image|>' }}
-{%- else -%}
-{{ raise_exception('GLM-5-Next supports only text and image chat content.') }}
+[gMASK]<sop>
+{%- set effective_reasoning_effort = reasoning_effort if reasoning_effort is defined and reasoning_effort in ['low', 'high'] else 'max' -%}
+{%- if effective_reasoning_effort is not none -%}<|system|>Reasoning Effort: {{ effective_reasoning_effort | capitalize }}{%- endif -%}
+{%- if tools -%}
+{%- macro tool_to_json(tool) -%}
+    {%- set ns_tool = namespace(first=true) -%}
+    {{ '{' -}}
+    {%- for k, v in tool.items() -%}
+        {%- if k != 'defer_loading' and k != 'strict' -%}
+            {%- if not ns_tool.first -%}{{- ', ' -}}{%- endif -%}
+            {%- set ns_tool.first = false -%}
+            "{{ k }}": {{ v | tojson(ensure_ascii=False) }}
+        {%- endif -%}
+    {%- endfor -%}
+    {{- '}' -}}
+{%- endmacro -%}
+{%- macro tool_references_to_response(refs) -%}
+    {{- '<tool_response><tools>\n' -}}
+    {%- for tr in refs -%}
+        {%- for tool in tools -%}
+            {%- if 'function' in tool -%}
+                {%- set tool = tool['function'] -%}
+            {%- endif -%}
+            {%- if tool.name == tr.name -%}
+                {{- tool_to_json(tool) + '\n' -}}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- endfor -%}
+    {{- '</tools></tool_response>' -}}
+{%- endmacro -%}
+<|system|>
+# Tools
+
+You may call one or more functions to assist with the user query.
+
+You are provided with function signatures within <tools></tools> XML tags:
+<tools>
+{% for tool in tools %}
+{%- if 'function' in tool -%}
+    {%- set tool = tool['function'] -%}
 {%- endif -%}
-{%- endfor -%}
+{% if tool.defer_loading is not defined or not tool.defer_loading %}
+{{ tool_to_json(tool) }}
+{% endif %}
+{% endfor %}
+</tools>
+
+For each function call, output the function name and arguments within the following XML format:
+<tool_call>{function-name}<arg_key>{arg-key-1}</arg_key><arg_value>{arg-value-1}</arg_value><arg_key>{arg-key-2}</arg_key><arg_value>{arg-value-2}</arg_value>...</tool_call>{%- endif -%}
+{%- macro emit_image() -%}<|begin_of_image|><|image|><|end_of_image|>{%- endmacro -%}
+{%- macro emit_video() -%}<|begin_of_video|><|video|><|end_of_video|>{%- endmacro -%}
+{%- macro emit_audio() -%}<|begin_of_audio|><|end_of_audio|>{%- endmacro -%}
+{%- macro visible_text(content) -%}
+    {%- if content is string -%}
+        {{- content -}}
+    {%- elif content is iterable and content is not mapping -%}
+        {%- for item in content -%}
+            {%- if item is mapping and item.type == 'text' -%}
+                {{- item.text -}}
+            {%- elif item is string -%}
+                {{- item -}}
+            {%- elif item is mapping and item.type in ['image', 'image_url'] -%}
+                {{- emit_image() -}}
+            {%- elif item is mapping and item.type in ['video', 'video_url'] -%}
+                {{- emit_video() -}}
+            {%- elif item is mapping and item.type in ['audio', 'audio_url', 'input_audio'] -%}
+                {{- emit_audio() -}}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- else -%}
+        {{- content }}
+    {%- endif -%}
+{%- endmacro -%}
+{%- macro tool_response(text) -%}
+{{- '<tool_response>' + text + '</tool_response>' -}}
+{%- endmacro -%}
+{%- macro render_tool_response(m) -%}
+{%- if m.content is string -%}
+    {{- tool_response(m.content) -}}
+{%- elif m.content and m.content is not mapping and m.content.0.type == "tool_reference" -%}
+    {{- tool_references_to_response(m.content) -}}
+{%- elif is_list_of_outputs(m) -%}
+    {%- for tr in m.content -%}
+        {%- if tr.output is iterable and tr.output is not string and tr.output is not mapping and tr.output and tr.output.0.type == "tool_reference" -%}
+            {{- tool_references_to_response(tr.output) -}}
+        {%- else -%}
+            {{- tool_response(visible_text(tr.output)) -}}
+        {%- endif -%}
+    {%- endfor -%}
+{%- else -%}
+    {{- tool_response(visible_text(m.content)) -}}
 {%- endif -%}
 {%- endmacro -%}
-{%- if messages and messages[0]['role'] == 'system' -%}
-{{ '[gMASK]<sop><|system|>\n' }}{{ render_content(messages[0]['content']) }}
-{%- set loop_messages = messages[1:] -%}
+{%- macro id_of(obj) -%}
+    {%- if obj.tool_call_id -%}
+        {{- obj.tool_call_id -}}
+    {%- elif obj.id -%}
+        {{- obj.id -}}
+    {%- endif -%}
+{%- endmacro -%}
+{%- macro is_list_of_outputs(m) -%}
+    {%- if m.content and m.content.0.output is defined -%}1{%- endif -%}
+{%- endmacro -%}
+{%- set ns = namespace(last_user_index=-1) -%}
+{%- for m in messages %}
+    {%- if m.role == 'user' %}
+        {%- set ns.last_user_index = loop.index0 -%}
+    {%- endif %}
+{%- endfor %}
+{%- for m in messages -%}
+{%- if m.role == 'user' -%}<|user|>{{ visible_text(m.content) }}
+{%- elif m.role == 'assistant' -%}
+<|assistant|>
+{%- set content = visible_text(m.content) %}
+{%- if m.reasoning_content is string %}
+    {%- set reasoning_content = m.reasoning_content %}
+{%- elif '</think>' in content %}
+    {%- set reasoning_content = content.split('</think>')[0].split('<think>')[-1] %}
+    {%- set content = content.split('</think>')[-1] %}
+{%- endif %}
+{%- if ((clear_thinking is defined and not clear_thinking) or loop.index0 > ns.last_user_index) and reasoning_content is defined -%}
+{{ '<think>' + reasoning_content +  '</think>'}}
 {%- else -%}
-{{ '[gMASK]<sop>' }}
-{%- set loop_messages = messages -%}
+{{ '<think></think>' }}
 {%- endif -%}
-{%- for message in loop_messages -%}
-{{ '<|' + message['role'] + '|>\n' }}{{ render_content(message['content']) }}
+{%- if content.strip() -%}
+{{ content.strip() }}
+{%- endif -%}
+{% if m.tool_calls %}
+{% for tc in m.tool_calls %}
+{%- if tc.function %}
+    {%- set tc = tc.function %}
+{%- endif %}
+{{- '<tool_call>' + tc.name -}}
+{% set _args = tc.arguments %}{% for k, v in _args.items() %}<arg_key>{{ k }}</arg_key><arg_value>{{ v | tojson(ensure_ascii=False) if v is not string else v }}</arg_value>{% endfor %}</tool_call>{% endfor %}
+{% endif %}
+{%- elif m.role == 'tool' -%}
+{%- if loop.first or (messages[loop.index0 - 1].role != "tool") %}
+    {{- '<|observation|>' -}}
+    {%- set block_start = loop.index0 -%}
+    {%- set ns_blk = namespace(end=block_start, broken=false) -%}
+    {%- for j in range(block_start, messages|length) -%}
+        {%- if not ns_blk.broken -%}
+            {%- if messages[j].role == 'tool' -%}
+                {%- set ns_blk.end = j -%}
+            {%- else -%}
+                {%- set ns_blk.broken = true -%}
+            {%- endif -%}
+        {%- endif -%}
+    {%- endfor -%}
+    {%- set ns_a = namespace(tool_calls=none) -%}
+    {%- if block_start > 0 and messages[block_start - 1].role == 'assistant' and messages[block_start - 1].tool_calls -%}
+        {%- set ns_a.tool_calls = messages[block_start - 1].tool_calls -%}
+    {%- endif -%}
+    {%- set ns_chk = namespace(can_sort=true) -%}
+    {%- if not ns_a.tool_calls -%}
+        {%- set ns_chk.can_sort = false -%}
+    {%- else -%}
+        {%- for k in range(block_start, ns_blk.end + 1) -%}
+            {%- set m = messages[k] -%}
+            {%- if is_list_of_outputs(m) -%}
+                {%- for entry in m.content -%}
+                    {%- set eid = id_of(entry) -%}
+                    {%- if not eid -%}
+                        {%- set ns_chk.can_sort = false -%}
+                    {%- endif -%}
+                {%- endfor -%}
+            {%- else -%}
+                {%- set tk_id = id_of(m) -%}
+                {%- if not tk_id -%}
+                    {%- set ns_chk.can_sort = false -%}
+                {%- endif -%}
+            {%- endif -%}
+        {%- endfor -%}
+        {%- for tc in ns_a.tool_calls -%}
+            {%- set tc_id = id_of(tc) -%}
+            {%- if not tc_id -%}
+                {%- set ns_chk.can_sort = false -%}
+            {%- endif -%}
+    {%- endfor -%}
+    {%- endif -%}
+    {%- if ns_chk.can_sort -%}
+        {%- for tc in ns_a.tool_calls -%}
+            {%- set tc_id = id_of(tc) -%}
+            {%- for k in range(block_start, ns_blk.end + 1) -%}
+                {%- set m = messages[k] -%}
+                {%- if is_list_of_outputs(m) -%}
+                    {%- for entry in m.content -%}
+                        {%- set eid = id_of(entry) -%}
+                        {%- if eid == tc_id -%}
+                            {%- if entry.output is iterable and entry.output is not string and entry.output is not mapping and entry.output and entry.output.0.type == "tool_reference" -%}
+                                {{- tool_references_to_response(entry.output) -}}
+                            {%- else -%}
+                                {{- tool_response(visible_text(entry.output)) -}}
+                            {%- endif -%}
+                        {%- endif -%}
+    {%- endfor -%}
+{%- else -%}
+                    {%- set tk_id = id_of(m) -%}
+                    {%- if tk_id == tc_id -%}
+                        {{- render_tool_response(m) -}}
+                    {%- endif -%}
+                {%- endif -%}
+            {%- endfor -%}
+        {%- endfor -%}
+    {%- else -%}
+        {%- for k in range(block_start, ns_blk.end + 1) -%}
+            {{- render_tool_response(messages[k]) -}}
+        {%- endfor -%}
+    {%- endif -%}
+{% endif -%}
+{%- elif m.role == 'system' -%}
+<|system|>{{ visible_text(m.content) }}
+{%- endif -%}
 {%- endfor -%}
 {%- if add_generation_prompt -%}
-{{ '<|assistant|>\n' }}
+    <|assistant|>{{- '<think>' -}}
 {%- endif -%}

--- a/examples/chat_template/glm5_next_multimodal.jinja
+++ b/examples/chat_template/glm5_next_multimodal.jinja
@@ -1,0 +1,28 @@
+{%- macro render_content(content) -%}
+{%- if content is string -%}
+{{ content }}
+{%- else -%}
+{%- for item in content -%}
+{%- if item['type'] == 'text' -%}
+{{ item['text'] }}
+{%- elif item['type'] == 'image' -%}
+{{ '<|image|>' }}
+{%- else -%}
+{{ raise_exception('GLM-5-Next supports only text and image chat content.') }}
+{%- endif -%}
+{%- endfor -%}
+{%- endif -%}
+{%- endmacro -%}
+{%- if messages and messages[0]['role'] == 'system' -%}
+{{ '[gMASK]<sop><|system|>\n' }}{{ render_content(messages[0]['content']) }}
+{%- set loop_messages = messages[1:] -%}
+{%- else -%}
+{{ '[gMASK]<sop>' }}
+{%- set loop_messages = messages -%}
+{%- endif -%}
+{%- for message in loop_messages -%}
+{{ '<|' + message['role'] + '|>\n' }}{{ render_content(message['content']) }}
+{%- endfor -%}
+{%- if add_generation_prompt -%}
+{{ '<|assistant|>\n' }}
+{%- endif -%}

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -70,7 +70,7 @@ dependencies = [
   "torchcodec==0.8.0 ; sys_platform != 'linux' or (sys_platform == 'linux' and platform_machine != 'aarch64' and platform_machine != 'arm64' and platform_machine != 'armv7l')", # torchcodec does not exist in those systems. If not provided, transformer will use torchvision instead by default.
   "torchvision==0.24.1",
   "tqdm",
-  "transformers-kt==5.6.0.post1",
+  "transformers-kt==5.6.0.post3",
   "uvicorn",
   "uvloop",
   "xgrammar==0.1.27",

--- a/python/sglang/jit_kernel/csrc/nsa/kpool_topk_transform.cuh
+++ b/python/sglang/jit_kernel/csrc/nsa/kpool_topk_transform.cuh
@@ -1,0 +1,462 @@
+/**
+ * @NOTE: The radix top-k core (fast_topk_cuda_tl_impl) is adapted from
+ * https://github.com/tile-ai/tilelang/blob/main/examples/deepseek_v32/topk_selector.py
+ * and was previously shipped as an AOT sgl-kernel op (fast_kpool_topk_transform_fused).
+ * It is re-implemented here as a lightweight JIT kernel for the NSA KPool indexer:
+ * select pool groups at pool granularity, expand each group to `pool_size` token
+ * indices, and optionally transform those indices through a page table or ragged offset.
+ *
+ * The pool-level top-k value is a compile-time constant injected via -DSGL_GROUP_TOPK.
+ */
+#include <sgl_kernel/tensor.h>  // For TensorMatcher, SymbolicSize, SymbolicDevice, is_type
+#include <sgl_kernel/utils.h>   // For RuntimeCheck, RuntimeDeviceCheck
+
+#include <sgl_kernel/utils.cuh>  // For LaunchKernel, type aliases
+
+#include <dlpack/dlpack.h>
+#include <tvm/ffi/container/tensor.h>
+
+#include <bit>
+#include <cstddef>
+#include <cstdint>
+#include <cuda_fp16.h>
+
+namespace {
+
+#ifndef C10_LIKELY
+#define C10_LIKELY(expr) (__builtin_expect(static_cast<bool>(expr), 1))
+#endif
+
+#ifndef SGL_GROUP_TOPK
+#define SGL_GROUP_TOPK 256
+#endif
+
+// Compile-time pool-level top-k (number of groups selected per row).
+inline constexpr int kGroupTopK = SGL_GROUP_TOPK;
+inline constexpr int kThreadsPerBlock = 1024;
+
+// Reduced from 128KB to 32KB to improve occupancy.
+// Each radix pass needs at most ~K candidates in the threshold bin,
+// so 4K entries per round (2 rounds = 8K entries = 32KB) is sufficient.
+inline constexpr std::size_t kSmem = 8 * 1024 * sizeof(uint32_t);  // 32KB (bytes)
+
+struct FastTopKParams {
+  const float* __restrict__ input;         // [B, input_stride]
+  const int32_t* __restrict__ row_starts;  // [B] or nullptr
+  int32_t* __restrict__ indices;           // unused here (kept for layout parity)
+  const int32_t* __restrict__ lengths;     // [B]
+  int64_t input_stride;
+};
+
+__device__ __forceinline__ auto convert_to_uint8(float x) -> uint8_t {
+  __half h = __float2half_rn(x);
+  uint16_t bits = __half_as_ushort(h);
+  uint16_t key = (bits & 0x8000) ? static_cast<uint16_t>(~bits) : static_cast<uint16_t>(bits | 0x8000);
+  return static_cast<uint8_t>(key >> 8);
+}
+
+__device__ __forceinline__ auto convert_to_uint32(float x) -> uint32_t {
+  uint32_t bits = __float_as_uint(x);
+  return (bits & 0x80000000u) ? ~bits : (bits | 0x80000000u);
+}
+
+template <int K>
+__device__ void
+fast_topk_cuda_tl_impl(const float* __restrict__ input, int* __restrict__ index, int row_start, int length) {
+  // An optimized topk kernel copied from tilelang kernel
+  // We assume length > K here, or it will crash
+  int topk = K;
+  constexpr auto BLOCK_SIZE = 1024;
+  constexpr auto RADIX = 256;
+  constexpr auto SMEM_INPUT_SIZE = kSmem / (2 * sizeof(int));
+
+  alignas(128) __shared__ int s_histogram_buf[2][RADIX + 128];
+  alignas(128) __shared__ int s_counter;
+  alignas(128) __shared__ int s_threshold_bin_id;
+  alignas(128) __shared__ int s_num_input[2];
+
+  auto& s_histogram = s_histogram_buf[0];
+  // allocate for two rounds
+  extern __shared__ int s_input_idx[][SMEM_INPUT_SIZE];
+
+  const int tx = threadIdx.x;
+
+  // stage 1: 8bit coarse histogram
+  if (tx < RADIX + 1) s_histogram[tx] = 0;
+  __syncthreads();
+
+  for (int idx = tx; idx < length; idx += BLOCK_SIZE) {
+    const auto bin = convert_to_uint8(input[idx + row_start]);
+    ::atomicAdd(&s_histogram[bin], 1);
+  }
+  __syncthreads();
+
+  const auto run_cumsum = [&] {
+#pragma unroll 8
+    for (int i = 0; i < 8; ++i) {
+      static_assert(1 << 8 == RADIX);
+      if (C10_LIKELY(tx < RADIX)) {
+        const auto j = 1 << i;
+        const auto k = i & 1;
+        auto value = s_histogram_buf[k][tx];
+        if (tx < RADIX - j) {
+          value += s_histogram_buf[k][tx + j];
+        }
+        s_histogram_buf[k ^ 1][tx] = value;
+      }
+      __syncthreads();
+    }
+  };
+
+  run_cumsum();
+  if (tx < RADIX && s_histogram[tx] > topk && s_histogram[tx + 1] <= topk) {
+    s_threshold_bin_id = tx;
+    s_num_input[0] = 0;
+    s_counter = 0;
+  }
+  __syncthreads();
+
+  const auto threshold_bin = s_threshold_bin_id;
+  topk -= s_histogram[threshold_bin + 1];
+
+  if (topk == 0) {
+    for (int idx = tx; idx < length; idx += BLOCK_SIZE) {
+      const auto bin = static_cast<int>(convert_to_uint8(input[idx + row_start]));
+      if (bin > threshold_bin) {
+        const auto pos = ::atomicAdd(&s_counter, 1);
+        index[pos] = idx;
+      }
+    }
+    __syncthreads();
+    return;
+  } else {
+    __syncthreads();
+    if (tx < RADIX + 1) {
+      s_histogram[tx] = 0;
+    }
+    __syncthreads();
+
+    for (int idx = tx; idx < length; idx += BLOCK_SIZE) {
+      const auto raw_input = input[idx + row_start];
+      const auto bin = static_cast<int>(convert_to_uint8(raw_input));
+      if (bin > threshold_bin) {
+        const auto pos = ::atomicAdd(&s_counter, 1);
+        index[pos] = idx;
+      } else if (bin == threshold_bin) {
+        const auto pos = ::atomicAdd(&s_num_input[0], 1);
+        /// NOTE: (dark) fuse the histogram computation here
+        if (C10_LIKELY(pos < SMEM_INPUT_SIZE)) {
+          s_input_idx[0][pos] = idx;
+          const auto bin = convert_to_uint32(raw_input);
+          const auto sub_bin = (bin >> 24) & 0xFF;
+          ::atomicAdd(&s_histogram[sub_bin], 1);
+        }
+      }
+    }
+    __syncthreads();
+  }
+
+  // stage 2: refine with 8bit radix passes
+#pragma unroll 4
+  for (int round = 0; round < 4; ++round) {
+    __shared__ int s_last_remain;
+    const auto r_idx = round % 2;
+
+    // clip here to prevent overflow
+    const auto _raw_num_input = s_num_input[r_idx];
+    const auto num_input = (_raw_num_input < int(SMEM_INPUT_SIZE)) ? _raw_num_input : int(SMEM_INPUT_SIZE);
+
+    run_cumsum();
+    if (tx < RADIX && s_histogram[tx] > topk && s_histogram[tx + 1] <= topk) {
+      s_threshold_bin_id = tx;
+      s_num_input[r_idx ^ 1] = 0;
+      s_last_remain = topk - s_histogram[tx + 1];
+    }
+    __syncthreads();
+
+    const auto threshold_bin = s_threshold_bin_id;
+    topk -= s_histogram[threshold_bin + 1];
+
+    if (topk == 0) {
+      for (int i = tx; i < num_input; i += BLOCK_SIZE) {
+        const auto idx = s_input_idx[r_idx][i];
+        const auto offset = 24 - round * 8;
+        const auto bin = (convert_to_uint32(input[idx + row_start]) >> offset) & 0xFF;
+        if (bin > threshold_bin) {
+          const auto pos = ::atomicAdd(&s_counter, 1);
+          index[pos] = idx;
+        }
+      }
+      __syncthreads();
+      break;
+    } else {
+      __syncthreads();
+      if (tx < RADIX + 1) {
+        s_histogram[tx] = 0;
+      }
+      __syncthreads();
+      for (int i = tx; i < num_input; i += BLOCK_SIZE) {
+        const auto idx = s_input_idx[r_idx][i];
+        const auto raw_input = input[idx + row_start];
+        const auto offset = 24 - round * 8;
+        const auto bin = (convert_to_uint32(raw_input) >> offset) & 0xFF;
+        if (bin > threshold_bin) {
+          const auto pos = ::atomicAdd(&s_counter, 1);
+          index[pos] = idx;
+        } else if (bin == threshold_bin) {
+          if (round == 3) {
+            const auto pos = ::atomicAdd(&s_last_remain, -1);
+            if (pos > 0) {
+              index[K - pos] = idx;
+            }
+          } else {
+            const auto pos = ::atomicAdd(&s_num_input[r_idx ^ 1], 1);
+            if (C10_LIKELY(pos < SMEM_INPUT_SIZE)) {
+              /// NOTE: (dark) fuse the histogram computation here
+              s_input_idx[r_idx ^ 1][pos] = idx;
+              const auto bin = convert_to_uint32(raw_input);
+              const auto sub_bin = (bin >> (offset - 8)) & 0xFF;
+              ::atomicAdd(&s_histogram[sub_bin], 1);
+            }
+          }
+        }
+      }
+      __syncthreads();
+    }
+  }
+}
+
+__device__ __forceinline__ int32_t transform_kpool_token(
+    int32_t raw_token,
+    const int32_t* __restrict__ page_table_entry,
+    const int32_t* __restrict__ topk_indices_offset,
+    int32_t offset) {
+  if (page_table_entry != nullptr) {
+    return page_table_entry[raw_token];
+  }
+  if (topk_indices_offset != nullptr) {
+    return raw_token + offset;
+  }
+  return raw_token;
+}
+
+template <int K>
+__global__ __launch_bounds__(kThreadsPerBlock) void kpool_topk_transform_kernel(
+    const __grid_constant__ FastTopKParams params,
+    int32_t* __restrict__ dst_token_indices,
+    const int64_t dst_stride,
+    const int32_t pool_size,
+    const int32_t token_topk,
+    const int32_t out_cols,
+    const int32_t* __restrict__ page_table,
+    const int64_t page_table_stride,
+    const int32_t* __restrict__ page_table_row_index,
+    const int32_t* __restrict__ topk_indices_offset,
+    const int32_t* __restrict__ seq_lens) {
+  const auto& [input, row_starts, _, lengths, input_stride] = params;
+  const auto bid = static_cast<uint64_t>(blockIdx.x);
+  const auto tid = threadIdx.x;
+  const auto row_start = row_starts == nullptr ? 0 : row_starts[bid];
+  const auto length = lengths[bid];
+  const auto score = input + bid * input_stride;
+  const auto dst = dst_token_indices + bid * dst_stride;
+  const auto page_table_row = page_table_row_index == nullptr ? bid : static_cast<uint64_t>(page_table_row_index[bid]);
+  const auto page_table_entry = page_table == nullptr ? nullptr : page_table + page_table_row * page_table_stride;
+  const auto offset = topk_indices_offset == nullptr ? 0 : topk_indices_offset[bid];
+  const bool append_tail = seq_lens != nullptr;
+  const auto full_pool_token_len = length * pool_size;
+  const auto history_len = full_pool_token_len < token_topk ? full_pool_token_len : token_topk;
+  const auto tail_count = append_tail ? seq_lens[bid] % pool_size : 0;
+
+  if (length <= K) {
+    for (int col = tid; col < out_cols; col += kThreadsPerBlock) {
+      if (col < history_len) {
+        const auto group_rank = col / pool_size;
+        const auto slot = col % pool_size;
+        const auto raw_token = group_rank * pool_size + slot;
+        dst[col] = transform_kpool_token(raw_token, page_table_entry, topk_indices_offset, offset);
+      } else if (append_tail && col < history_len + tail_count) {
+        const auto raw_token = length * pool_size + (col - history_len);
+        dst[col] = transform_kpool_token(raw_token, page_table_entry, topk_indices_offset, offset);
+      } else {
+        dst[col] = -1;
+      }
+    }
+    return;
+  }
+
+  __shared__ int s_indices[K];
+  fast_topk_cuda_tl_impl<K>(score, s_indices, row_start, length);
+  for (int col = tid; col < out_cols; col += kThreadsPerBlock) {
+    if (col < history_len) {
+      const auto group_rank = col / pool_size;
+      const auto group_id = s_indices[group_rank];
+      const auto slot = col % pool_size;
+      const auto raw_token = group_id * pool_size + slot;
+      dst[col] = transform_kpool_token(raw_token, page_table_entry, topk_indices_offset, offset);
+    } else if (append_tail && col < history_len + tail_count) {
+      const auto raw_token = length * pool_size + (col - history_len);
+      dst[col] = transform_kpool_token(raw_token, page_table_entry, topk_indices_offset, offset);
+    } else {
+      dst[col] = -1;
+    }
+  }
+}
+
+template <auto* f, std::size_t kMaxDynamicSMEM>
+void setup_kernel_smem_once(host::DebugInfo where = {}) {
+  [[maybe_unused]]
+  static const auto result = [] {
+    const auto fptr = std::bit_cast<const void*>(f);
+    return ::cudaFuncSetAttribute(fptr, ::cudaFuncAttributeMaxDynamicSharedMemorySize, kMaxDynamicSMEM);
+  }();
+  host::RuntimeDeviceCheck(result, where);
+}
+
+template <typename T>
+const T* optional_data_ptr(const tvm::ffi::Optional<tvm::ffi::TensorView>& opt) {
+  if (!opt.has_value()) {
+    return nullptr;
+  }
+  return static_cast<const T*>(opt.value().data_ptr());
+}
+
+struct KpoolTopKTransformKernel {
+  static constexpr auto kernel = kpool_topk_transform_kernel<kGroupTopK>;
+
+  // Pool-level radix top-k for the NSA KPool indexer.
+  //   score                : [B, S] strided float32 scores (one score per pool group)
+  //   lengths              : [B] int32 valid group count per row
+  //   dst_token_indices    : [B, out_cols] int32 output token indices (contiguous)
+  //   pool_size            : tokens per pool group
+  //   page_table  (opt)    : [B, P] strided int32 raw-token -> real-token map
+  //   topk_indices_offset  : [B] int32 per-row offset added to raw tokens (ragged)
+  //   row_starts  (opt)    : [B] int32 score row start offsets
+  //   seq_lens    (opt)    : [B] int32 sequence lengths; enables tail append
+  static void transform(
+      const tvm::ffi::TensorView score,
+      const tvm::ffi::TensorView lengths,
+      const tvm::ffi::TensorView dst_token_indices,
+      const int64_t pool_size,
+      const tvm::ffi::Optional<tvm::ffi::TensorView> page_table_opt,
+      const tvm::ffi::Optional<tvm::ffi::TensorView> topk_indices_offset_opt,
+      const tvm::ffi::Optional<tvm::ffi::TensorView> row_starts_opt,
+      const tvm::ffi::Optional<tvm::ffi::TensorView> seq_lens_opt,
+      const tvm::ffi::Optional<tvm::ffi::TensorView> page_table_row_index_opt) {
+    using namespace host;
+
+    auto B = SymbolicSize{"batch_size"};
+    auto S = SymbolicSize{"score_stride"};
+    auto out_cols_sym = SymbolicSize{"out_cols"};
+    auto device = SymbolicDevice{};
+    device.set_options<kDLCUDA>();
+
+    TensorMatcher({B, -1})  // strided scores
+        .with_strides({S, 1})
+        .with_dtype<float>()
+        .with_device(device)
+        .verify(score);
+    TensorMatcher({B})  // lengths, contiguous int32
+        .with_dtype<int32_t>()
+        .with_device(device)
+        .verify(lengths);
+    TensorMatcher({B, out_cols_sym})  // output, contiguous int32
+        .with_dtype<int32_t>()
+        .with_device(device)
+        .verify(dst_token_indices);
+
+    RuntimeCheck(pool_size > 1, "pool_size must be > 1, got ", pool_size);
+    RuntimeCheck(
+        !(page_table_opt.has_value() && topk_indices_offset_opt.has_value()),
+        "page_table and topk_indices_offset are mutually exclusive");
+    RuntimeCheck(
+        !page_table_row_index_opt.has_value() || page_table_opt.has_value(),
+        "page_table_row_index requires page_table");
+
+    const auto out_cols = static_cast<int32_t>(out_cols_sym.unwrap());
+    const auto tail_cols = seq_lens_opt.has_value() ? static_cast<int32_t>(pool_size) - 1 : 0;
+    RuntimeCheck(out_cols > tail_cols, "dst_token_indices columns ", out_cols, " must exceed tail ", tail_cols);
+    const auto token_topk = out_cols - tail_cols;
+    RuntimeCheck(token_topk % static_cast<int32_t>(pool_size) == 0, "token_topk must be a multiple of pool_size");
+    RuntimeCheck(
+        token_topk / static_cast<int32_t>(pool_size) == kGroupTopK,
+        "this module is built for group_topk=",
+        kGroupTopK,
+        " but got ",
+        token_topk / static_cast<int32_t>(pool_size));
+
+    const auto batch_size = static_cast<uint32_t>(B.unwrap());
+
+    int64_t page_table_stride = 0;
+    const int32_t* page_table_ptr = nullptr;
+    if (page_table_opt.has_value()) {
+      auto P = SymbolicSize{"page_table_stride"};
+      if (page_table_row_index_opt.has_value()) {
+        auto page_table_rows = SymbolicSize{"page_table_rows"};
+        TensorMatcher({page_table_rows, -1})  // compact shared page table
+            .with_strides({P, 1})
+            .with_dtype<int32_t>()
+            .with_device(device)
+            .verify(page_table_opt.value());
+      } else {
+        TensorMatcher({B, -1})  // one page-table row per score row
+            .with_strides({P, 1})
+            .with_dtype<int32_t>()
+            .with_device(device)
+            .verify(page_table_opt.value());
+      }
+      page_table_ptr = static_cast<const int32_t*>(page_table_opt.value().data_ptr());
+      page_table_stride = static_cast<int64_t>(P.unwrap());
+    }
+
+    if (topk_indices_offset_opt.has_value()) {
+      TensorMatcher({B})  //
+          .with_dtype<int32_t>()
+          .with_device(device)
+          .verify(topk_indices_offset_opt.value());
+    }
+    if (row_starts_opt.has_value()) {
+      TensorMatcher({B})  //
+          .with_dtype<int32_t>()
+          .with_device(device)
+          .verify(row_starts_opt.value());
+    }
+    if (seq_lens_opt.has_value()) {
+      TensorMatcher({B})  //
+          .with_dtype<int32_t>()
+          .with_device(device)
+          .verify(seq_lens_opt.value());
+    }
+    if (page_table_row_index_opt.has_value()) {
+      TensorMatcher({B})  //
+          .with_dtype<int32_t>()
+          .with_device(device)
+          .verify(page_table_row_index_opt.value());
+    }
+
+    const auto params = FastTopKParams{
+        .input = static_cast<const float*>(score.data_ptr()),
+        .row_starts = optional_data_ptr<int32_t>(row_starts_opt),
+        .indices = nullptr,
+        .lengths = static_cast<const int32_t*>(lengths.data_ptr()),
+        .input_stride = static_cast<int64_t>(S.unwrap()),
+    };
+
+    setup_kernel_smem_once<kernel, kSmem>();
+    LaunchKernel(batch_size, kThreadsPerBlock, device.unwrap(), kSmem)(
+        kernel,
+        params,
+        static_cast<int32_t*>(dst_token_indices.data_ptr()),
+        static_cast<int64_t>(dst_token_indices.strides()[0]),
+        static_cast<int32_t>(pool_size),
+        token_topk,
+        out_cols,
+        page_table_ptr,
+        page_table_stride,
+        optional_data_ptr<int32_t>(page_table_row_index_opt),
+        optional_data_ptr<int32_t>(topk_indices_offset_opt),
+        optional_data_ptr<int32_t>(seq_lens_opt));
+  }
+};
+
+}  // namespace

--- a/python/sglang/jit_kernel/kpool_topk_transform.py
+++ b/python/sglang/jit_kernel/kpool_topk_transform.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+import torch
+
+from sglang.jit_kernel.utils import cache_once, load_jit
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+# Pool-level top-k values that have dedicated, validated kernel instantiations.
+SUPPORTED_GROUP_TOPK = (128, 160, 192, 224, 256, 512)
+
+
+@cache_once
+def _jit_kpool_topk_transform_module(group_topk: int) -> Module:
+    """Compile and cache the kpool top-k transform module for a given group_topk."""
+    assert group_topk in SUPPORTED_GROUP_TOPK, (
+        "fast_kpool_topk_transform supports pool-level topk "
+        f"{SUPPORTED_GROUP_TOPK}, got {group_topk}"
+    )
+    return load_jit(
+        f"kpool_topk_transform_{group_topk}",
+        cuda_files=["nsa/kpool_topk_transform.cuh"],
+        cuda_wrappers=[("kpool_topk_transform", "KpoolTopKTransformKernel::transform")],
+        extra_cuda_cflags=[f"-DSGL_GROUP_TOPK={group_topk}"],
+    )
+
+
+def fast_kpool_topk_transform_fused(
+    score: torch.Tensor,
+    lengths: torch.Tensor,
+    pool_size: int,
+    topk: int,
+    page_table: Optional[torch.Tensor] = None,
+    topk_indices_offset: Optional[torch.Tensor] = None,
+    row_starts: Optional[torch.Tensor] = None,
+    seq_lens: Optional[torch.Tensor] = None,
+    page_table_row_index: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """
+    Pool-level radix top-k for the NSA kpool indexer.
+
+    Selects pool groups from ``score`` at pool granularity, expands each selected
+    group to ``pool_size`` token indices, and optionally transforms those token
+    indices through a page table or a ragged offset.
+    """
+    assert topk % pool_size == 0
+    group_topk = topk // pool_size
+    assert group_topk in SUPPORTED_GROUP_TOPK, (
+        "fast_kpool_topk_transform supports pool-level topk "
+        f"{SUPPORTED_GROUP_TOPK}, got {group_topk}"
+    )
+    assert score.dim() == 2
+    assert page_table is None or topk_indices_offset is None
+    assert page_table_row_index is None or page_table is not None
+    if seq_lens is not None:
+        assert seq_lens.dim() == 1
+        assert seq_lens.shape[0] == score.shape[0]
+    if page_table_row_index is not None:
+        assert page_table_row_index.dim() == 1
+        assert page_table_row_index.shape[0] == score.shape[0]
+
+    out_cols = topk + (pool_size - 1 if seq_lens is not None else 0)
+    dst_token_indices = score.new_empty((score.shape[0], out_cols), dtype=torch.int32)
+
+    module = _jit_kpool_topk_transform_module(group_topk)
+    module.kpool_topk_transform(
+        score,
+        lengths,
+        dst_token_indices,
+        pool_size,
+        page_table,
+        topk_indices_offset,
+        row_starts,
+        seq_lens,
+        page_table_row_index,
+    )
+    return dst_token_indices

--- a/python/sglang/kernels/ops/layernorm/mhc.py
+++ b/python/sglang/kernels/ops/layernorm/mhc.py
@@ -1,0 +1,284 @@
+"""Flat 2-D mHC functional front-ends used by GLM-5-Next.
+
+The existing KT TileLang kernels operate on ``[tokens, hc_mult, hidden]``.
+This module keeps the GLM runtime state flat as ``[tokens, hc_mult * hidden]``
+and supplies a pure-PyTorch reference.  The optimized backend is imported only
+when its existing environment flag is enabled, so importing this module does
+not load TileLang or change any pre-existing model path.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Tuple
+
+import torch
+import torch.nn.functional as F
+
+
+_TRUE_ENV_VALUES = frozenset({"1", "true", "yes", "on"})
+
+
+def _use_tilelang(env_name: str) -> bool:
+    return os.environ.get(env_name, "0").strip().lower() in _TRUE_ENV_VALUES
+
+
+def hc_expand(x: torch.Tensor, n: int) -> torch.Tensor:
+    """Replicate ``[tokens, hidden]`` into flat ``[tokens, n * hidden]``."""
+    assert x.dim() == 2, f"x must be 2-D, got {tuple(x.shape)}"
+    assert n > 0, f"n must be positive, got {n}"
+    return x.repeat(1, n)
+
+
+def hc_contract(x: torch.Tensor, n: int) -> torch.Tensor:
+    """Average flat ``[tokens, n * hidden]`` into ``[tokens, hidden]``."""
+    assert x.dim() == 2, f"x must be 2-D, got {tuple(x.shape)}"
+    assert n > 0, f"n must be positive, got {n}"
+    assert x.shape[-1] % n == 0, (
+        f"flat hidden width {x.shape[-1]} must be divisible by n={n}"
+    )
+    return x.unflatten(-1, (n, -1)).mean(dim=-2)
+
+
+def _validate_pre_inputs(
+    residual: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    sinkhorn_repeat: int,
+) -> tuple[int, int, int]:
+    assert residual.dim() == 3, (
+        f"residual must be [tokens, hc_mult, hidden], got {tuple(residual.shape)}"
+    )
+    tokens, hc_mult, hidden_size = residual.shape
+    mix_width = hc_mult * (2 + hc_mult)
+    assert fn.shape == (mix_width, hc_mult * hidden_size), (
+        f"fn must be {(mix_width, hc_mult * hidden_size)}, got {tuple(fn.shape)}"
+    )
+    assert hc_scale.shape == (3,), f"hc_scale must be (3,), got {tuple(hc_scale.shape)}"
+    assert hc_base.shape == (mix_width,), (
+        f"hc_base must be ({mix_width},), got {tuple(hc_base.shape)}"
+    )
+    assert fn.dtype == torch.float32
+    assert hc_scale.dtype == torch.float32
+    assert hc_base.dtype == torch.float32
+    assert sinkhorn_repeat >= 1
+    return tokens, hc_mult, hidden_size
+
+
+def _mhc_pre_torch(
+    residual: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    rms_eps: float,
+    hc_pre_eps: float,
+    hc_sinkhorn_eps: float,
+    hc_post_mult_value: float,
+    sinkhorn_repeat: int,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Pure-Torch mHC pre reference.
+
+    Returns ``post [T,N,1]``, ``comb [T,N,N]`` and ``layer_input [T,H]``.
+    Numerically sensitive normalization and Sinkhorn updates run in FP32.
+    """
+    tokens, hc_mult, hidden_size = _validate_pre_inputs(
+        residual, fn, hc_scale, hc_base, sinkhorn_repeat
+    )
+    output_dtype = residual.dtype
+
+    residual_fp32 = residual.reshape(tokens, hc_mult * hidden_size).float()
+    reciprocal_rms = torch.rsqrt(
+        residual_fp32.square().mean(-1, keepdim=True) + rms_eps
+    )
+    mixes = F.linear(residual_fp32, fn) * reciprocal_rms
+
+    pre_raw = mixes[:, :hc_mult]
+    post_raw = mixes[:, hc_mult : 2 * hc_mult]
+    comb_raw = mixes[:, 2 * hc_mult :].reshape(tokens, hc_mult, hc_mult)
+    pre_base = hc_base[:hc_mult]
+    post_base = hc_base[hc_mult : 2 * hc_mult]
+    comb_base = hc_base[2 * hc_mult :].reshape(hc_mult, hc_mult)
+
+    pre = torch.sigmoid(pre_raw * hc_scale[0] + pre_base) + hc_pre_eps
+    post = hc_post_mult_value * torch.sigmoid(post_raw * hc_scale[1] + post_base)
+    comb = comb_raw * hc_scale[2] + comb_base
+
+    comb = comb.softmax(-1) + hc_sinkhorn_eps
+    comb = comb / (comb.sum(-2, keepdim=True) + hc_sinkhorn_eps)
+    for _ in range(sinkhorn_repeat - 1):
+        comb = comb / (comb.sum(-1, keepdim=True) + hc_sinkhorn_eps)
+        comb = comb / (comb.sum(-2, keepdim=True) + hc_sinkhorn_eps)
+
+    layer_input = (pre.unsqueeze(-1) * residual.float()).sum(dim=1).to(output_dtype)
+    return post.unsqueeze(-1), comb, layer_input
+
+
+def _mhc_post_torch(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    post_layer_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+) -> torch.Tensor:
+    """Pure-Torch mHC post reference.
+
+    ``x`` is ``[T,H]`` and ``residual`` is ``[T,N,H]``.  The result is
+    ``[T,N,H]`` and follows the dtype of ``x``.
+    """
+    assert x.dim() == 2 and residual.dim() == 3
+    tokens, hc_mult, hidden_size = residual.shape
+    assert x.shape == (tokens, hidden_size)
+    assert post_layer_mix.shape == (tokens, hc_mult, 1)
+    assert comb_res_mix.shape == (tokens, hc_mult, hc_mult)
+
+    out = post_layer_mix * x.unsqueeze(1) + (
+        comb_res_mix.unsqueeze(-1) * residual.unsqueeze(2)
+    ).sum(dim=1)
+    return out.type_as(x)
+
+
+@torch._dynamo.disable
+def _mhc_pre_dispatch(
+    residual: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    rms_eps: float,
+    hc_pre_eps: float,
+    hc_sinkhorn_eps: float,
+    hc_post_mult_value: float,
+    sinkhorn_repeat: int,
+    norm_weight: torch.Tensor | None = None,
+    norm_eps: float | None = None,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, bool]:
+    """Dispatch to KT's existing TileLang kernel only when explicitly enabled."""
+    del norm_eps  # KT's current mHC kernel does not fuse the following RMSNorm.
+    if not _use_tilelang("SGLANG_OPT_USE_TILELANG_MHC_PRE"):
+        post_mix, comb_mix, layer_input = _mhc_pre_torch(
+            residual=residual,
+            fn=fn,
+            hc_scale=hc_scale,
+            hc_base=hc_base,
+            rms_eps=rms_eps,
+            hc_pre_eps=hc_pre_eps,
+            hc_sinkhorn_eps=hc_sinkhorn_eps,
+            hc_post_mult_value=hc_post_mult_value,
+            sinkhorn_repeat=sinkhorn_repeat,
+        )
+        return post_mix, comb_mix, layer_input, False
+
+    from sglang.srt.layers.mhc import mhc_pre as tilelang_mhc_pre
+
+    post_mix, comb_mix, layer_input = tilelang_mhc_pre(
+        residual=residual,
+        fn=fn,
+        hc_scale=hc_scale,
+        hc_base=hc_base,
+        rms_eps=rms_eps,
+        hc_pre_eps=hc_pre_eps,
+        hc_sinkhorn_eps=hc_sinkhorn_eps,
+        hc_post_mult_value=hc_post_mult_value,
+        sinkhorn_repeat=sinkhorn_repeat,
+    )
+    # ``norm_weight`` is intentionally not consumed: callers apply it when
+    # norm_fused is False.  This preserves the current KT kernel contract.
+    del norm_weight
+    return post_mix, comb_mix, layer_input, False
+
+
+@torch._dynamo.disable
+def _mhc_post_dispatch(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    post_layer_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+) -> torch.Tensor:
+    if not _use_tilelang("SGLANG_OPT_USE_TILELANG_MHC_POST"):
+        return _mhc_post_torch(x, residual, post_layer_mix, comb_res_mix)
+
+    from sglang.srt.layers.mhc import mhc_post as tilelang_mhc_post
+
+    return tilelang_mhc_post(x, residual, post_layer_mix, comb_res_mix)
+
+
+def hc_pre(
+    x: torch.Tensor,
+    hc_fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    hc_mult: int,
+    rms_eps: float,
+    hc_eps: float,
+    sinkhorn_iters: int,
+    post_mult_value: float = 2.0,
+    hc_norm_weight: torch.Tensor | None = None,
+    out_norm_weight: torch.Tensor | None = None,
+    out_norm_eps: float | None = None,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, bool]:
+    """Run mHC pre on flat ``x [T, N*H]``.
+
+    Returns ``layer_input [T,H]``, flattened ``h_res [T,N*N]``, flattened
+    ``h_post [T,N]``, and whether the following normalization was fused.
+    """
+    assert x.dim() == 2, f"x must be 2-D, got {tuple(x.shape)}"
+    assert hc_mult > 0 and x.shape[1] % hc_mult == 0
+    tokens, total_width = x.shape
+    hidden_size = total_width // hc_mult
+    if x.numel() == 0:
+        return (
+            x.new_zeros((tokens, hidden_size)),
+            torch.zeros(
+                (tokens, hc_mult * hc_mult),
+                device=x.device,
+                dtype=torch.float32,
+            ),
+            torch.zeros((tokens, hc_mult), device=x.device, dtype=torch.float32),
+            False,
+        )
+
+    fn = hc_fn if hc_norm_weight is None else hc_fn * hc_norm_weight
+    residual = x.reshape(tokens, hc_mult, hidden_size)
+    post_mix, comb_mix, layer_input, norm_fused = _mhc_pre_dispatch(
+        residual=residual,
+        fn=fn,
+        hc_scale=hc_scale,
+        hc_base=hc_base,
+        rms_eps=rms_eps,
+        hc_pre_eps=hc_eps,
+        hc_sinkhorn_eps=hc_eps,
+        hc_post_mult_value=post_mult_value,
+        sinkhorn_repeat=sinkhorn_iters,
+        norm_weight=out_norm_weight,
+        norm_eps=out_norm_eps,
+    )
+    return (
+        layer_input,
+        comb_mix.reshape(tokens, hc_mult * hc_mult),
+        post_mix.reshape(tokens, hc_mult),
+        norm_fused,
+    )
+
+
+def hc_post(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    h_post: torch.Tensor,
+    h_res: torch.Tensor,
+    hc_mult: int,
+) -> torch.Tensor:
+    """Run mHC post and return flat ``[T, N*H]`` state."""
+    assert x.dim() == 2 and residual.dim() == 2
+    tokens, hidden_size = x.shape
+    assert residual.shape == (tokens, hc_mult * hidden_size)
+    assert h_post.shape == (tokens, hc_mult)
+    assert h_res.shape == (tokens, hc_mult * hc_mult)
+    if tokens == 0:
+        return x.new_zeros((tokens, hc_mult * hidden_size))
+
+    out = _mhc_post_dispatch(
+        x,
+        residual.reshape(tokens, hc_mult, hidden_size),
+        h_post.reshape(tokens, hc_mult, 1),
+        h_res.reshape(tokens, hc_mult, hc_mult),
+    )
+    return out.reshape(tokens, hc_mult * hidden_size)

--- a/python/sglang/srt/configs/__init__.py
+++ b/python/sglang/srt/configs/__init__.py
@@ -7,6 +7,7 @@ from sglang.srt.configs.dots_ocr import DotsOCRConfig
 from sglang.srt.configs.dots_vlm import DotsVLMConfig
 from sglang.srt.configs.exaone import ExaoneConfig
 from sglang.srt.configs.falcon_h1 import FalconH1Config
+from sglang.srt.configs.glm5_next import Glm5NextConfig, Glm5NextTextConfig
 from sglang.srt.configs.granitemoehybrid import GraniteMoeHybridConfig
 from sglang.srt.configs.janus_pro import MultiModalityConfig
 from sglang.srt.configs.jet_nemotron import JetNemotronConfig
@@ -46,6 +47,8 @@ __all__ = [
     "Step3TextConfig",
     "Step3VisionEncoderConfig",
     "Olmo3Config",
+    "Glm5NextConfig",
+    "Glm5NextTextConfig",
     "KimiLinearConfig",
     "KimiK25Config",
     "Qwen3NextConfig",

--- a/python/sglang/srt/configs/glm5_next.py
+++ b/python/sglang/srt/configs/glm5_next.py
@@ -7,14 +7,69 @@ runtime vision implementation without changing text-only config loading.
 """
 
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any, List, Optional, Union
 
 from transformers.configuration_utils import PretrainedConfig
 
 from sglang.srt.configs.mamba_utils import KimiLinearCacheParams, KimiLinearStateShape
 
-
 _GLM5_NEXT_ARCH = "Glm5NextForConditionalGeneration"
+
+
+class Glm5NextGPUProfile(str, Enum):
+    """Validated cache/kernel policy for one GLM-5-Next GPU family.
+
+    Consumer GPUs deliberately use explicit profiles instead of inheriting the
+    generic DeepSeek NSA capability checks.  In particular, SM86 cannot execute
+    the E4M3 tensor-core index-cache path and therefore keeps both the latent and
+    KPool caches in BF16.
+    """
+
+    SM86_BF16 = "sm86_bf16"
+    SM89_FP8 = "sm89_fp8"
+    BLACKWELL_FP8 = "blackwell_fp8"
+
+    @property
+    def kv_cache_dtype(self) -> str:
+        return (
+            "bfloat16"
+            if self is Glm5NextGPUProfile.SM86_BF16
+            else "fp8_e4m3"
+        )
+
+    @property
+    def index_cache_dtype(self) -> str:
+        return "bfloat16" if self is Glm5NextGPUProfile.SM86_BF16 else "fp8_e4m3"
+
+    @property
+    def is_consumer_gpu(self) -> bool:
+        return self in (
+            Glm5NextGPUProfile.SM86_BF16,
+            Glm5NextGPUProfile.SM89_FP8,
+        )
+
+
+def get_glm5_next_gpu_profile(
+    capability: tuple[int, int],
+) -> Glm5NextGPUProfile:
+    """Resolve the exact GLM runtime policy or fail closed.
+
+    Keep the pre-existing major>=10 acceptance boundary intact while adding
+    only the two requested consumer architectures.  SM90 and other Ampere/Ada
+    variants remain unsupported until separately validated.
+    """
+
+    if capability == (8, 6):
+        return Glm5NextGPUProfile.SM86_BF16
+    if capability == (8, 9):
+        return Glm5NextGPUProfile.SM89_FP8
+    if capability[0] >= 10:
+        return Glm5NextGPUProfile.BLACKWELL_FP8
+    raise ValueError(
+        "GLM-5-Next supports NVIDIA SM86, SM89, or Blackwell (SM>=100); "
+        f"got SM{capability[0]}{capability[1]}."
+    )
 
 _GLM5_NEXT_TOP_LEVEL_CONFIG_KEYS = (
     "architectures",

--- a/python/sglang/srt/configs/glm5_next.py
+++ b/python/sglang/srt/configs/glm5_next.py
@@ -86,9 +86,48 @@ _GLM5_NEXT_TOP_LEVEL_CONFIG_KEYS = (
 
 
 class _Glm5NextVisionConfigHolder(PretrainedConfig):
-    """Field-preserving placeholder; it does not import any vision runtime."""
+    """GLM-5-Next vision config without importing the vision runtime."""
 
     model_type = "glm_ocr_vision"
+    base_config_key = "vision_config"
+
+    def __init__(
+        self,
+        depth: int = 24,
+        hidden_size: int = 1024,
+        intermediate_size: int = 4096,
+        num_heads: int = 16,
+        in_channels: int = 3,
+        patch_size: int = 14,
+        temporal_patch_size: int = 2,
+        spatial_merge_size: int = 2,
+        out_hidden_size: int = 4096,
+        projection_intermediate_size: int = 10240,
+        rms_norm_eps: float = 1e-5,
+        hidden_act: str = "silu",
+        image_size: int = 448,
+        initializer_range: float = 0.02,
+        attention_dropout: float = 0.0,
+        attention_bias: bool = True,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.depth = depth
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.num_heads = num_heads
+        self.in_channels = in_channels
+        self.patch_size = patch_size
+        self.temporal_patch_size = temporal_patch_size
+        self.spatial_merge_size = spatial_merge_size
+        self.out_hidden_size = out_hidden_size
+        self.projection_intermediate_size = projection_intermediate_size
+        self.rms_norm_eps = rms_norm_eps
+        self.hidden_act = hidden_act
+        self.image_size = image_size
+        self.initializer_range = initializer_range
+        self.attention_dropout = attention_dropout
+        self.attention_bias = attention_bias
 
 
 class Glm5NextTextConfig(PretrainedConfig):
@@ -386,12 +425,12 @@ class Glm5NextConfig(PretrainedConfig):
         self,
         text_config=None,
         vision_config=None,
-        image_token_id: int = 59280,
-        video_token_id: int = 59281,
-        image_start_token_id: int = 59256,
-        image_end_token_id: int = 59257,
-        video_start_token_id: int = 59258,
-        video_end_token_id: int = 59259,
+        image_token_id: int = 154854,
+        video_token_id: int = 154855,
+        image_start_token_id: int = 154830,
+        image_end_token_id: int = 154831,
+        video_start_token_id: int = 154832,
+        video_end_token_id: int = 154833,
         **kwargs,
     ):
         kwargs.setdefault("architectures", [_GLM5_NEXT_ARCH])

--- a/python/sglang/srt/configs/glm5_next.py
+++ b/python/sglang/srt/configs/glm5_next.py
@@ -1,0 +1,511 @@
+"""Configuration and capability gates for GLM-5-Next.
+
+The text implementation lands before the multimodal implementation.  Keep the
+vision configuration serializable here, but deliberately avoid importing the
+GLM-OCR vision stack.  Stage 7 can replace the lightweight holder with the
+runtime vision implementation without changing text-only config loading.
+"""
+
+from dataclasses import dataclass
+from typing import Any, List, Optional, Union
+
+from transformers.configuration_utils import PretrainedConfig
+
+from sglang.srt.configs.mamba_utils import KimiLinearCacheParams, KimiLinearStateShape
+
+
+_GLM5_NEXT_ARCH = "Glm5NextForConditionalGeneration"
+
+_GLM5_NEXT_TOP_LEVEL_CONFIG_KEYS = (
+    "architectures",
+    "vocab_size",
+    "hidden_size",
+    "head_dim",
+    "intermediate_size",
+    "moe_intermediate_size",
+    "num_hidden_layers",
+    "num_attention_heads",
+    "num_key_value_heads",
+    "hidden_act",
+    "max_position_embeddings",
+    "rms_norm_eps",
+    "use_cache",
+    "pad_token_id",
+    "bos_token_id",
+    "eos_token_id",
+    "rope_theta",
+    "rope_scaling",
+    "rope_parameters",
+    "partial_rotary_factor",
+    "tie_word_embeddings",
+    "attention_bias",
+    "attention_dropout",
+    "n_routed_experts",
+    "num_experts_per_tok",
+    "n_shared_experts",
+    "n_group",
+    "topk_group",
+    "norm_topk_prob",
+    "routed_scaling_factor",
+    "scoring_func",
+    "topk_method",
+    "first_k_dense_replace",
+    "moe_layer_freq",
+    "q_lora_rank",
+    "kv_lora_rank",
+    "qk_nope_head_dim",
+    "qk_rope_head_dim",
+    "v_head_dim",
+    "swiglu_limit",
+    "mhc",
+    "hc_mult",
+    "hc_sinkhorn_iters",
+    "hc_eps",
+    "num_nextn_predict_layers",
+    "linear_attn_config",
+    "linear_head_dim",
+    "linear_num_heads",
+    "linear_conv_kernel_dim",
+    "linear_lower_bound",
+    "gate_lower_bound",
+    "index_head_dim",
+    "index_topk",
+    "index_kpool",
+    "index_kpool_always_select_tail",
+    "index_kpool_compress",
+    "index_n_heads",
+    "index_topk_freq",
+    "index_topk_pattern",
+    "index_skip_topk_offset",
+    "index_share_for_mtp_iteration",
+    "indexer_rope_interleave",
+    "layer_types",
+    "mlp_layer_types",
+    "quantization_config",
+)
+
+
+class _Glm5NextVisionConfigHolder(PretrainedConfig):
+    """Field-preserving placeholder; it does not import any vision runtime."""
+
+    model_type = "glm_ocr_vision"
+
+
+class Glm5NextTextConfig(PretrainedConfig):
+    model_type = "glm5_next_text"
+    base_config_key = "text_config"
+    keys_to_ignore_at_inference = ["past_key_values"]
+
+    def __init__(
+        self,
+        vocab_size: int = 154880,
+        hidden_size: int = 4096,
+        head_dim: Optional[int] = 0,
+        intermediate_size: int = 12288,
+        moe_intermediate_size: int = 2048,
+        num_hidden_layers: int = 45,
+        num_attention_heads: int = 64,
+        num_key_value_heads: Optional[int] = 64,
+        hidden_act: str = "silu",
+        max_position_embeddings: int = 1048576,
+        rms_norm_eps: float = 1e-5,
+        use_cache: bool = True,
+        pad_token_id: Optional[int] = 154820,
+        bos_token_id: Optional[int] = None,
+        eos_token_id: Optional[Union[int, List[int]]] = None,
+        rope_theta: float = 800000.0,
+        rope_scaling: Optional[dict] = None,
+        rope_parameters: Optional[dict] = None,
+        partial_rotary_factor: float = 1.0,
+        tie_word_embeddings: bool = False,
+        attention_bias: bool = False,
+        attention_dropout: float = 0.0,
+        n_routed_experts: Optional[int] = 288,
+        num_experts_per_tok: int = 8,
+        n_shared_experts: int = 1,
+        n_group: int = 1,
+        topk_group: int = 1,
+        norm_topk_prob: bool = True,
+        routed_scaling_factor: float = 2.5,
+        scoring_func: str = "sigmoid",
+        topk_method: str = "noaux_tc",
+        first_k_dense_replace: int = 3,
+        moe_layer_freq: int = 1,
+        q_lora_rank: Optional[int] = 1536,
+        kv_lora_rank: int = 512,
+        qk_nope_head_dim: int = 256,
+        qk_rope_head_dim: int = 0,
+        v_head_dim: int = 256,
+        swiglu_limit: Optional[float] = 10.0,
+        mhc: bool = True,
+        hc_mult: int = 4,
+        hc_sinkhorn_iters: int = 20,
+        hc_eps: float = 1e-6,
+        num_nextn_predict_layers: int = 1,
+        linear_attn_config: Optional[dict] = None,
+        linear_head_dim: int = 128,
+        linear_num_heads: int = 64,
+        linear_conv_kernel_dim: int = 4,
+        linear_lower_bound: Optional[float] = -5.0,
+        gate_lower_bound: Optional[float] = None,
+        index_head_dim: Optional[int] = 128,
+        index_topk: Optional[int] = 2048,
+        index_kpool: int = 4,
+        index_kpool_always_select_tail: bool = True,
+        index_kpool_compress: bool = True,
+        index_n_heads: Optional[int] = 32,
+        index_topk_freq: int = 1,
+        index_topk_pattern: Optional[str] = None,
+        index_skip_topk_offset: Optional[int] = None,
+        index_share_for_mtp_iteration: bool = False,
+        indexer_rope_interleave: bool = True,
+        layer_types: Optional[List[str]] = None,
+        mlp_layer_types: Optional[List[str]] = None,
+        **kwargs,
+    ):
+        if eos_token_id is None:
+            eos_token_id = [154820, 154827, 154829]
+        if rope_scaling is None and rope_parameters is not None:
+            rope_scaling = rope_parameters
+        if rope_parameters is not None:
+            rope_theta = rope_parameters.get("rope_theta", rope_theta)
+            partial_rotary_factor = rope_parameters.get(
+                "partial_rotary_factor", partial_rotary_factor
+            )
+
+        if layer_types is None:
+            layer_types = [
+                "linear_attention"
+                if layer_idx % 4 != 3
+                else "deepseek_sparse_attention"
+                for layer_idx in range(num_hidden_layers)
+            ]
+        if len(layer_types) != num_hidden_layers:
+            raise ValueError(
+                "GLM-5-Next layer_types must contain exactly "
+                f"num_hidden_layers={num_hidden_layers} entries, got {len(layer_types)}"
+            )
+        unsupported_layer_types = set(layer_types) - {
+            "linear_attention",
+            "deepseek_sparse_attention",
+        }
+        if unsupported_layer_types:
+            raise ValueError(
+                f"Unsupported GLM-5-Next layer types: {sorted(unsupported_layer_types)}"
+            )
+
+        if mlp_layer_types is None:
+            mlp_layer_types = [
+                "dense" if layer_idx < first_k_dense_replace else "sparse"
+                for layer_idx in range(num_hidden_layers)
+            ]
+        if len(mlp_layer_types) != num_hidden_layers:
+            raise ValueError(
+                "GLM-5-Next mlp_layer_types must contain exactly "
+                f"num_hidden_layers={num_hidden_layers} entries, got {len(mlp_layer_types)}"
+            )
+
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+        self.head_dim = head_dim
+        self.intermediate_size = intermediate_size
+        self.moe_intermediate_size = moe_intermediate_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.num_key_value_heads = num_key_value_heads
+        self.hidden_act = hidden_act
+        self.max_position_embeddings = max_position_embeddings
+        self.rms_norm_eps = rms_norm_eps
+        self.use_cache = use_cache
+        self.rope_theta = rope_theta
+        self.rope_scaling = rope_scaling
+        self.partial_rotary_factor = partial_rotary_factor
+        self.attention_bias = attention_bias
+        self.attention_dropout = attention_dropout
+        self.n_routed_experts = n_routed_experts
+        self.num_experts_per_tok = num_experts_per_tok
+        self.n_shared_experts = n_shared_experts
+        self.n_group = n_group
+        self.topk_group = topk_group
+        self.norm_topk_prob = norm_topk_prob
+        self.routed_scaling_factor = routed_scaling_factor
+        self.scoring_func = scoring_func
+        self.topk_method = topk_method
+        self.first_k_dense_replace = first_k_dense_replace
+        self.moe_layer_freq = moe_layer_freq
+        self.q_lora_rank = q_lora_rank
+        self.kv_lora_rank = kv_lora_rank
+        self.qk_nope_head_dim = qk_nope_head_dim
+        self.qk_rope_head_dim = qk_rope_head_dim
+        self.qk_head_dim = qk_nope_head_dim + qk_rope_head_dim
+        self.v_head_dim = v_head_dim
+        self.swiglu_limit = swiglu_limit
+        self.mhc = mhc
+        self.hc_mult = hc_mult
+        self.hc_sinkhorn_iters = hc_sinkhorn_iters
+        self.hc_eps = hc_eps
+        self.num_nextn_predict_layers = num_nextn_predict_layers
+        self.linear_head_dim = linear_head_dim
+        self.linear_num_heads = linear_num_heads
+        self.linear_conv_kernel_dim = linear_conv_kernel_dim
+        self.linear_lower_bound = linear_lower_bound
+        self.gate_lower_bound = (
+            gate_lower_bound if gate_lower_bound is not None else linear_lower_bound
+        )
+        self.layer_types = list(layer_types)
+        self.mlp_layer_types = list(mlp_layer_types)
+
+        if linear_attn_config is None:
+            kda_layers = [
+                layer_idx
+                for layer_idx, layer_type in enumerate(self.layer_types)
+                if layer_type == "linear_attention"
+            ]
+            kda_layer_set = set(kda_layers)
+            linear_attn_config = {
+                "full_attn_layers": [
+                    layer_idx
+                    for layer_idx in range(num_hidden_layers)
+                    if layer_idx not in kda_layer_set
+                ],
+                "head_dim": linear_head_dim,
+                "kda_layers": kda_layers,
+                "num_heads": linear_num_heads,
+                "short_conv_kernel_size": linear_conv_kernel_dim,
+                "gate_lower_bound": self.gate_lower_bound,
+            }
+        self._validate_linear_attn_config(linear_attn_config)
+        self.linear_attn_config = linear_attn_config
+
+        self.index_head_dim = index_head_dim
+        self.index_topk = index_topk
+        self.index_kpool = index_kpool
+        self.index_kpool_always_select_tail = index_kpool_always_select_tail
+        self.index_kpool_compress = index_kpool_compress
+        self.index_n_heads = index_n_heads
+        self.index_topk_freq = index_topk_freq
+        self.index_topk_pattern = index_topk_pattern
+        self.index_skip_topk_offset = index_skip_topk_offset
+        self.index_share_for_mtp_iteration = index_share_for_mtp_iteration
+        self.indexer_rope_interleave = indexer_rope_interleave
+
+        # Compatibility aliases used by the existing KT Kimi/DeepSeek model
+        # skeleton.  They mirror the same values; no non-GLM config is changed.
+        self.num_experts = n_routed_experts
+        self.num_experts_per_token = num_experts_per_tok
+        self.num_shared_experts = n_shared_experts
+        self.num_expert_group = n_group
+        self.moe_renormalize = norm_topk_prob
+        self.moe_router_activation_func = scoring_func
+        self.use_grouped_topk = True
+        self.mla_use_nope = qk_rope_head_dim == 0
+
+        super().__init__(
+            pad_token_id=pad_token_id,
+            bos_token_id=bos_token_id,
+            eos_token_id=eos_token_id,
+            tie_word_embeddings=tie_word_embeddings,
+            **kwargs,
+        )
+        if rope_parameters is not None or rope_scaling is not None:
+            self.rope_parameters = rope_parameters or rope_scaling
+
+    def _validate_linear_attn_config(self, linear_attn_config: dict) -> None:
+        required = {
+            "full_attn_layers",
+            "head_dim",
+            "kda_layers",
+            "num_heads",
+            "short_conv_kernel_size",
+        }
+        missing = required - set(linear_attn_config)
+        if missing:
+            raise ValueError(
+                f"GLM-5-Next linear_attn_config is missing {sorted(missing)}"
+            )
+        kda_layers = list(linear_attn_config["kda_layers"])
+        full_attn_layers = list(linear_attn_config["full_attn_layers"])
+        if set(kda_layers) & set(full_attn_layers):
+            raise ValueError("KDA and full-attention layer sets must be disjoint")
+        if sorted(kda_layers + full_attn_layers) != list(range(self.num_hidden_layers)):
+            raise ValueError(
+                "KDA and full-attention layers must partition every decoder layer"
+            )
+
+    @property
+    def is_mla(self) -> bool:
+        return True
+
+    @property
+    def is_moe(self) -> bool:
+        return self.n_routed_experts is not None
+
+    @property
+    def is_linear_attn(self) -> bool:
+        return bool(self.linear_attn_config["kda_layers"])
+
+    def is_kda_layer(self, layer_idx: int) -> bool:
+        return layer_idx in self.linear_attn_config["kda_layers"]
+
+    @property
+    def linear_layer_ids(self) -> List[int]:
+        return list(self.linear_attn_config["kda_layers"])
+
+    @property
+    def nextn_layer_ids(self) -> List[int]:
+        num_nextn_layers = self.num_nextn_predict_layers or 0
+        return [self.num_hidden_layers + i for i in range(num_nextn_layers)]
+
+    @property
+    def full_attention_layer_ids(self) -> List[int]:
+        return list(self.linear_attn_config["full_attn_layers"])
+
+    @property
+    def mamba2_cache_params(self) -> KimiLinearCacheParams:
+        # Import lazily so config parsing remains CPU-only and side-effect free.
+        from sglang.srt.layers.dp_attention import get_attention_tp_size
+
+        shape = KimiLinearStateShape.create(
+            tp_world_size=get_attention_tp_size(),
+            num_heads=self.linear_attn_config["num_heads"],
+            head_dim=self.linear_attn_config["head_dim"],
+            conv_kernel_size=self.linear_attn_config["short_conv_kernel_size"],
+        )
+        return KimiLinearCacheParams(shape=shape, layers=self.linear_layer_ids)
+
+
+class Glm5NextConfig(PretrainedConfig):
+    model_type = "glm5_next"
+    sub_configs = {
+        "vision_config": _Glm5NextVisionConfigHolder,
+        "text_config": Glm5NextTextConfig,
+    }
+    keys_to_ignore_at_inference = ["past_key_values"]
+
+    def __init__(
+        self,
+        text_config=None,
+        vision_config=None,
+        image_token_id: int = 59280,
+        video_token_id: int = 59281,
+        image_start_token_id: int = 59256,
+        image_end_token_id: int = 59257,
+        video_start_token_id: int = 59258,
+        video_end_token_id: int = 59259,
+        **kwargs,
+    ):
+        kwargs.setdefault("architectures", [_GLM5_NEXT_ARCH])
+        top_level_text_config = {
+            key: kwargs[key]
+            for key in _GLM5_NEXT_TOP_LEVEL_CONFIG_KEYS
+            if key in kwargs
+        }
+
+        if isinstance(vision_config, dict):
+            self.vision_config = _Glm5NextVisionConfigHolder(**vision_config)
+        elif vision_config is None:
+            self.vision_config = _Glm5NextVisionConfigHolder()
+        else:
+            self.vision_config = vision_config
+
+        if isinstance(text_config, dict):
+            self.text_config = Glm5NextTextConfig(
+                **{**top_level_text_config, **text_config}
+            )
+        elif text_config is None:
+            self.text_config = Glm5NextTextConfig(**top_level_text_config)
+        else:
+            self.text_config = text_config
+
+        self.image_token_id = image_token_id
+        self.video_token_id = video_token_id
+        self.image_start_token_id = image_start_token_id
+        self.image_end_token_id = image_end_token_id
+        self.video_start_token_id = video_start_token_id
+        self.video_end_token_id = video_end_token_id
+
+        if getattr(self.text_config, "quantization_config", None) is not None:
+            self.quantization_config = self.text_config.quantization_config
+
+        super().__init__(**kwargs)
+        for key in _GLM5_NEXT_TOP_LEVEL_CONFIG_KEYS:
+            if hasattr(self.text_config, key):
+                setattr(self, key, getattr(self.text_config, key))
+
+
+def _unwrap_glm5_next_text_config(config: Any) -> tuple[Any, Any]:
+    root = getattr(config, "hf_config", config)
+    return root, getattr(root, "text_config", root)
+
+
+def is_glm5_next(config: Any) -> bool:
+    root, text = _unwrap_glm5_next_text_config(config)
+    root_type = getattr(root, "model_type", None)
+    text_type = getattr(text, "model_type", None)
+    architectures = getattr(root, "architectures", None) or getattr(
+        text, "architectures", None
+    )
+    architecture_matches = architectures is None or _GLM5_NEXT_ARCH in architectures
+    return architecture_matches and (
+        root_type == Glm5NextConfig.model_type
+        or text_type == Glm5NextTextConfig.model_type
+    )
+
+
+def uses_kpool4_compress(config: Any) -> bool:
+    _, text = _unwrap_glm5_next_text_config(config)
+    return (
+        is_glm5_next(config)
+        and getattr(text, "index_kpool", None) == 4
+        and getattr(text, "index_kpool_compress", False) is True
+        and getattr(text, "index_kpool_always_select_tail", False) is True
+    )
+
+
+def uses_kda_safe_gate(config: Any) -> bool:
+    _, text = _unwrap_glm5_next_text_config(config)
+    linear_attn_config = getattr(text, "linear_attn_config", None)
+    return (
+        is_glm5_next(config)
+        and isinstance(linear_attn_config, dict)
+        and bool(linear_attn_config.get("kda_layers"))
+        and linear_attn_config.get("gate_lower_bound") is not None
+    )
+
+
+def uses_zero_rope_mla(config: Any) -> bool:
+    _, text = _unwrap_glm5_next_text_config(config)
+    full_attention_layer_ids = getattr(text, "full_attention_layer_ids", [])
+    return (
+        is_glm5_next(config)
+        and bool(full_attention_layer_ids)
+        and getattr(text, "qk_rope_head_dim", None) == 0
+    )
+
+
+def uses_mhc(config: Any) -> bool:
+    _, text = _unwrap_glm5_next_text_config(config)
+    return is_glm5_next(config) and getattr(text, "mhc", False) is True
+
+
+@dataclass(frozen=True)
+class Glm5NextCapabilities:
+    is_glm5_next: bool
+    uses_kpool4_compress: bool
+    uses_kda_safe_gate: bool
+    uses_zero_rope_mla: bool
+    uses_mhc: bool
+
+    @classmethod
+    def from_config(cls, config: Any) -> "Glm5NextCapabilities":
+        return cls(
+            is_glm5_next=is_glm5_next(config),
+            uses_kpool4_compress=uses_kpool4_compress(config),
+            uses_kda_safe_gate=uses_kda_safe_gate(config),
+            uses_zero_rope_mla=uses_zero_rope_mla(config),
+            uses_mhc=uses_mhc(config),
+        )
+
+
+def get_glm5_next_capabilities(config: Any) -> Glm5NextCapabilities:
+    return Glm5NextCapabilities.from_config(config)

--- a/python/sglang/srt/configs/glm5_next.py
+++ b/python/sglang/srt/configs/glm5_next.py
@@ -291,13 +291,29 @@ class Glm5NextTextConfig(PretrainedConfig):
         self.gate_lower_bound = (
             gate_lower_bound if gate_lower_bound is not None else linear_lower_bound
         )
-        self.layer_types = list(layer_types)
+        # The pinned checkpoint names DSA layers
+        # ``deepseek_sparse_attention``.  transformers-kt 5.6 validates the
+        # generic ``PreTrainedConfig.layer_types`` field against its closed
+        # vocabulary, where the corresponding public name is ``sparse``.
+        # Keep the checkpoint-native names separately for provenance while
+        # exposing validator-compatible generic names to shared Transformers
+        # and SGLang helpers.  GLM runtime selection remains driven by the
+        # exact ``linear_attn_config`` partition below.
+        self._glm5_next_checkpoint_layer_types = list(layer_types)
+        self.layer_types = [
+            "linear_attention"
+            if layer_type == "linear_attention"
+            else "sparse"
+            for layer_type in layer_types
+        ]
         self.mlp_layer_types = list(mlp_layer_types)
 
         if linear_attn_config is None:
             kda_layers = [
                 layer_idx
-                for layer_idx, layer_type in enumerate(self.layer_types)
+                for layer_idx, layer_type in enumerate(
+                    self._glm5_next_checkpoint_layer_types
+                )
                 if layer_type == "linear_attention"
             ]
             kda_layer_set = set(kda_layers)
@@ -455,6 +471,13 @@ class Glm5NextConfig(PretrainedConfig):
             self.text_config = Glm5NextTextConfig(**top_level_text_config)
         else:
             self.text_config = text_config
+
+        # A legacy top-level ``layer_types`` copy is present in the pinned
+        # checkpoint.  The nested text config above has already validated and
+        # normalized it, so do not let the root PreTrainedConfig validate the
+        # raw checkpoint spelling a second time.
+        if "layer_types" in kwargs:
+            kwargs["layer_types"] = list(self.text_config.layer_types)
 
         self.image_token_id = image_token_id
         self.video_token_id = video_token_id

--- a/python/sglang/srt/configs/glm5_next.py
+++ b/python/sglang/srt/configs/glm5_next.py
@@ -15,6 +15,7 @@ from transformers.configuration_utils import PretrainedConfig
 from sglang.srt.configs.mamba_utils import KimiLinearCacheParams, KimiLinearStateShape
 
 _GLM5_NEXT_ARCH = "Glm5NextForConditionalGeneration"
+GLM5_NEXT_SUPPORTED_TP_SIZES = frozenset((1, 2, 4, 8))
 
 
 class Glm5NextGPUProfile(str, Enum):

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -205,7 +205,6 @@ class ModelConfig:
                 "Gemma3ForConditionalGeneration",
                 "Llama4ForConditionalGeneration",
                 "Step3VLForConditionalGeneration",
-                "Glm5NextForConditionalGeneration",
             ]
             if self.hf_config.architectures[0] in mm_disabled_models:
                 enable_multimodal = False
@@ -232,6 +231,14 @@ class ModelConfig:
         self.is_multimodal = enable_multimodal and is_multimodal_model(
             self.hf_config.architectures
         )
+        if self.is_glm5_next:
+            # The model constructor receives the HF config rather than this
+            # wrapper.  Preserve the resolved (including programmatic False
+            # and --language-only) decision on that exact config so GLM can
+            # construct or skip its ~1 GiB vision tower deterministically.
+            self.hf_config._glm5_next_multimodal_active = bool(
+                self.is_multimodal and not language_only
+            )
         self.is_multimodal_gen = enable_multimodal and is_multimodal_gen_model(
             self.hf_config.architectures
         )
@@ -1357,6 +1364,7 @@ multimodal_model_archs = [
     "Gemma3nForConditionalGeneration",
     "Glm4vForConditionalGeneration",
     "Glm4vMoeForConditionalGeneration",
+    "Glm5NextForConditionalGeneration",
     "GlmOcrForConditionalGeneration",
     "GlmAsrForConditionalGeneration",
     "Grok1VForCausalLM",

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -23,6 +23,7 @@ from typing import Any, List, Optional, Set, Union
 import torch
 from transformers import PretrainedConfig
 
+from sglang.srt.configs.glm5_next import get_glm5_next_capabilities
 from sglang.srt.environ import envs
 from sglang.srt.layers.quantization import QUANTIZATION_METHODS
 from sglang.srt.server_args import ServerArgs
@@ -183,6 +184,14 @@ class ModelConfig:
             **kwargs,
         )
         self.hf_text_config = get_hf_text_config(self.hf_config)
+        self.glm5_next_capabilities = get_glm5_next_capabilities(self.hf_config)
+        self.is_glm5_next = self.glm5_next_capabilities.is_glm5_next
+        self.uses_kpool4_compress = (
+            self.glm5_next_capabilities.uses_kpool4_compress
+        )
+        self.uses_kda_safe_gate = self.glm5_next_capabilities.uses_kda_safe_gate
+        self.uses_zero_rope_mla = self.glm5_next_capabilities.uses_zero_rope_mla
+        self.uses_mhc = self.glm5_next_capabilities.uses_mhc
         self.hf_generation_config = get_generation_config(
             self.model_path,
             trust_remote_code=trust_remote_code,
@@ -196,6 +205,7 @@ class ModelConfig:
                 "Gemma3ForConditionalGeneration",
                 "Llama4ForConditionalGeneration",
                 "Step3VLForConditionalGeneration",
+                "Glm5NextForConditionalGeneration",
             ]
             if self.hf_config.architectures[0] in mm_disabled_models:
                 enable_multimodal = False
@@ -501,6 +511,7 @@ class ModelConfig:
             or "DeepseekV3ForCausalLMNextN" in self.hf_config.architectures
             or "Glm4MoeLiteForCausalLM" in self.hf_config.architectures
             or "GlmMoeDsaForCausalLM" in self.hf_config.architectures
+            or "Glm5NextForConditionalGeneration" in self.hf_config.architectures
             or "LongcatFlashForCausalLM" in self.hf_config.architectures
             or "LongcatFlashForCausalLMNextN" in self.hf_config.architectures
             or "DotsVLMForCausalLM" in self.hf_config.architectures
@@ -516,9 +527,13 @@ class ModelConfig:
             self.qk_rope_head_dim = self.hf_text_config.qk_rope_head_dim
             self.v_head_dim = self.hf_text_config.v_head_dim
             self.index_head_dim = (
-                get_nsa_index_head_dim(self.hf_text_config)
-                if is_deepseek_nsa(self.hf_text_config)
-                else None
+                self.hf_text_config.index_head_dim
+                if self.is_glm5_next
+                else (
+                    get_nsa_index_head_dim(self.hf_text_config)
+                    if is_deepseek_nsa(self.hf_text_config)
+                    else None
+                )
             )
             # Handle rope scaling
             self.scaling = 1 / math.sqrt(self.qk_nope_head_dim + self.qk_rope_head_dim)

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -175,6 +175,7 @@ StructuralTagResponseFormat: TypeAlias = Union[
 ToolCallConstraint: TypeAlias = Union[
     Tuple[Literal["structural_tag"], StructuralTagResponseFormat],
     Tuple[Literal["json_schema"], Any],  # json_schema can be dict/str/None
+    Tuple[Literal["ebnf"], str],
 ]
 
 

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -351,18 +351,22 @@ class OpenAIServingChat(OpenAIServingBase):
             else:
                 tools = [item.model_dump() for item in request.tools]
             if self.tool_call_parser:
-                parser = FunctionCallParser(request.tools, self.tool_call_parser)
+                parser = FunctionCallParser(
+                    request.tools,
+                    self.tool_call_parser,
+                    tool_choice=request.tool_choice,
+                )
                 tool_call_constraint = parser.get_structure_constraint(
                     request.tool_choice
                 )
-            # Handle JSON schema constraint directly for required or named tool choice
-            if request.tool_choice == "required" or isinstance(
-                request.tool_choice, ToolChoice
+            if tool_call_constraint is None and (
+                request.tool_choice == "required"
+                or isinstance(request.tool_choice, ToolChoice)
             ):
-                json_schema = get_json_schema_constraint(
-                    request.tools, request.tool_choice
+                tool_call_constraint = (
+                    "json_schema",
+                    get_json_schema_constraint(request.tools, request.tool_choice),
                 )
-                tool_call_constraint = ("json_schema", json_schema)
 
         # Use chat template
         if self.template_manager.chat_template_name is None:
@@ -1113,8 +1117,13 @@ class OpenAIServingChat(OpenAIServingBase):
         """Process tool calls in the response"""
 
         # Handle required or named tool choice
-        if tool_choice == "required" or (
-            isinstance(tool_choice, ToolChoice) and tool_choice.type == "function"
+        native_forced_tool_format = self.tool_call_parser == "glm47"
+        if not native_forced_tool_format and (
+            tool_choice == "required"
+            or (
+                isinstance(tool_choice, ToolChoice)
+                and tool_choice.type == "function"
+            )
         ):
             # Set finish reason to tool_calls since we're processing tool calls
             if finish_reason["type"] == "stop":
@@ -1152,7 +1161,9 @@ class OpenAIServingChat(OpenAIServingBase):
                 return ToolCallProcessingResult(None, text, finish_reason)
 
         # Use parser since output is not constrained by JSON schema
-        parser = FunctionCallParser(tools, self.tool_call_parser)
+        parser = FunctionCallParser(
+            tools, self.tool_call_parser, tool_choice=tool_choice
+        )
         if parser.has_tool_call(text):
             if finish_reason["type"] == "stop":
                 finish_reason["type"] = "tool_calls"
@@ -1284,14 +1295,16 @@ class OpenAIServingChat(OpenAIServingBase):
         """Process tool calls in streaming response"""
         if index not in parser_dict:
             # Use JSON detector directly for required or named tool choice
-            if request.tool_choice == "required" or isinstance(
-                request.tool_choice, ToolChoice
+            if self.tool_call_parser != "glm47" and (
+                request.tool_choice == "required"
+                or isinstance(request.tool_choice, ToolChoice)
             ):
                 parser_dict[index] = JsonArrayParser()
             else:
                 parser_dict[index] = FunctionCallParser(
                     tools=request.tools,
                     tool_call_parser=self.tool_call_parser,
+                    tool_choice=request.tool_choice,
                 )
 
         parser = parser_dict[index]

--- a/python/sglang/srt/function_call/base_format_detector.py
+++ b/python/sglang/srt/function_call/base_format_detector.py
@@ -331,6 +331,12 @@ class BaseFormatDetector(ABC):
         """Return True if this detector supports structural tag format."""
         return True
 
+    def get_forced_tool_call_ebnf(self, tools: List[Tool], tool_choice) -> str | None:
+        """Return a native-format grammar for required/named calls if supported."""
+
+        del tools, tool_choice
+        return None
+
     @abstractmethod
     def structure_info(self) -> _GetInfoFunc:
         """

--- a/python/sglang/srt/function_call/function_call_parser.py
+++ b/python/sglang/srt/function_call/function_call_parser.py
@@ -1,5 +1,8 @@
+import json
 import logging
 from typing import Dict, List, Literal, Optional, Set, Tuple, Type, Union
+
+from jsonschema import Draft202012Validator, ValidationError
 
 from sglang.srt.entrypoints.openai.protocol import (
     LegacyStructuralTagResponseFormat,
@@ -75,7 +78,12 @@ class FunctionCallParser:
         "gigachat3": GigaChat3Detector,
     }
 
-    def __init__(self, tools: List[Tool], tool_call_parser: str):
+    def __init__(
+        self,
+        tools: List[Tool],
+        tool_call_parser: str,
+        tool_choice: Optional[Union[ToolChoice, str]] = None,
+    ):
         detector_class = self.ToolCallParserEnum.get(tool_call_parser)
         if detector_class:
             detector = detector_class()
@@ -84,7 +92,50 @@ class FunctionCallParser:
 
         self.detector = detector
         self.tools = tools
+        self.tool_choice = tool_choice
         self.tool_strict_level = envs.SGLANG_TOOL_STRICT_LEVEL.get()
+
+    def _validate_complete_calls(self, calls: List[ToolCallItem]) -> None:
+        if self.tool_choice != "required" and not isinstance(
+            self.tool_choice, ToolChoice
+        ):
+            return
+        if self.tool_choice == "required" and not calls:
+            raise ValueError("Required GLM tool choice produced no tool call.")
+
+        named_tool = (
+            self.tool_choice.function.name
+            if isinstance(self.tool_choice, ToolChoice)
+            else None
+        )
+        tools_by_name = {tool.function.name: tool for tool in self.tools}
+        for call in calls:
+            if named_tool is not None and call.name != named_tool:
+                raise ValueError(
+                    f"Named tool choice requires {named_tool!r}; got {call.name!r}."
+                )
+            tool = tools_by_name.get(call.name)
+            if tool is None:
+                raise ValueError(f"Model called undefined tool {call.name!r}.")
+            try:
+                arguments = json.loads(call.parameters)
+            except json.JSONDecodeError as error:
+                raise ValueError(
+                    f"Tool {call.name!r} returned invalid JSON arguments."
+                ) from error
+            if not isinstance(arguments, dict):
+                raise ValueError(
+                    f"Tool {call.name!r} arguments must decode to an object."
+                )
+            schema = tool.function.parameters
+            if schema:
+                try:
+                    Draft202012Validator(schema).validate(arguments)
+                except ValidationError as error:
+                    raise ValueError(
+                        f"Tool {call.name!r} arguments do not match its schema: "
+                        f"{error.message}"
+                    ) from error
 
     def has_tool_call(self, text: str) -> bool:
         """
@@ -117,6 +168,7 @@ class FunctionCallParser:
             return full_text, []
         parsed_result = self.detector.detect_and_parse(full_text, self.tools)
         tool_call_list = parsed_result.calls
+        self._validate_complete_calls(tool_call_list)
         if tool_call_list:
             return parsed_result.normal_text, tool_call_list
         else:
@@ -214,5 +266,10 @@ class FunctionCallParser:
             tag = self.get_structure_tag()
             return ("structural_tag", tag)
         elif tool_choice == "required" or isinstance(tool_choice, ToolChoice):
+            native_ebnf = self.detector.get_forced_tool_call_ebnf(
+                self.tools, tool_choice
+            )
+            if native_ebnf is not None:
+                return ("ebnf", native_ebnf)
             json_schema = get_json_schema_constraint(self.tools, tool_choice)
             return ("json_schema", json_schema)

--- a/python/sglang/srt/function_call/glm47_moe_detector.py
+++ b/python/sglang/srt/function_call/glm47_moe_detector.py
@@ -5,7 +5,7 @@ import re
 from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple
 
-from sglang.srt.entrypoints.openai.protocol import Tool
+from sglang.srt.entrypoints.openai.protocol import Tool, ToolChoice
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
 from sglang.srt.function_call.core_types import (
     StreamingParseResult,
@@ -780,6 +780,90 @@ class Glm47MoeDetector(BaseFormatDetector):
                 arguments[arg_key] = parsed_value if is_good_json else arg_value
 
         return arguments
+
+    def get_forced_tool_call_ebnf(self, tools: List[Tool], tool_choice) -> str | None:
+        """Constrain forced calls to GLM's native compact XML wire format.
+
+        Arguments follow the property order in the submitted JSON schema.  A
+        deterministic order keeps the grammar linear while still enforcing
+        required keys, excluding unknown/duplicate keys, and preserving the
+        exact format understood by the model and this detector.
+        """
+
+        selected_tools = tools
+        named_choice = isinstance(tool_choice, ToolChoice)
+        if named_choice:
+            selected_tools = [
+                tool
+                for tool in tools
+                if tool.function.name == tool_choice.function.name
+            ]
+        elif tool_choice != "required":
+            return None
+        if not selected_tools:
+            raise ValueError("Forced GLM tool choice resolved to no available tools.")
+
+        rules = []
+        call_rule_names = []
+        for tool_index, tool in enumerate(selected_tools):
+            function = tool.function
+            if not function.name:
+                raise ValueError("GLM tool names must be non-empty.")
+            parameters = function.parameters or {}
+            if not isinstance(parameters, dict):
+                raise ValueError(
+                    f"GLM tool {function.name!r} must use an object parameter schema."
+                )
+            properties = parameters.get("properties", {})
+            required_names = parameters.get("required", [])
+            if not isinstance(properties, dict) or not isinstance(
+                required_names, list
+            ):
+                raise ValueError(
+                    f"GLM tool {function.name!r} must use an object parameter schema."
+                )
+            required = set(required_names)
+            unknown_required = required - set(properties)
+            if unknown_required:
+                raise ValueError(
+                    f"GLM tool {function.name!r} requires undefined properties: "
+                    f"{sorted(unknown_required)}."
+                )
+
+            argument_parts = []
+            for property_index, property_name in enumerate(properties):
+                if not isinstance(property_name, str) or not property_name:
+                    raise ValueError("GLM tool argument names must be non-empty strings.")
+                argument_rule = f"tool_{tool_index}_arg_{property_index}"
+                rules.append(
+                    f"{argument_rule} ::= "
+                    f"{json.dumps('<arg_key>' + property_name + '</arg_key>')} ws "
+                    f"{json.dumps('<arg_value>')} value {json.dumps('</arg_value>')} ws"
+                )
+                if property_name in required:
+                    argument_parts.append(argument_rule)
+                else:
+                    argument_parts.append(f"({argument_rule})?")
+
+            call_rule = f"tool_{tool_index}_call"
+            call_rule_names.append(call_rule)
+            body = " ".join(argument_parts)
+            if body:
+                body = " ws " + body
+            rules.append(
+                f"{call_rule} ::= {json.dumps('<tool_call>' + function.name)}"
+                f"{body} {json.dumps('</tool_call>')}"
+            )
+
+        root = (
+            f"root ::= {call_rule_names[0]}"
+            if named_choice
+            else "root ::= tool_call+"
+        )
+        if not named_choice:
+            rules.insert(0, f"tool_call ::= {' | '.join(call_rule_names)}")
+        rules.extend(["value ::= [^<]*", "ws ::= [ \\t\\n\\r]*"])
+        return "\n".join([root, *rules])
 
     def supports_structural_tag(self) -> bool:
         return False

--- a/python/sglang/srt/layers/attention/attention_registry.py
+++ b/python/sglang/srt/layers/attention/attention_registry.py
@@ -208,6 +208,32 @@ def attn_backend_wrapper(runner: "ModelRunner", full_attn_backend: "AttentionBac
             full_attn_backend, sparse_backend, sparse_backend.sparse_layer_ids
         )
 
+    if getattr(runner.model_config, "is_glm5_next", False):
+        from sglang.srt.layers.attention.fla.utils import check_environments
+        from sglang.srt.layers.attention.hybrid_linear_attn_backend import (
+            HybridLinearAttnBackend,
+        )
+        from sglang.srt.layers.attention.linear.glm5_next_kda_backend import (
+            Glm5NextKDAAttnBackend,
+        )
+        from sglang.srt.layers.attention.linear.utils import (
+            initialize_linear_attn_config,
+        )
+        from sglang.srt.layers.attention.nsa_backend import NativeSparseAttnBackend
+
+        if not isinstance(full_attn_backend, NativeSparseAttnBackend):
+            raise ValueError(
+                "GLM-5-Next requires the nsa attention backend for its DSA layers."
+            )
+        check_environments()
+        initialize_linear_attn_config(runner.server_args)
+        linear_attn_backend = Glm5NextKDAAttnBackend(runner)
+        return HybridLinearAttnBackend(
+            full_attn_backend,
+            linear_attn_backend,
+            runner.model_config.hf_text_config.full_attention_layer_ids,
+        )
+
     if cfg := runner.mambaish_config:
         from sglang.srt.layers.attention.fla.utils import check_environments
         from sglang.srt.layers.attention.hybrid_linear_attn_backend import (

--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -140,6 +140,7 @@ class MambaAttnBackendBase(AttentionBackend):
         self.pad_slot_id = PAD_SLOT_ID
         self.device = model_runner.device
         self.req_to_token_pool: HybridReqToTokenPool = model_runner.req_to_token_pool
+        self.token_to_kv_pool = model_runner.token_to_kv_pool
         self.forward_metadata: ForwardMetadata = None
         self.state_indices_list = []
         self.query_start_loc_list = []
@@ -692,10 +693,26 @@ class HybridLinearAttnBackend(AttentionBackend):
         self.full_attn_backend = full_attn_backend
         self.linear_attn_backend = linear_attn_backend
         self.attn_backend_list = [full_attn_backend, linear_attn_backend]
+        # ForwardContext exposes the active hybrid wrapper.  On this KT base,
+        # every linear sidecar owns the runner's pools while some legacy full
+        # backends do not expose them yet.  Forward the sidecar references so
+        # existing Kimi/GDN/Mamba wrappers retain their constructor contract.
+        self.token_to_kv_pool = linear_attn_backend.token_to_kv_pool
+        self.req_to_token_pool = linear_attn_backend.req_to_token_pool
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         for attn_backend in self.attn_backend_list:
             attn_backend.init_forward_metadata(forward_batch)
+
+    def get_indexer_metadata(self, layer_id: int, forward_batch: ForwardBatch):
+        """Delegate sparse-index metadata to the full-attention backend.
+
+        Indexers resolve the active backend through ``ForwardContext``, which
+        points at this hybrid wrapper for KDA/DSA models.  The wrapper does not
+        own NSA metadata; its full-attention child does.
+        """
+
+        return self.full_attn_backend.get_indexer_metadata(layer_id, forward_batch)
 
     def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
         for attn_backend in self.attn_backend_list:

--- a/python/sglang/srt/layers/attention/linear/glm5_next_kda_backend.py
+++ b/python/sglang/srt/layers/attention/linear/glm5_next_kda_backend.py
@@ -1,0 +1,214 @@
+"""GLM-5-Next-only KDA attention backend.
+
+Contract: ``a`` and ``b`` are raw gate and raw beta logits in both prefill and
+decode.  This differs from Kimi prefill, whose model layer activates both
+tensors before entering :class:`KDAAttnBackend`.  Keeping a dedicated backend
+prevents the bounded GLM gate from changing Kimi's kernel selection, TF32,
+autotune, or padding behavior.
+
+This backend intentionally contains no CP, MTP, or CUDA-graph specialization.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple, Union
+
+import torch
+from einops import rearrange
+
+from sglang.srt.layers.attention.hybrid_linear_attn_backend import MambaAttnBackendBase
+from sglang.srt.layers.attention.linear.kernels.glm5_next_kda import (
+    Glm5NextTritonKDAKernel,
+)
+from sglang.srt.layers.attention.linear.kernels.glm5_next_kda_ops import (
+    restore_glm5_next_kda_padding,
+    trim_glm5_next_kda_padding,
+)
+from sglang.srt.layers.attention.mamba.causal_conv1d_triton import (
+    causal_conv1d_fn,
+    causal_conv1d_update,
+)
+from sglang.srt.layers.radix_linear_attention import RadixLinearAttention
+from sglang.srt.utils import is_cpu, is_npu
+
+if is_npu():
+    from sgl_kernel_npu.mamba.causal_conv1d import causal_conv1d_update_npu
+
+    causal_conv1d_update = causal_conv1d_update_npu
+elif is_cpu():
+    from sgl_kernel.mamba import causal_conv1d_update_cpu
+
+    causal_conv1d_update = causal_conv1d_update_cpu
+
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_executor.model_runner import ModelRunner
+
+
+class Glm5NextKDAAttnBackend(MambaAttnBackendBase):
+    """KDA backend consuming raw GLM gate/beta with an explicit lower bound."""
+
+    def __init__(self, model_runner: ModelRunner):
+        super().__init__(model_runner)
+        self.kernel = Glm5NextTritonKDAKernel()
+
+    @staticmethod
+    def _lower_bound(layer: RadixLinearAttention) -> float:
+        lower_bound = getattr(layer, "lower_bound", None)
+        if lower_bound is None:
+            raise ValueError(
+                "GLM-5-Next KDA requires an explicit negative gate lower_bound"
+            )
+        lower_bound = float(lower_bound)
+        if lower_bound >= 0:
+            raise ValueError(
+                f"GLM-5-Next KDA lower_bound must be negative, got {lower_bound}"
+            )
+        return lower_bound
+
+    def forward_decode(
+        self,
+        layer: RadixLinearAttention,
+        mixed_qkv: Union[torch.Tensor, Tuple[torch.Tensor, ...]],
+        a: torch.Tensor,
+        b: torch.Tensor,
+        **kwargs,
+    ):
+        q_proj_states, k_proj_states, v_proj_states = torch.split(
+            mixed_qkv,
+            [layer.q_dim, layer.k_dim, layer.v_dim],
+            dim=-1,
+        )
+        q_conv_weights, k_conv_weights, v_conv_weights = layer.conv_weights
+        q_conv_bias, k_conv_bias, v_conv_bias = layer.bias
+
+        layer_cache = self.req_to_token_pool.mamba2_layer_cache(layer.layer_id)
+        q_conv_state, k_conv_state, v_conv_state = layer_cache.conv
+        ssm_states = layer_cache.temporal
+        query_start_loc = self.forward_metadata.query_start_loc
+        cache_indices = self.forward_metadata.mamba_cache_indices
+
+        q = causal_conv1d_update(
+            q_proj_states,
+            q_conv_state.transpose(-1, -2),
+            q_conv_weights,
+            q_conv_bias,
+            activation="silu",
+            conv_state_indices=cache_indices,
+        )
+        k = causal_conv1d_update(
+            k_proj_states,
+            k_conv_state.transpose(-1, -2),
+            k_conv_weights,
+            k_conv_bias,
+            activation="silu",
+            conv_state_indices=cache_indices,
+        )
+        v = causal_conv1d_update(
+            v_proj_states,
+            v_conv_state.transpose(-1, -2),
+            v_conv_weights,
+            v_conv_bias,
+            activation="silu",
+            conv_state_indices=cache_indices,
+        )
+
+        q = rearrange(q, "n (h d) -> 1 n h d", d=layer.head_q_dim)
+        k = rearrange(k, "n (h d) -> 1 n h d", d=layer.head_k_dim)
+        v = rearrange(v, "n (h d) -> 1 n h d", d=layer.head_v_dim)
+        return self.kernel.decode(
+            q=q,
+            k=k,
+            v=v,
+            a=a,
+            b=b,
+            A_log=layer.A_log,
+            dt_bias=layer.dt_bias,
+            lower_bound=self._lower_bound(layer),
+            ssm_states=ssm_states,
+            cache_indices=cache_indices,
+            query_start_loc=query_start_loc,
+        )
+
+    def forward_extend(
+        self,
+        layer: RadixLinearAttention,
+        forward_batch: ForwardBatch,
+        mixed_qkv: Union[torch.Tensor, Tuple[torch.Tensor, ...]],
+        a: torch.Tensor,
+        b: torch.Tensor,
+        **kwargs,
+    ):
+        query_start_loc = self.forward_metadata.query_start_loc
+        cache_indices = self.forward_metadata.mamba_cache_indices
+        mixed_qkv, a, b, physical_num_tokens = trim_glm5_next_kda_padding(
+            mixed_qkv, a, b, query_start_loc
+        )
+        if mixed_qkv.shape[0] == 0:
+            return mixed_qkv.new_zeros(
+                (1, physical_num_tokens, layer.num_v_heads, layer.head_v_dim)
+            )
+
+        q_proj_states, k_proj_states, v_proj_states = torch.split(
+            mixed_qkv,
+            [layer.q_dim, layer.k_dim, layer.v_dim],
+            dim=-1,
+        )
+        q_conv_weights, k_conv_weights, v_conv_weights = layer.conv_weights
+        q_conv_bias, k_conv_bias, v_conv_bias = layer.bias
+
+        layer_cache = self.req_to_token_pool.mamba2_layer_cache(layer.layer_id)
+        q_conv_state, k_conv_state, v_conv_state = layer_cache.conv
+        ssm_states = layer_cache.temporal
+        has_initial_state = forward_batch.extend_prefix_lens > 0
+
+        q = causal_conv1d_fn(
+            q_proj_states.transpose(0, 1),
+            q_conv_weights,
+            q_conv_bias,
+            activation="silu",
+            conv_states=q_conv_state.transpose(-1, -2),
+            has_initial_state=has_initial_state,
+            cache_indices=cache_indices,
+            query_start_loc=query_start_loc,
+            seq_lens_cpu=forward_batch.extend_seq_lens_cpu,
+        ).transpose(0, 1)
+        k = causal_conv1d_fn(
+            k_proj_states.transpose(0, 1),
+            k_conv_weights,
+            k_conv_bias,
+            activation="silu",
+            conv_states=k_conv_state.transpose(-1, -2),
+            has_initial_state=has_initial_state,
+            cache_indices=cache_indices,
+            query_start_loc=query_start_loc,
+            seq_lens_cpu=forward_batch.extend_seq_lens_cpu,
+        ).transpose(0, 1)
+        v = causal_conv1d_fn(
+            v_proj_states.transpose(0, 1),
+            v_conv_weights,
+            v_conv_bias,
+            activation="silu",
+            conv_states=v_conv_state.transpose(-1, -2),
+            has_initial_state=has_initial_state,
+            cache_indices=cache_indices,
+            query_start_loc=query_start_loc,
+            seq_lens_cpu=forward_batch.extend_seq_lens_cpu,
+        ).transpose(0, 1)
+
+        q = rearrange(q, "n (h d) -> 1 n h d", d=layer.head_q_dim)
+        k = rearrange(k, "n (h d) -> 1 n h d", d=layer.head_k_dim)
+        v = rearrange(v, "n (h d) -> 1 n h d", d=layer.head_v_dim)
+        output = self.kernel.extend(
+            q=q,
+            k=k,
+            v=v,
+            g=a,
+            beta=b,
+            A_log=layer.A_log,
+            dt_bias=layer.dt_bias,
+            lower_bound=self._lower_bound(layer),
+            ssm_states=ssm_states,
+            cache_indices=cache_indices,
+            query_start_loc=query_start_loc,
+        )
+        return restore_glm5_next_kda_padding(output, physical_num_tokens)

--- a/python/sglang/srt/layers/attention/linear/kernels/glm5_next_kda.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/glm5_next_kda.py
@@ -1,0 +1,109 @@
+"""GLM-5-Next KDA kernel adapter.
+
+Unlike Kimi, GLM passes raw gate and raw beta logits for both prefill and
+decode.  This adapter activates those inputs with GLM's bounded gate and then
+reuses the unchanged Triton chunk-KDA implementation for prefill.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from sglang.srt.layers.attention.linear.kernels.glm5_next_kda_ops import (
+    glm5_next_safe_decode,
+    glm5_next_safe_gate,
+)
+from sglang.srt.layers.attention.linear.kernels.kda_triton import TritonKDAKernel
+
+
+class Glm5NextTritonKDAKernel(TritonKDAKernel):
+    """Bounded-gate KDA kernel used only by GLM-5-Next."""
+
+    def decode(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        *,
+        A_log: torch.Tensor,
+        dt_bias: torch.Tensor,
+        ssm_states: torch.Tensor,
+        cache_indices: torch.Tensor,
+        query_start_loc: torch.Tensor,
+        lower_bound: float,
+        **kwargs,
+    ) -> torch.Tensor:
+        head_k_dim = q.shape[-1]
+        if a.ndim == 2:
+            a = a.unsqueeze(0)
+        if a.ndim == 3:
+            a = a.unflatten(-1, (-1, head_k_dim))
+        if b.ndim == 2:
+            b = b.unsqueeze(0)
+        return glm5_next_safe_decode(
+            A_log=A_log,
+            raw_gate=a,
+            dt_bias=dt_bias,
+            lower_bound=lower_bound,
+            q=q,
+            k=k,
+            v=v,
+            raw_beta=b,
+            state_source=ssm_states,
+            state_indices=cache_indices,
+            query_start_loc=query_start_loc,
+            use_qk_l2norm_in_kernel=True,
+        )
+
+    def extend(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        g: torch.Tensor,
+        beta: torch.Tensor,
+        *,
+        A_log: torch.Tensor,
+        dt_bias: torch.Tensor,
+        lower_bound: float,
+        ssm_states: torch.Tensor,
+        cache_indices: torch.Tensor,
+        query_start_loc: torch.Tensor,
+        **kwargs,
+    ) -> torch.Tensor:
+        # GLM's model seam must pass both tensors before activation.  Normalize
+        # the raw gate to [..., H*D]; glm5_next_safe_gate returns [..., H, D].
+        head_k_dim = q.shape[-1]
+        if g.ndim == 2:
+            g = g.unsqueeze(0)
+        if g.ndim >= 4 and g.shape[-1] == head_k_dim:
+            g = g.flatten(-2)
+        if beta.ndim == 2:
+            beta = beta.unsqueeze(0)
+        activated_gate = glm5_next_safe_gate(
+            g,
+            A_log,
+            head_k_dim,
+            dt_bias=dt_bias,
+            lower_bound=lower_bound,
+        )
+        activated_beta = beta.float().sigmoid()
+
+        # Padding requests use -1.  KT's MambaPool reserves slot 0 as the
+        # padding sentinel and allocates real requests from [1, size].
+        safe_cache_indices = torch.where(cache_indices >= 0, cache_indices, 0).to(
+            torch.int32
+        )
+        return super().extend(
+            q,
+            k,
+            v,
+            activated_gate,
+            activated_beta,
+            ssm_states=ssm_states,
+            cache_indices=safe_cache_indices,
+            query_start_loc=query_start_loc,
+            **kwargs,
+        )

--- a/python/sglang/srt/layers/attention/linear/kernels/glm5_next_kda.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/glm5_next_kda.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import torch
 
+from sglang.srt.layers.attention.fla.kda import chunk_kda
+from sglang.srt.layers.attention.fla.l2norm import l2norm_fwd
 from sglang.srt.layers.attention.linear.kernels.glm5_next_kda_ops import (
     glm5_next_safe_decode,
     glm5_next_safe_gate,
@@ -89,21 +91,32 @@ class Glm5NextTritonKDAKernel(TritonKDAKernel):
             dt_bias=dt_bias,
             lower_bound=lower_bound,
         )
-        activated_beta = beta.float().sigmoid()
+        # The released GLM reference materializes sigmoid in b_proj's dtype
+        # before chunk KDA widens beta to FP32.  In production b_proj is BF16,
+        # so widening the raw logits first skips a real BF16 rounding boundary.
+        activated_beta = beta.sigmoid().float()
 
         # Padding requests use -1.  KT's MambaPool reserves slot 0 as the
         # padding sentinel and allocates real requests from [1, size].
         safe_cache_indices = torch.where(cache_indices >= 0, cache_indices, 0).to(
             torch.int32
         )
-        return super().extend(
-            q,
-            k,
-            v,
-            activated_gate,
-            activated_beta,
-            ssm_states=ssm_states,
-            cache_indices=safe_cache_indices,
-            query_start_loc=query_start_loc,
-            **kwargs,
+        input_dtype = q.dtype
+        # Match the released GLM recurrence: widen q/k/v together, normalize
+        # q/k in FP32, and keep every tl.dot operand FP32.  Widening q/k alone
+        # is not a valid Triton contract because v participates in the same
+        # chunk-core dot products.
+        normalized_q = l2norm_fwd(q.contiguous(), output_dtype=torch.float32)
+        normalized_k = l2norm_fwd(k.contiguous(), output_dtype=torch.float32)
+        output = chunk_kda(
+            q=normalized_q,
+            k=normalized_k,
+            v=v.float(),
+            g=activated_gate,
+            beta=activated_beta,
+            initial_state=ssm_states,
+            initial_state_indices=safe_cache_indices,
+            use_qk_l2norm_in_kernel=False,
+            cu_seqlens=query_start_loc,
         )
+        return output.to(input_dtype)

--- a/python/sglang/srt/layers/attention/linear/kernels/glm5_next_kda_ops.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/glm5_next_kda_ops.py
@@ -17,9 +17,25 @@ import triton.language as tl
 
 
 _MAX_TRITON_GRID_Z = 65535
-_SAFE_GATE_BLOCK_T = 32
-_SAFE_GATE_NUM_WARPS = 8
-_SAFE_GATE_NUM_STAGES = 3
+
+
+def glm5_next_kda_launch_config(
+    capability: tuple[int, int],
+) -> tuple[tuple[int, int, int], tuple[int, int]]:
+    """Return ``(gate, decode)`` static Triton configs for GLM GPUs."""
+
+    if capability == (8, 6):
+        # Four decode warps remove the single-warp kernel's local-memory
+        # spills on Ampere (verified with ptxas 12.8).
+        return (16, 4, 2), (4, 1)
+    if capability == (8, 9):
+        # The same geometry is spill-free on Ada; keep the larger gate tile
+        # selected for its higher-throughput BF16 prefill path.
+        return (32, 4, 3), (4, 1)
+    # Preserve the previously accepted kernel geometry for every other CUDA
+    # test/runtime.  The exact GLM server gate, not this low-level helper,
+    # controls which architectures can launch the model.
+    return (32, 8, 3), (1, 3)
 
 
 def _cdiv(a: int, b: int) -> int:
@@ -201,7 +217,11 @@ def glm5_next_safe_gate(
         )
     output = torch.empty_like(raw_gate, dtype=torch.float32)
 
-    grid = (_cdiv(num_tokens, _SAFE_GATE_BLOCK_T), num_heads)
+    gate_config, _ = glm5_next_kda_launch_config(
+        torch.cuda.get_device_capability(raw_gate.device)
+    )
+    block_t, num_warps, num_stages = gate_config
+    grid = (_cdiv(num_tokens, block_t), num_heads)
 
     _glm5_next_safe_gate_kernel[grid](
         raw_gate,
@@ -212,11 +232,11 @@ def glm5_next_safe_gate(
         num_tokens,
         num_heads,
         head_k_dim,
-        BT=_SAFE_GATE_BLOCK_T,
+        BT=block_t,
         BD=_next_power_of_2(head_k_dim),
         HAS_BIAS=dt_bias is not None,
-        num_warps=_SAFE_GATE_NUM_WARPS,
-        num_stages=_SAFE_GATE_NUM_STAGES,
+        num_warps=num_warps,
+        num_stages=num_stages,
     )
     return output.view(*original_shape, num_heads, head_k_dim)
 
@@ -480,6 +500,10 @@ def glm5_next_safe_decode(
     raw_beta = raw_beta.contiguous()
     output = q.new_empty(nk, *v.shape)
     grid, split_grid = glm5_next_decode_grid(nk, nv, num_sequences, num_value_heads)
+    _, decode_config = glm5_next_kda_launch_config(
+        torch.cuda.get_device_capability(q.device)
+    )
+    num_warps, num_stages = decode_config
     _glm5_next_safe_decode_kernel[grid](
         A_log=A_log,
         raw_gate=raw_gate,
@@ -506,7 +530,7 @@ def glm5_next_safe_decode(
         USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
         IS_VARLEN=query_start_loc is not None,
         SPLIT_N_HV_GRID=split_grid,
-        num_warps=1,
-        num_stages=3,
+        num_warps=num_warps,
+        num_stages=num_stages,
     )
     return output.squeeze(0)

--- a/python/sglang/srt/layers/attention/linear/kernels/glm5_next_kda_ops.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/glm5_next_kda_ops.py
@@ -1,0 +1,510 @@
+"""GLM-5-Next-only KDA gate and recurrent decode operations.
+
+The existing Kimi KDA kernels deliberately remain untouched.  GLM-5-Next uses
+raw beta plus a bounded gate, while Kimi uses the unbounded softplus gate when
+``lower_bound`` is absent.  Keeping the bounded kernels in this module avoids
+changing Kimi's launch signature, autotune cache, TF32 settings, or padding
+behavior.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+import triton
+import triton.language as tl
+
+
+_MAX_TRITON_GRID_Z = 65535
+_BT_AUTOTUNE = (32, 64, 128)
+_NUM_WARPS_AUTOTUNE = (2, 4, 8, 16) if torch.version.hip else (4, 8, 16, 32)
+
+
+def _cdiv(a: int, b: int) -> int:
+    return -(a // -b)
+
+
+def _next_power_of_2(n: int) -> int:
+    if n < 1:
+        return 1
+    return 1 << (n - 1).bit_length()
+
+
+def glm5_next_decode_grid(
+    nk: int, nv: int, num_sequences: int, num_value_heads: int
+) -> tuple[tuple[int, int, int], bool]:
+    """Return a CUDA-valid grid without changing the normal launch shape."""
+
+    if num_sequences * num_value_heads > _MAX_TRITON_GRID_Z:
+        # The safe decode kernel supports NK == 1.  Split sequence and head
+        # across Y/Z instead of overflowing CUDA's 65535-block Z dimension.
+        if nk != 1:
+            raise ValueError("GLM-5-Next split decode grid requires NK == 1")
+        return (nv, num_sequences, num_value_heads), True
+    return (nk, nv, num_sequences * num_value_heads), False
+
+
+def trim_glm5_next_kda_padding(
+    mixed_qkv: torch.Tensor,
+    raw_gate: torch.Tensor,
+    raw_beta: torch.Tensor,
+    query_start_loc: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, int]:
+    """Trim graph padding while accepting token-first or batch-first gates."""
+
+    physical_num_tokens = mixed_qkv.shape[0]
+    logical_num_tokens = int(query_start_loc[-1])
+    if logical_num_tokens > physical_num_tokens:
+        raise ValueError(
+            "query_start_loc describes more GLM KDA tokens than mixed_qkv: "
+            f"{logical_num_tokens} > {physical_num_tokens}"
+        )
+    if logical_num_tokens == physical_num_tokens:
+        return mixed_qkv, raw_gate, raw_beta, physical_num_tokens
+
+    def trim_token_axis(tensor: torch.Tensor, name: str) -> torch.Tensor:
+        if tensor.shape[0] == physical_num_tokens:
+            return tensor[:logical_num_tokens]
+        if tensor.ndim > 1 and tensor.shape[1] == physical_num_tokens:
+            return tensor[:, :logical_num_tokens]
+        raise ValueError(
+            f"Cannot identify the token axis for {name} with shape "
+            f"{tuple(tensor.shape)} and {physical_num_tokens} physical tokens"
+        )
+
+    return (
+        mixed_qkv[:logical_num_tokens],
+        trim_token_axis(raw_gate, "raw_gate"),
+        trim_token_axis(raw_beta, "raw_beta"),
+        physical_num_tokens,
+    )
+
+
+def restore_glm5_next_kda_padding(
+    output: torch.Tensor, physical_num_tokens: int
+) -> torch.Tensor:
+    """Restore zero rows expected by a padded hybrid-attention batch."""
+
+    logical_num_tokens = output.shape[1]
+    if logical_num_tokens > physical_num_tokens:
+        raise ValueError(
+            "GLM KDA output has more logical than physical tokens: "
+            f"{logical_num_tokens} > {physical_num_tokens}"
+        )
+    if logical_num_tokens == physical_num_tokens:
+        return output
+    padding = output.new_zeros(
+        (output.shape[0], physical_num_tokens - logical_num_tokens)
+        + tuple(output.shape[2:])
+    )
+    return torch.cat((output, padding), dim=1)
+
+
+def _torch_safe_gate(
+    raw_gate: torch.Tensor,
+    A_log: torch.Tensor,
+    head_k_dim: int,
+    dt_bias: Optional[torch.Tensor],
+    lower_bound: float,
+) -> torch.Tensor:
+    """CPU reference/fallback for the bounded GLM gate."""
+
+    original_shape = raw_gate.shape[:-1]
+    raw_gate = raw_gate.reshape(-1, raw_gate.shape[-1]).float()
+    num_heads = A_log.numel()
+    if num_heads * head_k_dim != raw_gate.shape[-1]:
+        raise ValueError(
+            "GLM KDA raw gate width must equal num_heads * head_k_dim: "
+            f"{raw_gate.shape[-1]} != {num_heads} * {head_k_dim}"
+        )
+    gate = raw_gate.view(-1, num_heads, head_k_dim)
+    if dt_bias is not None:
+        gate = gate + dt_bias.float().reshape(1, num_heads, head_k_dim)
+    scale = A_log.float().reshape(1, num_heads, 1).exp()
+    gate = lower_bound * torch.sigmoid(scale * gate)
+    return gate.view(*original_shape, num_heads, head_k_dim)
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({"BT": bt}, num_warps=num_warps, num_stages=num_stages)
+        for bt in _BT_AUTOTUNE
+        for num_warps in _NUM_WARPS_AUTOTUNE
+        for num_stages in (2, 3)
+    ],
+    key=["H", "D"],
+)
+@triton.jit
+def _glm5_next_safe_gate_kernel(
+    raw_gate,
+    A_log,
+    output,
+    dt_bias,
+    lower_bound,
+    T,
+    H,
+    D: tl.constexpr,
+    BT: tl.constexpr,
+    BD: tl.constexpr,
+    HAS_BIAS: tl.constexpr,
+):
+    i_t, i_h = tl.program_id(0), tl.program_id(1)
+    token_offset = i_t * BT
+
+    offsets_d = tl.arange(0, BD)
+    bias_mask = offsets_d < D
+    gate_ptr = tl.make_block_ptr(
+        base=raw_gate + i_h * D,
+        shape=(T, D),
+        strides=(H * D, 1),
+        offsets=(token_offset, 0),
+        block_shape=(BT, BD),
+        order=(1, 0),
+    )
+    output_ptr = tl.make_block_ptr(
+        base=output + i_h * D,
+        shape=(T, D),
+        strides=(H * D, 1),
+        offsets=(token_offset, 0),
+        block_shape=(BT, BD),
+        order=(1, 0),
+    )
+
+    gate = tl.load(gate_ptr, boundary_check=(0, 1)).to(tl.float32)
+    if HAS_BIAS:
+        bias = tl.load(dt_bias + i_h * D + offsets_d, mask=bias_mask, other=0.0).to(
+            tl.float32
+        )
+        gate += bias[None, :]
+
+    scale = tl.exp(tl.load(A_log + i_h).to(tl.float32))
+    gate = lower_bound * tl.sigmoid(scale * gate)
+    tl.store(output_ptr, gate, boundary_check=(0, 1))
+
+
+def glm5_next_safe_gate(
+    raw_gate: torch.Tensor,
+    A_log: torch.Tensor,
+    head_k_dim: int,
+    *,
+    dt_bias: Optional[torch.Tensor],
+    lower_bound: float,
+) -> torch.Tensor:
+    """Activate a raw GLM gate as ``lower_bound * sigmoid(exp(A)*x)``."""
+
+    if lower_bound >= 0:
+        raise ValueError(f"GLM KDA lower_bound must be negative, got {lower_bound}")
+    if raw_gate.device.type == "cpu":
+        return _torch_safe_gate(raw_gate, A_log, head_k_dim, dt_bias, lower_bound)
+
+    original_shape = raw_gate.shape[:-1]
+    raw_gate = raw_gate.reshape(-1, raw_gate.shape[-1])
+    num_tokens, width = raw_gate.shape
+    num_heads = A_log.numel()
+    if num_heads * head_k_dim != width:
+        raise ValueError(
+            "GLM KDA raw gate width must equal num_heads * head_k_dim: "
+            f"{width} != {num_heads} * {head_k_dim}"
+        )
+    output = torch.empty_like(raw_gate, dtype=torch.float32)
+
+    def grid(meta):
+        return (_cdiv(num_tokens, meta["BT"]), num_heads)
+
+    _glm5_next_safe_gate_kernel[grid](
+        raw_gate,
+        A_log,
+        output,
+        dt_bias,
+        lower_bound,
+        num_tokens,
+        num_heads,
+        head_k_dim,
+        BD=_next_power_of_2(head_k_dim),
+        HAS_BIAS=dt_bias is not None,
+    )
+    return output.view(*original_shape, num_heads, head_k_dim)
+
+
+@triton.jit(do_not_specialize=["T"])
+def _glm5_next_safe_decode_kernel(
+    A_log,
+    raw_gate,
+    dt_bias,
+    lower_bound,
+    q,
+    k,
+    v,
+    raw_beta,
+    output,
+    state_source,
+    state_indices,
+    query_start_loc,
+    scale,
+    T,
+    B: tl.constexpr,
+    H: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    USE_INITIAL_STATE: tl.constexpr,
+    USE_QK_L2NORM_IN_KERNEL: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    SPLIT_N_HV_GRID: tl.constexpr,
+):
+    if SPLIT_N_HV_GRID:
+        i_v, i_n, i_hv = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+        i_k = 0
+    else:
+        i_k, i_v, i_nh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+        i_n, i_hv = i_nh // HV, i_nh % HV
+    i_h = i_hv // (HV // H)
+
+    if IS_VARLEN:
+        bos, eos = (
+            tl.load(query_start_loc + i_n).to(tl.int64),
+            tl.load(query_start_loc + i_n + 1).to(tl.int64),
+        )
+        all_tokens = T
+        T = eos - bos
+    else:
+        bos, eos = i_n * T, i_n * T + T
+        all_tokens = B * T
+
+    offsets_k = i_k * BK + tl.arange(0, BK)
+    offsets_v = i_v * BV + tl.arange(0, BV)
+    mask_k = offsets_k < K
+    mask_v = offsets_v < V
+    mask_state = mask_k[:, None] & mask_v[None, :]
+
+    q_ptr = q + (bos * H + i_h) * K + offsets_k
+    k_ptr = k + (bos * H + i_h) * K + offsets_k
+    v_ptr = v + (bos * HV + i_hv) * V + offsets_v
+    beta_ptr = raw_beta + bos * HV + i_hv
+    output_ptr = output + ((i_k * all_tokens + bos) * HV + i_hv) * V + offsets_v
+    gate_ptr = raw_gate + (bos * HV + i_hv) * K + offsets_k
+    bias_ptr = dt_bias + i_hv * K + offsets_k
+    gate_scale = tl.exp(tl.load(A_log + i_hv).to(tl.float32))
+
+    state = tl.zeros([BK, BV], dtype=tl.float32)
+    if USE_INITIAL_STATE:
+        state_index = tl.load(state_indices + i_n)
+        if state_index >= 0:
+            state_ptr = (
+                state_source
+                + state_index * HV * K * V
+                + i_hv * K * V
+                + offsets_k[:, None] * V
+                + offsets_v[None, :]
+            )
+            state += tl.load(state_ptr, mask=mask_state, other=0).to(tl.float32)
+
+    for _ in range(0, T):
+        q_value = tl.load(q_ptr, mask=mask_k, other=0).to(tl.float32)
+        k_value = tl.load(k_ptr, mask=mask_k, other=0).to(tl.float32)
+        v_value = tl.load(v_ptr, mask=mask_v, other=0).to(tl.float32)
+        beta = tl.load(beta_ptr).to(tl.float32)
+        gate = tl.load(gate_ptr, mask=mask_k, other=0).to(tl.float32)
+        bias = tl.load(bias_ptr, mask=mask_k, other=0).to(tl.float32)
+
+        gate = lower_bound * tl.sigmoid(gate_scale * (gate + bias))
+        beta = tl.sigmoid(beta)
+        if USE_QK_L2NORM_IN_KERNEL:
+            q_value /= tl.sqrt(tl.sum(q_value * q_value) + 1e-6)
+            k_value /= tl.sqrt(tl.sum(k_value * k_value) + 1e-6)
+        q_value *= scale
+
+        state *= tl.exp(gate[:, None])
+        v_value -= tl.sum(state * k_value[:, None], axis=0)
+        v_value *= beta
+        state += k_value[:, None] * v_value[None, :]
+        result = tl.sum(state * q_value[:, None], axis=0)
+        tl.store(output_ptr, result.to(output_ptr.dtype.element_ty), mask=mask_v)
+
+        q_ptr += H * K
+        k_ptr += H * K
+        v_ptr += HV * V
+        beta_ptr += HV
+        output_ptr += HV * V
+        gate_ptr += HV * K
+
+    if USE_INITIAL_STATE:
+        state_index = tl.load(state_indices + i_n)
+        if state_index >= 0:
+            state_ptr = (
+                state_source
+                + state_index * HV * K * V
+                + i_hv * K * V
+                + offsets_k[:, None] * V
+                + offsets_v[None, :]
+            )
+            tl.store(
+                state_ptr,
+                state.to(state_ptr.dtype.element_ty),
+                mask=mask_state,
+            )
+
+
+def _torch_safe_decode(
+    *,
+    A_log: torch.Tensor,
+    raw_gate: torch.Tensor,
+    dt_bias: torch.Tensor,
+    lower_bound: float,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    raw_beta: torch.Tensor,
+    state_source: torch.Tensor,
+    state_indices: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    scale: float,
+    use_qk_l2norm_in_kernel: bool,
+) -> torch.Tensor:
+    output = torch.empty_like(v, dtype=q.dtype)
+    _, _, num_q_heads, head_k_dim = q.shape
+    num_value_heads = v.shape[2]
+    head_v_dim = v.shape[-1]
+    group_size = num_value_heads // num_q_heads
+    flat_A = A_log.float().reshape(-1)
+    flat_bias = dt_bias.float().reshape(num_value_heads, head_k_dim)
+
+    for sequence_id in range(query_start_loc.numel() - 1):
+        bos = int(query_start_loc[sequence_id])
+        eos = int(query_start_loc[sequence_id + 1])
+        state_index = int(state_indices[sequence_id])
+        if state_index >= 0:
+            state = state_source[state_index].float().clone()
+        else:
+            state = torch.zeros(
+                num_value_heads,
+                head_k_dim,
+                head_v_dim,
+                dtype=torch.float32,
+                device=q.device,
+            )
+
+        for token_id in range(bos, eos):
+            for value_head in range(num_value_heads):
+                query_head = value_head // group_size
+                q_value = q[0, token_id, query_head].float()
+                k_value = k[0, token_id, query_head].float()
+                if use_qk_l2norm_in_kernel:
+                    q_value = q_value / torch.sqrt(q_value.square().sum() + 1e-6)
+                    k_value = k_value / torch.sqrt(k_value.square().sum() + 1e-6)
+                q_value = q_value * scale
+
+                gate = lower_bound * torch.sigmoid(
+                    flat_A[value_head].exp()
+                    * (
+                        raw_gate[0, token_id, value_head].float()
+                        + flat_bias[value_head]
+                    )
+                )
+                beta = raw_beta[0, token_id, value_head].float().sigmoid()
+                head_state = state[value_head]
+                head_state *= gate.exp().unsqueeze(-1)
+                value = v[0, token_id, value_head].float()
+                value = (value - (head_state * k_value.unsqueeze(-1)).sum(0)) * beta
+                head_state += k_value.unsqueeze(-1) * value.unsqueeze(0)
+                output[0, token_id, value_head] = (
+                    (head_state * q_value.unsqueeze(-1)).sum(0).to(output.dtype)
+                )
+
+        if state_index >= 0:
+            state_source[state_index].copy_(state.to(state_source.dtype))
+    return output
+
+
+def glm5_next_safe_decode(
+    *,
+    A_log: torch.Tensor,
+    raw_gate: torch.Tensor,
+    dt_bias: torch.Tensor,
+    lower_bound: float,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    raw_beta: torch.Tensor,
+    state_source: torch.Tensor,
+    state_indices: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    scale: Optional[float] = None,
+    use_qk_l2norm_in_kernel: bool = True,
+) -> torch.Tensor:
+    """GLM bounded-gate decode; both gate and beta inputs are raw logits."""
+
+    if lower_bound >= 0:
+        raise ValueError(f"GLM KDA lower_bound must be negative, got {lower_bound}")
+    batch, tokens, num_q_heads, head_k_dim = k.shape
+    head_v_dim = v.shape[-1]
+    num_value_heads = v.shape[2]
+    num_sequences = batch if query_start_loc is None else query_start_loc.numel() - 1
+    block_k = triton.next_power_of_2(head_k_dim)
+    block_v = min(triton.next_power_of_2(head_v_dim), 32)
+    nk = triton.cdiv(head_k_dim, block_k)
+    nv = triton.cdiv(head_v_dim, block_v)
+    if nk != 1:
+        raise ValueError("GLM KDA decode currently requires NK == 1")
+    if scale is None:
+        scale = head_k_dim**-0.5
+    elif scale <= 0:
+        raise ValueError("scale must be positive")
+
+    if q.device.type == "cpu":
+        return _torch_safe_decode(
+            A_log=A_log,
+            raw_gate=raw_gate,
+            dt_bias=dt_bias,
+            lower_bound=lower_bound,
+            q=q,
+            k=k,
+            v=v,
+            raw_beta=raw_beta,
+            state_source=state_source,
+            state_indices=state_indices,
+            query_start_loc=query_start_loc,
+            scale=scale,
+            use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+        )
+
+    q = q.contiguous()
+    k = k.contiguous()
+    v = v.contiguous()
+    raw_gate = raw_gate.contiguous()
+    raw_beta = raw_beta.contiguous()
+    output = q.new_empty(nk, *v.shape)
+    grid, split_grid = glm5_next_decode_grid(nk, nv, num_sequences, num_value_heads)
+    _glm5_next_safe_decode_kernel[grid](
+        A_log=A_log,
+        raw_gate=raw_gate,
+        dt_bias=dt_bias,
+        lower_bound=lower_bound,
+        q=q,
+        k=k,
+        v=v,
+        raw_beta=raw_beta,
+        output=output,
+        state_source=state_source,
+        state_indices=state_indices,
+        query_start_loc=query_start_loc,
+        scale=scale,
+        T=tokens,
+        B=batch,
+        H=num_q_heads,
+        HV=num_value_heads,
+        K=head_k_dim,
+        V=head_v_dim,
+        BK=block_k,
+        BV=block_v,
+        USE_INITIAL_STATE=state_source is not None,
+        USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
+        IS_VARLEN=query_start_loc is not None,
+        SPLIT_N_HV_GRID=split_grid,
+        num_warps=1,
+        num_stages=3,
+    )
+    return output.squeeze(0)

--- a/python/sglang/srt/layers/attention/linear/kernels/glm5_next_kda_ops.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/glm5_next_kda_ops.py
@@ -17,8 +17,9 @@ import triton.language as tl
 
 
 _MAX_TRITON_GRID_Z = 65535
-_BT_AUTOTUNE = (32, 64, 128)
-_NUM_WARPS_AUTOTUNE = (2, 4, 8, 16) if torch.version.hip else (4, 8, 16, 32)
+_SAFE_GATE_BLOCK_T = 32
+_SAFE_GATE_NUM_WARPS = 8
+_SAFE_GATE_NUM_STAGES = 3
 
 
 def _cdiv(a: int, b: int) -> int:
@@ -126,15 +127,6 @@ def _torch_safe_gate(
     return gate.view(*original_shape, num_heads, head_k_dim)
 
 
-@triton.autotune(
-    configs=[
-        triton.Config({"BT": bt}, num_warps=num_warps, num_stages=num_stages)
-        for bt in _BT_AUTOTUNE
-        for num_warps in _NUM_WARPS_AUTOTUNE
-        for num_stages in (2, 3)
-    ],
-    key=["H", "D"],
-)
 @triton.jit
 def _glm5_next_safe_gate_kernel(
     raw_gate,
@@ -209,8 +201,7 @@ def glm5_next_safe_gate(
         )
     output = torch.empty_like(raw_gate, dtype=torch.float32)
 
-    def grid(meta):
-        return (_cdiv(num_tokens, meta["BT"]), num_heads)
+    grid = (_cdiv(num_tokens, _SAFE_GATE_BLOCK_T), num_heads)
 
     _glm5_next_safe_gate_kernel[grid](
         raw_gate,
@@ -221,8 +212,11 @@ def glm5_next_safe_gate(
         num_tokens,
         num_heads,
         head_k_dim,
+        BT=_SAFE_GATE_BLOCK_T,
         BD=_next_power_of_2(head_k_dim),
         HAS_BIAS=dt_bias is not None,
+        num_warps=_SAFE_GATE_NUM_WARPS,
+        num_stages=_SAFE_GATE_NUM_STAGES,
     )
     return output.view(*original_shape, num_heads, head_k_dim)
 
@@ -311,7 +305,11 @@ def _glm5_next_safe_decode_kernel(
         bias = tl.load(bias_ptr, mask=mask_k, other=0).to(tl.float32)
 
         gate = lower_bound * tl.sigmoid(gate_scale * (gate + bias))
-        beta = tl.sigmoid(beta)
+        # Match ``torch.sigmoid(b_proj(hidden_states))`` in the released GLM:
+        # sigmoid is materialized in the projection dtype (BF16 in production)
+        # before recurrent KDA widens it to FP32.  Keep this round inside the
+        # fused decode kernel rather than adding one launch per linear layer.
+        beta = tl.sigmoid(beta).to(raw_beta.dtype.element_ty).to(tl.float32)
         if USE_QK_L2NORM_IN_KERNEL:
             q_value /= tl.sqrt(tl.sum(q_value * q_value) + 1e-6)
             k_value /= tl.sqrt(tl.sum(k_value * k_value) + 1e-6)
@@ -404,7 +402,7 @@ def _torch_safe_decode(
                         + flat_bias[value_head]
                     )
                 )
-                beta = raw_beta[0, token_id, value_head].float().sigmoid()
+                beta = raw_beta[0, token_id, value_head].sigmoid().float()
                 head_state = state[value_head]
                 head_state *= gate.exp().unsqueeze(-1)
                 value = v[0, token_id, value_head].float()
@@ -435,7 +433,11 @@ def glm5_next_safe_decode(
     scale: Optional[float] = None,
     use_qk_l2norm_in_kernel: bool = True,
 ) -> torch.Tensor:
-    """GLM bounded-gate decode; both gate and beta inputs are raw logits."""
+    """GLM bounded-gate decode; both gate and beta inputs are raw logits.
+
+    Beta activation is rounded in ``raw_beta.dtype`` before FP32 recurrence,
+    matching the released model's projection/activation boundary.
+    """
 
     if lower_bound >= 0:
         raise ValueError(f"GLM KDA lower_bound must be negative, got {lower_bound}")

--- a/python/sglang/srt/layers/attention/nsa/glm5_next_indexer_logits.py
+++ b/python/sglang/srt/layers/attention/nsa/glm5_next_indexer_logits.py
@@ -1,0 +1,262 @@
+"""Eager correctness logits for the GLM-5-Next KPool indexer.
+
+DeepGEMM's FP8 MQA-logits kernels do not currently support SM120.  These
+helpers implement the same score contract with ordinary PyTorch operations:
+
+    sum_h(weight[q, h] * relu(dot(q_fp8[q, h], k_fp8[k]))) * k_scale[k]
+
+The query scale and the indexer softmax scale are already folded into
+``weight`` by ``IndexerKPool._get_logits_head_gate``.  This module is private
+to ``IndexerKPool``; the shared DeepSeek NSA indexer keeps its existing
+backends and behavior.
+
+This path is deliberately eager and chunked.  CUDA-graph capture and a fused
+high-performance SM120 implementation are Session C work.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+
+
+GLM5_NEXT_INDEX_HEAD_DIM = 128
+GLM5_NEXT_INDEX_PAGE_SIZE = 64
+GLM5_NEXT_INDEX_PAGE_NBYTES = GLM5_NEXT_INDEX_PAGE_SIZE * (GLM5_NEXT_INDEX_HEAD_DIM + 4)
+GLM5_NEXT_INDEX_SCALE_OFFSET = GLM5_NEXT_INDEX_PAGE_SIZE * GLM5_NEXT_INDEX_HEAD_DIM
+
+# Keep the largest temporary score tile bounded.  With GLM's 32 index heads,
+# the default tile is 32 * 2048 * 32 BF16 values (4 MiB), followed by an FP32
+# weighted temporary (8 MiB).
+_DEFAULT_QUERY_CHUNK = 32
+_DEFAULT_KEY_CHUNK = 2048
+
+
+def _validate_flat_inputs(
+    q_fp8: torch.Tensor,
+    k_fp8: torch.Tensor,
+    k_scale: torch.Tensor,
+    weights: torch.Tensor,
+    ks: torch.Tensor,
+    ke: torch.Tensor,
+) -> None:
+    if q_fp8.ndim != 3:
+        raise ValueError(f"q_fp8 must have shape [Q, H, D], got {q_fp8.shape}")
+    if k_fp8.ndim != 2:
+        raise ValueError(f"k_fp8 must have shape [K, D], got {k_fp8.shape}")
+    num_queries, num_heads, head_dim = q_fp8.shape
+    if head_dim != GLM5_NEXT_INDEX_HEAD_DIM:
+        raise ValueError(
+            f"GLM-5-Next indexer fallback requires head_dim=128, got {head_dim}"
+        )
+    if k_fp8.shape[1] != head_dim:
+        raise ValueError(f"K head_dim ({k_fp8.shape[1]}) does not match Q ({head_dim})")
+    if weights.shape != (num_queries, num_heads):
+        raise ValueError(
+            f"weights must have shape {(num_queries, num_heads)}, got {weights.shape}"
+        )
+    if k_scale.shape != (k_fp8.shape[0],):
+        raise ValueError(
+            f"k_scale must have shape {(k_fp8.shape[0],)}, got {k_scale.shape}"
+        )
+    if ks.shape != (num_queries,) or ke.shape != (num_queries,):
+        raise ValueError(
+            f"ks/ke must both have shape {(num_queries,)}, got {ks.shape}/{ke.shape}"
+        )
+    if q_fp8.device != k_fp8.device or q_fp8.device != k_scale.device:
+        raise ValueError("Q, K, and K scale must be on the same device")
+    if q_fp8.device != weights.device or q_fp8.device != ks.device:
+        raise ValueError("weights and ragged bounds must be on the Q device")
+    if ke.device != q_fp8.device:
+        raise ValueError("ragged end bounds must be on the Q device")
+
+
+def glm5_next_eager_fp8_mqa_logits(
+    q_fp8: torch.Tensor,
+    kv_fp8: tuple[torch.Tensor, torch.Tensor],
+    weights: torch.Tensor,
+    ks: torch.Tensor,
+    ke: torch.Tensor,
+    *,
+    query_chunk_size: int = _DEFAULT_QUERY_CHUNK,
+    key_chunk_size: int = _DEFAULT_KEY_CHUNK,
+) -> torch.Tensor:
+    """Chunked non-paged FP8 MQA logits with DeepGEMM-compatible math.
+
+    Entries outside each row's half-open ``[ks, ke)`` interval are ``-inf``.
+    The caller's KPool top-k transform already consumes those same bounds, but
+    initializing them here makes the eager correctness route deterministic.
+    """
+
+    k_fp8, k_scale = kv_fp8
+    _validate_flat_inputs(q_fp8, k_fp8, k_scale, weights, ks, ke)
+    if query_chunk_size <= 0 or key_chunk_size <= 0:
+        raise ValueError("query_chunk_size and key_chunk_size must be positive")
+
+    num_queries, _, _ = q_fp8.shape
+    num_keys = k_fp8.shape[0]
+    logits = torch.full(
+        (num_queries, num_keys),
+        float("-inf"),
+        dtype=torch.float32,
+        device=q_fp8.device,
+    )
+    if num_queries == 0 or num_keys == 0:
+        return logits
+
+    q_bf16 = q_fp8.to(torch.bfloat16)
+    k_bf16 = k_fp8.to(torch.bfloat16)
+    weights_fp32 = weights.float()
+    scales_fp32 = k_scale.float()
+    key_positions = torch.arange(num_keys, device=q_fp8.device)
+
+    for q_start in range(0, num_queries, query_chunk_size):
+        q_end = min(q_start + query_chunk_size, num_queries)
+        q_chunk = q_bf16[q_start:q_end]
+        weight_chunk = weights_fp32[q_start:q_end]
+        ks_chunk = ks[q_start:q_end].to(torch.int64)
+        ke_chunk = ke[q_start:q_end].to(torch.int64)
+
+        for k_start in range(0, num_keys, key_chunk_size):
+            k_end = min(k_start + key_chunk_size, num_keys)
+            key_chunk = k_bf16[k_start:k_end]
+
+            # [Q, K, H].  BF16 operands match SGLang's existing SM120 torch
+            # reference for paged MQA; weighting/reduction are FP32.
+            scores = torch.bmm(
+                key_chunk.unsqueeze(0).expand(q_end - q_start, -1, -1),
+                q_chunk.transpose(1, 2),
+            )
+            scores = F.relu(scores)
+            scores = (scores * weight_chunk.unsqueeze(1)).sum(dim=2)
+            scores = scores * scales_fp32[k_start:k_end].unsqueeze(0)
+
+            positions = key_positions[k_start:k_end].unsqueeze(0)
+            valid = (positions >= ks_chunk.unsqueeze(1)) & (
+                positions < ke_chunk.unsqueeze(1)
+            )
+            logits[q_start:q_end, k_start:k_end] = scores.masked_fill(
+                ~valid, float("-inf")
+            )
+
+    return logits
+
+
+def _paged_cache_keys_and_scales(
+    kv_cache_fp8: torch.Tensor,
+    page_ids: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Gather packed GLM index pages and return FP8 keys plus FP32 scales."""
+
+    if kv_cache_fp8.ndim < 2:
+        raise ValueError("packed KPool cache must have at least two dimensions")
+    cache_u8 = kv_cache_fp8.view(torch.uint8)
+    cache_flat = cache_u8.reshape(cache_u8.shape[0], -1)
+    if cache_flat.shape[1] != GLM5_NEXT_INDEX_PAGE_NBYTES:
+        raise ValueError(
+            "packed GLM index page must contain 64x128 FP8 bytes and 64 FP32 "
+            f"scales ({GLM5_NEXT_INDEX_PAGE_NBYTES} bytes), got "
+            f"{cache_flat.shape[1]}"
+        )
+
+    # Only pages below a valid logical sequence length are selected.  Clamping
+    # mirrors SGLang's existing torch paged-MQA reference and prevents a stale
+    # padding sentinel from becoming a negative Python-style index.
+    gathered = cache_flat.index_select(0, page_ids.to(torch.int64).clamp_min(0))
+    key_bytes = gathered[:, :GLM5_NEXT_INDEX_SCALE_OFFSET].contiguous()
+    scale_bytes = gathered[:, GLM5_NEXT_INDEX_SCALE_OFFSET:].contiguous()
+    keys = key_bytes.view(torch.float8_e4m3fn).reshape(-1, GLM5_NEXT_INDEX_HEAD_DIM)
+    scales = scale_bytes.view(torch.float32).reshape(-1)
+    return keys, scales
+
+
+def glm5_next_eager_fp8_paged_mqa_logits(
+    q_fp8: torch.Tensor,
+    kv_cache_fp8: torch.Tensor,
+    weights: torch.Tensor,
+    seq_lens: torch.Tensor,
+    page_table: torch.Tensor,
+    max_seq_len: int,
+    *,
+    key_chunk_size: int = _DEFAULT_KEY_CHUNK,
+) -> torch.Tensor:
+    """Chunked paged FP8 MQA logits for eager GLM decode on SM120."""
+
+    if q_fp8.ndim != 4 or q_fp8.shape[1] != 1:
+        raise ValueError(f"paged q_fp8 must have shape [B, 1, H, D], got {q_fp8.shape}")
+    batch_size, _, num_heads, head_dim = q_fp8.shape
+    if head_dim != GLM5_NEXT_INDEX_HEAD_DIM:
+        raise ValueError(
+            f"GLM-5-Next paged indexer fallback requires head_dim=128, got {head_dim}"
+        )
+    if weights.shape != (batch_size, num_heads):
+        raise ValueError(
+            f"weights must have shape {(batch_size, num_heads)}, got {weights.shape}"
+        )
+    if seq_lens.ndim == 2 and seq_lens.shape[1] == 1:
+        seq_lens = seq_lens.squeeze(1)
+    if seq_lens.shape != (batch_size,):
+        raise ValueError(
+            f"seq_lens must have shape {(batch_size,)}, got {seq_lens.shape}"
+        )
+    if page_table.ndim != 2 or page_table.shape[0] != batch_size:
+        raise ValueError(
+            f"page_table must have batch size {batch_size}, got {page_table.shape}"
+        )
+    if max_seq_len < 0:
+        raise ValueError(f"max_seq_len must be non-negative, got {max_seq_len}")
+    if key_chunk_size <= 0:
+        raise ValueError("key_chunk_size must be positive")
+
+    logits = torch.full(
+        (batch_size, max_seq_len),
+        float("-inf"),
+        dtype=torch.float32,
+        device=q_fp8.device,
+    )
+    if batch_size == 0 or max_seq_len == 0:
+        return logits
+
+    q_bf16 = q_fp8[:, 0].to(torch.bfloat16)
+    weights_fp32 = weights.float()
+    # One host sync is acceptable in this explicitly eager correctness path.
+    logical_lengths = seq_lens.detach().to(device="cpu", dtype=torch.int64).tolist()
+
+    for row, requested_len in enumerate(logical_lengths):
+        logical_len = min(max(int(requested_len), 0), max_seq_len)
+        logical_len = min(logical_len, page_table.shape[1] * GLM5_NEXT_INDEX_PAGE_SIZE)
+        if logical_len == 0:
+            continue
+
+        # Round the chunk to whole pages so cache extraction remains simple.
+        keys_per_chunk = max(
+            GLM5_NEXT_INDEX_PAGE_SIZE,
+            (key_chunk_size // GLM5_NEXT_INDEX_PAGE_SIZE) * GLM5_NEXT_INDEX_PAGE_SIZE,
+        )
+        for key_start in range(0, logical_len, keys_per_chunk):
+            key_end = min(key_start + keys_per_chunk, logical_len)
+            page_start = key_start // GLM5_NEXT_INDEX_PAGE_SIZE
+            page_end = (
+                key_end + GLM5_NEXT_INDEX_PAGE_SIZE - 1
+            ) // GLM5_NEXT_INDEX_PAGE_SIZE
+            keys, scales = _paged_cache_keys_and_scales(
+                kv_cache_fp8, page_table[row, page_start:page_end]
+            )
+            valid_keys = key_end - key_start
+            keys = keys[:valid_keys].to(torch.bfloat16)
+            scales = scales[:valid_keys].float()
+
+            scores = torch.matmul(keys, q_bf16[row].transpose(0, 1))
+            scores = F.relu(scores)
+            scores = (scores * weights_fp32[row].unsqueeze(0)).sum(dim=1)
+            logits[row, key_start:key_end] = scores * scales
+
+    return logits
+
+
+def use_glm5_next_eager_logits_on_device(device: torch.device) -> bool:
+    """Return true only for NVIDIA SM120, where current DeepGEMM is unsupported."""
+
+    if device.type != "cuda" or not torch.cuda.is_available():
+        return False
+    return torch.cuda.get_device_capability(device) == (12, 0)

--- a/python/sglang/srt/layers/attention/nsa/glm5_next_indexer_logits.py
+++ b/python/sglang/srt/layers/attention/nsa/glm5_next_indexer_logits.py
@@ -1,4 +1,4 @@
-"""Eager correctness logits for the GLM-5-Next KPool indexer.
+"""GLM-5-Next KPool indexer logits.
 
 DeepGEMM's FP8 MQA-logits kernels do not currently support SM120.  These
 helpers implement the same score contract with ordinary PyTorch operations:
@@ -10,11 +10,14 @@ The query scale and the indexer softmax scale are already folded into
 to ``IndexerKPool``; the shared DeepSeek NSA indexer keeps its existing
 backends and behavior.
 
-This path is deliberately eager and chunked.  CUDA-graph capture and a fused
-high-performance SM120 implementation are Session C work.
+The paged decode path is deliberately vectorized and device-length driven so
+it can be captured with the fixed buffers used by SGLang CUDA graphs.  The
+ragged prefill path remains statically chunked to bound its temporary memory.
 """
 
 from __future__ import annotations
+
+from collections.abc import Iterator
 
 import torch
 import torch.nn.functional as F
@@ -30,6 +33,12 @@ GLM5_NEXT_INDEX_SCALE_OFFSET = GLM5_NEXT_INDEX_PAGE_SIZE * GLM5_NEXT_INDEX_HEAD_
 # weighted temporary (8 MiB).
 _DEFAULT_QUERY_CHUNK = 32
 _DEFAULT_KEY_CHUNK = 2048
+
+# The ragged prefill caller consumes each row chunk before requesting the next
+# one.  Keeping this fixed (rather than deriving it from free GPU memory) makes
+# the allocation bound deterministic: at the final 500K boundary, one FP32
+# logits chunk is about 15.3 MiB instead of a 1.9-GiB [4096, 125056] matrix.
+GLM5_NEXT_PREFILL_QUERY_ROW_CHUNK = _DEFAULT_QUERY_CHUNK
 
 
 def _validate_flat_inputs(
@@ -71,7 +80,22 @@ def _validate_flat_inputs(
         raise ValueError("ragged end bounds must be on the Q device")
 
 
-def glm5_next_eager_fp8_mqa_logits(
+def glm5_next_prefill_query_row_ranges(
+    num_queries: int,
+    *,
+    query_chunk_size: int = GLM5_NEXT_PREFILL_QUERY_ROW_CHUNK,
+) -> Iterator[tuple[int, int]]:
+    """Yield deterministic half-open query-row chunks without tensor allocation."""
+
+    if num_queries < 0:
+        raise ValueError("num_queries must be non-negative")
+    if query_chunk_size <= 0:
+        raise ValueError("query_chunk_size must be positive")
+    for q_start in range(0, num_queries, query_chunk_size):
+        yield q_start, min(q_start + query_chunk_size, num_queries)
+
+
+def iter_glm5_next_eager_fp8_mqa_logits(
     q_fp8: torch.Tensor,
     kv_fp8: tuple[torch.Tensor, torch.Tensor],
     weights: torch.Tensor,
@@ -80,12 +104,14 @@ def glm5_next_eager_fp8_mqa_logits(
     *,
     query_chunk_size: int = _DEFAULT_QUERY_CHUNK,
     key_chunk_size: int = _DEFAULT_KEY_CHUNK,
-) -> torch.Tensor:
-    """Chunked non-paged FP8 MQA logits with DeepGEMM-compatible math.
+) -> Iterator[tuple[int, int, torch.Tensor]]:
+    """Yield bounded row chunks of non-paged FP8 MQA logits.
 
     Entries outside each row's half-open ``[ks, ke)`` interval are ``-inf``.
     The caller's KPool top-k transform already consumes those same bounds, but
     initializing them here makes the eager correctness route deterministic.
+    K and its scale are converted exactly once and retained across yielded row
+    chunks; consumers should finish top-k and release a chunk before advancing.
     """
 
     k_fp8, k_scale = kv_fp8
@@ -95,14 +121,21 @@ def glm5_next_eager_fp8_mqa_logits(
 
     num_queries, _, _ = q_fp8.shape
     num_keys = k_fp8.shape[0]
-    logits = torch.full(
-        (num_queries, num_keys),
-        float("-inf"),
-        dtype=torch.float32,
-        device=q_fp8.device,
-    )
     if num_queries == 0 or num_keys == 0:
-        return logits
+        for q_start, q_end in glm5_next_prefill_query_row_ranges(
+            num_queries, query_chunk_size=query_chunk_size
+        ):
+            yield (
+                q_start,
+                q_end,
+                torch.full(
+                    (q_end - q_start, num_keys),
+                    float("-inf"),
+                    dtype=torch.float32,
+                    device=q_fp8.device,
+                ),
+            )
+        return
 
     q_bf16 = q_fp8.to(torch.bfloat16)
     k_bf16 = k_fp8.to(torch.bfloat16)
@@ -110,12 +143,19 @@ def glm5_next_eager_fp8_mqa_logits(
     scales_fp32 = k_scale.float()
     key_positions = torch.arange(num_keys, device=q_fp8.device)
 
-    for q_start in range(0, num_queries, query_chunk_size):
-        q_end = min(q_start + query_chunk_size, num_queries)
+    for q_start, q_end in glm5_next_prefill_query_row_ranges(
+        num_queries, query_chunk_size=query_chunk_size
+    ):
         q_chunk = q_bf16[q_start:q_end]
         weight_chunk = weights_fp32[q_start:q_end]
         ks_chunk = ks[q_start:q_end].to(torch.int64)
         ke_chunk = ke[q_start:q_end].to(torch.int64)
+        logits_chunk = torch.full(
+            (q_end - q_start, num_keys),
+            float("-inf"),
+            dtype=torch.float32,
+            device=q_fp8.device,
+        )
 
         for k_start in range(0, num_keys, key_chunk_size):
             k_end = min(k_start + key_chunk_size, num_keys)
@@ -135,10 +175,47 @@ def glm5_next_eager_fp8_mqa_logits(
             valid = (positions >= ks_chunk.unsqueeze(1)) & (
                 positions < ke_chunk.unsqueeze(1)
             )
-            logits[q_start:q_end, k_start:k_end] = scores.masked_fill(
-                ~valid, float("-inf")
-            )
+            logits_chunk[:, k_start:k_end] = scores.masked_fill(~valid, float("-inf"))
 
+        yield q_start, q_end, logits_chunk
+        del logits_chunk
+
+
+def glm5_next_eager_fp8_mqa_logits(
+    q_fp8: torch.Tensor,
+    kv_fp8: tuple[torch.Tensor, torch.Tensor],
+    weights: torch.Tensor,
+    ks: torch.Tensor,
+    ke: torch.Tensor,
+    *,
+    query_chunk_size: int = _DEFAULT_QUERY_CHUNK,
+    key_chunk_size: int = _DEFAULT_KEY_CHUNK,
+) -> torch.Tensor:
+    """Materialize the complete logits matrix for small tests and callers.
+
+    Production GLM-5-Next ragged prefill consumes
+    :func:`iter_glm5_next_eager_fp8_mqa_logits` directly so its memory is
+    bounded by one query-row chunk.
+    """
+
+    k_fp8, k_scale = kv_fp8
+    _validate_flat_inputs(q_fp8, k_fp8, k_scale, weights, ks, ke)
+    logits = torch.full(
+        (q_fp8.shape[0], k_fp8.shape[0]),
+        float("-inf"),
+        dtype=torch.float32,
+        device=q_fp8.device,
+    )
+    for q_start, q_end, logits_chunk in iter_glm5_next_eager_fp8_mqa_logits(
+        q_fp8,
+        kv_fp8,
+        weights,
+        ks,
+        ke,
+        query_chunk_size=query_chunk_size,
+        key_chunk_size=key_chunk_size,
+    ):
+        logits[q_start:q_end] = logits_chunk
     return logits
 
 
@@ -180,7 +257,13 @@ def glm5_next_eager_fp8_paged_mqa_logits(
     *,
     key_chunk_size: int = _DEFAULT_KEY_CHUNK,
 ) -> torch.Tensor:
-    """Chunked paged FP8 MQA logits for eager GLM decode on SM120."""
+    """Graph-safe paged FP8 MQA logits for GLM decode on SM120.
+
+    ``max_seq_len`` and the page-table shape are capture-time constants.  The
+    logical lengths stay on device and only mask the fixed-width result.  In
+    particular, this function must not branch or choose launch geometry from
+    the dummy sequence lengths used while a graph is captured.
+    """
 
     if q_fp8.ndim != 4 or q_fp8.shape[1] != 1:
         raise ValueError(f"paged q_fp8 must have shape [B, 1, H, D], got {q_fp8.shape}")
@@ -208,49 +291,57 @@ def glm5_next_eager_fp8_paged_mqa_logits(
     if key_chunk_size <= 0:
         raise ValueError("key_chunk_size must be positive")
 
-    logits = torch.full(
-        (batch_size, max_seq_len),
-        float("-inf"),
-        dtype=torch.float32,
-        device=q_fp8.device,
+    # ``key_chunk_size`` is retained for source/API compatibility with the
+    # eager Session-AB helper.  Decode batch sizes are capped at 1/2/4, so a
+    # single vectorized launch is both graph-stable and bounded.
+    del key_chunk_size
+
+    max_pages = (
+        max_seq_len + GLM5_NEXT_INDEX_PAGE_SIZE - 1
+    ) // GLM5_NEXT_INDEX_PAGE_SIZE
+    if max_pages > page_table.shape[1]:
+        raise ValueError(
+            f"page_table has {page_table.shape[1]} pages but {max_pages} are "
+            f"required for max_seq_len={max_seq_len}"
+        )
+
+    # Gather every capture-width page.  Invalid logical positions are masked
+    # below using the replay-updated device lengths.  Clamp padding/stale table
+    # cells so even an entirely empty padded row can never address outside the
+    # physical index cache.
+    cache_u8 = kv_cache_fp8.view(torch.uint8)
+    cache_flat = cache_u8.reshape(cache_u8.shape[0], -1)
+    if cache_flat.shape[1] != GLM5_NEXT_INDEX_PAGE_NBYTES:
+        raise ValueError(
+            "packed GLM index page must contain 64x128 FP8 bytes and 64 FP32 "
+            f"scales ({GLM5_NEXT_INDEX_PAGE_NBYTES} bytes), got "
+            f"{cache_flat.shape[1]}"
+        )
+
+    page_ids = page_table[:, :max_pages].to(torch.int64)
+    page_ids = page_ids.clamp(min=0, max=cache_flat.shape[0] - 1)
+    gathered = cache_flat[page_ids]
+    key_bytes = gathered[..., :GLM5_NEXT_INDEX_SCALE_OFFSET].contiguous()
+    scale_bytes = gathered[..., GLM5_NEXT_INDEX_SCALE_OFFSET:].contiguous()
+
+    padded_seq_len = max_pages * GLM5_NEXT_INDEX_PAGE_SIZE
+    keys = key_bytes.view(torch.float8_e4m3fn).reshape(
+        batch_size, padded_seq_len, GLM5_NEXT_INDEX_HEAD_DIM
     )
-    if batch_size == 0 or max_seq_len == 0:
-        return logits
+    scales = scale_bytes.view(torch.float32).reshape(batch_size, padded_seq_len)
 
     q_bf16 = q_fp8[:, 0].to(torch.bfloat16)
-    weights_fp32 = weights.float()
-    # One host sync is acceptable in this explicitly eager correctness path.
-    logical_lengths = seq_lens.detach().to(device="cpu", dtype=torch.int64).tolist()
+    scores = torch.bmm(keys.to(torch.bfloat16), q_bf16.transpose(1, 2))
+    scores = F.relu(scores)
+    scores = (scores.float() * weights.float().unsqueeze(1)).sum(dim=2)
+    scores.mul_(scales.float())
 
-    for row, requested_len in enumerate(logical_lengths):
-        logical_len = min(max(int(requested_len), 0), max_seq_len)
-        logical_len = min(logical_len, page_table.shape[1] * GLM5_NEXT_INDEX_PAGE_SIZE)
-        if logical_len == 0:
-            continue
-
-        # Round the chunk to whole pages so cache extraction remains simple.
-        keys_per_chunk = max(
-            GLM5_NEXT_INDEX_PAGE_SIZE,
-            (key_chunk_size // GLM5_NEXT_INDEX_PAGE_SIZE) * GLM5_NEXT_INDEX_PAGE_SIZE,
-        )
-        for key_start in range(0, logical_len, keys_per_chunk):
-            key_end = min(key_start + keys_per_chunk, logical_len)
-            page_start = key_start // GLM5_NEXT_INDEX_PAGE_SIZE
-            page_end = (
-                key_end + GLM5_NEXT_INDEX_PAGE_SIZE - 1
-            ) // GLM5_NEXT_INDEX_PAGE_SIZE
-            keys, scales = _paged_cache_keys_and_scales(
-                kv_cache_fp8, page_table[row, page_start:page_end]
-            )
-            valid_keys = key_end - key_start
-            keys = keys[:valid_keys].to(torch.bfloat16)
-            scales = scales[:valid_keys].float()
-
-            scores = torch.matmul(keys, q_bf16[row].transpose(0, 1))
-            scores = F.relu(scores)
-            scores = (scores * weights_fp32[row].unsqueeze(0)).sum(dim=1)
-            logits[row, key_start:key_end] = scores * scales
-
+    logits = scores[:, :max_seq_len].contiguous()
+    positions = torch.arange(max_seq_len, dtype=torch.int32, device=q_fp8.device)
+    logical_lengths = seq_lens.to(torch.int32).clamp(min=0, max=max_seq_len)
+    logits.masked_fill_(
+        positions.unsqueeze(0) >= logical_lengths.unsqueeze(1), float("-inf")
+    )
     return logits
 
 

--- a/python/sglang/srt/layers/attention/nsa/glm5_next_indexer_triton.py
+++ b/python/sglang/srt/layers/attention/nsa/glm5_next_indexer_triton.py
@@ -1,0 +1,386 @@
+"""Architecture-local Triton scorer for GLM-5-Next KPool.
+
+The scorer keeps the model's exact contract: one ReLU dot product per index
+head, followed by the learned head reduction and the optional per-key FP8
+descale.  SM86 consumes BF16 Q/K directly; SM89 consumes E4M3 Q/K.  SM120
+continues to use its accepted eager implementation.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import torch
+import triton
+import triton.language as tl
+
+INDEX_HEAD_DIM = 128
+INDEX_PAGE_SIZE = 64
+
+
+def use_glm5_next_triton_indexer(device: torch.device) -> bool:
+    if device.type != "cuda" or not torch.cuda.is_available():
+        return False
+    return torch.cuda.get_device_capability(device) in ((8, 6), (8, 9))
+
+
+def glm5_next_indexer_launch_config(
+    capability: tuple[int, int],
+) -> tuple[int, int, int]:
+    """Return the offline-selected conservative config for SM86/SM89."""
+
+    if capability == (8, 6):
+        return 32, 4, 2
+    if capability == (8, 9):
+        return 64, 4, 3
+    raise ValueError(
+        f"GLM Triton indexer is unsupported on SM{capability[0]}{capability[1]}"
+    )
+
+
+def _validate_glm5_next_indexer_profile(
+    query: torch.Tensor,
+    index_k: torch.Tensor,
+    k_scale: torch.Tensor | None,
+) -> tuple[int, int]:
+    """Fail closed if cache precision does not match the consumer GPU profile."""
+
+    if not use_glm5_next_triton_indexer(query.device):
+        raise RuntimeError("GLM Triton indexer requires SM86 or SM89")
+    capability = torch.cuda.get_device_capability(query.device)
+    if index_k.device != query.device or (
+        k_scale is not None and k_scale.device != query.device
+    ):
+        raise ValueError("GLM Triton indexer inputs must share one CUDA device")
+    if capability == (8, 6):
+        if query.dtype != torch.bfloat16 or index_k.dtype != torch.bfloat16:
+            raise TypeError("SM86 GLM indexer requires BF16 query and KPool cache")
+        if k_scale is not None:
+            raise TypeError("SM86 GLM indexer must not receive an FP8 K scale")
+    else:
+        if query.dtype != torch.float8_e4m3fn or index_k.dtype != torch.float8_e4m3fn:
+            raise TypeError("SM89 GLM indexer requires E4M3 query and KPool cache")
+        if k_scale is None:
+            raise TypeError("SM89 GLM indexer requires the FP8 KPool scale")
+        if k_scale.dtype != torch.float32:
+            raise TypeError("SM89 GLM indexer requires an FP32 KPool scale")
+    return capability
+
+
+@triton.jit
+def _glm5_next_flat_mqa_logits_kernel(
+    q_ptr,
+    k_ptr,
+    k_scale_ptr,
+    weights_ptr,
+    ks_ptr,
+    ke_ptr,
+    logits_ptr,
+    num_keys: tl.int32,
+    stride_q_row: tl.constexpr,
+    stride_q_head: tl.constexpr,
+    stride_q_dim: tl.constexpr,
+    stride_k_row: tl.constexpr,
+    stride_k_dim: tl.constexpr,
+    stride_weights_row: tl.constexpr,
+    stride_weights_head: tl.constexpr,
+    stride_logits_row: tl.constexpr,
+    NUM_HEADS: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    USE_K_SCALE: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    row = tl.program_id(0)
+    key_block = tl.program_id(1)
+    key_offsets = key_block * BLOCK_K + tl.arange(0, BLOCK_K)
+    dim_offsets = tl.arange(0, HEAD_DIM)
+    head_offsets = tl.arange(0, NUM_HEADS)
+
+    keys = tl.load(
+        k_ptr
+        + key_offsets[:, None] * stride_k_row
+        + dim_offsets[None, :] * stride_k_dim,
+        mask=key_offsets[:, None] < num_keys,
+        other=0.0,
+    )
+    queries = tl.load(
+        q_ptr
+        + row * stride_q_row
+        + head_offsets[:, None] * stride_q_head
+        + dim_offsets[None, :] * stride_q_dim
+    )
+    head_scores = tl.dot(keys, tl.trans(queries), out_dtype=tl.float32)
+    head_scores = tl.maximum(head_scores, 0.0)
+    weights = tl.load(
+        weights_ptr + row * stride_weights_row + head_offsets * stride_weights_head
+    ).to(tl.float32)
+    logits = tl.sum(head_scores * weights[None, :], axis=1)
+    if USE_K_SCALE:
+        key_scale = tl.load(
+            k_scale_ptr + key_offsets,
+            mask=key_offsets < num_keys,
+            other=0.0,
+        ).to(tl.float32)
+        logits *= key_scale
+
+    row_start = tl.load(ks_ptr + row)
+    row_end = tl.load(ke_ptr + row)
+    valid = (
+        (key_offsets >= row_start) & (key_offsets < row_end) & (key_offsets < num_keys)
+    )
+    tl.store(
+        logits_ptr + row * stride_logits_row + key_offsets,
+        tl.where(valid, logits, -float("inf")),
+        mask=key_offsets < num_keys,
+    )
+
+
+@triton.jit
+def _glm5_next_paged_mqa_logits_kernel(
+    q_ptr,
+    cache_ptr,
+    cache_scale_ptr,
+    weights_ptr,
+    seq_lens_ptr,
+    page_table_ptr,
+    logits_ptr,
+    max_seq_len: tl.int32,
+    num_cache_pages: tl.int32,
+    stride_q_row: tl.constexpr,
+    stride_q_head: tl.constexpr,
+    stride_q_dim: tl.constexpr,
+    stride_cache_page: tl.constexpr,
+    stride_weights_row: tl.constexpr,
+    stride_weights_head: tl.constexpr,
+    stride_page_table_row: tl.constexpr,
+    stride_page_table_col: tl.constexpr,
+    stride_logits_row: tl.constexpr,
+    SCALE_OFFSET: tl.constexpr,
+    SCALE_PAGE_STRIDE: tl.constexpr,
+    NUM_HEADS: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    USE_K_SCALE: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    row = tl.program_id(0)
+    key_block = tl.program_id(1)
+    key_offsets = key_block * BLOCK_K + tl.arange(0, BLOCK_K)
+    dim_offsets = tl.arange(0, HEAD_DIM)
+    head_offsets = tl.arange(0, NUM_HEADS)
+
+    page_cols = key_offsets // PAGE_SIZE
+    token_offsets = key_offsets % PAGE_SIZE
+    pages = tl.load(
+        page_table_ptr
+        + row * stride_page_table_row
+        + page_cols * stride_page_table_col,
+        mask=key_offsets < max_seq_len,
+        other=0,
+    ).to(tl.int64)
+    page_valid = (pages >= 0) & (pages < num_cache_pages)
+    safe_pages = tl.minimum(tl.maximum(pages, 0), num_cache_pages - 1)
+    keys = tl.load(
+        cache_ptr
+        + safe_pages[:, None] * stride_cache_page
+        + token_offsets[:, None] * HEAD_DIM
+        + dim_offsets[None, :],
+        mask=page_valid[:, None] & (key_offsets[:, None] < max_seq_len),
+        other=0.0,
+    )
+    queries = tl.load(
+        q_ptr
+        + row * stride_q_row
+        + head_offsets[:, None] * stride_q_head
+        + dim_offsets[None, :] * stride_q_dim
+    )
+    head_scores = tl.dot(keys, tl.trans(queries), out_dtype=tl.float32)
+    head_scores = tl.maximum(head_scores, 0.0)
+    weights = tl.load(
+        weights_ptr + row * stride_weights_row + head_offsets * stride_weights_head
+    ).to(tl.float32)
+    logits = tl.sum(head_scores * weights[None, :], axis=1)
+    if USE_K_SCALE:
+        scales = tl.load(
+            cache_scale_ptr
+            + safe_pages * SCALE_PAGE_STRIDE
+            + SCALE_OFFSET
+            + token_offsets,
+            mask=page_valid & (key_offsets < max_seq_len),
+            other=0.0,
+        ).to(tl.float32)
+        logits *= scales
+
+    seq_len = tl.load(seq_lens_ptr + row)
+    valid = page_valid & (key_offsets < seq_len) & (key_offsets < max_seq_len)
+    tl.store(
+        logits_ptr + row * stride_logits_row + key_offsets,
+        tl.where(valid, logits, -float("inf")),
+        mask=key_offsets < max_seq_len,
+    )
+
+
+def iter_glm5_next_triton_mqa_logits(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    weights: torch.Tensor,
+    ks: torch.Tensor,
+    ke: torch.Tensor,
+    *,
+    k_scale: torch.Tensor | None = None,
+    query_chunk_size: int = 32,
+) -> Iterator[tuple[int, int, torch.Tensor]]:
+    capability = _validate_glm5_next_indexer_profile(q, k, k_scale)
+    if q.ndim != 3 or q.shape[-1] != INDEX_HEAD_DIM:
+        raise ValueError(f"q must have shape [Q,H,128], got {tuple(q.shape)}")
+    if k.ndim != 2 or k.shape[-1] != INDEX_HEAD_DIM:
+        raise ValueError(f"k must have shape [K,128], got {tuple(k.shape)}")
+    if weights.shape != q.shape[:2]:
+        raise ValueError(f"weights must have shape {tuple(q.shape[:2])}")
+    if weights.dtype != torch.float32:
+        raise TypeError("GLM Triton indexer weights must use FP32")
+    if k_scale is not None and k_scale.shape != (k.shape[0],):
+        raise ValueError("k_scale must have shape [K]")
+    if ks.dtype != torch.int32 or ke.dtype != torch.int32:
+        raise TypeError("GLM Triton ragged bounds must use int32")
+    if ks.shape != (q.shape[0],) or ke.shape != (q.shape[0],):
+        raise ValueError("GLM Triton ragged bounds must have one entry per query")
+    if weights.device != q.device or ks.device != q.device or ke.device != q.device:
+        raise ValueError("GLM Triton indexer metadata must share the query device")
+    if query_chunk_size <= 0:
+        raise ValueError("query_chunk_size must be positive")
+
+    block_k, num_warps, num_stages = glm5_next_indexer_launch_config(capability)
+    dummy_scale = k if k_scale is None else k_scale
+    for q_start in range(0, q.shape[0], query_chunk_size):
+        q_end = min(q_start + query_chunk_size, q.shape[0])
+        q_chunk = q[q_start:q_end].contiguous()
+        weights_chunk = weights[q_start:q_end].contiguous()
+        logits = torch.empty(
+            (q_end - q_start, k.shape[0]), dtype=torch.float32, device=q.device
+        )
+        grid = (q_end - q_start, triton.cdiv(k.shape[0], block_k))
+        _glm5_next_flat_mqa_logits_kernel[grid](
+            q_chunk,
+            k,
+            dummy_scale,
+            weights_chunk,
+            ks[q_start:q_end],
+            ke[q_start:q_end],
+            logits,
+            k.shape[0],
+            q_chunk.stride(0),
+            q_chunk.stride(1),
+            q_chunk.stride(2),
+            k.stride(0),
+            k.stride(1),
+            weights_chunk.stride(0),
+            weights_chunk.stride(1),
+            logits.stride(0),
+            NUM_HEADS=q.shape[1],
+            HEAD_DIM=INDEX_HEAD_DIM,
+            USE_K_SCALE=k_scale is not None,
+            BLOCK_K=block_k,
+            num_warps=num_warps,
+            num_stages=num_stages,
+        )
+        yield q_start, q_end, logits
+
+
+def glm5_next_triton_paged_mqa_logits(
+    q: torch.Tensor,
+    cache: torch.Tensor,
+    weights: torch.Tensor,
+    seq_lens: torch.Tensor,
+    page_table: torch.Tensor,
+    max_seq_len: int,
+    *,
+    use_k_scale: bool,
+) -> torch.Tensor:
+    if q.ndim == 4:
+        if q.shape[1] != 1:
+            raise ValueError("paged q next-token dimension must be one")
+        q = q[:, 0]
+    q = q.contiguous()
+    weights = weights.contiguous()
+    if q.ndim != 3 or q.shape[-1] != INDEX_HEAD_DIM:
+        raise ValueError(f"q must have shape [B,H,128], got {tuple(q.shape)}")
+    if weights.shape != q.shape[:2]:
+        raise ValueError(f"weights must have shape {tuple(q.shape[:2])}")
+    if weights.dtype != torch.float32:
+        raise TypeError("GLM Triton indexer weights must use FP32")
+    if cache.ndim != 2 or page_table.ndim != 2:
+        raise ValueError("cache and page_table must be two-dimensional")
+    if max_seq_len <= 0:
+        raise ValueError("max_seq_len must be positive")
+    if max_seq_len > page_table.shape[1] * INDEX_PAGE_SIZE:
+        raise ValueError("max_seq_len exceeds the KPool page-table capacity")
+    if cache.shape[0] == 0 or cache.stride(1) != 1:
+        raise ValueError("KPool cache must contain contiguous physical pages")
+    if seq_lens.dtype != torch.int32 or page_table.dtype != torch.int32:
+        raise TypeError("KPool lengths and page table must use int32")
+    if seq_lens.shape not in ((q.shape[0],), (q.shape[0], 1)):
+        raise ValueError("KPool lengths must have one entry per query")
+    seq_lens = seq_lens.view(-1)
+    if page_table.shape[0] != q.shape[0]:
+        raise ValueError("KPool page table must have one row per query")
+    if weights.device != q.device or seq_lens.device != q.device:
+        raise ValueError("KPool scorer metadata must share the query device")
+    if page_table.device != q.device or cache.device != q.device:
+        raise ValueError("KPool cache metadata must share the query device")
+
+    if use_k_scale:
+        if cache.dtype != torch.uint8:
+            raise TypeError("scaled KPool cache must use packed uint8 storage")
+        cache_values = cache.view(torch.float8_e4m3fn)
+        cache_scales = cache.view(torch.float32)
+        scale_offset = INDEX_PAGE_SIZE * INDEX_HEAD_DIM // 4
+        scale_page_stride = cache.shape[1] // 4
+    else:
+        if cache.dtype != torch.bfloat16:
+            raise TypeError("unscaled KPool cache must be BF16")
+        cache_values = cache
+        cache_scales = cache
+        scale_offset = 0
+        scale_page_stride = 0
+
+    capability = _validate_glm5_next_indexer_profile(
+        q,
+        cache_values,
+        cache_scales if use_k_scale else None,
+    )
+    block_k, num_warps, num_stages = glm5_next_indexer_launch_config(capability)
+    logits = torch.empty(
+        (q.shape[0], max_seq_len), dtype=torch.float32, device=q.device
+    )
+    grid = (q.shape[0], triton.cdiv(max_seq_len, block_k))
+    _glm5_next_paged_mqa_logits_kernel[grid](
+        q,
+        cache_values,
+        cache_scales,
+        weights,
+        seq_lens,
+        page_table,
+        logits,
+        max_seq_len,
+        cache.shape[0],
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        cache_values.stride(0),
+        weights.stride(0),
+        weights.stride(1),
+        page_table.stride(0),
+        page_table.stride(1),
+        logits.stride(0),
+        SCALE_OFFSET=scale_offset,
+        SCALE_PAGE_STRIDE=scale_page_stride,
+        NUM_HEADS=q.shape[1],
+        HEAD_DIM=INDEX_HEAD_DIM,
+        PAGE_SIZE=INDEX_PAGE_SIZE,
+        USE_K_SCALE=use_k_scale,
+        BLOCK_K=block_k,
+        num_warps=num_warps,
+        num_stages=num_stages,
+    )
+    return logits

--- a/python/sglang/srt/layers/attention/nsa/glm5_next_scaled_fp8.py
+++ b/python/sglang/srt/layers/attention/nsa/glm5_next_scaled_fp8.py
@@ -1,0 +1,150 @@
+"""Block-scaled FP8 helpers for GLM-5-Next's zero-RoPE latent cache.
+
+This module is intentionally model-local.  The released GLM-5-Next checkpoint
+uses a 512-wide latent as both sparse-attention key and value.  A raw E4M3 cast
+wastes most of the format's range, so exact GLM stores four FP32 descales (one
+per 128 latent channels) next to the unchanged 512-byte FP8 cache row.
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+GLM5_NEXT_LATENT_DIM = 512
+GLM5_NEXT_LATENT_SCALE_GROUP_SIZE = 128
+GLM5_NEXT_LATENT_SCALE_GROUPS = (
+    GLM5_NEXT_LATENT_DIM // GLM5_NEXT_LATENT_SCALE_GROUP_SIZE
+)
+GLM5_NEXT_FP8_MAX = 448.0
+
+
+def _validate_zero_rope_inputs(
+    q_nope: torch.Tensor,
+    q_rope: torch.Tensor,
+    k_nope: torch.Tensor,
+    k_rope: torch.Tensor,
+) -> None:
+    if q_nope.shape[-1] != GLM5_NEXT_LATENT_DIM:
+        raise ValueError(
+            f"GLM-5-Next scaled FP8 query must have width 512, got {q_nope.shape[-1]}"
+        )
+    if k_nope.shape[-1] != GLM5_NEXT_LATENT_DIM:
+        raise ValueError(
+            f"GLM-5-Next scaled FP8 key must have width 512, got {k_nope.shape[-1]}"
+        )
+    if q_rope.shape[-1] != 0 or k_rope.shape[-1] != 0:
+        raise ValueError(
+            "GLM-5-Next scaled FP8 latent helper accepts only zero-RoPE inputs"
+        )
+    if q_nope.device != q_rope.device:
+        raise ValueError("GLM-5-Next query components must share a device")
+    if k_nope.device != k_rope.device:
+        raise ValueError("GLM-5-Next key components must share a device")
+
+
+def glm5_next_quantize_latent_fp8(
+    tensor: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize the last dimension into four independently scaled FP8 blocks."""
+
+    if tensor.shape[-1] != GLM5_NEXT_LATENT_DIM:
+        raise ValueError(
+            f"GLM-5-Next latent quantization requires width 512, got {tensor.shape[-1]}"
+        )
+    if tensor.is_cuda:
+        # Reuse NSA's graph-safe Triton quantizer and its established
+        # dequant-scale convention: dequantized = fp8 * scale.
+        from sglang.srt.layers.attention.nsa.triton_kernel import act_quant
+
+        return act_quant(
+            tensor.contiguous(),
+            block_size=GLM5_NEXT_LATENT_SCALE_GROUP_SIZE,
+            # A power-of-two descale is an exact exponent shift for E4M3.  It
+            # preserves raw-cast rounding in the normal range while rescuing
+            # blocks that would otherwise underflow or overflow.
+            scale_fmt="ue8m0",
+        )
+
+    grouped = tensor.float().reshape(
+        *tensor.shape[:-1],
+        GLM5_NEXT_LATENT_SCALE_GROUPS,
+        GLM5_NEXT_LATENT_SCALE_GROUP_SIZE,
+    )
+    # Match act_quant's lower bound.  It keeps all-zero rows finite and avoids
+    # storing a zero descale in cache metadata.
+    amax = grouped.abs().amax(dim=-1).clamp_min(1.0e-4)
+    unrounded_scale = amax / GLM5_NEXT_FP8_MAX
+    scale = torch.pow(2.0, torch.ceil(torch.log2(unrounded_scale)))
+    quantized = (
+        (grouped / scale.unsqueeze(-1))
+        .clamp(-GLM5_NEXT_FP8_MAX, GLM5_NEXT_FP8_MAX)
+        .to(torch.float8_e4m3fn)
+        .reshape_as(tensor)
+    )
+    return quantized, scale.to(torch.float32)
+
+
+def glm5_next_dequantize_latent_fp8(
+    tensor: torch.Tensor,
+    scale: torch.Tensor,
+    *,
+    dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    """Reference dequantizer used by bounded prefill and CPU tests."""
+
+    expected_scale_shape = (
+        *tensor.shape[:-1],
+        GLM5_NEXT_LATENT_SCALE_GROUPS,
+    )
+    if tensor.shape[-1] != GLM5_NEXT_LATENT_DIM:
+        raise ValueError(
+            "GLM-5-Next latent dequantization requires width 512, "
+            f"got {tensor.shape[-1]}"
+        )
+    if tuple(scale.shape) != expected_scale_shape:
+        raise ValueError(
+            "GLM-5-Next latent scale shape mismatch: expected "
+            f"{expected_scale_shape}, got {tuple(scale.shape)}"
+        )
+    grouped = tensor.float().reshape(
+        *tensor.shape[:-1],
+        GLM5_NEXT_LATENT_SCALE_GROUPS,
+        GLM5_NEXT_LATENT_SCALE_GROUP_SIZE,
+    )
+    return (grouped * scale.float().unsqueeze(-1)).reshape_as(tensor).to(dtype)
+
+
+def glm5_next_mla_prepare_scaled_fp8_no_rope(
+    q_nope: torch.Tensor,
+    q_rope: torch.Tensor,
+    k_nope: torch.Tensor,
+    k_rope: torch.Tensor,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+]:
+    """Prepare BF16 Q plus scaled-FP8 K for exact GLM sparse attention.
+
+    Query is ephemeral and the model-local kernel accepts BF16 directly, so
+    quantizing it would lose precision without saving persistent memory.  Only
+    the cached key/value latent is quantized and accompanied by four descales.
+    """
+
+    _validate_zero_rope_inputs(q_nope, q_rope, k_nope, k_rope)
+    k_fp8, k_scale = glm5_next_quantize_latent_fp8(k_nope)
+    # Preserve the existing zero-width tensor contract used by the MLA writer.
+    k_rope_fp8 = k_rope.to(torch.float8_e4m3fn)
+    return q_nope.contiguous(), k_fp8, k_rope_fp8, k_scale
+
+
+__all__ = [
+    "GLM5_NEXT_LATENT_DIM",
+    "GLM5_NEXT_LATENT_SCALE_GROUP_SIZE",
+    "GLM5_NEXT_LATENT_SCALE_GROUPS",
+    "glm5_next_dequantize_latent_fp8",
+    "glm5_next_mla_prepare_scaled_fp8_no_rope",
+    "glm5_next_quantize_latent_fp8",
+]

--- a/python/sglang/srt/layers/attention/nsa/glm5_next_sparse_attention.py
+++ b/python/sglang/srt/layers/attention/nsa/glm5_next_sparse_attention.py
@@ -24,7 +24,22 @@ GLM5_NEXT_LATENT_SCALE_GROUP_SIZE = 128
 GLM5_NEXT_LATENT_SCALE_GROUPS = (
     GLM5_NEXT_SPARSE_HEAD_DIM // GLM5_NEXT_LATENT_SCALE_GROUP_SIZE
 )
-_TRITON_TOKEN_BLOCK = 16
+
+
+def glm5_next_sparse_mla_launch_config(
+    capability: tuple[int, int],
+) -> tuple[int, int, int]:
+    """Return static decode geometry tuned per supported GPU family."""
+
+    if capability == (8, 6):
+        # Ampere has a smaller register file per SM; halve the selected-token
+        # tile so the 512-wide online-softmax accumulator remains resident.
+        return 8, 4, 2
+    if capability == (8, 9):
+        return 16, 8, 2
+    # Retain the original geometry for existing CUDA unit tests and future
+    # backends.  The model/server dispatch remains the architecture gate.
+    return 16, 8, 2
 
 
 @triton.jit
@@ -135,6 +150,23 @@ def _glm5_next_sparse_mla_cuda(
 ) -> torch.Tensor:
     """Launch the graph-safe BF16-Q/raw-or-scaled-FP8-KV decode kernel."""
 
+    capability = torch.cuda.get_device_capability(query.device)
+    if capability == (8, 6):
+        if (
+            query.dtype != torch.bfloat16
+            or kv_cache.dtype != torch.bfloat16
+            or kv_scale is not None
+        ):
+            raise TypeError("SM86 GLM sparse MLA requires unscaled BF16 Q/KV")
+    elif capability == (8, 9):
+        if (
+            query.dtype != torch.bfloat16
+            or kv_cache.dtype != torch.float8_e4m3fn
+            or kv_scale is None
+            or kv_scale.dtype != torch.float32
+        ):
+            raise TypeError("SM89 GLM sparse MLA requires BF16 Q and scaled E4M3 KV")
+
     flat_kv = kv_cache.reshape(-1, GLM5_NEXT_SPARSE_HEAD_DIM)
     query_3d = query.contiguous()
     indices_2d = indices.contiguous()
@@ -147,6 +179,7 @@ def _glm5_next_sparse_mla_cuda(
         kv_scale_2d = flat_kv
     output = torch.empty_like(query_3d, dtype=torch.bfloat16)
     grid = (query_3d.shape[0], query_3d.shape[1])
+    block_t, num_warps, num_stages = glm5_next_sparse_mla_launch_config(capability)
     _glm5_next_sparse_mla_decode_kernel[grid](
         query_3d,
         flat_kv,
@@ -171,9 +204,9 @@ def _glm5_next_sparse_mla_cuda(
         HEAD_DIM=GLM5_NEXT_SPARSE_HEAD_DIM,
         SCALE_GROUP_SIZE=GLM5_NEXT_LATENT_SCALE_GROUP_SIZE,
         USE_KV_SCALE=use_kv_scale,
-        BLOCK_T=_TRITON_TOKEN_BLOCK,
-        num_warps=8,
-        num_stages=2,
+        BLOCK_T=block_t,
+        num_warps=num_warps,
+        num_stages=num_stages,
     )
     return output
 

--- a/python/sglang/srt/layers/attention/nsa/glm5_next_sparse_attention.py
+++ b/python/sglang/srt/layers/attention/nsa/glm5_next_sparse_attention.py
@@ -1,0 +1,105 @@
+"""Correctness fallback for GLM-5-Next's native zero-RoPE sparse MLA.
+
+FlashInfer first exposed the H512 kernel ABI in 0.6.17, but its TRTLLM-GEN
+implementation does not run on SM120 (for example RTX 5090).  Session AB also
+keeps CUDA graphs disabled.  This small, model-local eager implementation
+therefore provides a deterministic path without changing the pinned
+FlashInfer dependency or any existing DeepSeek NSA backend.
+
+The fallback deliberately processes a bounded number of query tokens at once.
+That keeps the gathered ``[query, topk, 512]`` workspace bounded during short
+correctness prefills.  A graph-safe high-performance kernel remains a Session-C
+replacement, not an implicit promise of this reference implementation.
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+def glm5_next_sparse_mla_reference(
+    query: torch.Tensor,
+    kv_cache: torch.Tensor,
+    indices: torch.Tensor,
+    *,
+    sm_scale: float,
+    chunk_size: int = 8,
+) -> torch.Tensor:
+    """Compute sparse latent attention over a raw FP8/BF16 H512 cache.
+
+    Args:
+        query: ``[num_query_tokens, num_heads, 512]``.
+        kv_cache: Any contiguous paged/flat layout whose last dimension is 512.
+        indices: ``[num_query_tokens, sparse_capacity]`` physical token indices;
+            invalid padding entries are ``-1``.
+        sm_scale: Scale applied before softmax.
+        chunk_size: Maximum query rows gathered at once.
+
+    Returns:
+        BF16 tensor ``[num_query_tokens, num_heads, 512]``.
+    """
+
+    if query.ndim != 3 or query.shape[-1] != 512:
+        raise ValueError(
+            "GLM-5-Next sparse MLA query must have shape [tokens, heads, 512], "
+            f"got {tuple(query.shape)}"
+        )
+    if kv_cache.shape[-1] != 512:
+        raise ValueError(
+            "GLM-5-Next sparse MLA KV cache must have width 512, "
+            f"got {kv_cache.shape[-1]}"
+        )
+    if indices.ndim != 2 or indices.shape[0] != query.shape[0]:
+        raise ValueError(
+            "GLM-5-Next sparse MLA indices must have shape [tokens, capacity], "
+            f"got {tuple(indices.shape)} for {query.shape[0]} query tokens"
+        )
+    if indices.dtype != torch.int32:
+        raise TypeError(
+            f"GLM-5-Next sparse MLA indices must be int32, got {indices.dtype}"
+        )
+    if query.device != kv_cache.device or query.device != indices.device:
+        raise ValueError("GLM-5-Next sparse MLA inputs must be on the same device")
+    if chunk_size <= 0:
+        raise ValueError(f"chunk_size must be positive, got {chunk_size}")
+
+    flat_kv = kv_cache.reshape(-1, 512)
+    output = torch.empty(
+        (*query.shape[:-1], 512),
+        dtype=torch.bfloat16,
+        device=query.device,
+    )
+
+    for start in range(0, query.shape[0], chunk_size):
+        end = min(start + chunk_size, query.shape[0])
+        chunk_indices = indices[start:end]
+        valid = chunk_indices >= 0
+        if bool(torch.any(chunk_indices[valid] >= flat_kv.shape[0]).item()):
+            bad_index = int(chunk_indices[valid].max().item())
+            raise IndexError(
+                "GLM-5-Next sparse MLA index exceeds the KV cache: "
+                f"max index {bad_index}, cache tokens {flat_kv.shape[0]}"
+            )
+
+        nonempty = valid.any(dim=-1)
+        safe_indices = chunk_indices.masked_fill(~valid, 0).to(torch.long)
+        selected_kv = flat_kv[safe_indices].to(torch.bfloat16)
+        query_chunk = query[start:end].to(torch.bfloat16)
+
+        scores = torch.bmm(query_chunk, selected_kv.transpose(1, 2)).float()
+        scores.mul_(float(sm_scale))
+        scores.masked_fill_(~valid.unsqueeze(1), float("-inf"))
+        # Empty rows occur only for padded eager work.  Give softmax a finite
+        # dummy slot and explicitly zero the resulting output below.
+        if not bool(torch.all(nonempty).item()):
+            scores[~nonempty] = 0.0
+
+        probabilities = torch.softmax(scores, dim=-1).to(torch.bfloat16)
+        chunk_output = torch.bmm(probabilities, selected_kv)
+        chunk_output[~nonempty] = 0
+        output[start:end] = chunk_output
+
+    return output
+
+
+__all__ = ["glm5_next_sparse_mla_reference"]

--- a/python/sglang/srt/layers/attention/nsa/glm5_next_sparse_attention.py
+++ b/python/sglang/srt/layers/attention/nsa/glm5_next_sparse_attention.py
@@ -1,20 +1,181 @@
-"""Correctness fallback for GLM-5-Next's native zero-RoPE sparse MLA.
+"""GLM-5-Next native zero-RoPE sparse MLA.
 
 FlashInfer first exposed the H512 kernel ABI in 0.6.17, but its TRTLLM-GEN
-implementation does not run on SM120 (for example RTX 5090).  Session AB also
-keeps CUDA graphs disabled.  This small, model-local eager implementation
-therefore provides a deterministic path without changing the pinned
-FlashInfer dependency or any existing DeepSeek NSA backend.
+implementation does not run on SM120 (for example RTX 5090).  This small,
+model-local implementation provides a deterministic graph-safe path without
+changing the pinned FlashInfer dependency or any existing DeepSeek NSA backend.
 
-The fallback deliberately processes a bounded number of query tokens at once.
-That keeps the gathered ``[query, topk, 512]`` workspace bounded during short
-correctness prefills.  A graph-safe high-performance kernel remains a Session-C
-replacement, not an implicit promise of this reference implementation.
+CUDA decode uses a BF16-query/scaled-FP8-KV Triton kernel with online softmax.
+It consumes the model's physical token indices directly, has fixed launch
+geometry for graph batch sizes 1/2/4, and does not materialize
+``[query, topk, 512]``.  The small PyTorch implementation remains the CPU
+correctness oracle.
 """
 
 from __future__ import annotations
 
 import torch
+import triton
+import triton.language as tl
+
+
+GLM5_NEXT_SPARSE_HEAD_DIM = 512
+GLM5_NEXT_LATENT_SCALE_GROUP_SIZE = 128
+GLM5_NEXT_LATENT_SCALE_GROUPS = (
+    GLM5_NEXT_SPARSE_HEAD_DIM // GLM5_NEXT_LATENT_SCALE_GROUP_SIZE
+)
+_TRITON_TOKEN_BLOCK = 16
+
+
+@triton.jit
+def _glm5_next_sparse_mla_decode_kernel(
+    query_ptr,
+    kv_ptr,
+    kv_scale_ptr,
+    indices_ptr,
+    output_ptr,
+    sm_scale: tl.float32,
+    num_kv_tokens: tl.int64,
+    topk: tl.int32,
+    stride_query_row: tl.constexpr,
+    stride_query_head: tl.constexpr,
+    stride_query_dim: tl.constexpr,
+    stride_kv_row: tl.constexpr,
+    stride_kv_dim: tl.constexpr,
+    stride_kv_scale_row: tl.constexpr,
+    stride_kv_scale_group: tl.constexpr,
+    stride_indices_row: tl.constexpr,
+    stride_indices_col: tl.constexpr,
+    stride_output_row: tl.constexpr,
+    stride_output_head: tl.constexpr,
+    stride_output_dim: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    SCALE_GROUP_SIZE: tl.constexpr,
+    USE_KV_SCALE: tl.constexpr,
+    BLOCK_T: tl.constexpr,
+):
+    row = tl.program_id(0)
+    head = tl.program_id(1)
+
+    dims = tl.arange(0, HEAD_DIM)
+    query = tl.load(
+        query_ptr
+        + row * stride_query_row
+        + head * stride_query_head
+        + dims * stride_query_dim
+    ).to(tl.float32)
+
+    running_max: tl.float32 = -1.0e30
+    running_sum: tl.float32 = 0.0
+    accumulator = tl.zeros([HEAD_DIM], tl.float32)
+    token_offsets = tl.arange(0, BLOCK_T)
+
+    # ``topk`` is a static tensor width at graph capture (2051 for the released
+    # checkpoint), while validity remains data-driven through the -1 sentinel.
+    for start in range(0, topk, BLOCK_T):
+        cols = start + token_offsets
+        in_bounds = cols < topk
+        physical = tl.load(
+            indices_ptr + row * stride_indices_row + cols * stride_indices_col,
+            mask=in_bounds,
+            other=-1,
+        ).to(tl.int64)
+        valid = in_bounds & (physical >= 0) & (physical < num_kv_tokens)
+        safe_physical = tl.where(valid, physical, 0)
+
+        kv = tl.load(
+            kv_ptr
+            + safe_physical[:, None] * stride_kv_row
+            + dims[None, :] * stride_kv_dim,
+            mask=valid[:, None],
+            other=0.0,
+        ).to(tl.float32)
+        if USE_KV_SCALE:
+            kv_scale = tl.load(
+                kv_scale_ptr
+                + safe_physical[:, None] * stride_kv_scale_row
+                + (dims[None, :] // SCALE_GROUP_SIZE) * stride_kv_scale_group,
+                mask=valid[:, None],
+                other=0.0,
+            ).to(tl.float32)
+            kv *= kv_scale
+        scores = tl.sum(kv * query[None, :], axis=1) * sm_scale
+        scores = tl.where(valid, scores, -1.0e30)
+
+        tile_max = tl.max(scores, axis=0)
+        next_max = tl.maximum(running_max, tile_max)
+        old_scale = tl.exp(running_max - next_max)
+        probabilities = tl.exp(scores - next_max)
+        probabilities = tl.where(valid, probabilities, 0.0)
+
+        running_sum = running_sum * old_scale + tl.sum(probabilities, axis=0)
+        accumulator = accumulator * old_scale + tl.sum(
+            probabilities[:, None] * kv, axis=0
+        )
+        running_max = next_max
+
+    denominator = tl.where(running_sum > 0.0, running_sum, 1.0)
+    output = accumulator / denominator
+    tl.store(
+        output_ptr
+        + row * stride_output_row
+        + head * stride_output_head
+        + dims * stride_output_dim,
+        output.to(tl.bfloat16),
+    )
+
+
+def _glm5_next_sparse_mla_cuda(
+    query: torch.Tensor,
+    kv_cache: torch.Tensor,
+    indices: torch.Tensor,
+    *,
+    sm_scale: float,
+    kv_scale: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Launch the graph-safe BF16-Q/raw-or-scaled-FP8-KV decode kernel."""
+
+    flat_kv = kv_cache.reshape(-1, GLM5_NEXT_SPARSE_HEAD_DIM)
+    query_3d = query.contiguous()
+    indices_2d = indices.contiguous()
+    use_kv_scale = kv_scale is not None
+    if use_kv_scale:
+        kv_scale_2d = kv_scale.contiguous()
+    else:
+        # Triton requires a pointer argument even when the constexpr branch is
+        # dead.  Reuse a live input pointer; its strides are never consumed.
+        kv_scale_2d = flat_kv
+    output = torch.empty_like(query_3d, dtype=torch.bfloat16)
+    grid = (query_3d.shape[0], query_3d.shape[1])
+    _glm5_next_sparse_mla_decode_kernel[grid](
+        query_3d,
+        flat_kv,
+        kv_scale_2d,
+        indices_2d,
+        output,
+        float(sm_scale),
+        flat_kv.shape[0],
+        indices_2d.shape[1],
+        query_3d.stride(0),
+        query_3d.stride(1),
+        query_3d.stride(2),
+        flat_kv.stride(0),
+        flat_kv.stride(1),
+        kv_scale_2d.stride(0),
+        kv_scale_2d.stride(1),
+        indices_2d.stride(0),
+        indices_2d.stride(1),
+        output.stride(0),
+        output.stride(1),
+        output.stride(2),
+        HEAD_DIM=GLM5_NEXT_SPARSE_HEAD_DIM,
+        SCALE_GROUP_SIZE=GLM5_NEXT_LATENT_SCALE_GROUP_SIZE,
+        USE_KV_SCALE=use_kv_scale,
+        BLOCK_T=_TRITON_TOKEN_BLOCK,
+        num_warps=8,
+        num_stages=2,
+    )
+    return output
 
 
 def glm5_next_sparse_mla_reference(
@@ -24,8 +185,12 @@ def glm5_next_sparse_mla_reference(
     *,
     sm_scale: float,
     chunk_size: int = 8,
+    use_cuda_decode_kernel: bool = True,
+    kv_scale: torch.Tensor | None = None,
+    current_chunk_kv: torch.Tensor | None = None,
+    current_chunk_locs: torch.Tensor | None = None,
 ) -> torch.Tensor:
-    """Compute sparse latent attention over a raw FP8/BF16 H512 cache.
+    """Compute sparse latent attention over a raw/scaled FP8 or BF16 cache.
 
     Args:
         query: ``[num_query_tokens, num_heads, 512]``.
@@ -34,17 +199,30 @@ def glm5_next_sparse_mla_reference(
             invalid padding entries are ``-1``.
         sm_scale: Scale applied before softmax.
         chunk_size: Maximum query rows gathered at once.
+        use_cuda_decode_kernel: Use the graph-safe raw-FP8 Triton kernel for
+            CUDA decode.  EXTEND/prefill must pass ``False`` so its BF16
+            matmul/softmax rounding remains aligned with the reference model.
+        kv_scale: Optional FP32 ``[physical_tokens, 4]`` block descales.
+            It uses 128 channels/group.  Production exact GLM keeps ephemeral
+            Q in BF16 and scales only its persistent FP8 latent cache.
+        current_chunk_kv: Optional pre-quantization BF16 latent rows for the
+            current EXTEND chunk.  Persistent history is still read from the
+            scaled-FP8 cache; only selected physical rows whose indices occur
+            in ``current_chunk_locs`` use these values.  Decode must not pass
+            this argument.
+        current_chunk_locs: Physical cache locations corresponding one-to-one
+            with ``current_chunk_kv``.
 
     Returns:
         BF16 tensor ``[num_query_tokens, num_heads, 512]``.
     """
 
-    if query.ndim != 3 or query.shape[-1] != 512:
+    if query.ndim != 3 or query.shape[-1] != GLM5_NEXT_SPARSE_HEAD_DIM:
         raise ValueError(
             "GLM-5-Next sparse MLA query must have shape [tokens, heads, 512], "
             f"got {tuple(query.shape)}"
         )
-    if kv_cache.shape[-1] != 512:
+    if kv_cache.shape[-1] != GLM5_NEXT_SPARSE_HEAD_DIM:
         raise ValueError(
             "GLM-5-Next sparse MLA KV cache must have width 512, "
             f"got {kv_cache.shape[-1]}"
@@ -63,9 +241,102 @@ def glm5_next_sparse_mla_reference(
     if chunk_size <= 0:
         raise ValueError(f"chunk_size must be positive, got {chunk_size}")
 
-    flat_kv = kv_cache.reshape(-1, 512)
+    use_kv_scale = kv_scale is not None
+    if use_kv_scale:
+        if kv_scale.ndim != 2 or kv_scale.shape != (
+            kv_cache.numel() // GLM5_NEXT_SPARSE_HEAD_DIM,
+            GLM5_NEXT_LATENT_SCALE_GROUPS,
+        ):
+            raise ValueError(
+                "GLM-5-Next KV scale must have shape [physical_tokens, 4], "
+                f"got {tuple(kv_scale.shape)}"
+            )
+        if kv_scale.device != query.device:
+            raise ValueError("GLM-5-Next KV scale must share the input device")
+
+    use_current_chunk_kv = current_chunk_kv is not None
+    if use_current_chunk_kv != (current_chunk_locs is not None):
+        raise ValueError(
+            "GLM-5-Next current-chunk KV and locations must be provided together"
+        )
+    if use_current_chunk_kv:
+        assert current_chunk_kv is not None and current_chunk_locs is not None
+        if use_cuda_decode_kernel:
+            raise ValueError(
+                "GLM-5-Next current-chunk BF16 KV is valid only for EXTEND"
+            )
+        if not use_kv_scale or kv_cache.dtype not in (
+            torch.float8_e4m3fn,
+            torch.float8_e5m2,
+        ):
+            raise ValueError(
+                "GLM-5-Next current-chunk BF16 KV requires a scaled-FP8 cache"
+            )
+        if current_chunk_kv.ndim != 2 or current_chunk_kv.shape[-1] != (
+            GLM5_NEXT_SPARSE_HEAD_DIM
+        ):
+            raise ValueError(
+                "GLM-5-Next current-chunk KV must have shape [tokens, 512], "
+                f"got {tuple(current_chunk_kv.shape)}"
+            )
+        if current_chunk_kv.dtype != torch.bfloat16:
+            raise TypeError(
+                "GLM-5-Next current-chunk KV must be BF16, "
+                f"got {current_chunk_kv.dtype}"
+            )
+        if (
+            current_chunk_locs.ndim != 1
+            or current_chunk_locs.numel() != current_chunk_kv.shape[0]
+            or current_chunk_locs.dtype == torch.bool
+            or current_chunk_locs.is_floating_point()
+        ):
+            raise ValueError(
+                "GLM-5-Next current-chunk locations must be a one-dimensional "
+                "integer tensor matching the KV row count"
+            )
+        if (
+            current_chunk_kv.device != query.device
+            or current_chunk_locs.device != query.device
+        ):
+            raise ValueError(
+                "GLM-5-Next current-chunk KV metadata must share the input device"
+            )
+        if current_chunk_kv.shape[0] == 0:
+            raise ValueError("GLM-5-Next current-chunk KV must not be empty")
+
+        # Physical cache locations are not guaranteed to be monotonic after
+        # allocator reuse.  Sort once per DSA layer, then use searchsorted for
+        # the bounded selected set instead of materializing a pool-sized BF16
+        # lookup table.  This keeps the 500k persistent cache in FP8.
+        sorted_current_locs, current_order = torch.sort(
+            current_chunk_locs.to(torch.int64)
+        )
+    else:
+        sorted_current_locs = None
+        current_order = None
+
+    if query.is_cuda and use_cuda_decode_kernel:
+        return _glm5_next_sparse_mla_cuda(
+            query,
+            kv_cache,
+            indices,
+            sm_scale=sm_scale,
+            kv_scale=kv_scale,
+        )
+
+    flat_kv = kv_cache.reshape(-1, GLM5_NEXT_SPARSE_HEAD_DIM)
+    # PyTorch CPU does not implement advanced indexing for float8 tensors, so
+    # its tiny unit-test oracle dequantizes the flat cache once.  CUDA prefill
+    # must not do that: the physical pool can hold millions of token slots.
+    # Gather its bounded sparse rows in FP8 and dequantize only that selection.
+    gather_kv = (
+        flat_kv.to(torch.bfloat16)
+        if not flat_kv.is_cuda
+        and flat_kv.dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
+        else flat_kv
+    )
     output = torch.empty(
-        (*query.shape[:-1], 512),
+        (*query.shape[:-1], GLM5_NEXT_SPARSE_HEAD_DIM),
         dtype=torch.bfloat16,
         device=query.device,
     )
@@ -83,8 +354,43 @@ def glm5_next_sparse_mla_reference(
 
         nonempty = valid.any(dim=-1)
         safe_indices = chunk_indices.masked_fill(~valid, 0).to(torch.long)
-        selected_kv = flat_kv[safe_indices].to(torch.bfloat16)
-        query_chunk = query[start:end].to(torch.bfloat16)
+        selected_kv = gather_kv[safe_indices]
+        query_chunk = query[start:end]
+        if use_kv_scale:
+            selected_scale = kv_scale[safe_indices]
+            selected_kv = (
+                selected_kv.float()
+                .reshape(
+                    *selected_kv.shape[:-1],
+                    GLM5_NEXT_LATENT_SCALE_GROUPS,
+                    GLM5_NEXT_LATENT_SCALE_GROUP_SIZE,
+                )
+                .mul(selected_scale.float().unsqueeze(-1))
+                .reshape(*selected_kv.shape[:-1], GLM5_NEXT_SPARSE_HEAD_DIM)
+                .to(torch.bfloat16)
+            )
+        else:
+            selected_kv = selected_kv.to(torch.bfloat16)
+        if use_current_chunk_kv:
+            assert (
+                current_chunk_kv is not None
+                and sorted_current_locs is not None
+                and current_order is not None
+            )
+            insertion = torch.searchsorted(
+                sorted_current_locs, safe_indices.to(torch.int64)
+            )
+            bounded = insertion.clamp_max(sorted_current_locs.numel() - 1)
+            is_current = valid & (
+                sorted_current_locs[bounded] == safe_indices.to(torch.int64)
+            )
+            current_rows = current_order[bounded]
+            selected_kv = torch.where(
+                is_current.unsqueeze(-1),
+                current_chunk_kv[current_rows],
+                selected_kv,
+            )
+        query_chunk = query_chunk.to(torch.bfloat16)
 
         scores = torch.bmm(query_chunk, selected_kv.transpose(1, 2)).float()
         scores.mul_(float(sm_scale))

--- a/python/sglang/srt/layers/attention/nsa/kpool_fp8_index.py
+++ b/python/sglang/srt/layers/attention/nsa/kpool_fp8_index.py
@@ -1,0 +1,1364 @@
+from typing import Optional, Tuple
+
+import torch
+import triton
+import triton.language as tl
+
+BLOCK_SIZE_K = 64
+INDEX_HEAD_DIM = 128
+KPOOL_SCORE_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
+
+# The fused radix selector stores one threshold-bin candidate list in 4,096
+# shared-memory entries. It is exact only while a row itself is no longer than
+# that capacity: a larger row can put more than 4,096 values in one coarse FP16
+# bin and the kernel clips the candidate list. Eager Session-AB execution may
+# synchronize and use torch.topk for longer rows.
+KPOOL_RADIX_EXACT_ROW_CAPACITY = 4096
+
+
+def build_pooled_page_table_64(
+    page_table_64: torch.Tensor,
+    pool_size: int,
+) -> torch.Tensor:
+    """Pack one logical pool page into the first token page of each page group.
+
+    Uses advanced indexing (gather) rather than strided slicing so the result
+    is always a freshly allocated row-major tensor. Strided slicing produces
+    a view whose .contiguous() short-circuits for shape==(1, 1), leaving
+    stride(-1) == pool_size and breaking downstream kernels that require
+    stride(-1) == 1 (e.g. deep_gemm.fp8_paged_mqa_logits).
+    """
+    assert BLOCK_SIZE_K % pool_size == 0, (
+        f"pool_size ({pool_size}) must divide page_size ({BLOCK_SIZE_K})"
+    )
+    idx = torch.arange(
+        0, page_table_64.shape[-1], pool_size, device=page_table_64.device
+    )
+    return page_table_64[..., idx]
+
+
+def gather_index_k_scale_prefix_into(
+    pool,
+    buf: torch.Tensor,
+    page_indices: torch.Tensor,
+    seq_len: int,
+    k_out: torch.Tensor,
+    scale_out: torch.Tensor,
+) -> None:
+    assert buf.dtype == torch.uint8
+    assert page_indices.dtype in (torch.int32, torch.int64)
+    assert k_out.dtype == torch.uint8
+    assert scale_out.dtype == torch.float32
+    assert pool.page_size == BLOCK_SIZE_K
+    assert k_out.shape[0] >= seq_len
+    assert k_out.shape[1] == INDEX_HEAD_DIM
+    assert scale_out.shape[0] >= seq_len
+    assert buf.is_contiguous()
+    assert page_indices.is_contiguous()
+    assert k_out.is_contiguous()
+    assert scale_out.is_contiguous()
+    if seq_len == 0:
+        return
+
+    _gather_index_k_scale_prefix_into_kernel[(seq_len,)](
+        buf,
+        buf.view(torch.float32),
+        page_indices,
+        k_out,
+        scale_out,
+        PAGE_SIZE=pool.page_size,
+        BUF_NUMEL_PER_PAGE=buf.shape[1],
+        HEAD_DIM=INDEX_HEAD_DIM,
+        S_OFFSET_NBYTES_IN_PAGE=pool.page_size * INDEX_HEAD_DIM,
+        BLOCK_D=triton.next_power_of_2(INDEX_HEAD_DIM),
+    )
+
+
+@triton.jit
+def _gather_index_k_scale_prefix_into_kernel(
+    buf_u8_ptr,
+    buf_fp32_ptr,
+    page_indices_ptr,
+    k_out_ptr,
+    scale_out_ptr,
+    PAGE_SIZE: tl.constexpr,
+    BUF_NUMEL_PER_PAGE: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    S_OFFSET_NBYTES_IN_PAGE: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    token_id = tl.program_id(0)
+    page_idx = token_id // PAGE_SIZE
+    token_offset_in_page = token_id % PAGE_SIZE
+    page = tl.load(page_indices_ptr + page_idx)
+
+    offs = tl.arange(0, BLOCK_D)
+    mask = offs < HEAD_DIM
+    src_k_offsets = page * BUF_NUMEL_PER_PAGE + token_offset_in_page * HEAD_DIM + offs
+    dst_k_offsets = token_id * HEAD_DIM + offs
+    k = tl.load(buf_u8_ptr + src_k_offsets, mask=mask)
+    tl.store(k_out_ptr + dst_k_offsets, k, mask=mask)
+
+    src_s_offset = (
+        page * BUF_NUMEL_PER_PAGE // 4
+        + S_OFFSET_NBYTES_IN_PAGE // 4
+        + token_offset_in_page
+    )
+    scale = tl.load(buf_fp32_ptr + src_s_offset)
+    tl.store(scale_out_ptr + token_id, scale)
+
+
+def kpool_build_ragged_layout(
+    full_page_table: torch.Tensor,
+    cu_pages_excl: torch.Tensor,
+    ragged_pool_pages: torch.Tensor,
+    cu_q_len_excl: torch.Tensor,
+    ragged_q_len: torch.Tensor,
+    pooled_seq_lens_expanded: torch.Tensor,
+    slots_per_page: int,
+    total_pool_pages: int,
+    total_q: int,
+    pool_size: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Build one flat pooled-page table plus per-q row starts/ends.
+
+    NSA stores 64 pooled entries per physical page. A pooled page therefore
+    corresponds to every ``pool_size``-th 64-token page in the original real
+    page table.
+    """
+    device = full_page_table.device
+    n_rag = cu_pages_excl.shape[0]
+    concat_page_table = torch.empty(
+        (total_pool_pages,), dtype=full_page_table.dtype, device=device
+    )
+    q_ks = torch.empty((total_q,), dtype=torch.int32, device=device)
+    q_ke = torch.empty((total_q,), dtype=torch.int32, device=device)
+    if n_rag == 0:
+        return concat_page_table, q_ks, q_ke
+
+    max_pool_pages = full_page_table.shape[1]
+    _kpool_build_ragged_layout_kernel[(n_rag,)](
+        full_page_table,
+        cu_pages_excl,
+        ragged_pool_pages,
+        cu_q_len_excl,
+        ragged_q_len,
+        pooled_seq_lens_expanded,
+        concat_page_table,
+        q_ks,
+        q_ke,
+        max_pool_pages,
+        slots_per_page,
+        pool_size,
+        BLOCK_PAGE=128,
+        BLOCK_Q=128,
+    )
+    return concat_page_table, q_ks, q_ke
+
+
+@triton.jit
+def _kpool_build_ragged_layout_kernel(
+    full_page_table_ptr,
+    cu_pages_excl_ptr,
+    ragged_pool_pages_ptr,
+    cu_q_len_excl_ptr,
+    ragged_q_len_ptr,
+    pooled_seq_lens_ptr,
+    concat_page_table_ptr,
+    q_ks_ptr,
+    q_ke_ptr,
+    MAX_POOL_PAGES,
+    SLOTS_PER_PAGE: tl.constexpr,
+    POOL_SIZE: tl.constexpr,
+    BLOCK_PAGE: tl.constexpr,
+    BLOCK_Q: tl.constexpr,
+):
+    k = tl.program_id(0)
+    page_start = tl.load(cu_pages_excl_ptr + k)
+    n_pages = tl.load(ragged_pool_pages_ptr + k)
+    q_start = tl.load(cu_q_len_excl_ptr + k)
+    q_count = tl.load(ragged_q_len_ptr + k)
+    ks_val = page_start * SLOTS_PER_PAGE
+
+    for p_off in tl.range(0, BLOCK_PAGE * tl.cdiv(n_pages, BLOCK_PAGE), BLOCK_PAGE):
+        p_offs = p_off + tl.arange(0, BLOCK_PAGE)
+        p_mask = p_offs < n_pages
+        source_cols = p_offs * POOL_SIZE
+        pages = tl.load(
+            full_page_table_ptr + k * MAX_POOL_PAGES + source_cols,
+            mask=p_mask,
+            other=0,
+        )
+        tl.store(concat_page_table_ptr + page_start + p_offs, pages, mask=p_mask)
+
+    for q_off in tl.range(0, BLOCK_Q * tl.cdiv(q_count, BLOCK_Q), BLOCK_Q):
+        q_offs = q_off + tl.arange(0, BLOCK_Q)
+        q_mask = q_offs < q_count
+        plen = tl.load(pooled_seq_lens_ptr + q_start + q_offs, mask=q_mask, other=0)
+        ke_val = tl.minimum(
+            ks_val + plen,
+            (page_start + n_pages) * SLOTS_PER_PAGE,
+        )
+        tl.store(
+            q_ks_ptr + q_start + q_offs,
+            tl.full([BLOCK_Q], ks_val, tl.int32),
+            mask=q_mask,
+        )
+        tl.store(q_ke_ptr + q_start + q_offs, ke_val, mask=q_mask)
+
+
+def compute_pooled_write_locs(
+    page_table_64: torch.Tensor,
+    pool_ids: torch.Tensor,
+    pool_size: int,
+) -> torch.Tensor:
+    """Map logical pooled-K ids to packed physical index-cache locations."""
+    assert page_table_64.ndim == 1
+    pool_ids = pool_ids.to(torch.int64)
+    pool_page_group = torch.div(pool_ids, BLOCK_SIZE_K, rounding_mode="floor")
+    token_page_row = pool_page_group * pool_size
+    packed_page = page_table_64.index_select(0, token_page_row.to(torch.int64))
+    return packed_page.to(torch.int64) * BLOCK_SIZE_K + torch.remainder(
+        pool_ids, BLOCK_SIZE_K
+    )
+
+
+def history_group_budget_for_topk(topk: int, pool_size: int) -> int:
+    assert topk % pool_size == 0
+    return topk // pool_size
+
+
+def expand_pooled_groups_to_topk(
+    group_ids: torch.Tensor,
+    group_valid: torch.Tensor,
+    topk: int,
+    pool_size: int,
+    page_table: torch.Tensor | None = None,
+    topk_offsets: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Expand selected full-pool ids to a strict-width token topk tensor."""
+    assert group_ids.ndim == 2
+    assert group_valid.shape == group_ids.shape
+    assert topk % pool_size == 0
+    assert group_ids.shape[1] == history_group_budget_for_topk(topk, pool_size)
+    assert page_table is None or topk_offsets is None
+
+    device = group_ids.device
+    offsets = torch.arange(pool_size, device=device, dtype=torch.int64)
+    token_ids = group_ids.to(torch.int64).unsqueeze(-1) * pool_size + offsets
+    token_ids = token_ids.reshape(group_ids.shape[0], topk)
+    valid = (
+        group_valid.unsqueeze(-1)
+        .expand(-1, -1, pool_size)
+        .reshape(group_ids.shape[0], topk)
+    )
+
+    if page_table is not None:
+        assert page_table.ndim == 2
+        assert page_table.shape[0] == group_ids.shape[0]
+        safe_ids = token_ids.clamp(min=0, max=page_table.shape[1] - 1)
+        output = torch.gather(page_table, dim=1, index=safe_ids).to(torch.int32)
+    elif topk_offsets is not None:
+        if topk_offsets.ndim == 2:
+            assert topk_offsets.shape[1] == 1
+            topk_offsets = topk_offsets.squeeze(1)
+        assert topk_offsets.ndim == 1
+        output = (token_ids + topk_offsets.to(torch.int64).unsqueeze(1)).to(torch.int32)
+    else:
+        output = token_ids.to(torch.int32)
+
+    return torch.where(valid, output, torch.full_like(output, -1))
+
+
+def append_kpool_tail_to_topk(
+    topk_result: torch.Tensor,
+    seq_lens: torch.Tensor,
+    pool_lens: torch.Tensor,
+    pool_size: int,
+    page_table: torch.Tensor | None = None,
+    topk_offsets: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Append non-pooled tail tokens after selected expanded-history tokens."""
+    assert topk_result.dtype == torch.int32
+    assert seq_lens.ndim == 1
+    assert pool_lens.ndim == 1
+    assert seq_lens.shape[0] == topk_result.shape[0]
+    assert pool_lens.shape[0] == topk_result.shape[0]
+
+    tail_pool = pool_size - 1
+    if tail_pool == 0:
+        return topk_result
+
+    rows, n_cols = topk_result.shape
+    out_cols = n_cols + tail_pool
+    out = torch.empty(
+        (rows, out_cols), dtype=topk_result.dtype, device=topk_result.device
+    )
+
+    if page_table is None:
+        page_table = topk_result
+        has_page_table = False
+        page_table_cols = 1
+    else:
+        assert page_table.ndim == 2
+        has_page_table = True
+        page_table_cols = page_table.shape[1]
+
+    if topk_offsets is None:
+        topk_offsets = seq_lens
+        has_topk_offsets = False
+    else:
+        if topk_offsets.ndim == 2:
+            assert topk_offsets.shape[1] == 1
+            topk_offsets = topk_offsets.squeeze(1)
+        assert topk_offsets.ndim == 1
+        has_topk_offsets = True
+
+    block_cols = triton.next_power_of_2(out_cols)
+    _append_kpool_tail_to_topk_kernel[(rows,)](
+        topk_result,
+        seq_lens,
+        pool_lens,
+        page_table,
+        topk_offsets,
+        out,
+        topk_result.stride(0),
+        topk_result.stride(1),
+        page_table.stride(0),
+        page_table.stride(1),
+        out.stride(0),
+        out.stride(1),
+        N_COLS=n_cols,
+        OUT_COLS=out_cols,
+        PAGE_TABLE_COLS=page_table_cols,
+        POOL_SIZE=pool_size,
+        HAS_PAGE_TABLE=has_page_table,
+        HAS_TOPK_OFFSETS=has_topk_offsets,
+        BLOCK_COLS=block_cols,
+    )
+    return out
+
+
+def _exact_topk_from_pooled_history_logits(
+    logits: torch.Tensor,
+    group_lengths: torch.Tensor,
+    *,
+    pool_size: int,
+    topk: int,
+    page_table: torch.Tensor | None = None,
+    topk_offsets: torch.Tensor | None = None,
+    seq_lens: torch.Tensor | None = None,
+    row_starts: torch.Tensor | None = None,
+    out_rows: int | None = None,
+    page_table_row_index: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Exact eager fallback for rows beyond the fused radix capacity."""
+
+    rows, cols = logits.shape
+    group_topk = history_group_budget_for_topk(topk, pool_size)
+    lengths_cpu = group_lengths.detach().to(device="cpu", dtype=torch.int64).tolist()
+    if row_starts is None:
+        starts_cpu = [0] * rows
+    else:
+        if row_starts.shape != group_lengths.shape:
+            raise ValueError(
+                "KPool row_starts must match group_lengths, got "
+                f"{tuple(row_starts.shape)} and {tuple(group_lengths.shape)}"
+            )
+        starts_cpu = row_starts.detach().to(device="cpu", dtype=torch.int64).tolist()
+
+    selected_groups = torch.zeros(
+        (rows, group_topk), dtype=torch.int64, device=logits.device
+    )
+    valid_counts = torch.empty((rows,), dtype=torch.int64, device=logits.device)
+    for row, (row_start, length) in enumerate(
+        zip(starts_cpu, lengths_cpu, strict=True)
+    ):
+        if row_start < 0 or length < 0 or row_start + length > cols:
+            raise ValueError(
+                "KPool exact top-k row bounds are invalid: "
+                f"row={row}, start={row_start}, length={length}, cols={cols}"
+            )
+        count = min(group_topk, length)
+        valid_counts[row] = count
+        if count == 0:
+            continue
+        selected_groups[row, :count] = torch.topk(
+            logits[row, row_start : row_start + length],
+            k=count,
+            largest=True,
+            sorted=False,
+        ).indices
+
+    rank = torch.arange(group_topk, device=logits.device, dtype=torch.int64)
+    group_valid = rank.unsqueeze(0) < valid_counts.unsqueeze(1)
+
+    effective_page_table = page_table
+    if page_table_row_index is not None:
+        if page_table is None:
+            raise ValueError("page_table_row_index requires page_table")
+        if page_table_row_index.shape != group_lengths.shape:
+            raise ValueError(
+                "KPool page_table_row_index must match group_lengths, got "
+                f"{tuple(page_table_row_index.shape)} and "
+                f"{tuple(group_lengths.shape)}"
+            )
+        effective_page_table = page_table.index_select(
+            0, page_table_row_index.to(device=page_table.device, dtype=torch.int64)
+        )
+
+    result = expand_pooled_groups_to_topk(
+        selected_groups,
+        group_valid,
+        topk=topk,
+        pool_size=pool_size,
+        page_table=effective_page_table,
+        topk_offsets=topk_offsets,
+    )
+    if seq_lens is not None:
+        result = append_kpool_tail_to_topk(
+            result,
+            seq_lens=seq_lens,
+            pool_lens=group_lengths,
+            pool_size=pool_size,
+            page_table=effective_page_table,
+            topk_offsets=topk_offsets,
+        )
+    if out_rows is None or out_rows == rows:
+        return result
+    padded = torch.full(
+        (out_rows, result.shape[1]), -1, dtype=result.dtype, device=result.device
+    )
+    padded[:rows] = result
+    return padded
+
+
+@triton.jit
+def _append_kpool_tail_to_topk_kernel(
+    topk_ptr,
+    seq_lens_ptr,
+    pool_lens_ptr,
+    page_table_ptr,
+    topk_offsets_ptr,
+    out_ptr,
+    topk_stride_0,
+    topk_stride_1,
+    page_table_stride_0,
+    page_table_stride_1,
+    out_stride_0,
+    out_stride_1,
+    N_COLS: tl.constexpr,
+    OUT_COLS: tl.constexpr,
+    PAGE_TABLE_COLS: tl.constexpr,
+    POOL_SIZE: tl.constexpr,
+    HAS_PAGE_TABLE: tl.constexpr,
+    HAS_TOPK_OFFSETS: tl.constexpr,
+    BLOCK_COLS: tl.constexpr,
+):
+    row = tl.program_id(0)
+    cols = tl.arange(0, BLOCK_COLS)
+    mask = cols < OUT_COLS
+
+    seq_len = tl.load(seq_lens_ptr + row).to(tl.int32)
+    pool_len = tl.load(pool_lens_ptr + row).to(tl.int32)
+    tail_start = pool_len * POOL_SIZE
+    history_len = tl.minimum(tail_start, N_COLS)
+    tail_count = seq_len % POOL_SIZE
+
+    is_history = cols < history_len
+    safe_history_cols = tl.minimum(cols, N_COLS - 1)
+    history_value = tl.load(
+        topk_ptr + row * topk_stride_0 + safe_history_cols * topk_stride_1,
+        mask=mask & is_history,
+        other=-1,
+    )
+
+    tail_offset = cols - history_len
+    is_tail = (tail_offset >= 0) & (tail_offset < tail_count)
+    tail_raw = tail_start + tail_offset
+    tail_value = tail_raw
+    if HAS_PAGE_TABLE:
+        safe_tail = tl.minimum(tl.maximum(tail_raw, 0), PAGE_TABLE_COLS - 1)
+        tail_value = tl.load(
+            page_table_ptr
+            + row * page_table_stride_0
+            + safe_tail * page_table_stride_1,
+            mask=mask & is_tail,
+            other=-1,
+        ).to(tl.int32)
+    if HAS_TOPK_OFFSETS:
+        offset = tl.load(topk_offsets_ptr + row).to(tl.int32)
+        tail_value = tail_raw + offset
+
+    value = tl.where(is_history, history_value, -1)
+    value = tl.where(is_tail, tail_value, value)
+    tl.store(out_ptr + row * out_stride_0 + cols * out_stride_1, value, mask=mask)
+
+
+def topk_from_pooled_history_logits(
+    logits: torch.Tensor,
+    group_lengths: torch.Tensor,
+    pool_size: int,
+    topk: int,
+    page_table: torch.Tensor | None = None,
+    topk_offsets: torch.Tensor | None = None,
+    seq_lens: torch.Tensor | None = None,
+    row_starts: torch.Tensor | None = None,
+    out_rows: int | None = None,
+    page_table_row_index: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Select full-pool groups, expand to tokens, and optionally append tail."""
+    assert logits.ndim == 2
+    assert group_lengths.ndim == 1
+    assert logits.shape[0] == group_lengths.shape[0]
+    assert topk > 0
+    assert topk % pool_size == 0
+    assert out_rows is None or out_rows >= logits.shape[0]
+    assert page_table_row_index is None or page_table is not None
+
+    _, cols = logits.shape
+    group_topk = history_group_budget_for_topk(topk, pool_size)
+    if topk_offsets is not None and topk_offsets.ndim == 2:
+        assert topk_offsets.shape[1] == 1
+        topk_offsets = topk_offsets.squeeze(1)
+
+    if group_topk not in (128, 160, 192, 224, 256, 512, 2048):
+        raise NotImplementedError(
+            "index_kpool topk only supports pooled group_topk in "
+            f"(128, 160, 192, 224, 256, 512, 2048), got {group_topk} "
+            f"(topk={topk}, pool_size={pool_size})."
+        )
+    if not logits.is_cuda or logits.dtype != torch.float32:
+        raise NotImplementedError(
+            "index_kpool topk requires CUDA float32 logits; PyTorch topk fallback "
+            f"is disabled. Got device={logits.device}, dtype={logits.dtype}."
+        )
+
+    if group_topk in (128, 160, 192, 224, 256, 512):
+        # The shared-memory radix kernel clips a threshold bin after 4,096
+        # candidates. A longer row is routed to an exact eager selector before
+        # the JIT kernel can lose a later high score. CUDA graph is disabled at
+        # the Session-AB boundary, so this host synchronization is intentional.
+        max_group_length = (
+            int(group_lengths.max().item()) if group_lengths.numel() else 0
+        )
+        if max_group_length > KPOOL_RADIX_EXACT_ROW_CAPACITY:
+            return _exact_topk_from_pooled_history_logits(
+                logits,
+                group_lengths,
+                pool_size=pool_size,
+                topk=topk,
+                page_table=page_table,
+                topk_offsets=topk_offsets,
+                seq_lens=seq_lens,
+                row_starts=row_starts,
+                out_rows=out_rows,
+                page_table_row_index=page_table_row_index,
+            )
+
+        from sglang.jit_kernel.kpool_topk_transform import (
+            fast_kpool_topk_transform_fused,
+        )
+
+        result = fast_kpool_topk_transform_fused(
+            score=logits,
+            lengths=group_lengths.to(torch.int32),
+            pool_size=pool_size,
+            topk=topk,
+            page_table=page_table,
+            topk_indices_offset=topk_offsets,
+            row_starts=row_starts,
+            seq_lens=seq_lens.to(torch.int32) if seq_lens is not None else None,
+            page_table_row_index=page_table_row_index,
+        )
+        if out_rows is None or out_rows == result.shape[0]:
+            return result
+        padded = torch.full(
+            (out_rows, result.shape[1]), -1, dtype=result.dtype, device=result.device
+        )
+        padded[: result.shape[0]] = result
+        return padded
+
+    assert page_table_row_index is None, (
+        "page_table_row_index requires the fused fast_kpool group_topk path"
+    )
+
+    from sgl_kernel import fast_topk_v2
+
+    selected_groups = fast_topk_v2(
+        logits,
+        group_lengths.to(torch.int32),
+        group_topk,
+        row_starts=row_starts,
+    )
+
+    rank = torch.arange(group_topk, device=logits.device, dtype=torch.int32)
+    max_valid_groups = min(cols, group_topk)
+    valid_counts = torch.minimum(
+        group_lengths.to(torch.int32),
+        torch.full_like(group_lengths.to(torch.int32), max_valid_groups),
+    )
+    group_valid = rank.unsqueeze(0) < valid_counts.unsqueeze(1)
+    expanded = expand_pooled_groups_to_topk(
+        selected_groups.contiguous(),
+        group_valid,
+        topk=topk,
+        pool_size=pool_size,
+        page_table=page_table,
+        topk_offsets=topk_offsets,
+    )
+    if seq_lens is None:
+        result = expanded
+    else:
+        result = append_kpool_tail_to_topk(
+            expanded,
+            seq_lens=seq_lens,
+            pool_lens=group_lengths,
+            pool_size=pool_size,
+            page_table=page_table,
+            topk_offsets=topk_offsets,
+        )
+    if out_rows is None or out_rows == result.shape[0]:
+        return result
+    padded = torch.full(
+        (out_rows, result.shape[1]), -1, dtype=result.dtype, device=result.device
+    )
+    padded[: result.shape[0]] = result
+    return padded
+
+
+def kpool_softmax_rotate_write_cache(
+    pool,
+    buf: torch.Tensor,
+    slot_k: torch.Tensor,
+    slot_score: torch.Tensor,
+    ape: torch.Tensor,
+    loc: torch.Tensor,
+    write_mask: torch.Tensor | None = None,
+    round_scale: bool = False,
+    return_compressed: bool = False,
+    write_cache: bool = True,
+) -> Optional[Tuple[torch.Tensor, torch.Tensor]]:
+    assert slot_k.ndim == 3
+    assert slot_score.shape == slot_k.shape
+    assert ape.shape == slot_k.shape[1:]
+    assert slot_k.shape[2] == INDEX_HEAD_DIM
+    assert slot_k.dtype == torch.bfloat16
+    assert slot_score.dtype in KPOOL_SCORE_DTYPES
+    assert ape.dtype == torch.float32
+    assert buf.dtype == torch.uint8
+    assert pool.page_size == BLOCK_SIZE_K
+    assert pool.index_head_dim == INDEX_HEAD_DIM
+    assert loc.dtype == torch.int64
+    assert write_cache or return_compressed
+
+    slot_k = slot_k.contiguous()
+    slot_score = slot_score.contiguous()
+    ape = ape.contiguous()
+    loc = loc.contiguous()
+    if write_mask is None:
+        write_mask = torch.empty((1,), dtype=torch.bool, device=slot_k.device)
+        has_write_mask = False
+    else:
+        assert write_mask.shape == (slot_k.shape[0],)
+        assert not return_compressed
+        write_mask = write_mask.contiguous()
+        has_write_mask = True
+
+    if slot_k.shape[0] == 0:
+        if return_compressed:
+            return (
+                torch.empty(
+                    (0, slot_k.shape[2]),
+                    dtype=torch.float8_e4m3fn,
+                    device=slot_k.device,
+                ),
+                torch.empty((0,), dtype=torch.float32, device=slot_k.device),
+            )
+        return None
+
+    buf_fp8 = buf.view(torch.float8_e4m3fn)
+    buf_fp32 = buf.view(torch.float32)
+    if return_compressed:
+        compressed_k = torch.empty(
+            (slot_k.shape[0], slot_k.shape[2]),
+            dtype=torch.float8_e4m3fn,
+            device=slot_k.device,
+        )
+        compressed_scale = torch.empty(
+            (slot_k.shape[0],), dtype=torch.float32, device=slot_k.device
+        )
+    else:
+        compressed_k = buf_fp8
+        compressed_scale = buf_fp32
+    _kpool_softmax_rotate_write_cache_kernel[(slot_k.shape[0],)](
+        buf_fp8,
+        buf_fp32,
+        slot_k,
+        slot_score,
+        ape,
+        loc,
+        write_mask,
+        compressed_k,
+        compressed_scale,
+        slot_k.stride(0),
+        slot_k.stride(1),
+        slot_score.stride(0),
+        slot_score.stride(1),
+        ape.stride(0),
+        PAGE_SIZE=pool.page_size,
+        BUF_NUMEL_PER_PAGE=buf.shape[1],
+        POOL_SIZE=slot_k.shape[1],
+        HEAD_DIM=slot_k.shape[2],
+        S_OFFSET_NBYTES_IN_PAGE=pool.page_size * pool.index_head_dim,
+        ROUND_SCALE=round_scale,
+        HAS_WRITE_MASK=has_write_mask,
+        RETURN_COMPRESSED=return_compressed,
+        WRITE_CACHE=write_cache,
+        BLOCK_D=triton.next_power_of_2(slot_k.shape[2]),
+    )
+    if return_compressed:
+        return compressed_k, compressed_scale
+    return None
+
+
+def kpool_decode_update_and_maybe_write_cache(
+    pool,
+    buf: torch.Tensor,
+    tail_k: torch.Tensor,
+    tail_score: torch.Tensor,
+    key: torch.Tensor,
+    slot_score: torch.Tensor,
+    ape: torch.Tensor,
+    block_tables: torch.Tensor,
+    req_pool_indices: torch.Tensor,
+    positions: torch.Tensor,
+    seq_lens: torch.Tensor,
+    out_cache_loc: torch.Tensor,
+    round_scale: bool = False,
+) -> None:
+    assert tail_k.ndim == 3
+    assert tail_score.shape == tail_k.shape
+    assert tail_k.shape[1] == pool.index_kpool + pool.tail_extra_slots
+    assert tail_k.shape[2] == INDEX_HEAD_DIM
+    assert key.ndim == 2 and key.shape[1] == INDEX_HEAD_DIM
+    assert slot_score.shape == key.shape
+    assert ape.shape == (pool.index_kpool, INDEX_HEAD_DIM)
+    assert tail_k.dtype == torch.bfloat16
+    assert key.dtype == torch.bfloat16
+    assert tail_score.dtype in KPOOL_SCORE_DTYPES
+    assert slot_score.dtype == tail_score.dtype
+    assert ape.dtype == torch.float32
+    assert buf.dtype == torch.uint8
+    assert pool.page_size == BLOCK_SIZE_K
+    assert pool.index_head_dim == INDEX_HEAD_DIM
+    assert tail_k.is_contiguous()
+    assert tail_score.is_contiguous()
+
+    batch = key.shape[0]
+    if batch == 0:
+        return
+
+    key = key.contiguous()
+    slot_score = slot_score.contiguous()
+    ape = ape.contiguous()
+    req_pool_indices = req_pool_indices.contiguous()
+    positions = positions.contiguous()
+    seq_lens = seq_lens.contiguous()
+    out_cache_loc = out_cache_loc.contiguous()
+
+    assert req_pool_indices.shape[0] >= batch
+    assert positions.shape[0] >= batch
+    assert seq_lens.shape[0] >= batch
+    assert out_cache_loc.shape[0] >= batch
+    assert block_tables.ndim == 2
+    assert block_tables.shape[0] >= batch
+
+    buf_fp8 = buf.view(torch.float8_e4m3fn)
+    buf_fp32 = buf.view(torch.float32)
+    _kpool_decode_update_and_maybe_write_cache_kernel[(batch,)](
+        buf_fp8,
+        buf_fp32,
+        tail_k,
+        tail_score,
+        key,
+        slot_score,
+        ape,
+        block_tables,
+        req_pool_indices,
+        positions,
+        seq_lens,
+        out_cache_loc,
+        tail_k.stride(0),
+        tail_k.stride(1),
+        tail_score.stride(0),
+        tail_score.stride(1),
+        key.stride(0),
+        slot_score.stride(0),
+        ape.stride(0),
+        block_tables.stride(0),
+        block_tables.stride(1),
+        REQ_POOL_SIZE=tail_k.shape[0],
+        PAGE_SIZE=pool.page_size,
+        BUF_NUMEL_PER_PAGE=buf.shape[1],
+        POOL_SIZE=pool.index_kpool,
+        TAIL_SIZE=tail_k.shape[1],
+        HEAD_DIM=tail_k.shape[2],
+        BLOCK_TABLE_COLS=block_tables.shape[1],
+        S_OFFSET_NBYTES_IN_PAGE=pool.slots_per_page * pool.index_head_dim,
+        ROUND_SCALE=round_scale,
+        BLOCK_D=triton.next_power_of_2(tail_k.shape[2]),
+        SLOTS_PER_PAGE=pool.slots_per_page,
+    )
+
+
+@triton.jit
+def _hadamard128_stage(x, GROUPS: tl.constexpr, STRIDE: tl.constexpr):
+    x3 = tl.reshape(x, (GROUPS, 2, STRIDE))
+    x3 = tl.trans(x3, 0, 2, 1)
+    a, b = tl.split(x3)
+    x3 = tl.join(a + b, a - b)
+    x3 = tl.trans(x3, 0, 2, 1)
+    return tl.reshape(x3, (128,))
+
+
+@triton.jit
+def _hadamard128(x):
+    x = _hadamard128_stage(x, 64, 1)
+    x = _hadamard128_stage(x, 32, 2)
+    x = _hadamard128_stage(x, 16, 4)
+    x = _hadamard128_stage(x, 8, 8)
+    x = _hadamard128_stage(x, 4, 16)
+    x = _hadamard128_stage(x, 2, 32)
+    x = _hadamard128_stage(x, 1, 64)
+    return x * 0.08838834764831845
+
+
+@triton.jit
+def _kpool_softmax_rotate_write_cache_kernel(
+    buf_fp8_ptr,
+    buf_fp32_ptr,
+    slot_k_ptr,
+    slot_score_ptr,
+    ape_ptr,
+    loc_ptr,
+    write_mask_ptr,
+    compressed_k_ptr,
+    compressed_scale_ptr,
+    slot_k_stride_0,
+    slot_k_stride_1,
+    slot_score_stride_0,
+    slot_score_stride_1,
+    ape_stride_0,
+    PAGE_SIZE: tl.constexpr,
+    BUF_NUMEL_PER_PAGE: tl.constexpr,
+    POOL_SIZE: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    S_OFFSET_NBYTES_IN_PAGE: tl.constexpr,
+    ROUND_SCALE: tl.constexpr,
+    HAS_WRITE_MASK: tl.constexpr,
+    RETURN_COMPRESSED: tl.constexpr,
+    WRITE_CACHE: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    row = tl.program_id(0)
+    do_write = True
+    if HAS_WRITE_MASK:
+        do_write = tl.load(write_mask_ptr + row)
+
+    offs = tl.arange(0, BLOCK_D)
+    mask = (offs < HEAD_DIM) & do_write
+
+    max_score = tl.full((BLOCK_D,), -float("inf"), tl.float32)
+    for slot in tl.static_range(0, POOL_SIZE):
+        score = tl.load(
+            slot_score_ptr
+            + row * slot_score_stride_0
+            + slot * slot_score_stride_1
+            + offs,
+            mask=mask,
+            other=0.0,
+        ).to(tl.float32)
+        score += tl.load(ape_ptr + slot * ape_stride_0 + offs, mask=mask, other=0.0).to(
+            tl.float32
+        )
+        max_score = tl.maximum(max_score, score)
+
+    acc = tl.full((BLOCK_D,), 0.0, tl.float32)
+    denom = tl.full((BLOCK_D,), 0.0, tl.float32)
+    for slot in tl.static_range(0, POOL_SIZE):
+        score = tl.load(
+            slot_score_ptr
+            + row * slot_score_stride_0
+            + slot * slot_score_stride_1
+            + offs,
+            mask=mask,
+            other=0.0,
+        ).to(tl.float32)
+        score += tl.load(ape_ptr + slot * ape_stride_0 + offs, mask=mask, other=0.0).to(
+            tl.float32
+        )
+        prob = tl.exp(score - max_score)
+        denom += prob
+        k = tl.load(
+            slot_k_ptr + row * slot_k_stride_0 + slot * slot_k_stride_1 + offs,
+            mask=mask,
+            other=0.0,
+        ).to(tl.float32)
+        acc += k * prob
+
+    x = acc / denom
+    x = tl.where(do_write, x, 0.0).to(tl.bfloat16).to(tl.float32)
+    x = _hadamard128(x).to(tl.bfloat16).to(tl.float32)
+
+    fp8_min = -448.0
+    fp8_max = 448.0
+    fp8_max_inv = 1.0 / fp8_max
+    absmax = tl.max(tl.abs(x), axis=0)
+    absmax = tl.maximum(absmax, 1e-4)
+
+    if ROUND_SCALE:
+        log_val = tl.log2(absmax * fp8_max_inv)
+        scale = tl.exp2(tl.ceil(log_val))
+    else:
+        scale = absmax * fp8_max_inv
+
+    quantized = x / scale
+    quantized = tl.minimum(tl.maximum(quantized, fp8_min), fp8_max)
+
+    if WRITE_CACHE:
+        loc = tl.load(loc_ptr + row, mask=do_write, other=0)
+        loc_page_index = loc // PAGE_SIZE
+        loc_token_offset_in_page = loc % PAGE_SIZE
+        out_k_offsets = (
+            loc_page_index * BUF_NUMEL_PER_PAGE
+            + loc_token_offset_in_page * HEAD_DIM
+            + offs
+        )
+        out_s_offset = (
+            loc_page_index * BUF_NUMEL_PER_PAGE // 4
+            + S_OFFSET_NBYTES_IN_PAGE // 4
+            + loc_token_offset_in_page
+        )
+
+        tl.store(buf_fp8_ptr + out_k_offsets, quantized, mask=mask)
+        tl.store(buf_fp32_ptr + out_s_offset, scale, mask=do_write)
+    if RETURN_COMPRESSED:
+        tl.store(
+            compressed_k_ptr + row * HEAD_DIM + offs,
+            quantized,
+            mask=offs < HEAD_DIM,
+        )
+        tl.store(compressed_scale_ptr + row, scale)
+
+
+@triton.jit
+def _kpool_decode_update_and_maybe_write_cache_kernel(
+    buf_fp8_ptr,
+    buf_fp32_ptr,
+    tail_k_ptr,
+    tail_score_ptr,
+    key_ptr,
+    slot_score_ptr,
+    ape_ptr,
+    block_tables_ptr,
+    req_pool_indices_ptr,
+    positions_ptr,
+    seq_lens_ptr,
+    out_cache_loc_ptr,
+    tail_k_stride_0,
+    tail_k_stride_1,
+    tail_score_stride_0,
+    tail_score_stride_1,
+    key_stride_0,
+    slot_score_stride_0,
+    ape_stride_0,
+    block_tables_stride_0,
+    block_tables_stride_1,
+    REQ_POOL_SIZE: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    BUF_NUMEL_PER_PAGE: tl.constexpr,
+    POOL_SIZE: tl.constexpr,
+    TAIL_SIZE: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_TABLE_COLS: tl.constexpr,
+    S_OFFSET_NBYTES_IN_PAGE: tl.constexpr,
+    ROUND_SCALE: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    SLOTS_PER_PAGE: tl.constexpr,
+):
+    row = tl.program_id(0)
+    offs = tl.arange(0, BLOCK_D)
+    dim_mask = offs < HEAD_DIM
+
+    req_raw = tl.load(req_pool_indices_ptr + row)
+    req_valid = (req_raw >= 0) & (req_raw < REQ_POOL_SIZE)
+    req = tl.minimum(tl.maximum(req_raw, 0), REQ_POOL_SIZE - 1)
+
+    pos = tl.load(positions_ptr + row)
+    safe_pos = tl.maximum(pos, 0)
+    seq_len = tl.load(seq_lens_ptr + row)
+    cache_loc = tl.load(out_cache_loc_ptr + row)
+    pos_valid = req_valid & (cache_loc != 0) & (pos >= 0) & (pos < seq_len)
+
+    slot = safe_pos % POOL_SIZE
+    phys_slot = safe_pos % TAIL_SIZE
+
+    key = tl.load(
+        key_ptr + row * key_stride_0 + offs,
+        mask=dim_mask,
+        other=0.0,
+    ).to(tl.float32)
+    score_current = tl.load(
+        slot_score_ptr + row * slot_score_stride_0 + offs,
+        mask=dim_mask,
+        other=0.0,
+    ).to(tl.float32)
+
+    if pos_valid & (slot == POOL_SIZE - 1):
+        pool_logical_start = safe_pos - slot
+        max_score = tl.full((BLOCK_D,), -float("inf"), tl.float32)
+        for pool_slot in tl.static_range(0, POOL_SIZE):
+            is_current = pool_slot == slot
+            phys = (pool_logical_start + pool_slot) % TAIL_SIZE
+            score_buf = tl.load(
+                tail_score_ptr
+                + req * tail_score_stride_0
+                + phys * tail_score_stride_1
+                + offs,
+                mask=dim_mask,
+                other=0.0,
+            ).to(tl.float32)
+            score = tl.where(is_current, score_current, score_buf)
+            score += tl.load(
+                ape_ptr + pool_slot * ape_stride_0 + offs,
+                mask=dim_mask,
+                other=0.0,
+            ).to(tl.float32)
+            max_score = tl.maximum(max_score, score)
+
+        acc = tl.full((BLOCK_D,), 0.0, tl.float32)
+        denom = tl.full((BLOCK_D,), 0.0, tl.float32)
+        for pool_slot in tl.static_range(0, POOL_SIZE):
+            is_current = pool_slot == slot
+            phys = (pool_logical_start + pool_slot) % TAIL_SIZE
+            score_buf = tl.load(
+                tail_score_ptr
+                + req * tail_score_stride_0
+                + phys * tail_score_stride_1
+                + offs,
+                mask=dim_mask,
+                other=0.0,
+            ).to(tl.float32)
+            score = tl.where(is_current, score_current, score_buf)
+            score += tl.load(
+                ape_ptr + pool_slot * ape_stride_0 + offs,
+                mask=dim_mask,
+                other=0.0,
+            ).to(tl.float32)
+            prob = tl.exp(score - max_score)
+            denom += prob
+            k_buf = tl.load(
+                tail_k_ptr + req * tail_k_stride_0 + phys * tail_k_stride_1 + offs,
+                mask=dim_mask,
+                other=0.0,
+            ).to(tl.float32)
+            k = tl.where(is_current, key, k_buf)
+            acc += k * prob
+
+        x = (acc / denom).to(tl.bfloat16).to(tl.float32)
+        x = _hadamard128(x).to(tl.bfloat16).to(tl.float32)
+
+        fp8_min = -448.0
+        fp8_max = 448.0
+        fp8_max_inv = 1.0 / fp8_max
+        absmax = tl.max(tl.abs(x), axis=0)
+        absmax = tl.maximum(absmax, 1e-4)
+
+        if ROUND_SCALE:
+            log_val = tl.log2(absmax * fp8_max_inv)
+            scale = tl.exp2(tl.ceil(log_val))
+        else:
+            scale = absmax * fp8_max_inv
+
+        quantized = x / scale
+        quantized = tl.minimum(tl.maximum(quantized, fp8_min), fp8_max)
+
+        pool_id = safe_pos // POOL_SIZE
+        pool_page_group = pool_id // SLOTS_PER_PAGE
+        token_page_row = pool_page_group * POOL_SIZE
+        token_page_row = tl.minimum(tl.maximum(token_page_row, 0), BLOCK_TABLE_COLS - 1)
+        packed_page = tl.load(
+            block_tables_ptr
+            + row * block_tables_stride_0
+            + token_page_row * block_tables_stride_1,
+        )
+        loc_page_index = packed_page.to(tl.int64)
+        loc_token_offset_in_page = pool_id % SLOTS_PER_PAGE
+        out_k_offsets = (
+            loc_page_index * BUF_NUMEL_PER_PAGE
+            + loc_token_offset_in_page * HEAD_DIM
+            + offs
+        )
+        out_s_offset = (
+            loc_page_index * BUF_NUMEL_PER_PAGE // 4
+            + S_OFFSET_NBYTES_IN_PAGE // 4
+            + loc_token_offset_in_page
+        )
+
+        tl.store(buf_fp8_ptr + out_k_offsets, quantized, mask=dim_mask)
+        tl.store(buf_fp32_ptr + out_s_offset, scale)
+
+    tail_k_offset = req * tail_k_stride_0 + phys_slot * tail_k_stride_1 + offs
+    tail_score_offset = (
+        req * tail_score_stride_0 + phys_slot * tail_score_stride_1 + offs
+    )
+    update_mask = dim_mask & pos_valid
+    tl.store(tail_k_ptr + tail_k_offset, key, mask=update_mask)
+    tl.store(tail_score_ptr + tail_score_offset, score_current, mask=update_mask)
+
+
+@triton.jit
+def _hadamard_quantize_fp8(acc, denom, ROUND_SCALE: tl.constexpr):
+    x = (acc / denom).to(tl.bfloat16).to(tl.float32)
+    x = _hadamard128(x).to(tl.bfloat16).to(tl.float32)
+
+    fp8_max_inv = 1.0 / 448.0
+    absmax = tl.maximum(tl.max(tl.abs(x), axis=0), 1e-4)
+    if ROUND_SCALE:
+        scale = tl.exp2(tl.ceil(tl.log2(absmax * fp8_max_inv)))
+    else:
+        scale = absmax * fp8_max_inv
+
+    quantized = tl.minimum(tl.maximum(x / scale, -448.0), 448.0)
+    return quantized, scale
+
+
+@triton.jit
+def _kpool_assemble_softmax_rotate_write_cache_kernel(
+    buf_fp8_ptr,
+    buf_fp32_ptr,
+    chunk_k_ptr,
+    chunk_score_ptr,
+    tail_k_ptr,
+    tail_score_ptr,
+    req_pool_idx_ptr,
+    n_from_tail_ptr,
+    chunk_src_start_ptr,
+    tail_logical_base_ptr,
+    ape_ptr,
+    loc_ptr,
+    write_mask_ptr,
+    chunk_stride_0,
+    tail_stride_0,
+    tail_stride_1,
+    ape_stride_0,
+    BUF_NUMEL_PER_PAGE: tl.constexpr,
+    POOL_SIZE: tl.constexpr,
+    TAIL_SIZE: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    S_OFFSET_NBYTES_IN_PAGE: tl.constexpr,
+    ROUND_SCALE: tl.constexpr,
+    HAS_WRITE_MASK: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    SLOTS_PER_PAGE: tl.constexpr,
+):
+    row = tl.program_id(0)
+    if HAS_WRITE_MASK:
+        if not tl.load(write_mask_ptr + row):
+            return
+
+    offs = tl.arange(0, BLOCK_D)
+    mask = offs < HEAD_DIM
+
+    n_tail = tl.load(n_from_tail_ptr + row)
+    req = tl.load(req_pool_idx_ptr + row)
+    chunk_src = tl.load(chunk_src_start_ptr + row)
+    tail_base = tl.load(tail_logical_base_ptr + row)
+
+    m = tl.full((BLOCK_D,), -float("inf"), tl.float32)
+    acc = tl.full((BLOCK_D,), 0.0, tl.float32)
+    denom = tl.full((BLOCK_D,), 0.0, tl.float32)
+    for slot in tl.static_range(0, POOL_SIZE):
+        if slot < n_tail:
+            phys = (tail_base + slot) % TAIL_SIZE
+            off = req * tail_stride_0 + phys * tail_stride_1 + offs
+            score = tl.load(tail_score_ptr + off, mask=mask, other=0.0).to(tl.float32)
+            k = tl.load(tail_k_ptr + off, mask=mask, other=0.0).to(tl.float32)
+        else:
+            off = (chunk_src + (slot - n_tail)) * chunk_stride_0 + offs
+            score = tl.load(chunk_score_ptr + off, mask=mask, other=0.0).to(tl.float32)
+            k = tl.load(chunk_k_ptr + off, mask=mask, other=0.0).to(tl.float32)
+
+        score += tl.load(ape_ptr + slot * ape_stride_0 + offs, mask=mask, other=0.0).to(
+            tl.float32
+        )
+        new_m = tl.maximum(m, score)
+        rescale = tl.exp(m - new_m)
+        prob = tl.exp(score - new_m)
+        denom = denom * rescale + prob
+        acc = acc * rescale + k * prob
+        m = new_m
+
+    quantized, scale = _hadamard_quantize_fp8(acc, denom, ROUND_SCALE)
+
+    loc = tl.load(loc_ptr + row)
+    loc_page_index = loc // SLOTS_PER_PAGE
+    loc_token_offset_in_page = loc % SLOTS_PER_PAGE
+    out_k_offsets = (
+        loc_page_index * BUF_NUMEL_PER_PAGE + loc_token_offset_in_page * HEAD_DIM + offs
+    )
+    out_s_offset = (
+        loc_page_index * BUF_NUMEL_PER_PAGE // 4
+        + S_OFFSET_NBYTES_IN_PAGE // 4
+        + loc_token_offset_in_page
+    )
+
+    tl.store(buf_fp8_ptr + out_k_offsets, quantized, mask=mask)
+    tl.store(buf_fp32_ptr + out_s_offset, scale)
+
+
+def kpool_assemble_softmax_rotate_write_cache(
+    pool,
+    buf: torch.Tensor,
+    chunk_k: torch.Tensor,
+    chunk_score: torch.Tensor,
+    tail_k: torch.Tensor,
+    tail_score: torch.Tensor,
+    req_pool_idx: torch.Tensor,
+    n_from_tail: torch.Tensor,
+    chunk_src_start: torch.Tensor,
+    tail_logical_base: torch.Tensor,
+    ape: torch.Tensor,
+    loc: torch.Tensor,
+    write_mask: torch.Tensor | None = None,
+    round_scale: bool = False,
+) -> None:
+    pool_size = pool.index_kpool
+    n_pools = req_pool_idx.shape[0]
+    if n_pools == 0:
+        return
+
+    chunk_k = chunk_k.contiguous()
+    chunk_score = chunk_score.contiguous()
+    ape = ape.contiguous()
+    loc = loc.contiguous()
+    if write_mask is None:
+        write_mask = torch.empty((1,), dtype=torch.bool, device=chunk_k.device)
+        has_write_mask = False
+    else:
+        write_mask = write_mask.contiguous()
+        has_write_mask = True
+
+    buf_fp8 = buf.view(torch.float8_e4m3fn)
+    buf_fp32 = buf.view(torch.float32)
+    slots_per_page = pool.slots_per_page
+
+    _kpool_assemble_softmax_rotate_write_cache_kernel[(n_pools,)](
+        buf_fp8,
+        buf_fp32,
+        chunk_k,
+        chunk_score,
+        tail_k,
+        tail_score,
+        req_pool_idx,
+        n_from_tail,
+        chunk_src_start,
+        tail_logical_base,
+        ape,
+        loc,
+        write_mask,
+        chunk_k.stride(0),
+        tail_k.stride(0),
+        tail_k.stride(1),
+        ape.stride(0),
+        BUF_NUMEL_PER_PAGE=buf.shape[1],
+        POOL_SIZE=pool_size,
+        TAIL_SIZE=tail_k.shape[1],
+        HEAD_DIM=INDEX_HEAD_DIM,
+        S_OFFSET_NBYTES_IN_PAGE=slots_per_page * INDEX_HEAD_DIM,
+        ROUND_SCALE=round_scale,
+        HAS_WRITE_MASK=has_write_mask,
+        BLOCK_D=triton.next_power_of_2(INDEX_HEAD_DIM),
+        SLOTS_PER_PAGE=slots_per_page,
+    )
+
+
+def scatter_kpool_tail_updates(
+    pool,
+    chunk_k: torch.Tensor,
+    chunk_score: torch.Tensor,
+    tail_k: torch.Tensor,
+    tail_score: torch.Tensor,
+    req_pool_idx: torch.Tensor,
+    dst_logical_start: torch.Tensor,
+    chunk_src_start: torch.Tensor,
+    n_write: torch.Tensor,
+) -> None:
+    pool_size = pool.index_kpool
+    n_rows = req_pool_idx.shape[0]
+    if n_rows == 0:
+        return
+
+    chunk_k = chunk_k.contiguous()
+    chunk_score = chunk_score.contiguous()
+    _scatter_kpool_tail_updates_kernel[(n_rows, pool_size)](
+        chunk_k,
+        chunk_score,
+        tail_k,
+        tail_score,
+        req_pool_idx,
+        dst_logical_start,
+        chunk_src_start,
+        n_write,
+        chunk_k.stride(0),
+        tail_k.stride(0),
+        tail_k.stride(1),
+        POOL_SIZE=pool_size,
+        TAIL_SIZE=tail_k.shape[1],
+        HEAD_DIM=INDEX_HEAD_DIM,
+        BLOCK_D=triton.next_power_of_2(INDEX_HEAD_DIM),
+    )
+
+
+@triton.jit
+def _scatter_kpool_tail_updates_kernel(
+    chunk_k_ptr,
+    chunk_score_ptr,
+    tail_k_ptr,
+    tail_score_ptr,
+    req_pool_idx_ptr,
+    dst_logical_start_ptr,
+    chunk_src_start_ptr,
+    n_write_ptr,
+    chunk_stride_0,
+    tail_stride_0,
+    tail_stride_1,
+    POOL_SIZE: tl.constexpr,
+    TAIL_SIZE: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    row = tl.program_id(0)
+    slot = tl.program_id(1)
+
+    n_w = tl.load(n_write_ptr + row)
+    if slot >= n_w:
+        return
+
+    req = tl.load(req_pool_idx_ptr + row)
+    dst_logical_start = tl.load(dst_logical_start_ptr + row)
+    src_off = tl.load(chunk_src_start_ptr + row) + slot
+
+    offs = tl.arange(0, BLOCK_D)
+    mask = offs < HEAD_DIM
+    k = tl.load(chunk_k_ptr + src_off * chunk_stride_0 + offs, mask=mask)
+    s = tl.load(chunk_score_ptr + src_off * chunk_stride_0 + offs, mask=mask)
+
+    dst = (
+        req * tail_stride_0
+        + ((dst_logical_start + slot) % TAIL_SIZE) * tail_stride_1
+        + offs
+    )
+    tl.store(tail_k_ptr + dst, k, mask=mask)
+    tl.store(tail_score_ptr + dst, s, mask=mask)

--- a/python/sglang/srt/layers/attention/nsa/kpool_fp8_index.py
+++ b/python/sglang/srt/layers/attention/nsa/kpool_fp8_index.py
@@ -72,6 +72,62 @@ def gather_index_k_scale_prefix_into(
     )
 
 
+def gather_index_k_bf16_prefix_into(
+    pool,
+    buf: torch.Tensor,
+    page_indices: torch.Tensor,
+    seq_len: int,
+    k_out: torch.Tensor,
+) -> None:
+    """Gather a paged all-BF16 GLM KPool prefix into bounded scratch."""
+
+    assert buf.dtype == torch.bfloat16
+    assert page_indices.dtype in (torch.int32, torch.int64)
+    assert k_out.dtype == torch.bfloat16
+    assert pool.page_size == BLOCK_SIZE_K
+    assert k_out.shape[0] >= seq_len
+    assert k_out.shape[1] == INDEX_HEAD_DIM
+    assert buf.is_contiguous()
+    assert page_indices.is_contiguous()
+    assert k_out.is_contiguous()
+    if seq_len == 0:
+        return
+
+    _gather_index_k_bf16_prefix_into_kernel[(seq_len,)](
+        buf,
+        page_indices,
+        k_out,
+        PAGE_SIZE=pool.page_size,
+        BUF_NUMEL_PER_PAGE=buf.shape[1],
+        HEAD_DIM=INDEX_HEAD_DIM,
+        BLOCK_D=triton.next_power_of_2(INDEX_HEAD_DIM),
+        num_warps=4,
+    )
+
+
+@triton.jit
+def _gather_index_k_bf16_prefix_into_kernel(
+    buf_ptr,
+    page_indices_ptr,
+    k_out_ptr,
+    PAGE_SIZE: tl.constexpr,
+    BUF_NUMEL_PER_PAGE: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    token_id = tl.program_id(0)
+    page_idx = token_id // PAGE_SIZE
+    token_offset_in_page = token_id % PAGE_SIZE
+    page = tl.load(page_indices_ptr + page_idx)
+
+    offs = tl.arange(0, BLOCK_D)
+    mask = offs < HEAD_DIM
+    src = page * BUF_NUMEL_PER_PAGE + token_offset_in_page * HEAD_DIM + offs
+    dst = token_id * HEAD_DIM + offs
+    value = tl.load(buf_ptr + src, mask=mask, other=0.0)
+    tl.store(k_out_ptr + dst, value, mask=mask)
+
+
 @triton.jit
 def _gather_index_k_scale_prefix_into_kernel(
     buf_u8_ptr,
@@ -629,11 +685,24 @@ def kpool_softmax_rotate_write_cache(
     assert slot_k.dtype == torch.bfloat16
     assert slot_score.dtype in KPOOL_SCORE_DTYPES
     assert ape.dtype == torch.float32
-    assert buf.dtype == torch.uint8
     assert pool.page_size == BLOCK_SIZE_K
     assert pool.index_head_dim == INDEX_HEAD_DIM
     assert loc.dtype == torch.int64
     assert write_cache or return_compressed
+
+    if buf.dtype == torch.bfloat16:
+        return _kpool_softmax_rotate_write_cache_bf16(
+            pool=pool,
+            buf=buf,
+            slot_k=slot_k,
+            slot_score=slot_score,
+            ape=ape,
+            loc=loc,
+            write_mask=write_mask,
+            return_compressed=return_compressed,
+            write_cache=write_cache,
+        )
+    assert buf.dtype == torch.uint8
 
     slot_k = slot_k.contiguous()
     slot_score = slot_score.contiguous()
@@ -705,6 +774,177 @@ def kpool_softmax_rotate_write_cache(
     return None
 
 
+def _kpool_softmax_rotate_write_cache_bf16(
+    *,
+    pool,
+    buf: torch.Tensor,
+    slot_k: torch.Tensor,
+    slot_score: torch.Tensor,
+    ape: torch.Tensor,
+    loc: torch.Tensor,
+    write_mask: torch.Tensor | None,
+    return_compressed: bool,
+    write_cache: bool,
+) -> Optional[Tuple[torch.Tensor, torch.Tensor]]:
+    """SM86 KPool writer with no FP8 quantization or scale sidecar."""
+
+    slot_k = slot_k.contiguous()
+    slot_score = slot_score.contiguous()
+    ape = ape.contiguous()
+    loc = loc.contiguous()
+    if write_mask is None:
+        write_mask = torch.empty((1,), dtype=torch.bool, device=slot_k.device)
+        has_write_mask = False
+    else:
+        assert write_mask.shape == (slot_k.shape[0],)
+        assert not return_compressed
+        write_mask = write_mask.contiguous()
+        has_write_mask = True
+
+    if slot_k.shape[0] == 0:
+        if return_compressed:
+            return (
+                torch.empty(
+                    (0, slot_k.shape[2]),
+                    dtype=torch.bfloat16,
+                    device=slot_k.device,
+                ),
+                torch.empty((0,), dtype=torch.float32, device=slot_k.device),
+            )
+        return None
+
+    compressed_k = (
+        torch.empty(
+            (slot_k.shape[0], slot_k.shape[2]),
+            dtype=torch.bfloat16,
+            device=slot_k.device,
+        )
+        if return_compressed
+        else buf
+    )
+    compressed_scale = (
+        torch.empty(
+            (slot_k.shape[0],), dtype=torch.float32, device=slot_k.device
+        )
+        if return_compressed
+        else buf
+    )
+    _kpool_softmax_rotate_write_cache_bf16_kernel[(slot_k.shape[0],)](
+        buf,
+        slot_k,
+        slot_score,
+        ape,
+        loc,
+        write_mask,
+        compressed_k,
+        compressed_scale,
+        slot_k.stride(0),
+        slot_k.stride(1),
+        slot_score.stride(0),
+        slot_score.stride(1),
+        ape.stride(0),
+        PAGE_SIZE=pool.page_size,
+        BUF_NUMEL_PER_PAGE=buf.shape[1],
+        POOL_SIZE=slot_k.shape[1],
+        HEAD_DIM=slot_k.shape[2],
+        HAS_WRITE_MASK=has_write_mask,
+        RETURN_COMPRESSED=return_compressed,
+        WRITE_CACHE=write_cache,
+        BLOCK_D=triton.next_power_of_2(slot_k.shape[2]),
+        num_warps=4,
+        num_stages=2,
+    )
+    if return_compressed:
+        return compressed_k, compressed_scale
+    return None
+
+
+@triton.jit
+def _kpool_softmax_rotate_write_cache_bf16_kernel(
+    buf_ptr,
+    slot_k_ptr,
+    slot_score_ptr,
+    ape_ptr,
+    loc_ptr,
+    write_mask_ptr,
+    compressed_k_ptr,
+    compressed_scale_ptr,
+    slot_k_stride_0,
+    slot_k_stride_1,
+    slot_score_stride_0,
+    slot_score_stride_1,
+    ape_stride_0,
+    PAGE_SIZE: tl.constexpr,
+    BUF_NUMEL_PER_PAGE: tl.constexpr,
+    POOL_SIZE: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    HAS_WRITE_MASK: tl.constexpr,
+    RETURN_COMPRESSED: tl.constexpr,
+    WRITE_CACHE: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    row = tl.program_id(0)
+    do_write = True
+    if HAS_WRITE_MASK:
+        do_write = tl.load(write_mask_ptr + row)
+
+    offs = tl.arange(0, BLOCK_D)
+    mask = (offs < HEAD_DIM) & do_write
+    max_score = tl.full((BLOCK_D,), -float("inf"), tl.float32)
+    for slot in tl.static_range(0, POOL_SIZE):
+        score = tl.load(
+            slot_score_ptr
+            + row * slot_score_stride_0
+            + slot * slot_score_stride_1
+            + offs,
+            mask=mask,
+            other=0.0,
+        ).to(tl.float32)
+        score += tl.load(
+            ape_ptr + slot * ape_stride_0 + offs, mask=mask, other=0.0
+        ).to(tl.float32)
+        max_score = tl.maximum(max_score, score)
+
+    acc = tl.zeros((BLOCK_D,), tl.float32)
+    denom = tl.zeros((BLOCK_D,), tl.float32)
+    for slot in tl.static_range(0, POOL_SIZE):
+        score = tl.load(
+            slot_score_ptr
+            + row * slot_score_stride_0
+            + slot * slot_score_stride_1
+            + offs,
+            mask=mask,
+            other=0.0,
+        ).to(tl.float32)
+        score += tl.load(
+            ape_ptr + slot * ape_stride_0 + offs, mask=mask, other=0.0
+        ).to(tl.float32)
+        prob = tl.exp(score - max_score)
+        denom += prob
+        key = tl.load(
+            slot_k_ptr + row * slot_k_stride_0 + slot * slot_k_stride_1 + offs,
+            mask=mask,
+            other=0.0,
+        ).to(tl.float32)
+        acc += key * prob
+
+    compressed = (acc / denom).to(tl.bfloat16).to(tl.float32)
+    compressed = _hadamard128(compressed).to(tl.bfloat16)
+    if WRITE_CACHE:
+        loc = tl.load(loc_ptr + row, mask=do_write, other=0)
+        page = loc // PAGE_SIZE
+        token = loc % PAGE_SIZE
+        out = page * BUF_NUMEL_PER_PAGE + token * HEAD_DIM + offs
+        tl.store(buf_ptr + out, compressed, mask=mask)
+    if RETURN_COMPRESSED:
+        tl.store(
+            compressed_k_ptr + row * HEAD_DIM + offs,
+            compressed,
+            mask=offs < HEAD_DIM,
+        )
+        tl.store(compressed_scale_ptr + row, 1.0)
+
+
 def kpool_decode_update_and_maybe_write_cache(
     pool,
     buf: torch.Tensor,
@@ -732,7 +972,6 @@ def kpool_decode_update_and_maybe_write_cache(
     assert tail_score.dtype in KPOOL_SCORE_DTYPES
     assert slot_score.dtype == tail_score.dtype
     assert ape.dtype == torch.float32
-    assert buf.dtype == torch.uint8
     assert pool.page_size == BLOCK_SIZE_K
     assert pool.index_head_dim == INDEX_HEAD_DIM
     assert tail_k.is_contiguous()
@@ -741,6 +980,24 @@ def kpool_decode_update_and_maybe_write_cache(
     batch = key.shape[0]
     if batch == 0:
         return
+
+    if buf.dtype == torch.bfloat16:
+        _kpool_decode_update_and_maybe_write_cache_bf16(
+            pool=pool,
+            buf=buf,
+            tail_k=tail_k,
+            tail_score=tail_score,
+            key=key,
+            slot_score=slot_score,
+            ape=ape,
+            block_tables=block_tables,
+            req_pool_indices=req_pool_indices,
+            positions=positions,
+            seq_lens=seq_lens,
+            out_cache_loc=out_cache_loc,
+        )
+        return
+    assert buf.dtype == torch.uint8
 
     key = key.contiguous()
     slot_score = slot_score.contiguous()
@@ -792,6 +1049,64 @@ def kpool_decode_update_and_maybe_write_cache(
         ROUND_SCALE=round_scale,
         BLOCK_D=triton.next_power_of_2(tail_k.shape[2]),
         SLOTS_PER_PAGE=pool.slots_per_page,
+    )
+
+
+def _kpool_decode_update_and_maybe_write_cache_bf16(
+    *,
+    pool,
+    buf: torch.Tensor,
+    tail_k: torch.Tensor,
+    tail_score: torch.Tensor,
+    key: torch.Tensor,
+    slot_score: torch.Tensor,
+    ape: torch.Tensor,
+    block_tables: torch.Tensor,
+    req_pool_indices: torch.Tensor,
+    positions: torch.Tensor,
+    seq_lens: torch.Tensor,
+    out_cache_loc: torch.Tensor,
+) -> None:
+    key = key.contiguous()
+    slot_score = slot_score.contiguous()
+    ape = ape.contiguous()
+    req_pool_indices = req_pool_indices.contiguous()
+    positions = positions.contiguous()
+    seq_lens = seq_lens.contiguous()
+    out_cache_loc = out_cache_loc.contiguous()
+    batch = key.shape[0]
+
+    _kpool_decode_update_and_maybe_write_cache_bf16_kernel[(batch,)](
+        buf,
+        tail_k,
+        tail_score,
+        key,
+        slot_score,
+        ape,
+        block_tables,
+        req_pool_indices,
+        positions,
+        seq_lens,
+        out_cache_loc,
+        tail_k.stride(0),
+        tail_k.stride(1),
+        tail_score.stride(0),
+        tail_score.stride(1),
+        key.stride(0),
+        slot_score.stride(0),
+        ape.stride(0),
+        block_tables.stride(0),
+        block_tables.stride(1),
+        REQ_POOL_SIZE=tail_k.shape[0],
+        BUF_NUMEL_PER_PAGE=buf.shape[1],
+        POOL_SIZE=pool.index_kpool,
+        TAIL_SIZE=tail_k.shape[1],
+        HEAD_DIM=tail_k.shape[2],
+        BLOCK_TABLE_COLS=block_tables.shape[1],
+        BLOCK_D=triton.next_power_of_2(tail_k.shape[2]),
+        SLOTS_PER_PAGE=pool.slots_per_page,
+        num_warps=4,
+        num_stages=2,
     )
 
 
@@ -1102,6 +1417,136 @@ def _kpool_decode_update_and_maybe_write_cache_kernel(
 
 
 @triton.jit
+def _kpool_decode_update_and_maybe_write_cache_bf16_kernel(
+    buf_ptr,
+    tail_k_ptr,
+    tail_score_ptr,
+    key_ptr,
+    slot_score_ptr,
+    ape_ptr,
+    block_tables_ptr,
+    req_pool_indices_ptr,
+    positions_ptr,
+    seq_lens_ptr,
+    out_cache_loc_ptr,
+    tail_k_stride_0,
+    tail_k_stride_1,
+    tail_score_stride_0,
+    tail_score_stride_1,
+    key_stride_0,
+    slot_score_stride_0,
+    ape_stride_0,
+    block_tables_stride_0,
+    block_tables_stride_1,
+    REQ_POOL_SIZE: tl.constexpr,
+    BUF_NUMEL_PER_PAGE: tl.constexpr,
+    POOL_SIZE: tl.constexpr,
+    TAIL_SIZE: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_TABLE_COLS: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    SLOTS_PER_PAGE: tl.constexpr,
+):
+    row = tl.program_id(0)
+    offs = tl.arange(0, BLOCK_D)
+    dim_mask = offs < HEAD_DIM
+
+    req_raw = tl.load(req_pool_indices_ptr + row)
+    req_valid = (req_raw >= 0) & (req_raw < REQ_POOL_SIZE)
+    req = tl.minimum(tl.maximum(req_raw, 0), REQ_POOL_SIZE - 1)
+    pos = tl.load(positions_ptr + row)
+    safe_pos = tl.maximum(pos, 0)
+    seq_len = tl.load(seq_lens_ptr + row)
+    cache_loc = tl.load(out_cache_loc_ptr + row)
+    pos_valid = req_valid & (cache_loc != 0) & (pos >= 0) & (pos < seq_len)
+    slot = safe_pos % POOL_SIZE
+    phys_slot = safe_pos % TAIL_SIZE
+
+    key = tl.load(
+        key_ptr + row * key_stride_0 + offs, mask=dim_mask, other=0.0
+    ).to(tl.float32)
+    score_current = tl.load(
+        slot_score_ptr + row * slot_score_stride_0 + offs,
+        mask=dim_mask,
+        other=0.0,
+    ).to(tl.float32)
+
+    if pos_valid & (slot == POOL_SIZE - 1):
+        pool_logical_start = safe_pos - slot
+        max_score = tl.full((BLOCK_D,), -float("inf"), tl.float32)
+        for pool_slot in tl.static_range(0, POOL_SIZE):
+            is_current = pool_slot == slot
+            phys = (pool_logical_start + pool_slot) % TAIL_SIZE
+            score_buf = tl.load(
+                tail_score_ptr
+                + req * tail_score_stride_0
+                + phys * tail_score_stride_1
+                + offs,
+                mask=dim_mask,
+                other=0.0,
+            ).to(tl.float32)
+            score = tl.where(is_current, score_current, score_buf)
+            score += tl.load(
+                ape_ptr + pool_slot * ape_stride_0 + offs,
+                mask=dim_mask,
+                other=0.0,
+            ).to(tl.float32)
+            max_score = tl.maximum(max_score, score)
+
+        acc = tl.zeros((BLOCK_D,), tl.float32)
+        denom = tl.zeros((BLOCK_D,), tl.float32)
+        for pool_slot in tl.static_range(0, POOL_SIZE):
+            is_current = pool_slot == slot
+            phys = (pool_logical_start + pool_slot) % TAIL_SIZE
+            score_buf = tl.load(
+                tail_score_ptr
+                + req * tail_score_stride_0
+                + phys * tail_score_stride_1
+                + offs,
+                mask=dim_mask,
+                other=0.0,
+            ).to(tl.float32)
+            score = tl.where(is_current, score_current, score_buf)
+            score += tl.load(
+                ape_ptr + pool_slot * ape_stride_0 + offs,
+                mask=dim_mask,
+                other=0.0,
+            ).to(tl.float32)
+            prob = tl.exp(score - max_score)
+            denom += prob
+            key_buf = tl.load(
+                tail_k_ptr + req * tail_k_stride_0 + phys * tail_k_stride_1 + offs,
+                mask=dim_mask,
+                other=0.0,
+            ).to(tl.float32)
+            acc += tl.where(is_current, key, key_buf) * prob
+
+        compressed = (acc / denom).to(tl.bfloat16).to(tl.float32)
+        compressed = _hadamard128(compressed).to(tl.bfloat16)
+        pool_id = safe_pos // POOL_SIZE
+        pool_page_group = pool_id // SLOTS_PER_PAGE
+        token_page_row = tl.minimum(
+            tl.maximum(pool_page_group * POOL_SIZE, 0), BLOCK_TABLE_COLS - 1
+        )
+        packed_page = tl.load(
+            block_tables_ptr
+            + row * block_tables_stride_0
+            + token_page_row * block_tables_stride_1
+        ).to(tl.int64)
+        token = pool_id % SLOTS_PER_PAGE
+        out = packed_page * BUF_NUMEL_PER_PAGE + token * HEAD_DIM + offs
+        tl.store(buf_ptr + out, compressed, mask=dim_mask)
+
+    tail_k_offset = req * tail_k_stride_0 + phys_slot * tail_k_stride_1 + offs
+    tail_score_offset = (
+        req * tail_score_stride_0 + phys_slot * tail_score_stride_1 + offs
+    )
+    update_mask = dim_mask & pos_valid
+    tl.store(tail_k_ptr + tail_k_offset, key, mask=update_mask)
+    tl.store(tail_score_ptr + tail_score_offset, score_current, mask=update_mask)
+
+
+@triton.jit
 def _hadamard_quantize_fp8(acc, denom, ROUND_SCALE: tl.constexpr):
     x = (acc / denom).to(tl.bfloat16).to(tl.float32)
     x = _hadamard128(x).to(tl.bfloat16).to(tl.float32)
@@ -1222,6 +1667,25 @@ def kpool_assemble_softmax_rotate_write_cache(
     if n_pools == 0:
         return
 
+    if buf.dtype == torch.bfloat16:
+        _kpool_assemble_softmax_rotate_write_cache_bf16(
+            pool=pool,
+            buf=buf,
+            chunk_k=chunk_k,
+            chunk_score=chunk_score,
+            tail_k=tail_k,
+            tail_score=tail_score,
+            req_pool_idx=req_pool_idx,
+            n_from_tail=n_from_tail,
+            chunk_src_start=chunk_src_start,
+            tail_logical_base=tail_logical_base,
+            ape=ape,
+            loc=loc,
+            write_mask=write_mask,
+        )
+        return
+    assert buf.dtype == torch.uint8
+
     chunk_k = chunk_k.contiguous()
     chunk_score = chunk_score.contiguous()
     ape = ape.contiguous()
@@ -1302,6 +1766,138 @@ def scatter_kpool_tail_updates(
         HEAD_DIM=INDEX_HEAD_DIM,
         BLOCK_D=triton.next_power_of_2(INDEX_HEAD_DIM),
     )
+
+
+def _kpool_assemble_softmax_rotate_write_cache_bf16(
+    *,
+    pool,
+    buf: torch.Tensor,
+    chunk_k: torch.Tensor,
+    chunk_score: torch.Tensor,
+    tail_k: torch.Tensor,
+    tail_score: torch.Tensor,
+    req_pool_idx: torch.Tensor,
+    n_from_tail: torch.Tensor,
+    chunk_src_start: torch.Tensor,
+    tail_logical_base: torch.Tensor,
+    ape: torch.Tensor,
+    loc: torch.Tensor,
+    write_mask: torch.Tensor | None,
+) -> None:
+    chunk_k = chunk_k.contiguous()
+    chunk_score = chunk_score.contiguous()
+    ape = ape.contiguous()
+    loc = loc.contiguous()
+    if write_mask is None:
+        write_mask = torch.empty((1,), dtype=torch.bool, device=chunk_k.device)
+        has_write_mask = False
+    else:
+        write_mask = write_mask.contiguous()
+        has_write_mask = True
+
+    _kpool_assemble_softmax_rotate_write_cache_bf16_kernel[
+        (req_pool_idx.shape[0],)
+    ](
+        buf,
+        chunk_k,
+        chunk_score,
+        tail_k,
+        tail_score,
+        req_pool_idx,
+        n_from_tail,
+        chunk_src_start,
+        tail_logical_base,
+        ape,
+        loc,
+        write_mask,
+        chunk_k.stride(0),
+        tail_k.stride(0),
+        tail_k.stride(1),
+        ape.stride(0),
+        BUF_NUMEL_PER_PAGE=buf.shape[1],
+        POOL_SIZE=pool.index_kpool,
+        TAIL_SIZE=tail_k.shape[1],
+        HEAD_DIM=INDEX_HEAD_DIM,
+        HAS_WRITE_MASK=has_write_mask,
+        BLOCK_D=triton.next_power_of_2(INDEX_HEAD_DIM),
+        SLOTS_PER_PAGE=pool.slots_per_page,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+@triton.jit
+def _kpool_assemble_softmax_rotate_write_cache_bf16_kernel(
+    buf_ptr,
+    chunk_k_ptr,
+    chunk_score_ptr,
+    tail_k_ptr,
+    tail_score_ptr,
+    req_pool_idx_ptr,
+    n_from_tail_ptr,
+    chunk_src_start_ptr,
+    tail_logical_base_ptr,
+    ape_ptr,
+    loc_ptr,
+    write_mask_ptr,
+    chunk_stride_0,
+    tail_stride_0,
+    tail_stride_1,
+    ape_stride_0,
+    BUF_NUMEL_PER_PAGE: tl.constexpr,
+    POOL_SIZE: tl.constexpr,
+    TAIL_SIZE: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    HAS_WRITE_MASK: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    SLOTS_PER_PAGE: tl.constexpr,
+):
+    row = tl.program_id(0)
+    if HAS_WRITE_MASK:
+        if not tl.load(write_mask_ptr + row):
+            return
+
+    offs = tl.arange(0, BLOCK_D)
+    mask = offs < HEAD_DIM
+    n_tail = tl.load(n_from_tail_ptr + row)
+    req = tl.load(req_pool_idx_ptr + row)
+    chunk_src = tl.load(chunk_src_start_ptr + row)
+    tail_base = tl.load(tail_logical_base_ptr + row)
+
+    running_max = tl.full((BLOCK_D,), -float("inf"), tl.float32)
+    acc = tl.zeros((BLOCK_D,), tl.float32)
+    denom = tl.zeros((BLOCK_D,), tl.float32)
+    for slot in tl.static_range(0, POOL_SIZE):
+        if slot < n_tail:
+            phys = (tail_base + slot) % TAIL_SIZE
+            src = req * tail_stride_0 + phys * tail_stride_1 + offs
+            score = tl.load(tail_score_ptr + src, mask=mask, other=0.0).to(
+                tl.float32
+            )
+            key = tl.load(tail_k_ptr + src, mask=mask, other=0.0).to(tl.float32)
+        else:
+            src = (chunk_src + (slot - n_tail)) * chunk_stride_0 + offs
+            score = tl.load(chunk_score_ptr + src, mask=mask, other=0.0).to(
+                tl.float32
+            )
+            key = tl.load(chunk_k_ptr + src, mask=mask, other=0.0).to(tl.float32)
+        score += tl.load(
+            ape_ptr + slot * ape_stride_0 + offs, mask=mask, other=0.0
+        ).to(tl.float32)
+        next_max = tl.maximum(running_max, score)
+        rescale = tl.exp(running_max - next_max)
+        prob = tl.exp(score - next_max)
+        denom = denom * rescale + prob
+        acc = acc * rescale + key * prob
+        running_max = next_max
+
+    compressed = (acc / denom).to(tl.bfloat16).to(tl.float32)
+    compressed = _hadamard128(compressed).to(tl.bfloat16)
+    loc = tl.load(loc_ptr + row)
+    page = loc // SLOTS_PER_PAGE
+    token = loc % SLOTS_PER_PAGE
+    out = page * BUF_NUMEL_PER_PAGE + token * HEAD_DIM + offs
+    tl.store(buf_ptr + out, compressed, mask=mask)
 
 
 @triton.jit

--- a/python/sglang/srt/layers/attention/nsa/kpool_fp8_index.py
+++ b/python/sglang/srt/layers/attention/nsa/kpool_fp8_index.py
@@ -8,12 +8,10 @@ BLOCK_SIZE_K = 64
 INDEX_HEAD_DIM = 128
 KPOOL_SCORE_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
 
-# The fused radix selector stores one threshold-bin candidate list in 4,096
-# shared-memory entries. It is exact only while a row itself is no longer than
-# that capacity: a larger row can put more than 4,096 values in one coarse FP16
-# bin and the kernel clips the candidate list. Eager Session-AB execution may
-# synchronize and use torch.topk for longer rows.
-KPOOL_RADIX_EXACT_ROW_CAPACITY = 4096
+# Each fixed-width shard contributes its local top-k to a second exact top-k.
+# The union is mathematically sufficient for the global result and, unlike the
+# old shared-memory radix selector, has no candidate-capacity correctness cap.
+KPOOL_HIERARCHICAL_TOPK_CHUNK_SIZE = 32768
 
 
 def build_pooled_page_table_64(
@@ -352,43 +350,107 @@ def _exact_topk_from_pooled_history_logits(
     out_rows: int | None = None,
     page_table_row_index: torch.Tensor | None = None,
 ) -> torch.Tensor:
-    """Exact eager fallback for rows beyond the fused radix capacity."""
+    """Device-only exact hierarchical top-k over arbitrary row lengths.
+
+    The shard loop depends only on the static logits width captured by CUDA
+    graph.  Replay-varying row starts/lengths stay on device, so this routine
+    contains no host synchronization or data-dependent Python control flow.
+    Keeping the best ``K`` entries from every shard is exact: every global
+    top-``K`` value must be in its shard's local top-``K`` set.
+    """
 
     rows, cols = logits.shape
     group_topk = history_group_budget_for_topk(topk, pool_size)
-    lengths_cpu = group_lengths.detach().to(device="cpu", dtype=torch.int64).tolist()
-    if row_starts is None:
-        starts_cpu = [0] * rows
-    else:
-        if row_starts.shape != group_lengths.shape:
-            raise ValueError(
-                "KPool row_starts must match group_lengths, got "
-                f"{tuple(row_starts.shape)} and {tuple(group_lengths.shape)}"
-            )
-        starts_cpu = row_starts.detach().to(device="cpu", dtype=torch.int64).tolist()
+    if row_starts is not None and row_starts.shape != group_lengths.shape:
+        raise ValueError(
+            "KPool row_starts must match group_lengths, got "
+            f"{tuple(row_starts.shape)} and {tuple(group_lengths.shape)}"
+        )
 
-    selected_groups = torch.zeros(
-        (rows, group_topk), dtype=torch.int64, device=logits.device
+    starts = (
+        torch.zeros_like(group_lengths, dtype=torch.int64)
+        if row_starts is None
+        else row_starts.to(torch.int64)
+    ).clamp(min=0, max=cols)
+    bounded_lengths = torch.minimum(
+        group_lengths.to(torch.int64).clamp_min(0),
+        torch.full_like(starts, cols) - starts,
     )
-    valid_counts = torch.empty((rows,), dtype=torch.int64, device=logits.device)
-    for row, (row_start, length) in enumerate(
-        zip(starts_cpu, lengths_cpu, strict=True)
-    ):
-        if row_start < 0 or length < 0 or row_start + length > cols:
-            raise ValueError(
-                "KPool exact top-k row bounds are invalid: "
-                f"row={row}, start={row_start}, length={length}, cols={cols}"
+
+    if cols == 0:
+        selected_groups = torch.zeros(
+            (rows, group_topk), dtype=torch.int64, device=logits.device
+        )
+    else:
+        positions = torch.arange(cols, dtype=torch.int64, device=logits.device)
+        valid = (positions.unsqueeze(0) >= starts.unsqueeze(1)) & (
+            positions.unsqueeze(0) < (starts + bounded_lengths).unsqueeze(1)
+        )
+        masked_logits = logits.masked_fill(~valid, float("-inf"))
+
+        candidate_values = []
+        candidate_indices = []
+        for chunk_start in range(0, cols, KPOOL_HIERARCHICAL_TOPK_CHUNK_SIZE):
+            chunk_end = min(chunk_start + KPOOL_HIERARCHICAL_TOPK_CHUNK_SIZE, cols)
+            chunk_width = chunk_end - chunk_start
+            local_k = min(group_topk, chunk_width)
+            values, indices = torch.topk(
+                masked_logits[:, chunk_start:chunk_end],
+                k=local_k,
+                dim=1,
+                largest=True,
+                sorted=False,
             )
-        count = min(group_topk, length)
-        valid_counts[row] = count
-        if count == 0:
-            continue
-        selected_groups[row, :count] = torch.topk(
-            logits[row, row_start : row_start + length],
-            k=count,
+            indices = indices.to(torch.int64) + chunk_start
+            if local_k != group_topk:
+                pad_width = group_topk - local_k
+                values = torch.cat(
+                    [
+                        values,
+                        torch.full(
+                            (rows, pad_width),
+                            float("-inf"),
+                            dtype=values.dtype,
+                            device=values.device,
+                        ),
+                    ],
+                    dim=1,
+                )
+                indices = torch.cat(
+                    [
+                        indices,
+                        torch.zeros(
+                            (rows, pad_width),
+                            dtype=torch.int64,
+                            device=indices.device,
+                        ),
+                    ],
+                    dim=1,
+                )
+            candidate_values.append(values)
+            candidate_indices.append(indices)
+
+        all_values = torch.cat(candidate_values, dim=1)
+        all_indices = torch.cat(candidate_indices, dim=1)
+        _, candidate_rank = torch.topk(
+            all_values,
+            k=group_topk,
+            dim=1,
             largest=True,
-            sorted=False,
-        ).indices
+            # Keep every finite candidate before the padded ``-inf`` entries.
+            # ``group_valid`` below is a prefix mask when a short sequence has
+            # fewer than ``group_topk`` groups, so this ordering is part of the
+            # correctness contract rather than a presentation preference.
+            sorted=True,
+        )
+        selected_groups = torch.gather(
+            all_indices, 1, candidate_rank
+        ) - starts.unsqueeze(1)
+
+    valid_counts = torch.minimum(
+        bounded_lengths,
+        torch.full_like(bounded_lengths, group_topk),
+    )
 
     rank = torch.arange(group_topk, device=logits.device, dtype=torch.int64)
     group_valid = rank.unsqueeze(0) < valid_counts.unsqueeze(1)
@@ -534,97 +596,18 @@ def topk_from_pooled_history_logits(
             f"is disabled. Got device={logits.device}, dtype={logits.dtype}."
         )
 
-    if group_topk in (128, 160, 192, 224, 256, 512):
-        # The shared-memory radix kernel clips a threshold bin after 4,096
-        # candidates. A longer row is routed to an exact eager selector before
-        # the JIT kernel can lose a later high score. CUDA graph is disabled at
-        # the Session-AB boundary, so this host synchronization is intentional.
-        max_group_length = (
-            int(group_lengths.max().item()) if group_lengths.numel() else 0
-        )
-        if max_group_length > KPOOL_RADIX_EXACT_ROW_CAPACITY:
-            return _exact_topk_from_pooled_history_logits(
-                logits,
-                group_lengths,
-                pool_size=pool_size,
-                topk=topk,
-                page_table=page_table,
-                topk_offsets=topk_offsets,
-                seq_lens=seq_lens,
-                row_starts=row_starts,
-                out_rows=out_rows,
-                page_table_row_index=page_table_row_index,
-            )
-
-        from sglang.jit_kernel.kpool_topk_transform import (
-            fast_kpool_topk_transform_fused,
-        )
-
-        result = fast_kpool_topk_transform_fused(
-            score=logits,
-            lengths=group_lengths.to(torch.int32),
-            pool_size=pool_size,
-            topk=topk,
-            page_table=page_table,
-            topk_indices_offset=topk_offsets,
-            row_starts=row_starts,
-            seq_lens=seq_lens.to(torch.int32) if seq_lens is not None else None,
-            page_table_row_index=page_table_row_index,
-        )
-        if out_rows is None or out_rows == result.shape[0]:
-            return result
-        padded = torch.full(
-            (out_rows, result.shape[1]), -1, dtype=result.dtype, device=result.device
-        )
-        padded[: result.shape[0]] = result
-        return padded
-
-    assert page_table_row_index is None, (
-        "page_table_row_index requires the fused fast_kpool group_topk path"
-    )
-
-    from sgl_kernel import fast_topk_v2
-
-    selected_groups = fast_topk_v2(
+    return _exact_topk_from_pooled_history_logits(
         logits,
-        group_lengths.to(torch.int32),
-        group_topk,
-        row_starts=row_starts,
-    )
-
-    rank = torch.arange(group_topk, device=logits.device, dtype=torch.int32)
-    max_valid_groups = min(cols, group_topk)
-    valid_counts = torch.minimum(
-        group_lengths.to(torch.int32),
-        torch.full_like(group_lengths.to(torch.int32), max_valid_groups),
-    )
-    group_valid = rank.unsqueeze(0) < valid_counts.unsqueeze(1)
-    expanded = expand_pooled_groups_to_topk(
-        selected_groups.contiguous(),
-        group_valid,
-        topk=topk,
+        group_lengths,
         pool_size=pool_size,
+        topk=topk,
         page_table=page_table,
         topk_offsets=topk_offsets,
+        seq_lens=seq_lens,
+        row_starts=row_starts,
+        out_rows=out_rows,
+        page_table_row_index=page_table_row_index,
     )
-    if seq_lens is None:
-        result = expanded
-    else:
-        result = append_kpool_tail_to_topk(
-            expanded,
-            seq_lens=seq_lens,
-            pool_lens=group_lengths,
-            pool_size=pool_size,
-            page_table=page_table,
-            topk_offsets=topk_offsets,
-        )
-    if out_rows is None or out_rows == result.shape[0]:
-        return result
-    padded = torch.full(
-        (out_rows, result.shape[1]), -1, dtype=result.dtype, device=result.device
-    )
-    padded[: result.shape[0]] = result
-    return padded
 
 
 def kpool_softmax_rotate_write_cache(

--- a/python/sglang/srt/layers/attention/nsa/kpool_plan.py
+++ b/python/sglang/srt/layers/attention/nsa/kpool_plan.py
@@ -12,7 +12,6 @@ from sglang.srt.layers.attention.nsa.kpool_fp8_index import (
     build_pooled_page_table_64,
     kpool_build_ragged_layout,
 )
-from sglang.srt.model_executor.forward_context import get_req_to_token_pool
 from sglang.srt.utils import is_cuda
 
 if TYPE_CHECKING:
@@ -22,6 +21,27 @@ if TYPE_CHECKING:
 
 _RAGGED_SCRATCH_K_U8: Optional[torch.Tensor] = None
 _RAGGED_SCRATCH_K_SCALE: Optional[torch.Tensor] = None
+
+
+def _req_to_token_table_from_batch(forward_batch: ForwardBatch) -> torch.Tensor:
+    """Use the batch-owned request table as the authoritative metadata source.
+
+    Keeping this dependency explicit avoids ambient-context ordering assumptions
+    in eager, direct metadata initialization, and CUDA Graph capture paths.  Fail
+    closed for synthetic or incomplete batches.
+    """
+
+    req_to_token_pool = getattr(forward_batch, "req_to_token_pool", None)
+    if req_to_token_pool is None:
+        raise RuntimeError(
+            "GLM-5-Next KPool metadata requires ForwardBatch.req_to_token_pool"
+        )
+    req_to_token = getattr(req_to_token_pool, "req_to_token", None)
+    if req_to_token is None:
+        raise RuntimeError(
+            "GLM-5-Next KPool metadata requires a req_to_token table"
+        )
+    return req_to_token
 
 
 def _get_ragged_scratch(
@@ -379,7 +399,7 @@ def _kpool_plan_to_gpu(
     ragged_paged_page_table = None
     ragged_paged_page_table_row_index = None
     if need_paged:
-        req_to_token = get_req_to_token_pool().req_to_token
+        req_to_token = _req_to_token_table_from_batch(forward_batch)
         ragged_paged_page_table_row_index = torch.repeat_interleave(
             local_req_pool_indices.to(torch.int32), ragged_q_len_t
         )

--- a/python/sglang/srt/layers/attention/nsa/kpool_plan.py
+++ b/python/sglang/srt/layers/attention/nsa/kpool_plan.py
@@ -1,0 +1,579 @@
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, List, NamedTuple, Optional
+
+import torch
+
+from sglang.srt.environ import envs
+from sglang.srt.layers.attention.nsa.kpool_fp8_index import (
+    INDEX_HEAD_DIM,
+    build_pooled_page_table_64,
+    kpool_build_ragged_layout,
+)
+from sglang.srt.model_executor.forward_context import get_req_to_token_pool
+from sglang.srt.utils import is_cuda
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.attention.nsa_backend import NSAMetadata, TopkTransformMethod
+    from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+
+
+_RAGGED_SCRATCH_K_U8: Optional[torch.Tensor] = None
+_RAGGED_SCRATCH_K_SCALE: Optional[torch.Tensor] = None
+
+
+def _get_ragged_scratch(
+    total_k_rows: int, device: torch.device
+) -> tuple[torch.Tensor, torch.Tensor]:
+    global _RAGGED_SCRATCH_K_U8, _RAGGED_SCRATCH_K_SCALE
+    cur = _RAGGED_SCRATCH_K_U8
+    grow = (
+        cur is None
+        or cur.device.type != device.type
+        or (device.index is not None and cur.device.index != device.index)
+        or cur.shape[0] < total_k_rows
+    )
+    if grow:
+        _RAGGED_SCRATCH_K_U8 = torch.empty(
+            (total_k_rows, INDEX_HEAD_DIM), dtype=torch.uint8, device=device
+        )
+        _RAGGED_SCRATCH_K_SCALE = torch.empty(
+            (total_k_rows,), dtype=torch.float32, device=device
+        )
+    return _RAGGED_SCRATCH_K_U8[:total_k_rows], _RAGGED_SCRATCH_K_SCALE[:total_k_rows]
+
+
+@dataclass(frozen=True)
+class PoolWriteRows:
+    req: torch.Tensor
+    pool_id: torch.Tensor
+    n_from_tail: torch.Tensor
+    chunk_src: torch.Tensor
+    tail_logical_base: torch.Tensor
+    write_loc: torch.Tensor
+
+    @property
+    def is_empty(self) -> bool:
+        return self.pool_id.shape[0] == 0
+
+
+@dataclass(frozen=True)
+class TailWriteRows:
+    req: torch.Tensor
+    dst_logical_start: torch.Tensor
+    chunk_src: torch.Tensor
+    n_write: torch.Tensor
+
+    @property
+    def is_empty(self) -> bool:
+        return self.req.shape[0] == 0
+
+
+@dataclass(frozen=True)
+class KPoolExtendPlan:
+    writes: PoolWriteRows
+    tails: TailWriteRows
+    pooled_seq_lens_expanded: torch.Tensor
+    seq_lens_expanded: torch.Tensor
+    ragged_concat_page_table: torch.Tensor
+    ragged_q_ks: torch.Tensor
+    ragged_q_ke: torch.Tensor
+    ragged_total_k_rows: int
+    ragged_k_u8: Optional[torch.Tensor]
+    ragged_k_scale: Optional[torch.Tensor]
+    ragged_paged_page_table: Optional[torch.Tensor]
+    ragged_paged_page_table_row_index: Optional[torch.Tensor]
+
+
+def _is_kpool_layout_enabled(pool_size: int, real_page_size: int) -> bool:
+    return pool_size == 4 and real_page_size == 64
+
+
+@dataclass
+class _KPoolCpuPlan:
+    pool_batch_idx: List[int] = field(default_factory=list)
+    pool_req: List[int] = field(default_factory=list)
+    pool_pool_id: List[int] = field(default_factory=list)
+    pool_n_from_tail: List[int] = field(default_factory=list)
+    pool_chunk_src: List[int] = field(default_factory=list)
+    pool_tail_logical_base: List[int] = field(default_factory=list)
+
+    tail_req: List[int] = field(default_factory=list)
+    tail_dst_logical_start: List[int] = field(default_factory=list)
+    tail_chunk_src: List[int] = field(default_factory=list)
+    tail_n_write: List[int] = field(default_factory=list)
+
+    ragged_q_len: List[int] = field(default_factory=list)
+    ragged_pool_pages: List[int] = field(default_factory=list)
+    cu_pages_excl: List[int] = field(default_factory=list)
+    cu_q_len_excl: List[int] = field(default_factory=list)
+    total_pool_pages: int = 0
+
+
+class _KPoolDecompose(NamedTuple):
+    first_slot: int
+    base_pool: int
+    n_pool: int
+    tail_n_write: int
+
+
+def _decompose_compress(start: int, length: int, pool_size: int) -> _KPoolDecompose:
+    first_slot = start % pool_size
+    base_pool = start // pool_size
+    n_pool = (start + length) // pool_size - base_pool
+    consumed = max(0, n_pool * pool_size - first_slot)
+    tail_n = length - consumed
+    return _KPoolDecompose(
+        first_slot=first_slot,
+        base_pool=base_pool,
+        n_pool=n_pool,
+        tail_n_write=tail_n,
+    )
+
+
+def _append_compress_rows(
+    plan: _KPoolCpuPlan,
+    pool_size: int,
+    batch_size: int,
+    extend_seq_lens_cpu: List[int],
+    seq_lens_cpu: List[int],
+    req_pool_indices_cpu: List[int],
+) -> None:
+    q_offset = 0
+    for i in range(batch_size):
+        q_len = extend_seq_lens_cpu[i]
+        assert q_len > 0, f"extend_seq_lens_cpu[{i}] = {q_len}; expected > 0"
+
+        seq_len = seq_lens_cpu[i]
+        req = req_pool_indices_cpu[i]
+        d = _decompose_compress(seq_len - q_len, q_len, pool_size)
+
+        if d.n_pool > 0:
+            plan.pool_batch_idx.extend([i] * d.n_pool)
+            plan.pool_req.extend([req] * d.n_pool)
+            plan.pool_pool_id.extend(range(d.base_pool, d.base_pool + d.n_pool))
+            plan.pool_n_from_tail.append(d.first_slot)
+            plan.pool_n_from_tail.extend([0] * (d.n_pool - 1))
+            bulk_start = q_offset + pool_size - d.first_slot
+            plan.pool_chunk_src.append(q_offset)
+            plan.pool_chunk_src.extend(
+                range(bulk_start, bulk_start + (d.n_pool - 1) * pool_size, pool_size)
+            )
+            plan.pool_tail_logical_base.extend(
+                range(
+                    d.base_pool * pool_size,
+                    (d.base_pool + d.n_pool) * pool_size,
+                    pool_size,
+                )
+            )
+
+        if d.tail_n_write > 0:
+            consumed = q_len - d.tail_n_write
+            plan.tail_req.append(req)
+            plan.tail_dst_logical_start.append(seq_len - q_len + consumed)
+            plan.tail_chunk_src.append(q_offset + consumed)
+            plan.tail_n_write.append(d.tail_n_write)
+
+        q_offset += q_len
+
+
+def _append_local_rows(
+    plan: _KPoolCpuPlan,
+    pool_size: int,
+    slots_per_page: int,
+    local_extend_seq_lens_cpu: List[int],
+    local_seq_lens_cpu: List[int],
+) -> None:
+    q_offset = 0
+    for q_len, seq_len in zip(
+        local_extend_seq_lens_cpu, local_seq_lens_cpu, strict=True
+    ):
+        assert q_len > 0, f"local_extend_seq_lens_cpu has non-positive {q_len = }"
+        plan.ragged_q_len.append(q_len)
+        pool_seq_len = seq_len // pool_size
+        pool_pages_i = (pool_seq_len + slots_per_page - 1) // slots_per_page
+        plan.ragged_pool_pages.append(pool_pages_i)
+        plan.cu_pages_excl.append(plan.total_pool_pages)
+        plan.cu_q_len_excl.append(q_offset)
+        plan.total_pool_pages += pool_pages_i
+        q_offset += q_len
+
+
+def _kpool_cpu_plan(
+    forward_batch: ForwardBatch,
+    pool_size: int,
+    slots_per_page: int,
+    *,
+    local_extend_seq_lens_cpu: Optional[List[int]] = None,
+    local_seq_lens_cpu: Optional[List[int]] = None,
+) -> _KPoolCpuPlan:
+    plan = _KPoolCpuPlan()
+
+    extend_seq_lens_cpu = forward_batch.extend_seq_lens_cpu
+    if isinstance(extend_seq_lens_cpu, torch.Tensor):
+        extend_seq_lens_cpu = extend_seq_lens_cpu.tolist()
+    seq_lens_cpu = forward_batch.seq_lens_cpu.tolist()
+    req_pool_indices_cpu = forward_batch.req_pool_indices.tolist()
+
+    _append_compress_rows(
+        plan,
+        pool_size,
+        forward_batch.batch_size,
+        extend_seq_lens_cpu,
+        seq_lens_cpu,
+        req_pool_indices_cpu,
+    )
+
+    if local_extend_seq_lens_cpu is None:
+        local_extend_seq_lens_cpu = extend_seq_lens_cpu
+        local_seq_lens_cpu = seq_lens_cpu
+
+    _append_local_rows(
+        plan,
+        pool_size,
+        slots_per_page,
+        local_extend_seq_lens_cpu,
+        local_seq_lens_cpu,
+    )
+    return plan
+
+
+def _kpool_plan_to_gpu(
+    cpu: _KPoolCpuPlan,
+    forward_batch: ForwardBatch,
+    full_real_page_table: torch.Tensor,
+    local_real_page_table: torch.Tensor,
+    local_seqlens_expanded: torch.Tensor,
+    local_req_pool_indices: torch.Tensor,
+    pool_size: int,
+    slots_per_page: int,
+    topk_transform_method: TopkTransformMethod,
+) -> KPoolExtendPlan:
+    from sglang.srt.layers.attention.nsa_backend import TopkTransformMethod
+
+    device = forward_batch.seq_lens.device
+    n_pool = len(cpu.pool_pool_id)
+    n_tail = len(cpu.tail_req)
+    n_rag = len(cpu.ragged_q_len)
+
+    total_pool_pages = cpu.total_pool_pages
+    ragged_total_k_rows = total_pool_pages * slots_per_page
+
+    need_paged = (
+        topk_transform_method == TopkTransformMethod.PAGED
+        and envs.SGLANG_NSA_FUSE_TOPK.get()
+        and n_rag > 0
+    )
+
+    i64_total = 4 * n_pool + 2 * n_tail
+    if i64_total > 0:
+        i64_cpu = torch.tensor(
+            cpu.pool_req
+            + cpu.pool_pool_id
+            + cpu.pool_chunk_src
+            + cpu.pool_batch_idx
+            + cpu.tail_req
+            + cpu.tail_chunk_src,
+            dtype=torch.int64,
+            pin_memory=True,
+        )
+        i64_gpu = i64_cpu.to(device, non_blocking=True)
+        c = 0
+        pool_req_t = i64_gpu[c : c + n_pool]
+        c += n_pool
+        pool_pool_id_t = i64_gpu[c : c + n_pool]
+        c += n_pool
+        pool_chunk_src_t = i64_gpu[c : c + n_pool]
+        c += n_pool
+        pool_batch_idx_t = i64_gpu[c : c + n_pool]
+        c += n_pool
+        tail_req_t = i64_gpu[c : c + n_tail]
+        c += n_tail
+        tail_chunk_src_t = i64_gpu[c : c + n_tail]
+    else:
+        empty_i64 = torch.empty((0,), dtype=torch.int64, device=device)
+        pool_req_t = pool_pool_id_t = pool_chunk_src_t = pool_batch_idx_t = empty_i64
+        tail_req_t = tail_chunk_src_t = empty_i64
+
+    i32_total = 2 * n_pool + 2 * n_tail + 4 * n_rag
+    if i32_total > 0:
+        i32_cpu = torch.tensor(
+            cpu.pool_n_from_tail
+            + cpu.pool_tail_logical_base
+            + cpu.tail_dst_logical_start
+            + cpu.tail_n_write
+            + cpu.ragged_pool_pages
+            + cpu.ragged_q_len
+            + cpu.cu_pages_excl
+            + cpu.cu_q_len_excl,
+            dtype=torch.int32,
+            pin_memory=True,
+        )
+        i32_gpu = i32_cpu.to(device, non_blocking=True)
+        c = 0
+        pool_n_from_tail_t = i32_gpu[c : c + n_pool]
+        c += n_pool
+        pool_tail_logical_base_t = i32_gpu[c : c + n_pool]
+        c += n_pool
+        tail_dst_logical_start_t = i32_gpu[c : c + n_tail]
+        c += n_tail
+        tail_n_write_t = i32_gpu[c : c + n_tail]
+        c += n_tail
+        ragged_pool_pages_t = i32_gpu[c : c + n_rag]
+        c += n_rag
+        ragged_q_len_t = i32_gpu[c : c + n_rag]
+        c += n_rag
+        cu_pages_excl_t = i32_gpu[c : c + n_rag]
+        c += n_rag
+        cu_q_len_excl_t = i32_gpu[c : c + n_rag]
+    else:
+        empty_i32 = torch.empty((0,), dtype=torch.int32, device=device)
+        pool_n_from_tail_t = pool_tail_logical_base_t = empty_i32
+        tail_dst_logical_start_t = tail_n_write_t = empty_i32
+        ragged_pool_pages_t = ragged_q_len_t = empty_i32
+        cu_pages_excl_t = cu_q_len_excl_t = empty_i32
+
+    if n_pool > 0:
+        pool_page_group = torch.div(
+            pool_pool_id_t, slots_per_page, rounding_mode="floor"
+        )
+        token_page_row = pool_page_group * pool_size
+        packed_page = full_real_page_table[pool_batch_idx_t, token_page_row].to(
+            torch.int64
+        )
+        pool_write_locs = packed_page * slots_per_page + torch.remainder(
+            pool_pool_id_t, slots_per_page
+        )
+    else:
+        pool_write_locs = torch.empty((0,), dtype=torch.int64, device=device)
+
+    pooled_seq_lens_expanded = torch.div(
+        local_seqlens_expanded, pool_size, rounding_mode="floor"
+    ).to(torch.int32)
+
+    if n_rag > 0:
+        (
+            ragged_concat_page_table,
+            ragged_q_ks,
+            ragged_q_ke,
+        ) = kpool_build_ragged_layout(
+            full_page_table=local_real_page_table,
+            cu_pages_excl=cu_pages_excl_t,
+            ragged_pool_pages=ragged_pool_pages_t,
+            cu_q_len_excl=cu_q_len_excl_t,
+            ragged_q_len=ragged_q_len_t,
+            pooled_seq_lens_expanded=pooled_seq_lens_expanded,
+            slots_per_page=slots_per_page,
+            total_pool_pages=total_pool_pages,
+            total_q=pooled_seq_lens_expanded.shape[0],
+            pool_size=pool_size,
+        )
+    else:
+        empty_i32_dev = torch.empty((0,), dtype=torch.int32, device=device)
+        ragged_concat_page_table = empty_i32_dev
+        ragged_q_ks = empty_i32_dev
+        ragged_q_ke = empty_i32_dev
+
+    ragged_paged_page_table = None
+    ragged_paged_page_table_row_index = None
+    if need_paged:
+        req_to_token = get_req_to_token_pool().req_to_token
+        ragged_paged_page_table_row_index = torch.repeat_interleave(
+            local_req_pool_indices.to(torch.int32), ragged_q_len_t
+        )
+        ragged_paged_page_table = req_to_token
+
+    if ragged_total_k_rows > 0:
+        ragged_k_u8, ragged_k_scale = _get_ragged_scratch(ragged_total_k_rows, device)
+    else:
+        ragged_k_u8 = None
+        ragged_k_scale = None
+
+    return KPoolExtendPlan(
+        writes=PoolWriteRows(
+            req=pool_req_t,
+            pool_id=pool_pool_id_t,
+            n_from_tail=pool_n_from_tail_t,
+            chunk_src=pool_chunk_src_t,
+            tail_logical_base=pool_tail_logical_base_t,
+            write_loc=pool_write_locs,
+        ),
+        tails=TailWriteRows(
+            req=tail_req_t,
+            dst_logical_start=tail_dst_logical_start_t,
+            chunk_src=tail_chunk_src_t,
+            n_write=tail_n_write_t,
+        ),
+        pooled_seq_lens_expanded=pooled_seq_lens_expanded,
+        seq_lens_expanded=local_seqlens_expanded,
+        ragged_concat_page_table=ragged_concat_page_table,
+        ragged_q_ks=ragged_q_ks,
+        ragged_q_ke=ragged_q_ke,
+        ragged_total_k_rows=ragged_total_k_rows,
+        ragged_k_u8=ragged_k_u8,
+        ragged_k_scale=ragged_k_scale,
+        ragged_paged_page_table=ragged_paged_page_table,
+        ragged_paged_page_table_row_index=ragged_paged_page_table_row_index,
+    )
+
+
+def init_kpool_extend_metadata(
+    metadata: NSAMetadata,
+    forward_batch: ForwardBatch,
+    *,
+    pool_size: int,
+    real_page_size: int,
+    slots_per_page: int,
+    topk_transform_method: TopkTransformMethod,
+    full_real_page_table: torch.Tensor,
+    full_seqlens_expanded: torch.Tensor,
+    local_real_page_table: Optional[torch.Tensor] = None,
+    local_seqlens_expanded: Optional[torch.Tensor] = None,
+    local_extend_seq_lens_cpu: Optional[List[int]] = None,
+    local_seq_lens_cpu: Optional[List[int]] = None,
+    local_req_pool_indices: Optional[torch.Tensor] = None,
+) -> NSAMetadata:
+    mode = forward_batch.forward_mode
+    is_extend_like = mode.is_extend_without_speculative()
+    if (
+        not _is_kpool_layout_enabled(pool_size, real_page_size)
+        or not is_extend_like
+        or forward_batch.extend_seq_lens_cpu is None
+        or forward_batch.seq_lens_cpu is None
+    ):
+        return metadata
+
+    if local_real_page_table is None:
+        local_real_page_table = full_real_page_table
+    if local_seqlens_expanded is None:
+        local_seqlens_expanded = full_seqlens_expanded
+    if local_req_pool_indices is None:
+        local_req_pool_indices = forward_batch.req_pool_indices
+
+    cpu = _kpool_cpu_plan(
+        forward_batch,
+        pool_size,
+        slots_per_page,
+        local_extend_seq_lens_cpu=local_extend_seq_lens_cpu,
+        local_seq_lens_cpu=local_seq_lens_cpu,
+    )
+    plan = _kpool_plan_to_gpu(
+        cpu,
+        forward_batch,
+        full_real_page_table,
+        local_real_page_table,
+        local_seqlens_expanded,
+        local_req_pool_indices,
+        pool_size,
+        slots_per_page,
+        topk_transform_method,
+    )
+    return dataclasses.replace(metadata, kpool_extend_plan=plan)
+
+
+def _compute_pool_schedule_metadata(
+    pool_seqlens: torch.Tensor,
+    *,
+    slots_per_page: int,
+) -> Optional[torch.Tensor]:
+    if not is_cuda():
+        return None
+    try:
+        import deep_gemm
+
+        return deep_gemm.get_paged_mqa_logits_metadata(
+            pool_seqlens.contiguous().view(-1, 1).clamp(min=1),
+            slots_per_page,
+            deep_gemm.get_num_sms(),
+        )
+    except (ImportError, ModuleNotFoundError):
+        return None
+
+
+def init_pooled_paged_mqa_metadata(
+    metadata: NSAMetadata,
+    seqlens_32: torch.Tensor,
+    forward_mode: ForwardMode,
+    *,
+    pool_size: int,
+    real_page_size: int,
+    slots_per_page: int,
+    build_schedule_metadata: bool = True,
+) -> NSAMetadata:
+    if (
+        not _is_kpool_layout_enabled(pool_size, real_page_size)
+        or not is_cuda()
+        or not forward_mode.is_decode_or_idle()
+    ):
+        return metadata
+
+    pool_seqlens = torch.div(seqlens_32, pool_size, rounding_mode="floor").to(
+        torch.int32
+    )
+    pooled_page_table = build_pooled_page_table_64(
+        metadata.real_page_table, pool_size
+    ).contiguous()
+    schedule = (
+        _compute_pool_schedule_metadata(
+            pool_seqlens,
+            slots_per_page=slots_per_page,
+        )
+        if build_schedule_metadata
+        else None
+    )
+    return dataclasses.replace(
+        metadata,
+        pooled_index_kpool=pool_size,
+        pooled_cache_seqlens_int32=pool_seqlens,
+        pooled_real_page_table=pooled_page_table,
+        pooled_paged_mqa_schedule_metadata=schedule,
+    )
+
+
+def update_pooled_paged_mqa_metadata(
+    metadata: NSAMetadata,
+    seqlens_32: torch.Tensor,
+    forward_mode: ForwardMode,
+    *,
+    pool_size: int,
+    real_page_size: int,
+    slots_per_page: int,
+    build_schedule_metadata: bool = True,
+) -> None:
+    if (
+        not _is_kpool_layout_enabled(pool_size, real_page_size)
+        or not is_cuda()
+        or not forward_mode.is_decode_or_idle()
+    ):
+        return
+
+    if (
+        metadata.pooled_index_kpool != pool_size
+        or metadata.pooled_cache_seqlens_int32 is None
+        or metadata.pooled_real_page_table is None
+    ):
+        return
+
+    pool_seqlens = torch.div(seqlens_32, pool_size, rounding_mode="floor").to(
+        torch.int32
+    )
+    metadata.pooled_cache_seqlens_int32[: pool_seqlens.shape[0]].copy_(pool_seqlens)
+    pooled_page_table = build_pooled_page_table_64(
+        metadata.real_page_table, pool_size
+    ).contiguous()
+    metadata.pooled_real_page_table[
+        : pooled_page_table.shape[0], : pooled_page_table.shape[1]
+    ].copy_(pooled_page_table)
+
+    if (
+        build_schedule_metadata
+        and metadata.pooled_paged_mqa_schedule_metadata is not None
+    ):
+        new_schedule = _compute_pool_schedule_metadata(
+            metadata.pooled_cache_seqlens_int32,
+            slots_per_page=slots_per_page,
+        )
+        if new_schedule is not None:
+            metadata.pooled_paged_mqa_schedule_metadata.copy_(new_schedule)

--- a/python/sglang/srt/layers/attention/nsa/kpool_plan.py
+++ b/python/sglang/srt/layers/attention/nsa/kpool_plan.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 
 _RAGGED_SCRATCH_K_U8: Optional[torch.Tensor] = None
 _RAGGED_SCRATCH_K_SCALE: Optional[torch.Tensor] = None
+_RAGGED_SCRATCH_K_BF16: Optional[torch.Tensor] = None
 
 
 def _req_to_token_table_from_batch(forward_batch: ForwardBatch) -> torch.Tensor:
@@ -65,6 +66,24 @@ def _get_ragged_scratch(
     return _RAGGED_SCRATCH_K_U8[:total_k_rows], _RAGGED_SCRATCH_K_SCALE[:total_k_rows]
 
 
+def _get_ragged_bf16_scratch(
+    total_k_rows: int, device: torch.device
+) -> torch.Tensor:
+    global _RAGGED_SCRATCH_K_BF16
+    cur = _RAGGED_SCRATCH_K_BF16
+    grow = (
+        cur is None
+        or cur.device.type != device.type
+        or (device.index is not None and cur.device.index != device.index)
+        or cur.shape[0] < total_k_rows
+    )
+    if grow:
+        _RAGGED_SCRATCH_K_BF16 = torch.empty(
+            (total_k_rows, INDEX_HEAD_DIM), dtype=torch.bfloat16, device=device
+        )
+    return _RAGGED_SCRATCH_K_BF16[:total_k_rows]
+
+
 @dataclass(frozen=True)
 class PoolWriteRows:
     req: torch.Tensor
@@ -103,6 +122,7 @@ class KPoolExtendPlan:
     ragged_total_k_rows: int
     ragged_k_u8: Optional[torch.Tensor]
     ragged_k_scale: Optional[torch.Tensor]
+    ragged_k_bf16: Optional[torch.Tensor]
     ragged_paged_page_table: Optional[torch.Tensor]
     ragged_paged_page_table_row_index: Optional[torch.Tensor]
 
@@ -270,6 +290,7 @@ def _kpool_plan_to_gpu(
     pool_size: int,
     slots_per_page: int,
     topk_transform_method: TopkTransformMethod,
+    index_cache_dtype: torch.dtype,
 ) -> KPoolExtendPlan:
     from sglang.srt.layers.attention.nsa_backend import TopkTransformMethod
 
@@ -405,11 +426,17 @@ def _kpool_plan_to_gpu(
         )
         ragged_paged_page_table = req_to_token
 
-    if ragged_total_k_rows > 0:
+    if ragged_total_k_rows > 0 and index_cache_dtype == torch.bfloat16:
+        ragged_k_u8 = None
+        ragged_k_scale = None
+        ragged_k_bf16 = _get_ragged_bf16_scratch(ragged_total_k_rows, device)
+    elif ragged_total_k_rows > 0:
         ragged_k_u8, ragged_k_scale = _get_ragged_scratch(ragged_total_k_rows, device)
+        ragged_k_bf16 = None
     else:
         ragged_k_u8 = None
         ragged_k_scale = None
+        ragged_k_bf16 = None
 
     return KPoolExtendPlan(
         writes=PoolWriteRows(
@@ -434,6 +461,7 @@ def _kpool_plan_to_gpu(
         ragged_total_k_rows=ragged_total_k_rows,
         ragged_k_u8=ragged_k_u8,
         ragged_k_scale=ragged_k_scale,
+        ragged_k_bf16=ragged_k_bf16,
         ragged_paged_page_table=ragged_paged_page_table,
         ragged_paged_page_table_row_index=ragged_paged_page_table_row_index,
     )
@@ -454,6 +482,7 @@ def init_kpool_extend_metadata(
     local_extend_seq_lens_cpu: Optional[List[int]] = None,
     local_seq_lens_cpu: Optional[List[int]] = None,
     local_req_pool_indices: Optional[torch.Tensor] = None,
+    index_cache_dtype: torch.dtype = torch.float8_e4m3fn,
 ) -> NSAMetadata:
     mode = forward_batch.forward_mode
     is_extend_like = mode.is_extend_without_speculative()
@@ -489,6 +518,7 @@ def init_kpool_extend_metadata(
         pool_size,
         slots_per_page,
         topk_transform_method,
+        index_cache_dtype,
     )
     return dataclasses.replace(metadata, kpool_extend_plan=plan)
 

--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer_kpool.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer_kpool.py
@@ -31,14 +31,26 @@ from sglang.srt.layers.linear import ReplicatedLinear
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.layers.rotary_embedding import get_rope_wrapper
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
-from sglang.srt.model_executor.forward_context import (
-    get_attn_backend,
-    get_token_to_kv_pool,
-)
+from sglang.srt.model_executor.forward_context import get_attn_backend
 from sglang.srt.server_args import get_global_server_args
 
 if TYPE_CHECKING:
-    from sglang.srt.mem_cache.memory_pool import NSATokenToKVPool
+    from sglang.srt.mem_cache.memory_pool import KVCache, NSATokenToKVPool
+
+
+def _token_pool_from_batch(forward_batch: ForwardBatch) -> "KVCache":
+    """Return the cache pool owned by this forward, or fail closed.
+
+    KPool plans and sequence metadata are derived from ``forward_batch``.  Use
+    the pool carried by that same batch so nested backend contexts cannot pair
+    a batch-local plan with an unrelated ambient cache.  Both eager execution
+    and CUDA Graph capture populate this field.
+    """
+
+    pool = getattr(forward_batch, "token_to_kv_pool", None)
+    if pool is None:
+        raise RuntimeError("GLM-5-Next KPool requires ForwardBatch.token_to_kv_pool")
+    return pool
 
 
 class IndexerKPool(MultiPlatformOp):
@@ -218,7 +230,7 @@ class IndexerKPool(MultiPlatformOp):
             kpool_softmax_rotate_write_cache,
         )
 
-        pool = get_token_to_kv_pool()
+        pool = _token_pool_from_batch(forward_batch)
         if hasattr(pool, "invalidate_index_buffer_for_layer"):
             pool.invalidate_index_buffer_for_layer(layer_id)
         if hasattr(pool, "_is_layer_owned") and not pool._is_layer_owned(layer_id):
@@ -253,7 +265,7 @@ class IndexerKPool(MultiPlatformOp):
         if batch == 0:
             return
 
-        pool = get_token_to_kv_pool()
+        pool = _token_pool_from_batch(forward_batch)
         if hasattr(pool, "invalidate_index_buffer_for_layer"):
             pool.invalidate_index_buffer_for_layer(layer_id)
         if hasattr(pool, "_is_layer_owned") and not pool._is_layer_owned(layer_id):
@@ -303,7 +315,7 @@ class IndexerKPool(MultiPlatformOp):
             scatter_kpool_tail_updates,
         )
 
-        pool = get_token_to_kv_pool()
+        pool = _token_pool_from_batch(forward_batch)
         if hasattr(pool, "invalidate_index_buffer_for_layer"):
             pool.invalidate_index_buffer_for_layer(layer_id)
         if hasattr(pool, "_is_layer_owned") and not pool._is_layer_owned(layer_id):
@@ -648,9 +660,9 @@ class IndexerKPool(MultiPlatformOp):
         metadata: BaseIndexerMetadata,
     ) -> torch.Tensor:
         if TYPE_CHECKING:
-            assert isinstance(get_token_to_kv_pool(), NSATokenToKVPool)
+            assert isinstance(_token_pool_from_batch(forward_batch), NSATokenToKVPool)
 
-        pool = get_token_to_kv_pool()
+        pool = _token_pool_from_batch(forward_batch)
         page_size = pool.page_size
         # NOTE(dark): blocksize = 64 is hardcoded in deep_gemm
         assert page_size == 64, "only support page size 64"
@@ -744,25 +756,6 @@ class IndexerKPool(MultiPlatformOp):
         )
         return topk_result
 
-    def _should_chunk_mqa_logits(
-        self, num_q: int, num_k: int, device: torch.device
-    ) -> Tuple[bool, int]:
-        """
-        Detect whether we need to chunk the MQA logits computation to avoid OOM
-        Return: (need_chunk, free_mem)
-        """
-        # Quick static check for normal batches
-        if num_q * num_k < 8_000_000:  # 8M elements ≈ 32MB logits
-            return False, 0
-
-        free_mem, total_mem = torch.cuda.mem_get_info(device)
-        bytes_per_elem = 4  # float32
-        logits_bytes = num_q * num_k * bytes_per_elem
-
-        # Logits should not exceed 50% of free memory or 30% of total memory
-        need_chunk = (logits_bytes * 2 > free_mem) or (logits_bytes > total_mem * 0.3)
-        return need_chunk, free_mem
-
     def _get_topk_ragged_kpool_plan(
         self,
         forward_batch: ForwardBatch,
@@ -797,7 +790,7 @@ class IndexerKPool(MultiPlatformOp):
             k_u8 = plan.ragged_k_u8
             k_scale = plan.ragged_k_scale
             assert k_u8 is not None and k_scale is not None
-            pool = get_token_to_kv_pool()
+            pool = _token_pool_from_batch(forward_batch)
             gather_index_k_scale_prefix_into(
                 pool=pool,
                 buf=self._get_index_k_read_buffer(pool, layer_id),
@@ -808,26 +801,44 @@ class IndexerKPool(MultiPlatformOp):
             )
             k_fp8 = k_u8.view(torch.float8_e4m3fn)
             if self._should_use_eager_logits(q_fp8):
-                from sglang.srt.layers.attention.nsa.glm5_next_indexer_logits import (
-                    glm5_next_eager_fp8_mqa_logits,
+                topk_method = getattr(metadata, "topk_transform_method", None)
+                attn_metadata = getattr(metadata, "attn_metadata", None)
+                page_table_all = None
+                page_table_row_index_all = None
+                topk_offsets_all = None
+                if envs.SGLANG_NSA_FUSE_TOPK.get():
+                    if getattr(topk_method, "name", "") == "PAGED":
+                        page_table_all = plan.ragged_paged_page_table
+                        page_table_row_index_all = (
+                            plan.ragged_paged_page_table_row_index
+                        )
+                    elif getattr(topk_method, "name", "") == "RAGGED":
+                        topk_offsets_all = getattr(
+                            attn_metadata, "topk_indices_offset", None
+                        )
+
+                return self._topk_from_glm5_next_eager_logits_rows(
+                    q_fp8[:n_real].contiguous(),
+                    (k_fp8.contiguous(), k_scale.contiguous()),
+                    weights[:n_real].contiguous(),
+                    pool_lens,
+                    seq_lens_expanded,
+                    ks_per_q,
+                    ke_per_q,
+                    total_q=total_q,
+                    page_table=page_table_all,
+                    topk_offsets=topk_offsets_all,
+                    page_table_row_index=page_table_row_index_all,
                 )
 
-                logits = glm5_next_eager_fp8_mqa_logits(
-                    q_fp8[:n_real].contiguous(),
-                    (k_fp8.contiguous(), k_scale.contiguous()),
-                    weights[:n_real].contiguous(),
-                    ks_per_q,
-                    ke_per_q,
-                )
-            else:
-                logits = deep_gemm.fp8_mqa_logits(
-                    q_fp8[:n_real].contiguous(),
-                    (k_fp8.contiguous(), k_scale.contiguous()),
-                    weights[:n_real].contiguous(),
-                    ks_per_q,
-                    ke_per_q,
-                    clean_logits=True,
-                )
+            logits = deep_gemm.fp8_mqa_logits(
+                q_fp8[:n_real].contiguous(),
+                (k_fp8.contiguous(), k_scale.contiguous()),
+                weights[:n_real].contiguous(),
+                ks_per_q,
+                ke_per_q,
+                clean_logits=True,
+            )
         else:
             logits = torch.empty((n_real, 0), dtype=torch.float32, device=device)
 
@@ -854,6 +865,87 @@ class IndexerKPool(MultiPlatformOp):
             page_table_row_index=page_table_row_index_all,
         )
 
+    def _topk_from_glm5_next_eager_logits_rows(
+        self,
+        q_fp8: torch.Tensor,
+        kv_fp8: tuple[torch.Tensor, torch.Tensor],
+        weights: torch.Tensor,
+        pool_lens: torch.Tensor,
+        seq_lens: torch.Tensor,
+        ks: torch.Tensor,
+        ke: torch.Tensor,
+        *,
+        total_q: int,
+        page_table: Optional[torch.Tensor],
+        topk_offsets: Optional[torch.Tensor],
+        page_table_row_index: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        """Score/select fixed query-row chunks for exact-GLM SM120 prefill."""
+
+        from sglang.srt.layers.attention.nsa.glm5_next_indexer_logits import (
+            iter_glm5_next_eager_fp8_mqa_logits,
+        )
+
+        n_real = q_fp8.shape[0]
+        if total_q < n_real:
+            raise ValueError(
+                "GLM-5-Next total query rows cannot be smaller than real queries"
+            )
+        if not (
+            pool_lens.shape[0]
+            == seq_lens.shape[0]
+            == ks.shape[0]
+            == ke.shape[0]
+            == n_real
+        ):
+            raise ValueError("GLM-5-Next ragged row metadata must match real queries")
+        if topk_offsets is not None and topk_offsets.shape[0] != n_real:
+            raise ValueError("GLM-5-Next ragged topk offsets must match real queries")
+        if page_table_row_index is not None and page_table_row_index.shape[0] != n_real:
+            raise ValueError("GLM-5-Next paged row mapping must match real queries")
+        if (page_table is None) != (page_table_row_index is None):
+            raise ValueError(
+                "GLM-5-Next paged table and row mapping must be provided together"
+            )
+
+        # Consume each fixed query-row logits chunk immediately. At the final
+        # 500K boundary this avoids simultaneously retaining multi-GiB
+        # [4096, 125056] logits/mask tensors. The complete K payload is
+        # converted only once inside the iterator.
+        topk_result = torch.full(
+            (total_q, self.index_topk + self.index_kpool - 1),
+            -1,
+            dtype=torch.int32,
+            device=q_fp8.device,
+        )
+        logits_rows = iter_glm5_next_eager_fp8_mqa_logits(
+            q_fp8,
+            kv_fp8,
+            weights,
+            ks,
+            ke,
+        )
+        for q_start, q_end, logits_chunk in logits_rows:
+            topk_offsets_chunk = (
+                None if topk_offsets is None else topk_offsets[q_start:q_end]
+            )
+            page_table_row_index_chunk = (
+                None
+                if page_table_row_index is None
+                else page_table_row_index[q_start:q_end]
+            )
+            topk_result[q_start:q_end] = self._topk_from_kpool_logits(
+                logits_chunk,
+                pool_lens[q_start:q_end],
+                seq_lens=seq_lens[q_start:q_end],
+                page_table=page_table,
+                topk_offsets=topk_offsets_chunk,
+                row_starts=ks[q_start:q_end],
+                page_table_row_index=page_table_row_index_chunk,
+            )
+            del logits_chunk
+        return topk_result
+
     def _get_topk_ragged(
         self,
         forward_batch: ForwardBatch,
@@ -863,7 +955,9 @@ class IndexerKPool(MultiPlatformOp):
         metadata: BaseIndexerMetadata,
     ) -> torch.Tensor:
         assert forward_batch.forward_mode.is_extend_without_speculative()
-        assert get_token_to_kv_pool().page_size == 64, "only support page size 64"
+        assert _token_pool_from_batch(forward_batch).page_size == 64, (
+            "only support page size 64"
+        )
         assert getattr(metadata.attn_metadata, "kpool_extend_plan", None) is not None
         return self._get_topk_ragged_kpool_plan(
             forward_batch,
@@ -910,11 +1004,10 @@ class IndexerKPool(MultiPlatformOp):
         layer_id: int,
         return_indices: bool = True,
     ) -> Optional[torch.Tensor]:
-        """Eager-only GLM-5-Next KPool forward path.
+        """GLM-5-Next KPool forward path.
 
-        Decode and non-speculative extend are supported. CP, MTP, and CUDA
-        graph capture must keep using their pre-existing NSA implementation
-        until their KPool contracts are integrated independently.
+        Decode (including CUDA-graph replay) and non-speculative extend are
+        supported. CP and MTP remain outside this model-local contract.
         """
         if is_hip():
             from sglang.srt.layers.attention.nsa.tilelang_kernel import act_quant
@@ -922,7 +1015,7 @@ class IndexerKPool(MultiPlatformOp):
             from sglang.srt.layers.attention.nsa.triton_kernel import act_quant
 
         if TYPE_CHECKING:
-            assert isinstance(get_token_to_kv_pool(), NSATokenToKVPool)
+            assert isinstance(_token_pool_from_batch(forward_batch), NSATokenToKVPool)
 
         metadata = get_attn_backend().get_indexer_metadata(layer_id, forward_batch)
         if metadata is None:
@@ -940,7 +1033,8 @@ class IndexerKPool(MultiPlatformOp):
             )
         if not (mode.is_decode() or mode.is_extend_without_speculative()):
             raise NotImplementedError(
-                "GLM-5-Next KPool currently supports eager decode and eager extend only"
+                "GLM-5-Next KPool supports decode (including CUDA graphs) and "
+                "non-speculative extend only"
             )
 
         if mode.is_extend_without_speculative():

--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer_kpool.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer_kpool.py
@@ -651,6 +651,14 @@ class IndexerKPool(MultiPlatformOp):
 
         return use_glm5_next_eager_logits_on_device(q_fp8.device)
 
+    @staticmethod
+    def _should_use_triton_logits(query: torch.Tensor) -> bool:
+        from sglang.srt.layers.attention.nsa.glm5_next_indexer_triton import (
+            use_glm5_next_triton_indexer,
+        )
+
+        return use_glm5_next_triton_indexer(query.device)
+
     def _get_topk_paged(
         self,
         forward_batch: ForwardBatch,
@@ -670,7 +678,7 @@ class IndexerKPool(MultiPlatformOp):
         # NOTE(dark): this support extend/decode/decode+graph
         block_tables = metadata.get_page_table_64()
 
-        kv_cache_fp8 = self._get_index_k_read_buffer(pool, layer_id)
+        kv_cache = self._get_index_k_read_buffer(pool, layer_id)
 
         blocksize = page_size
         seqlens_32 = metadata.get_seqlens_int32()
@@ -681,17 +689,15 @@ class IndexerKPool(MultiPlatformOp):
             q_fp8 = q_fp8[:n_real]
             weights = weights[:n_real]
         q_fp8 = q_fp8.unsqueeze(1)  # the next_n dim is 1 now
-        assert len(kv_cache_fp8.shape) == 2
+        assert len(kv_cache.shape) == 2
         block_kv = 64
         num_heads_kv = 1
         head_dim_with_sf = 132
-        kv_cache_fp8 = kv_cache_fp8.view(
-            kv_cache_fp8.shape[0], block_kv, num_heads_kv, head_dim_with_sf
-        )
         assert len(weights.shape) == 3
         weights = weights.squeeze(2)
         use_tilelang_paged_mqa = self._should_use_tilelang_paged_mqa_logits(q_fp8)
         use_eager_logits = self._should_use_eager_logits(q_fp8)
+        use_triton_logits = self._should_use_triton_logits(q_fp8)
 
         pool_seqlens, pool_context_lens, pool_block_tables, pool_schedule_metadata = (
             self._get_kpool_decode_metadata(
@@ -700,14 +706,32 @@ class IndexerKPool(MultiPlatformOp):
                 seqlens_32,
                 blocksize,
                 build_schedule_metadata=not (
-                    use_tilelang_paged_mqa or use_eager_logits
+                    use_tilelang_paged_mqa or use_eager_logits or use_triton_logits
                 ),
             )
         )
         pool_max_seq_len = pool_block_tables.shape[1] * blocksize
-        if use_eager_logits:
+        if use_triton_logits:
+            from sglang.srt.layers.attention.nsa.glm5_next_indexer_triton import (
+                glm5_next_triton_paged_mqa_logits,
+            )
+
+            logits = glm5_next_triton_paged_mqa_logits(
+                q_fp8,
+                kv_cache,
+                weights,
+                pool_seqlens,
+                pool_block_tables,
+                pool_max_seq_len,
+                use_k_scale=not getattr(pool, "index_cache_is_bf16", False),
+            )
+        elif use_eager_logits:
             from sglang.srt.layers.attention.nsa.glm5_next_indexer_logits import (
                 glm5_next_eager_fp8_paged_mqa_logits,
+            )
+
+            kv_cache_fp8 = kv_cache.view(
+                kv_cache.shape[0], block_kv, num_heads_kv, head_dim_with_sf
             )
 
             logits = glm5_next_eager_fp8_paged_mqa_logits(
@@ -723,6 +747,9 @@ class IndexerKPool(MultiPlatformOp):
                 tilelang_fp8_paged_mqa_logits,
             )
 
+            kv_cache_fp8 = kv_cache.view(
+                kv_cache.shape[0], block_kv, num_heads_kv, head_dim_with_sf
+            )
             logits = tilelang_fp8_paged_mqa_logits(
                 q_fp8,
                 kv_cache_fp8,
@@ -734,6 +761,9 @@ class IndexerKPool(MultiPlatformOp):
                 clean_logits=False,
             )
         else:
+            kv_cache_fp8 = kv_cache.view(
+                kv_cache.shape[0], block_kv, num_heads_kv, head_dim_with_sf
+            )
             logits = deep_gemm.fp8_paged_mqa_logits(
                 q_fp8,
                 kv_cache_fp8,
@@ -787,20 +817,40 @@ class IndexerKPool(MultiPlatformOp):
         )
 
         if total_k_rows > 0:
-            k_u8 = plan.ragged_k_u8
-            k_scale = plan.ragged_k_scale
-            assert k_u8 is not None and k_scale is not None
             pool = _token_pool_from_batch(forward_batch)
-            gather_index_k_scale_prefix_into(
-                pool=pool,
-                buf=self._get_index_k_read_buffer(pool, layer_id),
-                page_indices=plan.ragged_concat_page_table,
-                seq_len=total_k_rows,
-                k_out=k_u8,
-                scale_out=k_scale,
-            )
-            k_fp8 = k_u8.view(torch.float8_e4m3fn)
-            if self._should_use_eager_logits(q_fp8):
+            if getattr(pool, "index_cache_is_bf16", False):
+                from sglang.srt.layers.attention.nsa.kpool_fp8_index import (
+                    gather_index_k_bf16_prefix_into,
+                )
+
+                k_bf16 = plan.ragged_k_bf16
+                assert k_bf16 is not None
+                gather_index_k_bf16_prefix_into(
+                    pool=pool,
+                    buf=self._get_index_k_read_buffer(pool, layer_id),
+                    page_indices=plan.ragged_concat_page_table,
+                    seq_len=total_k_rows,
+                    k_out=k_bf16,
+                )
+                index_k = k_bf16
+                k_scale = None
+            else:
+                k_u8 = plan.ragged_k_u8
+                k_scale = plan.ragged_k_scale
+                assert k_u8 is not None and k_scale is not None
+                gather_index_k_scale_prefix_into(
+                    pool=pool,
+                    buf=self._get_index_k_read_buffer(pool, layer_id),
+                    page_indices=plan.ragged_concat_page_table,
+                    seq_len=total_k_rows,
+                    k_out=k_u8,
+                    scale_out=k_scale,
+                )
+                index_k = k_u8.view(torch.float8_e4m3fn)
+
+            if self._should_use_eager_logits(q_fp8) or self._should_use_triton_logits(
+                q_fp8
+            ):
                 topk_method = getattr(metadata, "topk_transform_method", None)
                 attn_metadata = getattr(metadata, "attn_metadata", None)
                 page_table_all = None
@@ -817,9 +867,10 @@ class IndexerKPool(MultiPlatformOp):
                             attn_metadata, "topk_indices_offset", None
                         )
 
-                return self._topk_from_glm5_next_eager_logits_rows(
+                return self._topk_from_glm5_next_model_local_logits_rows(
                     q_fp8[:n_real].contiguous(),
-                    (k_fp8.contiguous(), k_scale.contiguous()),
+                    index_k.contiguous(),
+                    None if k_scale is None else k_scale.contiguous(),
                     weights[:n_real].contiguous(),
                     pool_lens,
                     seq_lens_expanded,
@@ -831,9 +882,10 @@ class IndexerKPool(MultiPlatformOp):
                     page_table_row_index=page_table_row_index_all,
                 )
 
+            assert k_scale is not None, "DeepGEMM KPool requires scaled FP8 K"
             logits = deep_gemm.fp8_mqa_logits(
                 q_fp8[:n_real].contiguous(),
-                (k_fp8.contiguous(), k_scale.contiguous()),
+                (index_k.contiguous(), k_scale.contiguous()),
                 weights[:n_real].contiguous(),
                 ks_per_q,
                 ke_per_q,
@@ -865,10 +917,11 @@ class IndexerKPool(MultiPlatformOp):
             page_table_row_index=page_table_row_index_all,
         )
 
-    def _topk_from_glm5_next_eager_logits_rows(
+    def _topk_from_glm5_next_model_local_logits_rows(
         self,
-        q_fp8: torch.Tensor,
-        kv_fp8: tuple[torch.Tensor, torch.Tensor],
+        query: torch.Tensor,
+        index_k: torch.Tensor,
+        k_scale: Optional[torch.Tensor],
         weights: torch.Tensor,
         pool_lens: torch.Tensor,
         seq_lens: torch.Tensor,
@@ -880,13 +933,16 @@ class IndexerKPool(MultiPlatformOp):
         topk_offsets: Optional[torch.Tensor],
         page_table_row_index: Optional[torch.Tensor],
     ) -> torch.Tensor:
-        """Score/select fixed query-row chunks for exact-GLM SM120 prefill."""
+        """Score/select bounded rows with the architecture-local GLM scorer."""
 
         from sglang.srt.layers.attention.nsa.glm5_next_indexer_logits import (
             iter_glm5_next_eager_fp8_mqa_logits,
         )
+        from sglang.srt.layers.attention.nsa.glm5_next_indexer_triton import (
+            iter_glm5_next_triton_mqa_logits,
+        )
 
-        n_real = q_fp8.shape[0]
+        n_real = query.shape[0]
         if total_q < n_real:
             raise ValueError(
                 "GLM-5-Next total query rows cannot be smaller than real queries"
@@ -916,15 +972,27 @@ class IndexerKPool(MultiPlatformOp):
             (total_q, self.index_topk + self.index_kpool - 1),
             -1,
             dtype=torch.int32,
-            device=q_fp8.device,
+            device=query.device,
         )
-        logits_rows = iter_glm5_next_eager_fp8_mqa_logits(
-            q_fp8,
-            kv_fp8,
-            weights,
-            ks,
-            ke,
-        )
+        if self._should_use_triton_logits(query):
+            logits_rows = iter_glm5_next_triton_mqa_logits(
+                query,
+                index_k,
+                weights,
+                ks,
+                ke,
+                k_scale=k_scale,
+            )
+        else:
+            if k_scale is None:
+                raise RuntimeError("SM120 eager scorer requires an FP8 K scale")
+            logits_rows = iter_glm5_next_eager_fp8_mqa_logits(
+                query,
+                (index_k, k_scale),
+                weights,
+                ks,
+                ke,
+            )
         for q_start, q_end, logits_chunk in logits_rows:
             topk_offsets_chunk = (
                 None if topk_offsets is None else topk_offsets[q_start:q_end]
@@ -1058,7 +1126,14 @@ class IndexerKPool(MultiPlatformOp):
             forward_batch=forward_batch,
             precompute_compress_gate=False,
         )
-        q_fp8, q_scale = act_quant(query, self.block_size, self.scale_fmt)
+        pool = _token_pool_from_batch(forward_batch)
+        if getattr(pool, "index_cache_is_bf16", False):
+            q_fp8 = query.contiguous()
+            q_scale = torch.ones(
+                (*query.shape[:-1], 1), dtype=torch.float32, device=query.device
+            )
+        else:
+            q_fp8, q_scale = act_quant(query, self.block_size, self.scale_fmt)
         self._compress_write(
             x=x,
             key=key,

--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer_kpool.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer_kpool.py
@@ -1,0 +1,985 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from einops import rearrange
+from transformers import PretrainedConfig
+
+from sglang.srt.layers.attention.nsa.nsa_indexer import (
+    BaseIndexerMetadata,
+    rotate_activation,
+)
+from sglang.srt.layers.layernorm import LayerNorm
+from sglang.srt.layers.utils import MultiPlatformOp
+from sglang.srt.utils import add_prefix, ceil_align, is_cuda, is_hip, is_npu
+
+if is_cuda():
+    try:
+        import deep_gemm
+    except ImportError as e:
+        deep_gemm = e
+
+if is_npu():
+    import custom_ops  # noqa: F401
+
+from sglang.srt.environ import envs
+from sglang.srt.layers import deep_gemm_wrapper
+from sglang.srt.layers.linear import ReplicatedLinear
+from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.layers.rotary_embedding import get_rope_wrapper
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_executor.forward_context import (
+    get_attn_backend,
+    get_token_to_kv_pool,
+)
+from sglang.srt.server_args import get_global_server_args
+
+if TYPE_CHECKING:
+    from sglang.srt.mem_cache.memory_pool import NSATokenToKVPool
+
+
+class IndexerKPool(MultiPlatformOp):
+    def __init__(
+        self,
+        hidden_size: int,
+        index_n_heads: int,
+        index_head_dim: int,
+        rope_head_dim: int,
+        index_topk: int,
+        q_lora_rank: int,
+        max_position_embeddings: int,
+        rope_theta: float,
+        layer_id: int,
+        scale_fmt: Optional[str],
+        block_size: int = 128,
+        rope_scaling: Optional[Dict[str, Any]] = None,
+        is_neox_style: bool = True,
+        prefix: str = "",
+        quant_config: Optional[QuantizationConfig] = None,
+        alt_stream: Optional[torch.cuda.Stream] = None,
+        skip_rope: bool = False,
+        config: Optional[PretrainedConfig] = None,
+    ):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.n_heads = index_n_heads
+        self.head_dim = index_head_dim
+        self.rope_head_dim = rope_head_dim
+        self.index_topk = index_topk
+        self.q_lora_rank = q_lora_rank
+        self.layer_id = layer_id
+        self.alt_stream = alt_stream
+        self.compress_gate_stream = None
+        self.skip_rope = skip_rope
+
+        assert config is not None, "KPool indexer requires the model config"
+        self.index_kpool = config.index_kpool
+        self.index_kpool_always_select_tail = config.index_kpool_always_select_tail
+        self.index_kpool_compress = config.index_kpool_compress
+
+        assert self.index_kpool == 4, (
+            f"GLM-5-Next requires index_kpool=4, got {self.index_kpool}"
+        )
+        assert self.index_kpool_compress, "GLM-5-Next requires KPool compression"
+        assert self.index_kpool_always_select_tail, (
+            "GLM-5-Next requires index_kpool_always_select_tail"
+        )
+
+        assert self.index_topk % self.index_kpool == 0, (
+            f"index_topk ({self.index_topk}) must be divisible by "
+            f"index_kpool ({self.index_kpool})"
+        )
+        assert 64 % self.index_kpool == 0, (
+            f"index_kpool ({self.index_kpool}) must divide page_size (64)"
+        )
+
+        self.index_kpool_compress_ape = nn.Parameter(
+            torch.zeros(self.index_kpool, self.head_dim, dtype=torch.float32)
+        )
+        self.index_kpool_compress_gate = nn.Parameter(
+            torch.empty(self.head_dim, self.hidden_size, dtype=torch.bfloat16)
+        )
+
+        if is_cuda() and self.alt_stream is not None:
+            self.compress_gate_stream = torch.cuda.Stream()
+
+        if is_cuda():
+            self.sm_count = deep_gemm.get_num_sms()
+            self.half_device_sm_count = ceil_align(self.sm_count // 2, 8)
+
+        self.wq_b = ReplicatedLinear(
+            self.q_lora_rank,
+            self.n_heads * self.head_dim,
+            bias=False,
+            quant_config=quant_config,
+            prefix=add_prefix("wq_b", prefix),
+        )
+
+        self.wk = ReplicatedLinear(
+            self.hidden_size,
+            self.head_dim,
+            bias=False,
+            quant_config=quant_config,
+            prefix=add_prefix("wk", prefix),
+        )
+        # NOTE: weights_proj in the checkpoint is stored in bf16, while the parameters here are stored in fp32 for convenience
+        self.weights_proj = ReplicatedLinear(
+            self.hidden_size,
+            self.n_heads,
+            bias=False,
+            params_dtype=torch.float32,
+            prefix=add_prefix("weights_proj", prefix),
+        )
+        self.k_norm = LayerNorm(self.head_dim, dtype=torch.float32)
+        if not self.skip_rope:
+            self.rotary_emb = get_rope_wrapper(
+                rope_head_dim,
+                rotary_dim=rope_head_dim,
+                max_position=max_position_embeddings,
+                base=rope_theta,  # type: ignore
+                rope_scaling=rope_scaling,
+                is_neox_style=is_neox_style,
+                device=get_global_server_args().device,
+            )
+        self.block_size = block_size
+        self.scale_fmt = scale_fmt
+        self.softmax_scale = self.head_dim**-0.5
+
+    @staticmethod
+    def _materialize_gate_input(x: torch.Tensor) -> torch.Tensor:
+        """Materialize KT's optional grouped-FP8 activation tuple for BF16 gates."""
+        if not isinstance(x, tuple):
+            return x
+        assert len(x) in (2, 3), (
+            "tuple activations must be (x_fp8, x_scale[, residual])"
+        )
+        x_q, x_scale = x[0], x[1]
+        if (
+            x_scale is not None
+            and x_q.dim() == 2
+            and x_scale.dim() == 2
+            and x_q.shape[0] == x_scale.shape[0]
+        ):
+            rows, width = x_q.shape
+            groups = x_scale.shape[1]
+            if groups > 0 and width % groups == 0:
+                group_width = width // groups
+                return (
+                    x_q.to(torch.float32)
+                    .view(rows, groups, group_width)
+                    .mul_(x_scale.to(torch.float32).unsqueeze(-1))
+                    .view(rows, width)
+                    .to(torch.bfloat16)
+                )
+        return x_q.to(torch.bfloat16)
+
+    @torch.compile(dynamic=True)
+    def _get_logits_head_gate(self, x: torch.Tensor, q_scale: torch.Tensor):
+        x = self._materialize_gate_input(x)
+        weights, _ = self.weights_proj(x.float())
+        weights = weights * self.n_heads**-0.5
+        weights = weights.unsqueeze(-1) * q_scale * self.softmax_scale
+        return weights
+
+    @staticmethod
+    def _get_index_k_read_buffer(pool, layer_id: int) -> torch.Tensor:
+        if hasattr(pool, "get_broadcastable_index_k_with_scale_buffer"):
+            return pool.get_broadcastable_index_k_with_scale_buffer(layer_id)
+        if hasattr(pool, "_get_broadcastable_index_buffer"):
+            return pool._get_broadcastable_index_buffer(layer_id)
+        return pool.get_index_k_with_scale_buffer(layer_id=layer_id)
+
+    def _write_compressed_pooled_index_cache(
+        self,
+        slot_k,
+        slot_score,
+        write_locs,
+        forward_batch,
+        layer_id,
+        write_mask=None,
+        return_compressed: bool = False,
+        write_cache: bool = True,
+    ):
+        if slot_k.shape[0] == 0:
+            if return_compressed:
+                return (
+                    torch.empty(
+                        (0, self.head_dim),
+                        dtype=torch.float8_e4m3fn,
+                        device=slot_k.device,
+                    ),
+                    torch.empty((0,), dtype=torch.float32, device=slot_k.device),
+                )
+            return None
+        from sglang.srt.layers.attention.nsa.kpool_fp8_index import (
+            kpool_softmax_rotate_write_cache,
+        )
+
+        pool = get_token_to_kv_pool()
+        if hasattr(pool, "invalidate_index_buffer_for_layer"):
+            pool.invalidate_index_buffer_for_layer(layer_id)
+        if hasattr(pool, "_is_layer_owned") and not pool._is_layer_owned(layer_id):
+            if not return_compressed:
+                return None
+            write_cache = False
+
+        buf = pool.get_index_k_with_scale_buffer(layer_id=layer_id)
+        return kpool_softmax_rotate_write_cache(
+            pool=pool,
+            buf=buf,
+            slot_k=slot_k,
+            slot_score=slot_score,
+            ape=self.index_kpool_compress_ape,
+            loc=write_locs.contiguous(),
+            write_mask=write_mask.contiguous() if write_mask is not None else None,
+            round_scale=self.scale_fmt is not None,
+            return_compressed=return_compressed,
+            write_cache=write_cache,
+        )
+
+    def _compress_write_decode(
+        self,
+        key,
+        gate_score,
+        positions,
+        forward_batch,
+        layer_id,
+        metadata,
+    ):
+        batch = key.shape[0]
+        if batch == 0:
+            return
+
+        pool = get_token_to_kv_pool()
+        if hasattr(pool, "invalidate_index_buffer_for_layer"):
+            pool.invalidate_index_buffer_for_layer(layer_id)
+        if hasattr(pool, "_is_layer_owned") and not pool._is_layer_owned(layer_id):
+            return
+
+        pool.kpool_decode_update_index_cache(
+            layer_id=layer_id,
+            key=key,
+            slot_score=gate_score,
+            ape=self.index_kpool_compress_ape,
+            block_tables=metadata.get_page_table_64(),
+            req_pool_indices=forward_batch.req_pool_indices[:batch],
+            positions=positions[:batch],
+            seq_lens=metadata.get_seqlens_int32()[:batch],
+            out_cache_loc=forward_batch.out_cache_loc[:batch],
+            round_scale=self.scale_fmt is not None,
+        )
+
+    def _compress_write_extend(
+        self,
+        key,
+        gate_score,
+        positions,
+        forward_batch,
+        layer_id,
+        metadata,
+        return_compressed: bool = False,
+        write_cache: bool = True,
+    ):
+        """Apply the eager multi-pool compression plan and update the tail.
+
+        CP, speculative decoding, and CUDA-graph write plans intentionally live
+        outside this GLM-5-Next bring-up path.
+        """
+        assert not return_compressed, "deferred KPool cache writes are unsupported"
+        assert write_cache, "eager KPool extend always writes the cache"
+        assert (
+            forward_batch.seq_lens_cpu is not None
+            and forward_batch.extend_seq_lens_cpu is not None
+        )
+        attn_metadata = getattr(metadata, "attn_metadata", None)
+        plan = getattr(attn_metadata, "kpool_extend_plan", None)
+        assert plan is not None, "eager KPool extend requires kpool_extend_plan"
+
+        from sglang.srt.layers.attention.nsa.kpool_fp8_index import (
+            kpool_assemble_softmax_rotate_write_cache,
+            scatter_kpool_tail_updates,
+        )
+
+        pool = get_token_to_kv_pool()
+        if hasattr(pool, "invalidate_index_buffer_for_layer"):
+            pool.invalidate_index_buffer_for_layer(layer_id)
+        if hasattr(pool, "_is_layer_owned") and not pool._is_layer_owned(layer_id):
+            return None
+
+        writes, tails = plan.writes, plan.tails
+        if writes.is_empty and tails.is_empty:
+            return None
+
+        tail_k_buf, tail_score_buf = pool.get_compress_tail_buffers(layer_id)
+        if not writes.is_empty:
+            buf = pool.get_index_k_with_scale_buffer(layer_id=layer_id)
+            kpool_assemble_softmax_rotate_write_cache(
+                pool=pool,
+                buf=buf,
+                chunk_k=key,
+                chunk_score=gate_score,
+                tail_k=tail_k_buf,
+                tail_score=tail_score_buf,
+                req_pool_idx=writes.req,
+                n_from_tail=writes.n_from_tail,
+                chunk_src_start=writes.chunk_src,
+                tail_logical_base=writes.tail_logical_base,
+                ape=self.index_kpool_compress_ape,
+                loc=writes.write_loc,
+                write_mask=None,
+                round_scale=self.scale_fmt is not None,
+            )
+
+        if not tails.is_empty:
+            scatter_kpool_tail_updates(
+                pool=pool,
+                chunk_k=key,
+                chunk_score=gate_score,
+                tail_k=tail_k_buf,
+                tail_score=tail_score_buf,
+                req_pool_idx=tails.req,
+                dst_logical_start=tails.dst_logical_start,
+                chunk_src_start=tails.chunk_src,
+                n_write=tails.n_write,
+            )
+        return None
+
+    def _compress_write(
+        self,
+        x,
+        key,
+        positions,
+        forward_batch,
+        layer_id,
+        metadata,
+        gate_score: Optional[torch.Tensor] = None,
+        return_compressed: bool = False,
+        write_cache: bool = True,
+    ):
+        if key.shape[0] == 0:
+            return None
+
+        if gate_score is None:
+            gate_score = F.linear(
+                self._materialize_gate_input(x), self.index_kpool_compress_gate
+            )
+
+        if forward_batch.forward_mode.is_decode_or_idle():
+            self._compress_write_decode(
+                key=key,
+                gate_score=gate_score,
+                positions=positions,
+                forward_batch=forward_batch,
+                layer_id=layer_id,
+                metadata=metadata,
+            )
+        elif forward_batch.forward_mode.is_extend_without_speculative():
+            return self._compress_write_extend(
+                key=key,
+                gate_score=gate_score,
+                positions=positions,
+                forward_batch=forward_batch,
+                layer_id=layer_id,
+                metadata=metadata,
+                return_compressed=return_compressed,
+                write_cache=write_cache,
+            )
+        else:
+            raise NotImplementedError(
+                "index_kpool_compress currently supports decode and extend only."
+            )
+        return None
+
+    def _compute_gate_score_if_missing(
+        self, x: torch.Tensor, gate_score: Optional[torch.Tensor]
+    ) -> torch.Tensor:
+        if gate_score is not None:
+            return gate_score
+        return F.linear(self._materialize_gate_input(x), self.index_kpool_compress_gate)
+
+    def _get_q_k_bf16(
+        self,
+        q_lora: torch.Tensor,
+        x: torch.Tensor,
+        positions: torch.Tensor,
+        enable_dual_stream: bool,
+        forward_batch: ForwardBatch,
+        precompute_compress_gate: bool = False,
+    ):
+        gate_score = None
+        if enable_dual_stream:
+            current_stream = torch.cuda.current_stream()
+            self.alt_stream.wait_stream(current_stream)
+            if precompute_compress_gate:
+                assert self.compress_gate_stream is not None
+                self.compress_gate_stream.wait_stream(current_stream)
+
+            with deep_gemm_wrapper.configure_deep_gemm_num_sms(
+                self.half_device_sm_count
+            ):
+                query, _ = self.wq_b(q_lora)
+                query = rearrange(query, "l (h d) -> l h d", d=self.head_dim)
+                q_rope, _ = torch.split(
+                    query,
+                    [self.rope_head_dim, self.head_dim - self.rope_head_dim],
+                    dim=-1,
+                )
+            with torch.cuda.stream(self.alt_stream):
+                key, _ = self.wk(x)
+                key = self.k_norm(key)
+
+                k_rope, _ = torch.split(
+                    key,
+                    [self.rope_head_dim, self.head_dim - self.rope_head_dim],
+                    dim=-1,
+                )
+
+            if precompute_compress_gate:
+                with torch.cuda.stream(self.compress_gate_stream):
+                    gate_score = F.linear(
+                        self._materialize_gate_input(x),
+                        self.index_kpool_compress_gate,
+                    )
+
+            current_stream.wait_stream(self.alt_stream)
+        else:
+            query, _ = self.wq_b(q_lora)
+            query = rearrange(query, "l (h d) -> l h d", d=self.head_dim)
+            q_rope, _ = torch.split(
+                query, [self.rope_head_dim, self.head_dim - self.rope_head_dim], dim=-1
+            )
+            key, _ = self.wk(x)
+            key = self.k_norm(key)
+            k_rope, _ = torch.split(
+                key, [self.rope_head_dim, self.head_dim - self.rope_head_dim], dim=-1
+            )
+
+        if not self.skip_rope:
+            q_rope, k_rope = self.rotary_emb(positions, q_rope, k_rope)
+
+            query[..., : self.rope_head_dim] = q_rope
+            key[..., : self.rope_head_dim] = k_rope
+
+        query = rotate_activation(query)
+
+        return query, key, gate_score
+
+    def _get_k_bf16(
+        self,
+        x: torch.Tensor,
+        positions: torch.Tensor,
+    ):
+        key, _ = self.wk(x)
+        key = self.k_norm(key)
+        k_rope, _ = torch.split(
+            key, [self.rope_head_dim, self.head_dim - self.rope_head_dim], dim=-1
+        )
+
+        if not self.skip_rope:
+            _, k_rope = self.rotary_emb(positions, k_rope, k_rope)
+            key[..., : self.rope_head_dim] = k_rope
+        return key
+
+    def _full_topk_for_short_sequence(
+        self, metadata: BaseIndexerMetadata, device: torch.device
+    ) -> torch.Tensor:
+        seq_lens_expanded = metadata.get_seqlens_expanded()
+        dummy_logits = torch.zeros(
+            seq_lens_expanded.shape[0],
+            self.index_topk,
+            dtype=torch.float32,
+            device=device,
+        )
+        topk_full = metadata.topk_transform(dummy_logits, self.index_topk)
+        if self.index_kpool == 1:
+            return topk_full
+        padding = torch.full(
+            (topk_full.shape[0], self.index_kpool - 1),
+            -1,
+            dtype=topk_full.dtype,
+            device=topk_full.device,
+        )
+        return torch.cat([topk_full, padding], dim=1)
+
+    def _topk_from_kpool_logits(
+        self,
+        logits: torch.Tensor,
+        pool_lens: torch.Tensor,
+        seq_lens: Optional[torch.Tensor] = None,
+        page_table: Optional[torch.Tensor] = None,
+        topk_offsets: Optional[torch.Tensor] = None,
+        row_starts: Optional[torch.Tensor] = None,
+        out_rows: Optional[int] = None,
+        page_table_row_index: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        from sglang.srt.layers.attention.nsa.kpool_fp8_index import (
+            topk_from_pooled_history_logits,
+        )
+
+        n_rows = logits.shape[0]
+        if (
+            page_table is not None
+            and page_table_row_index is None
+            and page_table.shape[0] != n_rows
+        ):
+            page_table = page_table[:n_rows]
+        if topk_offsets is not None and topk_offsets.shape[0] != n_rows:
+            topk_offsets = topk_offsets[:n_rows]
+        if page_table_row_index is not None and page_table_row_index.shape[0] != n_rows:
+            page_table_row_index = page_table_row_index[:n_rows]
+
+        return topk_from_pooled_history_logits(
+            logits=logits,
+            group_lengths=pool_lens,
+            pool_size=self.index_kpool,
+            topk=self.index_topk,
+            page_table=page_table,
+            topk_offsets=topk_offsets,
+            seq_lens=seq_lens,
+            row_starts=row_starts,
+            out_rows=out_rows,
+            page_table_row_index=page_table_row_index,
+        )
+
+    def _get_kpool_decode_metadata(
+        self,
+        metadata: BaseIndexerMetadata,
+        block_tables: torch.Tensor,
+        seqlens_32: torch.Tensor,
+        blocksize: int,
+        build_schedule_metadata: bool = True,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+        from sglang.srt.layers.attention.nsa.kpool_fp8_index import (
+            build_pooled_page_table_64,
+        )
+
+        attn_metadata = getattr(metadata, "attn_metadata", None)
+        pool_seqlens = getattr(attn_metadata, "pooled_cache_seqlens_int32", None)
+        pool_block_tables = getattr(attn_metadata, "pooled_real_page_table", None)
+        pool_schedule_metadata = getattr(
+            attn_metadata, "pooled_paged_mqa_schedule_metadata", None
+        )
+
+        if (
+            pool_seqlens is None
+            or pool_block_tables is None
+            or getattr(attn_metadata, "pooled_index_kpool", 1) != self.index_kpool
+        ):
+            pool_seqlens = torch.div(
+                seqlens_32, self.index_kpool, rounding_mode="floor"
+            ).to(torch.int32)
+            pool_block_tables = build_pooled_page_table_64(
+                block_tables, self.index_kpool
+            ).contiguous()
+            pool_schedule_metadata = None
+        else:
+            pool_seqlens = pool_seqlens[: seqlens_32.shape[0]]
+            pool_block_tables = pool_block_tables[
+                : block_tables.shape[0],
+                : (block_tables.shape[1] + self.index_kpool - 1) // self.index_kpool,
+            ]
+
+        pool_context_lens = pool_seqlens.contiguous().view(-1, 1)
+        if pool_schedule_metadata is None and build_schedule_metadata:
+            pool_schedule_metadata = deep_gemm.get_paged_mqa_logits_metadata(
+                pool_context_lens.clamp(min=1), blocksize, self.sm_count
+            )
+
+        return (
+            pool_seqlens,
+            pool_context_lens,
+            pool_block_tables,
+            pool_schedule_metadata,
+        )
+
+    @staticmethod
+    def _kpool_fused_topk_mapping(
+        metadata: BaseIndexerMetadata,
+        paged_page_table: Optional[torch.Tensor] = None,
+        paged_page_table_row_index: Optional[torch.Tensor] = None,
+    ) -> Tuple[Optional[torch.Tensor], Optional[torch.Tensor], Optional[torch.Tensor]]:
+        if not envs.SGLANG_NSA_FUSE_TOPK.get():
+            return None, None, None
+
+        topk_method = getattr(metadata, "topk_transform_method", None)
+        attn_metadata = getattr(metadata, "attn_metadata", None)
+        if getattr(topk_method, "name", "") == "PAGED":
+            page_table_1 = (
+                paged_page_table
+                if paged_page_table is not None
+                else getattr(attn_metadata, "page_table_1", None)
+            )
+            assert page_table_1 is not None
+            row_index = (
+                paged_page_table_row_index if paged_page_table is not None else None
+            )
+            return page_table_1, None, row_index
+        if getattr(topk_method, "name", "") == "RAGGED":
+            return None, getattr(attn_metadata, "topk_indices_offset", None), None
+        return None, None, None
+
+    @staticmethod
+    def _should_use_tilelang_paged_mqa_logits(q_fp8: torch.Tensor) -> bool:
+        if not is_cuda():
+            return False
+        arch_major, _ = torch.cuda.get_device_capability(q_fp8.device)
+        num_heads = q_fp8.shape[2]
+        return arch_major == 9 and num_heads not in (32, 64)
+
+    @staticmethod
+    def _should_use_eager_logits(q_fp8: torch.Tensor) -> bool:
+        """Keep the unfused SM120 route private to GLM-5-Next KPool."""
+
+        from sglang.srt.layers.attention.nsa.glm5_next_indexer_logits import (
+            use_glm5_next_eager_logits_on_device,
+        )
+
+        return use_glm5_next_eager_logits_on_device(q_fp8.device)
+
+    def _get_topk_paged(
+        self,
+        forward_batch: ForwardBatch,
+        layer_id: int,
+        q_fp8: torch.Tensor,
+        weights: torch.Tensor,
+        metadata: BaseIndexerMetadata,
+    ) -> torch.Tensor:
+        if TYPE_CHECKING:
+            assert isinstance(get_token_to_kv_pool(), NSATokenToKVPool)
+
+        pool = get_token_to_kv_pool()
+        page_size = pool.page_size
+        # NOTE(dark): blocksize = 64 is hardcoded in deep_gemm
+        assert page_size == 64, "only support page size 64"
+
+        # NOTE(dark): this support extend/decode/decode+graph
+        block_tables = metadata.get_page_table_64()
+
+        kv_cache_fp8 = self._get_index_k_read_buffer(pool, layer_id)
+
+        blocksize = page_size
+        seqlens_32 = metadata.get_seqlens_int32()
+        assert len(q_fp8.shape) == 3
+        num_q_padded = q_fp8.shape[0]
+        n_real = seqlens_32.shape[0]
+        if n_real < num_q_padded:
+            q_fp8 = q_fp8[:n_real]
+            weights = weights[:n_real]
+        q_fp8 = q_fp8.unsqueeze(1)  # the next_n dim is 1 now
+        assert len(kv_cache_fp8.shape) == 2
+        block_kv = 64
+        num_heads_kv = 1
+        head_dim_with_sf = 132
+        kv_cache_fp8 = kv_cache_fp8.view(
+            kv_cache_fp8.shape[0], block_kv, num_heads_kv, head_dim_with_sf
+        )
+        assert len(weights.shape) == 3
+        weights = weights.squeeze(2)
+        use_tilelang_paged_mqa = self._should_use_tilelang_paged_mqa_logits(q_fp8)
+        use_eager_logits = self._should_use_eager_logits(q_fp8)
+
+        pool_seqlens, pool_context_lens, pool_block_tables, pool_schedule_metadata = (
+            self._get_kpool_decode_metadata(
+                metadata,
+                block_tables,
+                seqlens_32,
+                blocksize,
+                build_schedule_metadata=not (
+                    use_tilelang_paged_mqa or use_eager_logits
+                ),
+            )
+        )
+        pool_max_seq_len = pool_block_tables.shape[1] * blocksize
+        if use_eager_logits:
+            from sglang.srt.layers.attention.nsa.glm5_next_indexer_logits import (
+                glm5_next_eager_fp8_paged_mqa_logits,
+            )
+
+            logits = glm5_next_eager_fp8_paged_mqa_logits(
+                q_fp8,
+                kv_cache_fp8,
+                weights,
+                pool_seqlens,
+                pool_block_tables,
+                pool_max_seq_len,
+            )
+        elif use_tilelang_paged_mqa:
+            from sglang.srt.layers.attention.nsa.tilelang_kernel import (
+                tilelang_fp8_paged_mqa_logits,
+            )
+
+            logits = tilelang_fp8_paged_mqa_logits(
+                q_fp8,
+                kv_cache_fp8,
+                weights,
+                pool_seqlens,
+                pool_block_tables,
+                pool_schedule_metadata,
+                pool_max_seq_len,
+                clean_logits=False,
+            )
+        else:
+            logits = deep_gemm.fp8_paged_mqa_logits(
+                q_fp8,
+                kv_cache_fp8,
+                weights,
+                pool_context_lens,
+                pool_block_tables,
+                pool_schedule_metadata,
+                pool_max_seq_len,
+                clean_logits=False,
+            )
+
+        page_table_1, topk_offsets, _ = self._kpool_fused_topk_mapping(metadata)
+        topk_result = self._topk_from_kpool_logits(
+            logits,
+            pool_seqlens,
+            seq_lens=seqlens_32,
+            page_table=page_table_1,
+            topk_offsets=topk_offsets,
+            out_rows=num_q_padded if num_q_padded != n_real else None,
+        )
+        return topk_result
+
+    def _should_chunk_mqa_logits(
+        self, num_q: int, num_k: int, device: torch.device
+    ) -> Tuple[bool, int]:
+        """
+        Detect whether we need to chunk the MQA logits computation to avoid OOM
+        Return: (need_chunk, free_mem)
+        """
+        # Quick static check for normal batches
+        if num_q * num_k < 8_000_000:  # 8M elements ≈ 32MB logits
+            return False, 0
+
+        free_mem, total_mem = torch.cuda.mem_get_info(device)
+        bytes_per_elem = 4  # float32
+        logits_bytes = num_q * num_k * bytes_per_elem
+
+        # Logits should not exceed 50% of free memory or 30% of total memory
+        need_chunk = (logits_bytes * 2 > free_mem) or (logits_bytes > total_mem * 0.3)
+        return need_chunk, free_mem
+
+    def _get_topk_ragged_kpool_plan(
+        self,
+        forward_batch: ForwardBatch,
+        layer_id: int,
+        q_fp8: torch.Tensor,
+        weights: torch.Tensor,
+        metadata: BaseIndexerMetadata,
+    ) -> torch.Tensor:
+        from sglang.srt.layers.attention.nsa.kpool_fp8_index import (
+            gather_index_k_scale_prefix_into,
+        )
+
+        plan = metadata.attn_metadata.kpool_extend_plan
+        assert plan is not None, "kpool extend plan is required"
+        assert len(weights.shape) == 3
+        weights = weights.squeeze(-1)
+
+        device = q_fp8.device
+        total_q = q_fp8.shape[0]
+        seq_lens_expanded = plan.seq_lens_expanded
+        pool_lens = plan.pooled_seq_lens_expanded
+        ks_per_q = plan.ragged_q_ks
+        ke_per_q = plan.ragged_q_ke
+        total_k_rows = plan.ragged_total_k_rows
+
+        n_real = seq_lens_expanded.shape[0]
+        assert n_real <= total_q, (
+            f"plan has more real rows ({n_real}) than q_fp8 ({total_q})"
+        )
+
+        if total_k_rows > 0:
+            k_u8 = plan.ragged_k_u8
+            k_scale = plan.ragged_k_scale
+            assert k_u8 is not None and k_scale is not None
+            pool = get_token_to_kv_pool()
+            gather_index_k_scale_prefix_into(
+                pool=pool,
+                buf=self._get_index_k_read_buffer(pool, layer_id),
+                page_indices=plan.ragged_concat_page_table,
+                seq_len=total_k_rows,
+                k_out=k_u8,
+                scale_out=k_scale,
+            )
+            k_fp8 = k_u8.view(torch.float8_e4m3fn)
+            if self._should_use_eager_logits(q_fp8):
+                from sglang.srt.layers.attention.nsa.glm5_next_indexer_logits import (
+                    glm5_next_eager_fp8_mqa_logits,
+                )
+
+                logits = glm5_next_eager_fp8_mqa_logits(
+                    q_fp8[:n_real].contiguous(),
+                    (k_fp8.contiguous(), k_scale.contiguous()),
+                    weights[:n_real].contiguous(),
+                    ks_per_q,
+                    ke_per_q,
+                )
+            else:
+                logits = deep_gemm.fp8_mqa_logits(
+                    q_fp8[:n_real].contiguous(),
+                    (k_fp8.contiguous(), k_scale.contiguous()),
+                    weights[:n_real].contiguous(),
+                    ks_per_q,
+                    ke_per_q,
+                    clean_logits=True,
+                )
+        else:
+            logits = torch.empty((n_real, 0), dtype=torch.float32, device=device)
+
+        topk_method = getattr(metadata, "topk_transform_method", None)
+        attn_metadata = getattr(metadata, "attn_metadata", None)
+        page_table_all = None
+        page_table_row_index_all = None
+        topk_offsets_all = None
+        if envs.SGLANG_NSA_FUSE_TOPK.get():
+            if getattr(topk_method, "name", "") == "PAGED":
+                page_table_all = plan.ragged_paged_page_table
+                page_table_row_index_all = plan.ragged_paged_page_table_row_index
+            elif getattr(topk_method, "name", "") == "RAGGED":
+                topk_offsets_all = getattr(attn_metadata, "topk_indices_offset", None)
+
+        return self._topk_from_kpool_logits(
+            logits,
+            pool_lens,
+            seq_lens=seq_lens_expanded,
+            page_table=page_table_all,
+            topk_offsets=topk_offsets_all,
+            row_starts=ks_per_q,
+            out_rows=total_q,
+            page_table_row_index=page_table_row_index_all,
+        )
+
+    def _get_topk_ragged(
+        self,
+        forward_batch: ForwardBatch,
+        layer_id: int,
+        q_fp8: torch.Tensor,
+        weights: torch.Tensor,
+        metadata: BaseIndexerMetadata,
+    ) -> torch.Tensor:
+        assert forward_batch.forward_mode.is_extend_without_speculative()
+        assert get_token_to_kv_pool().page_size == 64, "only support page size 64"
+        assert getattr(metadata.attn_metadata, "kpool_extend_plan", None) is not None
+        return self._get_topk_ragged_kpool_plan(
+            forward_batch,
+            layer_id,
+            q_fp8,
+            weights,
+            metadata,
+        )
+
+    def _forward_cuda_skip_logits(
+        self,
+        x: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        layer_id: int,
+        act_quant,
+        metadata: BaseIndexerMetadata,
+        return_indices: bool = True,
+    ) -> Optional[torch.Tensor]:
+        assert forward_batch.forward_mode.is_extend_without_speculative()
+
+        key = self._get_k_bf16(x, positions)
+        self._compress_write(
+            x=x,
+            key=key,
+            positions=positions,
+            forward_batch=forward_batch,
+            layer_id=layer_id,
+            metadata=metadata,
+        )
+
+        if not return_indices:
+            return None
+
+        x_meta = x[0] if isinstance(x, tuple) else x
+        return self._full_topk_for_short_sequence(metadata, x_meta.device)
+
+    def forward_cuda(
+        self,
+        x: torch.Tensor,
+        q_lora: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        layer_id: int,
+        return_indices: bool = True,
+    ) -> Optional[torch.Tensor]:
+        """Eager-only GLM-5-Next KPool forward path.
+
+        Decode and non-speculative extend are supported. CP, MTP, and CUDA
+        graph capture must keep using their pre-existing NSA implementation
+        until their KPool contracts are integrated independently.
+        """
+        if is_hip():
+            from sglang.srt.layers.attention.nsa.tilelang_kernel import act_quant
+        elif not is_npu():
+            from sglang.srt.layers.attention.nsa.triton_kernel import act_quant
+
+        if TYPE_CHECKING:
+            assert isinstance(get_token_to_kv_pool(), NSATokenToKVPool)
+
+        metadata = get_attn_backend().get_indexer_metadata(layer_id, forward_batch)
+        if metadata is None:
+            return None
+
+        x_meta = x[0] if isinstance(x, tuple) else x
+        assert forward_batch.seq_lens_cpu is not None
+        mode = forward_batch.forward_mode
+        if mode.is_idle() or len(forward_batch.seq_lens_cpu) == 0:
+            return torch.full(
+                (x_meta.shape[0], self.index_topk + self.index_kpool - 1),
+                -1,
+                dtype=torch.int,
+                device=x_meta.device,
+            )
+        if not (mode.is_decode() or mode.is_extend_without_speculative()):
+            raise NotImplementedError(
+                "GLM-5-Next KPool currently supports eager decode and eager extend only"
+            )
+
+        if mode.is_extend_without_speculative():
+            max_kv_len = forward_batch.seq_lens_cpu.max().item()
+            if max_kv_len <= self.index_topk:
+                return self._forward_cuda_skip_logits(
+                    x,
+                    positions,
+                    forward_batch,
+                    layer_id,
+                    act_quant,
+                    metadata,
+                    return_indices,
+                )
+
+        query, key, gate_score = self._get_q_k_bf16(
+            q_lora,
+            x,
+            positions,
+            enable_dual_stream=False,
+            forward_batch=forward_batch,
+            precompute_compress_gate=False,
+        )
+        q_fp8, q_scale = act_quant(query, self.block_size, self.scale_fmt)
+        self._compress_write(
+            x=x,
+            key=key,
+            positions=positions,
+            forward_batch=forward_batch,
+            layer_id=layer_id,
+            metadata=metadata,
+            gate_score=gate_score,
+        )
+        if not return_indices:
+            return None
+
+        weights = self._get_logits_head_gate(x, q_scale)
+        if mode.is_decode():
+            return self._get_topk_paged(
+                forward_batch, layer_id, q_fp8, weights, metadata
+            )
+        return self._get_topk_ragged(forward_batch, layer_id, q_fp8, weights, metadata)

--- a/python/sglang/srt/layers/attention/nsa/utils.py
+++ b/python/sglang/srt/layers/attention/nsa/utils.py
@@ -28,8 +28,25 @@ if TYPE_CHECKING:
     from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 
 
-def compute_nsa_seqlens(original_seq_lens, nsa_index_topk: int):
-    return original_seq_lens.clamp(max=nsa_index_topk)
+def compute_nsa_seqlens(
+    original_seq_lens, nsa_index_topk: int, index_kpool: int = 1
+):
+    """Compute sparse-attention lengths, preserving a KPool ragged tail.
+
+    ``index_kpool=1`` is the historical NSA behavior.  For GLM-5-Next's
+    KPool4 layout, history is selected as complete pools while the at-most
+    three unpooled tokens at the end are always appended to the sparse set.
+    """
+
+    if index_kpool <= 1:
+        return original_seq_lens.clamp(max=nsa_index_topk)
+
+    full_pool_tokens = (
+        torch.div(original_seq_lens, index_kpool, rounding_mode="floor")
+        * index_kpool
+    )
+    selected_history_tokens = full_pool_tokens.clamp(max=nsa_index_topk)
+    return selected_history_tokens + (original_seq_lens - full_pool_tokens)
 
 
 def is_nsa_enable_prefill_cp():

--- a/python/sglang/srt/layers/attention/nsa_backend.py
+++ b/python/sglang/srt/layers/attention/nsa_backend.py
@@ -13,6 +13,9 @@ from sglang.srt.layers.attention.nsa.dequant_k_cache import dequantize_k_cache_p
 from sglang.srt.layers.attention.nsa.glm5_next_sparse_attention import (
     glm5_next_sparse_mla_reference,
 )
+from sglang.srt.layers.attention.nsa.glm5_next_scaled_fp8 import (
+    glm5_next_mla_prepare_scaled_fp8_no_rope,
+)
 from sglang.srt.layers.attention.nsa.nsa_backend_mtp_precompute import (
     NativeSparseAttnBackendMTPPrecomputeMixin,
     PrecomputedMetadata,
@@ -306,6 +309,11 @@ class NativeSparseAttnBackend(
         self.device = model_runner.device
         assert isinstance(model_runner.page_size, int)
         self.real_page_size = model_runner.page_size
+        # ForwardContext may publish this backend directly or through the
+        # hybrid KDA/DSA wrapper.  Keep the normal AttentionBackend pool
+        # contract so both routes resolve the same persistent pool objects.
+        self.req_to_token_pool = model_runner.req_to_token_pool
+        self.token_to_kv_pool = model_runner.token_to_kv_pool
         self.num_splits = (
             1 if model_runner.server_args.enable_deterministic_inference else 0
         )
@@ -315,9 +323,7 @@ class NativeSparseAttnBackend(
         # Do not widen their object contract for a nested config that is used
         # exclusively by the exact GLM wrapper.
         text_config = (
-            model_runner.model_config.hf_text_config
-            if is_glm5_next
-            else hf_config
+            model_runner.model_config.hf_text_config if is_glm5_next else hf_config
         )
         self.is_glm5_next = is_glm5_next
         self.use_nsa = is_deepseek_nsa(hf_config) or is_glm5_next
@@ -326,9 +332,7 @@ class NativeSparseAttnBackend(
             model_runner.token_to_kv_pool.nsa_kv_cache_store_fp8
         )
         self.nsa_index_topk = (
-            text_config.index_topk
-            if is_glm5_next
-            else get_nsa_index_topk(hf_config)
+            text_config.index_topk if is_glm5_next else get_nsa_index_topk(hf_config)
         )
         self.nsa_index_kpool = (
             int(getattr(text_config, "index_kpool", 1)) if is_glm5_next else 1
@@ -410,6 +414,63 @@ class NativeSparseAttnBackend(
             0, max_seqlen_k, page_size, device=page_table.device, dtype=torch.int32
         )
         return page_table[:, strided_indices] // page_size
+
+    def _init_glm5_next_kpool_graph_metadata(
+        self, metadata: NSAMetadata, forward_mode: ForwardMode
+    ) -> NSAMetadata:
+        """Allocate the stable pooled decode views captured by exact GLM."""
+
+        if not (
+            self.is_glm5_next
+            and self.nsa_index_kpool == 4
+            and forward_mode.is_decode_or_idle()
+        ):
+            return metadata
+
+        from sglang.srt.layers.attention.nsa.kpool_plan import (
+            init_pooled_paged_mqa_metadata,
+        )
+
+        return init_pooled_paged_mqa_metadata(
+            metadata,
+            metadata.cache_seqlens_int32,
+            forward_mode,
+            pool_size=self.nsa_index_kpool,
+            real_page_size=self.real_page_size,
+            # GLM's compressed index cache still stores 64 pooled entries in
+            # each physical page; this is not real_page_size / pool_size.
+            slots_per_page=64,
+            # SM120 consumes the graph-safe model-local scorer and has no
+            # DeepGEMM schedule.  Other Blackwell variants keep the existing
+            # schedule contract.
+            build_schedule_metadata=self.device_capability != (12, 0),
+        )
+
+    def _update_glm5_next_kpool_graph_metadata(
+        self, metadata: NSAMetadata, forward_mode: ForwardMode
+    ) -> None:
+        """Refresh pooled views in-place before replay, preserving pointers."""
+
+        if not (
+            self.is_glm5_next
+            and self.nsa_index_kpool == 4
+            and forward_mode.is_decode_or_idle()
+        ):
+            return
+
+        from sglang.srt.layers.attention.nsa.kpool_plan import (
+            update_pooled_paged_mqa_metadata,
+        )
+
+        update_pooled_paged_mqa_metadata(
+            metadata,
+            metadata.cache_seqlens_int32,
+            forward_mode,
+            pool_size=self.nsa_index_kpool,
+            real_page_size=self.real_page_size,
+            slots_per_page=64,
+            build_schedule_metadata=self.device_capability != (12, 0),
+        )
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         """Init the metadata for a forward pass."""
@@ -607,9 +668,9 @@ class NativeSparseAttnBackend(
                         )
                     ]
                 )
-                assert page_table_1_flattened.shape[0] == sum(
-                    indexer_seq_lens_cpu
-                ), f"{page_table_1_flattened.shape[0] = } must be the same as {sum(indexer_seq_lens_cpu) = }"
+                assert page_table_1_flattened.shape[0] == sum(indexer_seq_lens_cpu), (
+                    f"{page_table_1_flattened.shape[0] = } must be the same as {sum(indexer_seq_lens_cpu) = }"
+                )
 
                 # Validate indices when logical tokens exceed physical capacity
                 # This is likely to be triggered by PP with high kv reuse & parallelism
@@ -650,10 +711,14 @@ class NativeSparseAttnBackend(
         paged_mqa_schedule_metadata = None
         # DeepGEMM paged MQA logits path needs a schedule metadata tensor.
         # Compute it once per forward batch and reuse it across layers.
-        if is_cuda() and (
-            forward_batch.forward_mode.is_decode_or_idle()
-            or forward_batch.forward_mode.is_target_verify()
-            or forward_batch.forward_mode.is_draft_extend()
+        if (
+            is_cuda()
+            and not (self.is_glm5_next and self.device_capability == (12, 0))
+            and (
+                forward_batch.forward_mode.is_decode_or_idle()
+                or forward_batch.forward_mode.is_target_verify()
+                or forward_batch.forward_mode.is_draft_extend()
+            )
         ):
             try:
                 import deep_gemm
@@ -752,6 +817,9 @@ class NativeSparseAttnBackend(
                     pool_size=self.nsa_index_kpool,
                     real_page_size=self.real_page_size,
                     slots_per_page=slots_per_page,
+                    build_schedule_metadata=not (
+                        self.is_glm5_next and self.device_capability == (12, 0)
+                    ),
                 )
         self.forward_metadata = metadata
 
@@ -986,10 +1054,14 @@ class NativeSparseAttnBackend(
         real_page_table = self._transform_table_1_to_real(page_table_1)
 
         paged_mqa_schedule_metadata = None
-        if is_cuda() and (
-            forward_mode.is_decode_or_idle()
-            or forward_mode.is_target_verify()
-            or forward_mode.is_draft_extend()
+        if (
+            is_cuda()
+            and not (self.is_glm5_next and self.device_capability == (12, 0))
+            and (
+                forward_mode.is_decode_or_idle()
+                or forward_mode.is_target_verify()
+                or forward_mode.is_draft_extend()
+            )
         ):
             try:
                 import deep_gemm
@@ -1025,6 +1097,7 @@ class NativeSparseAttnBackend(
             real_page_table=real_page_table,
             nsa_extend_seq_lens_list=nsa_extend_seq_lens_list,
         )
+        metadata = self._init_glm5_next_kpool_graph_metadata(metadata, forward_mode)
         self.decode_cuda_graph_metadata[bs] = metadata
         self.forward_metadata = metadata
 
@@ -1161,10 +1234,14 @@ class NativeSparseAttnBackend(
             )
 
         # Update DeepGEMM paged MQA schedule metadata outside the captured graph.
-        if is_cuda() and (
-            forward_mode.is_decode_or_idle()
-            or forward_mode.is_target_verify()
-            or forward_mode.is_draft_extend()
+        if (
+            is_cuda()
+            and not (self.is_glm5_next and self.device_capability == (12, 0))
+            and (
+                forward_mode.is_decode_or_idle()
+                or forward_mode.is_target_verify()
+                or forward_mode.is_draft_extend()
+            )
         ):
             try:
                 import deep_gemm
@@ -1206,6 +1283,11 @@ class NativeSparseAttnBackend(
             metadata.real_page_table[:new_rows, :new_cols].copy_(real_table)
         else:
             assert metadata.real_page_table is metadata.page_table_1
+
+        # The graph captures these pooled tensors by address.  Recompute their
+        # contents after the real page table is refreshed and copy in-place;
+        # never replace a field with a replay-time allocation.
+        self._update_glm5_next_kpool_graph_metadata(metadata, forward_mode)
 
         if self.nsa_decode_impl == "flashmla_kv":
             flashmla_metadata = metadata.flashmla_metadata.slice(
@@ -1453,9 +1535,9 @@ class NativeSparseAttnBackend(
         if self.use_mha:
             assert k is not None and v is not None
             assert q_rope is None, "MHA_ONE_SHOT path should not pass q_rope"
-            assert (
-                layer.tp_k_head_num == layer.tp_q_head_num > 1
-            ), "MHA_ONE_SHOT requires dense multi-head config"
+            assert layer.tp_k_head_num == layer.tp_q_head_num > 1, (
+                "MHA_ONE_SHOT requires dense multi-head config"
+            )
             return self._forward_standard_mha(
                 q=q,
                 k=k,
@@ -1870,8 +1952,8 @@ class NativeSparseAttnBackend(
 
         # Verify batch sizes match (length of cu_seqlens should be batch_size + 1)
         assert len(cu_seqlens_q) == len(cu_seqlens_k), (
-            f"batch_size mismatch: cu_seqlens_q has {len(cu_seqlens_q)-1} requests, "
-            f"cu_seqlens_k has {len(cu_seqlens_k)-1} requests"
+            f"batch_size mismatch: cu_seqlens_q has {len(cu_seqlens_q) - 1} requests, "
+            f"cu_seqlens_k has {len(cu_seqlens_k) - 1} requests"
         )
 
         # Use TRTLLm ragged attention for SM100 (Blackwell/B200) to avoid FA4 accuracy issues
@@ -1996,6 +2078,19 @@ class NativeSparseAttnBackend(
         metadata = self.forward_metadata
 
         merge_query = q_rope is not None and self.qk_rope_head_dim > 0
+        glm5_key_scale = None
+        glm5_current_chunk_kv = None
+        glm5_current_chunk_locs = None
+        use_glm5_scaled_fp8 = (
+            self.is_glm5_next
+            and self.device_capability == (12, 0)
+            and self.kv_cache_dtype == torch.float8_e4m3fn
+        )
+        use_glm5_current_chunk_bf16 = (
+            use_glm5_scaled_fp8
+            and is_prefill
+            and forward_batch.forward_mode.is_extend_without_speculative()
+        )
         if self.kv_cache_dtype == torch.float8_e4m3fn:
             # For FP8 path, we quantize the query and rope parts and merge them into a single tensor
             # Note: rope application in deepseek_v2.py:forward_absorb_prepare is skipped for FP8 decode path of this trtllm_mla backend
@@ -2005,14 +2100,32 @@ class NativeSparseAttnBackend(
                 assert self.qk_rope_head_dim == 0, (
                     "missing RoPE cache is valid only for zero-RoPE MLA"
                 )
-                q, k, k_rope = mla_quantize_for_fp8_no_rope(
-                    q,
-                    q_rope,
-                    k.squeeze(1),
-                    k_rope.squeeze(1),
-                    self.kv_lora_rank,
-                    self.qk_rope_head_dim,
-                )
+                if use_glm5_scaled_fp8:
+                    if use_glm5_current_chunk_bf16:
+                        glm5_current_chunk_kv = k.squeeze(1).contiguous()
+                        if glm5_current_chunk_kv.dtype != torch.bfloat16:
+                            raise TypeError(
+                                "GLM-5-Next EXTEND current-chunk latent must be "
+                                f"BF16 before FP8 cache storage, got "
+                                f"{glm5_current_chunk_kv.dtype}"
+                            )
+                    q, k, k_rope, glm5_key_scale = (
+                        glm5_next_mla_prepare_scaled_fp8_no_rope(
+                            q,
+                            q_rope,
+                            k.squeeze(1),
+                            k_rope.squeeze(1),
+                        )
+                    )
+                else:
+                    q, k, k_rope = mla_quantize_for_fp8_no_rope(
+                        q,
+                        q_rope,
+                        k.squeeze(1),
+                        k_rope.squeeze(1),
+                        self.kv_lora_rank,
+                        self.qk_rope_head_dim,
+                    )
             else:
                 q, k, k_rope = mla_quantize_and_rope_for_fp8(
                     q,
@@ -2029,17 +2142,23 @@ class NativeSparseAttnBackend(
 
             # Save KV cache if requested
         if save_kv_cache:
-            assert (
-                k is not None and k_rope is not None
-            ), "For populating trtllm_mla kv cache, both k_nope and k_rope should be not None."
+            assert k is not None and k_rope is not None, (
+                "For populating trtllm_mla kv cache, both k_nope and k_rope should be not None."
+            )
             cache_loc = (
                 forward_batch.out_cache_loc
                 if not layer.is_cross_attention
                 else forward_batch.encoder_out_cache_loc
             )
+            if glm5_current_chunk_kv is not None:
+                glm5_current_chunk_locs = cache_loc
             forward_batch.token_to_kv_pool.set_mla_kv_buffer(
                 layer, cache_loc, k, k_rope
             )
+            if glm5_key_scale is not None:
+                forward_batch.token_to_kv_pool.set_latent_scale_buffer(
+                    layer.layer_id, cache_loc, glm5_key_scale
+                )
 
         k_cache = forward_batch.token_to_kv_pool.get_key_buffer(layer.layer_id)
         kv_cache = k_cache.view(-1, self.real_page_size, self.kv_cache_dim).unsqueeze(1)
@@ -2082,6 +2201,45 @@ class NativeSparseAttnBackend(
                     f"indices plus three tail indices ({expected_top_k} total), "
                     f"got {sparse_mla_top_k}"
                 )
+        if use_glm5_scaled_fp8:
+            # Q remains BF16 and dynamic block scales reconstruct K/V.
+            # Checkpoint-level static k_scale belongs to the legacy raw-cast
+            # convention and must not be applied a second time.
+            bmm1_scale = layer.scaling
+        else:
+            q_scale = 1.0
+            k_scale = (
+                layer.k_scale_float
+                if getattr(layer, "k_scale_float", None) is not None
+                else 1.0
+            )
+            bmm1_scale = q_scale * k_scale * layer.scaling
+
+        if self.is_glm5_next and self.device_capability == (12, 0):
+            latent_scale = (
+                forward_batch.token_to_kv_pool.get_latent_scale_buffer(layer.layer_id)
+                if use_glm5_scaled_fp8
+                else None
+            )
+            # CUDA Graph decode needs the fixed-shape scaled-FP8 H512 Triton
+            # kernel.  EXTEND keeps history in that same persistent cache, but
+            # selected rows from its current chunk use the pre-quantization
+            # BF16 latent.  This avoids an unnecessary write/read FP8 round on
+            # new tokens without allocating a 500k-token BF16 cache.
+            return glm5_next_sparse_mla_reference(
+                query=q_all,
+                kv_cache=kv_cache,
+                indices=page_table_1,
+                sm_scale=bmm1_scale,
+                use_cuda_decode_kernel=not is_prefill,
+                kv_scale=latent_scale,
+                current_chunk_kv=glm5_current_chunk_kv,
+                current_chunk_locs=glm5_current_chunk_locs,
+            )
+
+        # Padding to a multiple of four belongs to FlashInfer's TRTLLM ABI.
+        # The exact GLM kernel above consumes its native 2048+3 width and must
+        # dispatch before this shared-backend transform.
         padded_sparse_mla_top_k = ((sparse_mla_top_k + 3) // 4) * 4
         if padded_sparse_mla_top_k != sparse_mla_top_k:
             page_table_1 = torch.cat(
@@ -2100,25 +2258,6 @@ class NativeSparseAttnBackend(
                 dim=1,
             )
         sparse_mla_top_k = padded_sparse_mla_top_k
-        q_scale = 1.0
-        k_scale = (
-            layer.k_scale_float
-            if getattr(layer, "k_scale_float", None) is not None
-            else 1.0
-        )
-        bmm1_scale = q_scale * k_scale * layer.scaling
-
-        if self.is_glm5_next:
-            # FlashInfer <=0.6.16 has no native H512 ABI; 0.6.17 adds it for
-            # TRTLLM-GEN architectures but still reports "Unsupported
-            # architecture" on SM120.  Keep the exact GLM eager path correct
-            # without upgrading the global dependency used by existing models.
-            return glm5_next_sparse_mla_reference(
-                query=q_all,
-                kv_cache=kv_cache,
-                indices=page_table_1,
-                sm_scale=bmm1_scale,
-            )
 
         batch_size = page_table_1.shape[0]
         _, num_heads, head_dim = q_all.shape
@@ -2234,8 +2373,7 @@ class NativeSparseAttnBackend(
         """
         if (
             # disable for MTP
-            self.nsa_kv_cache_store_fp8
-            and self.nsa_prefill_impl == "flashmla_sparse"
+            self.nsa_kv_cache_store_fp8 and self.nsa_prefill_impl == "flashmla_sparse"
         ):
             topk_transform_method = TopkTransformMethod.RAGGED
         else:
@@ -2272,7 +2410,6 @@ class NativeSparseAttnBackend(
 
 
 class NativeSparseAttnMultiStepBackend:
-
     def __init__(
         self, model_runner: ModelRunner, topk: int, speculative_num_steps: int
     ):

--- a/python/sglang/srt/layers/attention/nsa_backend.py
+++ b/python/sglang/srt/layers/attention/nsa_backend.py
@@ -76,6 +76,8 @@ else:
 
 # Reuse this workspace buffer across all NSA backend instances
 global_workspace_buffer = None
+_GLM5_NEXT_NATIVE_CUDA_CAPS = ((8, 6), (8, 9), (12, 0))
+_GLM5_NEXT_SCALED_FP8_CUDA_CAPS = ((8, 9), (12, 0))
 
 # Control whether to use fused metadata copy kernel (default: enabled)
 # Set SGLANG_USE_FUSED_METADATA_COPY=0 or false to disable
@@ -385,7 +387,13 @@ class NativeSparseAttnBackend(
         self.kv_cache_dtype = model_runner.kv_cache_dtype
 
         # Allocate global workspace buffer for TRT-LLM kernels (ragged attention on SM100/B200, or trtllm decode)
-        if self.device_sm_major >= 10 or self.nsa_decode_impl == "trtllm":
+        uses_glm5_native_backend = (
+            self.is_glm5_next
+            and self.device_capability in _GLM5_NEXT_NATIVE_CUDA_CAPS
+        )
+        if not uses_glm5_native_backend and (
+            self.device_sm_major >= 10 or self.nsa_decode_impl == "trtllm"
+        ):
             global global_workspace_buffer
             if global_workspace_buffer is None:
                 global_workspace_buffer = torch.empty(
@@ -443,7 +451,8 @@ class NativeSparseAttnBackend(
             # SM120 consumes the graph-safe model-local scorer and has no
             # DeepGEMM schedule.  Other Blackwell variants keep the existing
             # schedule contract.
-            build_schedule_metadata=self.device_capability != (12, 0),
+            build_schedule_metadata=self.device_capability
+            not in _GLM5_NEXT_NATIVE_CUDA_CAPS,
         )
 
     def _update_glm5_next_kpool_graph_metadata(
@@ -469,7 +478,8 @@ class NativeSparseAttnBackend(
             pool_size=self.nsa_index_kpool,
             real_page_size=self.real_page_size,
             slots_per_page=64,
-            build_schedule_metadata=self.device_capability != (12, 0),
+            build_schedule_metadata=self.device_capability
+            not in _GLM5_NEXT_NATIVE_CUDA_CAPS,
         )
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
@@ -713,7 +723,10 @@ class NativeSparseAttnBackend(
         # Compute it once per forward batch and reuse it across layers.
         if (
             is_cuda()
-            and not (self.is_glm5_next and self.device_capability == (12, 0))
+            and not (
+                self.is_glm5_next
+                and self.device_capability in _GLM5_NEXT_NATIVE_CUDA_CAPS
+            )
             and (
                 forward_batch.forward_mode.is_decode_or_idle()
                 or forward_batch.forward_mode.is_target_verify()
@@ -808,6 +821,11 @@ class NativeSparseAttnBackend(
                     topk_transform_method=topk_transform_method,
                     full_real_page_table=metadata.real_page_table,
                     full_seqlens_expanded=seqlens_expanded,
+                    index_cache_dtype=getattr(
+                        forward_batch.token_to_kv_pool,
+                        "index_cache_dtype",
+                        torch.float8_e4m3fn,
+                    ),
                 )
             elif forward_batch.forward_mode.is_decode_or_idle():
                 metadata = init_pooled_paged_mqa_metadata(
@@ -818,7 +836,8 @@ class NativeSparseAttnBackend(
                     real_page_size=self.real_page_size,
                     slots_per_page=slots_per_page,
                     build_schedule_metadata=not (
-                        self.is_glm5_next and self.device_capability == (12, 0)
+                        self.is_glm5_next
+                        and self.device_capability in _GLM5_NEXT_NATIVE_CUDA_CAPS
                     ),
                 )
         self.forward_metadata = metadata
@@ -1056,7 +1075,10 @@ class NativeSparseAttnBackend(
         paged_mqa_schedule_metadata = None
         if (
             is_cuda()
-            and not (self.is_glm5_next and self.device_capability == (12, 0))
+            and not (
+                self.is_glm5_next
+                and self.device_capability in _GLM5_NEXT_NATIVE_CUDA_CAPS
+            )
             and (
                 forward_mode.is_decode_or_idle()
                 or forward_mode.is_target_verify()
@@ -1236,7 +1258,10 @@ class NativeSparseAttnBackend(
         # Update DeepGEMM paged MQA schedule metadata outside the captured graph.
         if (
             is_cuda()
-            and not (self.is_glm5_next and self.device_capability == (12, 0))
+            and not (
+                self.is_glm5_next
+                and self.device_capability in _GLM5_NEXT_NATIVE_CUDA_CAPS
+            )
             and (
                 forward_mode.is_decode_or_idle()
                 or forward_mode.is_target_verify()
@@ -2073,8 +2098,6 @@ class NativeSparseAttnBackend(
         is_prefill: bool = False,
     ) -> torch.Tensor:
         """Forward using TRT-LLM sparse MLA kernel."""
-        import flashinfer.decode
-
         metadata = self.forward_metadata
 
         merge_query = q_rope is not None and self.qk_rope_head_dim > 0
@@ -2083,7 +2106,7 @@ class NativeSparseAttnBackend(
         glm5_current_chunk_locs = None
         use_glm5_scaled_fp8 = (
             self.is_glm5_next
-            and self.device_capability == (12, 0)
+            and self.device_capability in _GLM5_NEXT_SCALED_FP8_CUDA_CAPS
             and self.kv_cache_dtype == torch.float8_e4m3fn
         )
         use_glm5_current_chunk_bf16 = (
@@ -2215,7 +2238,10 @@ class NativeSparseAttnBackend(
             )
             bmm1_scale = q_scale * k_scale * layer.scaling
 
-        if self.is_glm5_next and self.device_capability == (12, 0):
+        if (
+            self.is_glm5_next
+            and self.device_capability in _GLM5_NEXT_NATIVE_CUDA_CAPS
+        ):
             latent_scale = (
                 forward_batch.token_to_kv_pool.get_latent_scale_buffer(layer.layer_id)
                 if use_glm5_scaled_fp8
@@ -2236,6 +2262,12 @@ class NativeSparseAttnBackend(
                 current_chunk_kv=glm5_current_chunk_kv,
                 current_chunk_locs=glm5_current_chunk_locs,
             )
+
+        # The GLM-native path above deliberately has no FlashInfer ABI
+        # dependency: consumer GPUs can execute it even when the installed
+        # TRTLLM-GEN kernels do not contain their architecture.  Import only
+        # after that dispatch, for the shared DeepSeek implementation below.
+        import flashinfer.decode
 
         # Padding to a multiple of four belongs to FlashInfer's TRTLLM ABI.
         # The exact GLM kernel above consumes its native 2048+3 width and must

--- a/python/sglang/srt/layers/attention/nsa_backend.py
+++ b/python/sglang/srt/layers/attention/nsa_backend.py
@@ -10,6 +10,9 @@ from sglang.srt.configs.model_config import get_nsa_index_topk, is_deepseek_nsa
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
 from sglang.srt.layers.attention.nsa.dequant_k_cache import dequantize_k_cache_paged
+from sglang.srt.layers.attention.nsa.glm5_next_sparse_attention import (
+    glm5_next_sparse_mla_reference,
+)
 from sglang.srt.layers.attention.nsa.nsa_backend_mtp_precompute import (
     NativeSparseAttnBackendMTPPrecomputeMixin,
     PrecomputedMetadata,
@@ -36,6 +39,7 @@ from sglang.srt.layers.attention.nsa.utils import (
 from sglang.srt.layers.attention.utils import (
     concat_mla_absorb_q_general,
     mla_quantize_and_rope_for_fp8,
+    mla_quantize_for_fp8_no_rope,
 )
 from sglang.srt.layers.dp_attention import get_attention_tp_size
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
@@ -148,6 +152,14 @@ class NSAMetadata:
     indexer_seq_lens_cpu: Optional[torch.Tensor] = None
     # batch index for each token.
     token_to_batch_idx: Optional[torch.Tensor] = None
+
+    # GLM-5-Next KPool4 metadata.  Defaults preserve the historical NSA
+    # layout byte-for-byte for every non-GLM model.
+    pooled_index_kpool: int = 1
+    pooled_cache_seqlens_int32: Optional[torch.Tensor] = None
+    pooled_real_page_table: Optional[torch.Tensor] = None
+    pooled_paged_mqa_schedule_metadata: Optional[torch.Tensor] = None
+    kpool_extend_plan: Optional[object] = None
 
 
 class TopkTransformMethod(IntEnum):
@@ -297,12 +309,35 @@ class NativeSparseAttnBackend(
         self.num_splits = (
             1 if model_runner.server_args.enable_deterministic_inference else 0
         )
-        self.use_nsa = is_deepseek_nsa(model_runner.model_config.hf_config)
-        assert self.use_nsa, "NSA backend only supports DeepSeek NSA"
+        hf_config = model_runner.model_config.hf_config
+        is_glm5_next = getattr(model_runner.model_config, "is_glm5_next", False)
+        # Legacy DeepSeek NSA constructors and tests only require ``hf_config``.
+        # Do not widen their object contract for a nested config that is used
+        # exclusively by the exact GLM wrapper.
+        text_config = (
+            model_runner.model_config.hf_text_config
+            if is_glm5_next
+            else hf_config
+        )
+        self.is_glm5_next = is_glm5_next
+        self.use_nsa = is_deepseek_nsa(hf_config) or is_glm5_next
+        assert self.use_nsa, "NSA backend only supports DeepSeek NSA or GLM-5-Next"
         self.nsa_kv_cache_store_fp8 = (
             model_runner.token_to_kv_pool.nsa_kv_cache_store_fp8
         )
-        self.nsa_index_topk = get_nsa_index_topk(model_runner.model_config.hf_config)
+        self.nsa_index_topk = (
+            text_config.index_topk
+            if is_glm5_next
+            else get_nsa_index_topk(hf_config)
+        )
+        self.nsa_index_kpool = (
+            int(getattr(text_config, "index_kpool", 1)) if is_glm5_next else 1
+        )
+        if is_glm5_next:
+            assert self.nsa_index_kpool == 4, (
+                "GLM-5-Next eager NSA integration requires index_kpool=4"
+            )
+        self.needs_cpu_seq_lens = self.nsa_index_kpool > 1
         self.max_context_len = model_runner.model_config.context_len
         self.num_q_heads = (
             model_runner.model_config.num_attention_heads // get_attention_tp_size()
@@ -604,6 +639,7 @@ class NativeSparseAttnBackend(
         nsa_cache_seqlens_int32 = compute_nsa_seqlens(
             original_seq_lens=seqlens_expanded,
             nsa_index_topk=self.nsa_index_topk,
+            index_kpool=self.nsa_index_kpool,
         )
         nsa_cache_seqlens_int32 = pad_nsa_cache_seqlens(
             forward_batch, nsa_cache_seqlens_int32
@@ -668,6 +704,55 @@ class NativeSparseAttnBackend(
             indexer_seq_lens_cpu=indexer_seq_lens_cpu,
             token_to_batch_idx=token_to_batch_idx,
         )
+
+        if self.nsa_index_kpool > 1:
+            from sglang.srt.layers.attention.nsa.kpool_plan import (
+                init_kpool_extend_metadata,
+                init_pooled_paged_mqa_metadata,
+            )
+
+            slots_per_page = getattr(
+                forward_batch.token_to_kv_pool,
+                "slots_per_page",
+                self.real_page_size // self.nsa_index_kpool,
+            )
+            if forward_batch.forward_mode.is_extend_without_speculative():
+                coordinator = getattr(
+                    forward_batch.token_to_kv_pool,
+                    "kpool_lifecycle_coordinator",
+                    None,
+                )
+                assert coordinator is not None, (
+                    "GLM-5-Next KPool requests must be initialized before prefill"
+                )
+                request_rows = [
+                    int(row)
+                    for row in forward_batch.req_pool_indices.detach().cpu().tolist()
+                ]
+                unprepared_rows = [
+                    row for row in request_rows if not coordinator.is_prepared(row)
+                ]
+                if unprepared_rows:
+                    coordinator.prepare_kpool_request(unprepared_rows)
+                metadata = init_kpool_extend_metadata(
+                    metadata,
+                    forward_batch,
+                    pool_size=self.nsa_index_kpool,
+                    real_page_size=self.real_page_size,
+                    slots_per_page=slots_per_page,
+                    topk_transform_method=topk_transform_method,
+                    full_real_page_table=metadata.real_page_table,
+                    full_seqlens_expanded=seqlens_expanded,
+                )
+            elif forward_batch.forward_mode.is_decode_or_idle():
+                metadata = init_pooled_paged_mqa_metadata(
+                    metadata,
+                    metadata.cache_seqlens_int32,
+                    forward_batch.forward_mode,
+                    pool_size=self.nsa_index_kpool,
+                    real_page_size=self.real_page_size,
+                    slots_per_page=slots_per_page,
+                )
         self.forward_metadata = metadata
 
     def _cal_indexer_k_start_end(
@@ -814,7 +899,9 @@ class NativeSparseAttnBackend(
             # NOTE(dark): this is always arange, since we are decoding
             cu_seqlens_q = self.decode_cuda_graph_metadata["cu_seqlens_q"][: bs + 1]
             nsa_cache_seqlens_int32 = compute_nsa_seqlens(
-                cache_seqlens_int32, nsa_index_topk=self.nsa_index_topk
+                cache_seqlens_int32,
+                nsa_index_topk=self.nsa_index_topk,
+                index_kpool=self.nsa_index_kpool,
             )
 
             seqlens_expanded = cache_seqlens_int32
@@ -874,7 +961,9 @@ class NativeSparseAttnBackend(
                 ]
             )
             nsa_cache_seqlens_int32 = compute_nsa_seqlens(
-                seqlens_expanded, nsa_index_topk=self.nsa_index_topk
+                seqlens_expanded,
+                nsa_index_topk=self.nsa_index_topk,
+                index_kpool=self.nsa_index_kpool,
             )
             nsa_extend_seq_lens_list = [1] * bs * self.speculative_num_draft_tokens
 
@@ -974,7 +1063,9 @@ class NativeSparseAttnBackend(
             page_indices = self.req_to_token[req_pool_indices, :max_len]
             metadata.page_table_1[:, :max_len].copy_(page_indices)
             nsa_cache_seqlens = compute_nsa_seqlens(
-                cache_seqlens, nsa_index_topk=self.nsa_index_topk
+                cache_seqlens,
+                nsa_index_topk=self.nsa_index_topk,
+                index_kpool=self.nsa_index_kpool,
             )
             metadata.nsa_cache_seqlens_int32.copy_(nsa_cache_seqlens)
             seqlens_expanded = cache_seqlens
@@ -1018,7 +1109,9 @@ class NativeSparseAttnBackend(
             )
             metadata.nsa_seqlens_expanded.copy_(seqlens_expanded)
             nsa_cache_seqlens = compute_nsa_seqlens(
-                seqlens_expanded, self.nsa_index_topk
+                seqlens_expanded,
+                self.nsa_index_topk,
+                index_kpool=self.nsa_index_kpool,
             )
             metadata.nsa_cache_seqlens_int32.copy_(nsa_cache_seqlens)
         elif forward_mode.is_draft_extend(include_v2=True):
@@ -1059,7 +1152,9 @@ class NativeSparseAttnBackend(
                 seqlens_expanded
             )
             nsa_cache_seqlens = compute_nsa_seqlens(
-                seqlens_expanded, self.nsa_index_topk
+                seqlens_expanded,
+                self.nsa_index_topk,
+                index_kpool=self.nsa_index_kpool,
             )
             metadata.nsa_cache_seqlens_int32[: seqlens_expanded.shape[0]].copy_(
                 nsa_cache_seqlens
@@ -1336,6 +1431,7 @@ class NativeSparseAttnBackend(
                 cos_sin_cache,
                 is_neox,
                 llama_4_scaling,
+                is_prefill=self.is_glm5_next,
             )
 
         if k is not None:
@@ -1892,33 +1988,43 @@ class NativeSparseAttnBackend(
         cos_sin_cache: Optional[torch.Tensor] = None,
         is_neox: Optional[bool] = False,
         llama_4_scaling: Optional[torch.Tensor] = None,
+        is_prefill: bool = False,
     ) -> torch.Tensor:
         """Forward using TRT-LLM sparse MLA kernel."""
         import flashinfer.decode
 
         metadata = self.forward_metadata
 
-        merge_query = q_rope is not None
+        merge_query = q_rope is not None and self.qk_rope_head_dim > 0
         if self.kv_cache_dtype == torch.float8_e4m3fn:
             # For FP8 path, we quantize the query and rope parts and merge them into a single tensor
             # Note: rope application in deepseek_v2.py:forward_absorb_prepare is skipped for FP8 decode path of this trtllm_mla backend
             assert q_rope is not None, "For FP8 path q_rope should not be None."
             assert k_rope is not None, "For FP8 path k_rope should not be None."
-            assert (
-                cos_sin_cache is not None
-            ), "For FP8 path cos_sin_cache should not be None."
-
-            q, k, k_rope = mla_quantize_and_rope_for_fp8(
-                q,
-                q_rope,
-                k.squeeze(1),
-                k_rope.squeeze(1),
-                forward_batch.positions,
-                cos_sin_cache,
-                is_neox,
-                self.kv_lora_rank,
-                self.qk_rope_head_dim,
-            )
+            if cos_sin_cache is None:
+                assert self.qk_rope_head_dim == 0, (
+                    "missing RoPE cache is valid only for zero-RoPE MLA"
+                )
+                q, k, k_rope = mla_quantize_for_fp8_no_rope(
+                    q,
+                    q_rope,
+                    k.squeeze(1),
+                    k_rope.squeeze(1),
+                    self.kv_lora_rank,
+                    self.qk_rope_head_dim,
+                )
+            else:
+                q, k, k_rope = mla_quantize_and_rope_for_fp8(
+                    q,
+                    q_rope,
+                    k.squeeze(1),
+                    k_rope.squeeze(1),
+                    forward_batch.positions,
+                    cos_sin_cache,
+                    is_neox,
+                    self.kv_lora_rank,
+                    self.qk_rope_head_dim,
+                )
             merge_query = False
 
             # Save KV cache if requested
@@ -1953,6 +2059,13 @@ class NativeSparseAttnBackend(
 
         if envs.SGLANG_NSA_FUSE_TOPK.get():
             page_table_1 = topk_indices
+        elif is_prefill:
+            page_table_1 = transform_index_page_table_prefill(
+                page_table=metadata.page_table_1,
+                topk_indices=topk_indices,
+                extend_lens_cpu=metadata.nsa_extend_seq_lens_list,
+                page_size=1,
+            )
         else:
             page_table_1 = transform_index_page_table_decode(
                 page_table=metadata.page_table_1,
@@ -1960,6 +2073,33 @@ class NativeSparseAttnBackend(
                 page_size=1,
             )
 
+        sparse_mla_top_k = page_table_1.shape[-1]
+        if self.is_glm5_next:
+            expected_top_k = self.nsa_index_topk + self.nsa_index_kpool - 1
+            if sparse_mla_top_k != expected_top_k:
+                raise RuntimeError(
+                    "GLM-5-Next sparse MLA requires all 2048 pooled-history "
+                    f"indices plus three tail indices ({expected_top_k} total), "
+                    f"got {sparse_mla_top_k}"
+                )
+        padded_sparse_mla_top_k = ((sparse_mla_top_k + 3) // 4) * 4
+        if padded_sparse_mla_top_k != sparse_mla_top_k:
+            page_table_1 = torch.cat(
+                [
+                    page_table_1,
+                    torch.full(
+                        (
+                            page_table_1.shape[0],
+                            padded_sparse_mla_top_k - sparse_mla_top_k,
+                        ),
+                        -1,
+                        dtype=page_table_1.dtype,
+                        device=page_table_1.device,
+                    ),
+                ],
+                dim=1,
+            )
+        sparse_mla_top_k = padded_sparse_mla_top_k
         q_scale = 1.0
         k_scale = (
             layer.k_scale_float
@@ -1967,6 +2107,18 @@ class NativeSparseAttnBackend(
             else 1.0
         )
         bmm1_scale = q_scale * k_scale * layer.scaling
+
+        if self.is_glm5_next:
+            # FlashInfer <=0.6.16 has no native H512 ABI; 0.6.17 adds it for
+            # TRTLLM-GEN architectures but still reports "Unsupported
+            # architecture" on SM120.  Keep the exact GLM eager path correct
+            # without upgrading the global dependency used by existing models.
+            return glm5_next_sparse_mla_reference(
+                query=q_all,
+                kv_cache=kv_cache,
+                indices=page_table_1,
+                sm_scale=bmm1_scale,
+            )
 
         batch_size = page_table_1.shape[0]
         _, num_heads, head_dim = q_all.shape
@@ -1986,7 +2138,7 @@ class NativeSparseAttnBackend(
             block_tables=block_tables,
             seq_lens=seq_lens,
             max_seq_len=metadata.max_seq_len_k,
-            sparse_mla_top_k=self.nsa_index_topk,
+            sparse_mla_top_k=sparse_mla_top_k,
             bmm1_scale=bmm1_scale,
             backend="trtllm-gen",
         )

--- a/python/sglang/srt/layers/attention/utils.py
+++ b/python/sglang/srt/layers/attention/utils.py
@@ -409,6 +409,28 @@ def mla_quantize_and_rope_for_fp8(
     return q_out, k_nope_out, k_rope_out
 
 
+def mla_quantize_for_fp8_no_rope(
+    q_nope: torch.Tensor,
+    q_rope: torch.Tensor,
+    k_nope: torch.Tensor,
+    k_rope: torch.Tensor,
+    kv_lora_rank: int,
+    qk_rope_head_dim: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Quantize an MLA query/cache when the configured RoPE width is zero."""
+
+    q_len, num_heads = q_rope.shape[:2]
+    q_out = q_rope.new_empty(
+        q_len,
+        num_heads,
+        kv_lora_rank + qk_rope_head_dim,
+        dtype=fp8_dtype,
+    )
+    q_out[..., :kv_lora_rank] = q_nope.to(fp8_dtype)
+    q_out[..., kv_lora_rank:] = q_rope.to(fp8_dtype)
+    return q_out, k_nope.to(fp8_dtype), k_rope.to(fp8_dtype)
+
+
 def concat_mla_absorb_q_general(q_nope, q_rope):
     if _is_cuda and q_nope.shape[-1] == 512 and q_rope.shape[-1] == 64:
         return concat_mla_absorb_q(q_nope, q_rope)

--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -237,9 +237,14 @@ class AttnTpContext:
         flag = self.use_input_scattered(forward_batch)
         old_flag = self.input_scattered
         self.input_scattered_ = flag
-        yield
-        self.input_scattered_ = old_flag
-        self.attn_inputs_ = None
+        try:
+            yield
+        finally:
+            # Attention inputs can retain the current batch and its latent
+            # tensors.  Always restore/clear them, including when a model
+            # layer raises during forward.
+            self.input_scattered_ = old_flag
+            self.attn_inputs_ = None
 
 
 ATTN_TP_CONTEXT = AttnTpContext()

--- a/python/sglang/srt/layers/communicator_mhc.py
+++ b/python/sglang/srt/layers/communicator_mhc.py
@@ -1,0 +1,352 @@
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0
+"""Minimal non-CP mHC layer communicator for GLM-5-Next.
+
+This module deliberately supports the first bring-up topology only:
+``attention DP == 1`` and ``attention CP == 1``.  It reuses the existing
+communicator's TP decisions and replaces only the pre/post residual algebra.
+DP/CP buffer sizing and hybrid-CP routing remain separate integration seams.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import partial
+from typing import Callable, Optional
+
+import torch
+
+from sglang.kernels.ops.layernorm.mhc import hc_contract, hc_expand
+from sglang.srt.distributed import tensor_model_parallel_all_reduce
+from sglang.srt.layers.communicator import (
+    AttentionInputs,
+    CommunicateContext,
+    CommunicateSimpleFn,
+    CommunicateSummableTensorPairFn,
+    CommunicateWithAllReduceAndLayerNormFn,
+    LayerCommunicator,
+    LayerScatterModes,
+    ScatterMode,
+    get_attn_tp_context,
+)
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+
+
+@dataclass
+class MHCState:
+    """Parameter-free runtime state shared by attention and FFN mHC stages."""
+
+    hc_mult: int
+    hc_attn_pre: Callable
+    hc_ffn_pre: Callable
+    hc_post: Callable
+    h_res: Optional[torch.Tensor] = None
+    h_post: Optional[torch.Tensor] = None
+
+    @staticmethod
+    def _resolve_out_norm(out_norm):
+        if out_norm is None:
+            return None, None
+        return out_norm.weight.data, out_norm.variance_epsilon
+
+    @staticmethod
+    def _apply_unfused_norm(hidden_states, out_norm, norm_fused):
+        if out_norm is not None and not norm_fused and hidden_states.shape[0] != 0:
+            return out_norm(hidden_states)
+        return hidden_states
+
+    def attn_split(
+        self,
+        hidden_states: torch.Tensor,
+        out_norm: Optional[torch.nn.Module] = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        residual = hidden_states
+        out_norm_weight, out_norm_eps = self._resolve_out_norm(out_norm)
+        hidden_states, self.h_res, self.h_post, norm_fused = self.hc_attn_pre(
+            hidden_states, out_norm_weight, out_norm_eps
+        )
+        hidden_states = self._apply_unfused_norm(hidden_states, out_norm, norm_fused)
+        return hidden_states, residual
+
+    def attn_to_mlp(
+        self,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor,
+        out_norm: Optional[torch.nn.Module] = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        assert self.h_res is not None and self.h_post is not None
+        hidden_states = self.hc_post(hidden_states, residual, self.h_res, self.h_post)
+        residual = hidden_states
+        out_norm_weight, out_norm_eps = self._resolve_out_norm(out_norm)
+        hidden_states, self.h_res, self.h_post, norm_fused = self.hc_ffn_pre(
+            hidden_states, out_norm_weight, out_norm_eps
+        )
+        hidden_states = self._apply_unfused_norm(hidden_states, out_norm, norm_fused)
+        return hidden_states, residual
+
+    def mlp_combine(
+        self, hidden_states: torch.Tensor, residual: torch.Tensor
+    ) -> torch.Tensor:
+        assert self.h_res is not None and self.h_post is not None
+        return self.hc_post(hidden_states, residual, self.h_res, self.h_post)
+
+    def reset_aux(self) -> None:
+        self.h_res = None
+        self.h_post = None
+
+
+class MHCCommunicateWithAllReduceAndLayerNormFn(CommunicateWithAllReduceAndLayerNormFn):
+    """Non-CP replacements for attention-output communication."""
+
+    @staticmethod
+    def get_fn(
+        hidden_states_input_mode: ScatterMode,
+        residual_input_mode: ScatterMode,
+        hidden_states_output_mode: ScatterMode,
+        residual_output_mode: ScatterMode,
+        context: CommunicateContext,
+    ):
+        fn = CommunicateWithAllReduceAndLayerNormFn.get_fn(
+            hidden_states_input_mode,
+            residual_input_mode,
+            hidden_states_output_mode,
+            residual_output_mode,
+            context,
+        )
+        replacements = {
+            CommunicateWithAllReduceAndLayerNormFn._simple: (
+                MHCCommunicateWithAllReduceAndLayerNormFn._simple
+            ),
+            CommunicateWithAllReduceAndLayerNormFn._gather_hidden_states_and_residual: (
+                MHCCommunicateWithAllReduceAndLayerNormFn._gather_hidden_states_and_residual
+            ),
+        }
+        base_fn = fn.func if isinstance(fn, partial) else fn
+        replacement = replacements.get(base_fn)
+        if replacement is None:
+            raise NotImplementedError(
+                "minimal MHCLayerCommunicator does not support scattered/DP/CP "
+                f"mode transition via {getattr(base_fn, '__name__', base_fn)}"
+            )
+        if isinstance(fn, partial):
+            return partial(replacement, *fn.args, **(fn.keywords or {}))
+        return replacement
+
+    @staticmethod
+    def _simple(
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor,
+        forward_batch: ForwardBatch,
+        layernorm: torch.nn.Module,
+        context: CommunicateContext,
+        *,
+        mhc: MHCState,
+    ):
+        del forward_batch, context
+        return mhc.attn_to_mlp(hidden_states, residual, out_norm=layernorm)
+
+    @staticmethod
+    def _gather_hidden_states_and_residual(
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor,
+        forward_batch: ForwardBatch,
+        layernorm: torch.nn.Module,
+        context: CommunicateContext,
+        *,
+        residual_input_mode,
+        mhc: MHCState,
+    ):
+        del forward_batch
+        assert context.attn_dp_size == 1 and context.attn_cp_size == 1
+        if residual_input_mode == ScatterMode.SCATTERED:
+            raise NotImplementedError(
+                "minimal MHCLayerCommunicator requires an unscattered residual"
+            )
+        hidden_states = tensor_model_parallel_all_reduce(hidden_states)
+        return mhc.attn_to_mlp(hidden_states, residual, out_norm=layernorm)
+
+
+class MHCCommunicateSummableTensorPairFn(CommunicateSummableTensorPairFn):
+    """mHC replacement for the ordinary no-scatter layer-output transition."""
+
+    @staticmethod
+    def get_fn(
+        hidden_states_input_mode: ScatterMode,
+        residual_input_mode: ScatterMode,
+        output_mode: ScatterMode,
+        context: CommunicateContext,
+    ):
+        fn = CommunicateSummableTensorPairFn.get_fn(
+            hidden_states_input_mode,
+            residual_input_mode,
+            output_mode,
+            context,
+        )
+        if fn is not CommunicateSummableTensorPairFn._trivial:
+            raise NotImplementedError(
+                "minimal MHCLayerCommunicator does not support DP/CP/scattered "
+                f"layer output via {getattr(fn, '__name__', fn)}"
+            )
+        return MHCCommunicateSummableTensorPairFn._trivial
+
+    @staticmethod
+    def _trivial(
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor,
+        forward_batch: ForwardBatch,
+        context: CommunicateContext,
+        *,
+        mhc: MHCState,
+        is_last_layer: bool,
+        **kwargs,
+    ):
+        del forward_batch, context, kwargs
+        hidden_states = mhc.mlp_combine(hidden_states, residual)
+        if is_last_layer:
+            hidden_states = hc_contract(hidden_states, mhc.hc_mult)
+        return hidden_states, None
+
+
+class MHCLayerCommunicator(LayerCommunicator):
+    """Explicitly selected mHC communicator for TP-only, non-CP execution."""
+
+    def __init__(
+        self,
+        layer_scatter_modes: LayerScatterModes,
+        input_layernorm: torch.nn.Module,
+        post_attention_layernorm: torch.nn.Module,
+        allow_reduce_scatter: bool = False,
+        is_last_layer: bool = False,
+        qkv_latent_func: Optional[Callable] = None,
+        *,
+        is_first_layer: bool,
+        hc_mult: int,
+        hc_attn_pre: Callable,
+        hc_ffn_pre: Callable,
+        hc_post: Callable,
+    ):
+        self.is_first_layer = is_first_layer
+        self.mhc = MHCState(
+            hc_mult=hc_mult,
+            hc_attn_pre=hc_attn_pre,
+            hc_ffn_pre=hc_ffn_pre,
+            hc_post=hc_post,
+        )
+        super().__init__(
+            layer_scatter_modes,
+            input_layernorm,
+            post_attention_layernorm,
+            allow_reduce_scatter,
+            is_last_layer,
+            qkv_latent_func,
+        )
+
+    def _post_init_communicate(self):
+        if self._context.attn_dp_size != 1 or self._context.attn_cp_size != 1:
+            raise NotImplementedError(
+                "minimal MHCLayerCommunicator requires attention DP=1 and CP=1"
+            )
+        self._communicate_simple_fn = CommunicateSimpleFn.get_fn(
+            input_mode=self.layer_scatter_modes.layer_input_mode,
+            output_mode=self.layer_scatter_modes.attn_mode,
+            context=self._context,
+        )
+        self._communicate_with_all_reduce_and_layer_norm_fn = (
+            MHCCommunicateWithAllReduceAndLayerNormFn.get_fn(
+                hidden_states_input_mode=self.layer_scatter_modes.attn_mode,
+                residual_input_mode=self.layer_scatter_modes.layer_input_mode,
+                hidden_states_output_mode=self.layer_scatter_modes.mlp_mode,
+                residual_output_mode=self.layer_scatter_modes.middle_residual_mode,
+                context=self._context,
+            )
+        )
+        self._communicate_summable_tensor_pair_fn = (
+            MHCCommunicateSummableTensorPairFn.get_fn(
+                hidden_states_input_mode=self.layer_scatter_modes.mlp_mode,
+                residual_input_mode=self.layer_scatter_modes.middle_residual_mode,
+                output_mode=self.layer_scatter_modes.layer_output_mode,
+                context=self._context,
+            )
+        )
+
+    def _assert_non_scattered(self) -> None:
+        if get_attn_tp_context().input_scattered:
+            raise NotImplementedError(
+                "minimal MHCLayerCommunicator does not support scattered TP input"
+            )
+
+    def prepare_attn(
+        self,
+        hidden_states: torch.Tensor,
+        residual: Optional[torch.Tensor],
+        forward_batch: ForwardBatch,
+        quant_format: str = "",
+        post_residual_addition: Optional[torch.Tensor] = None,
+    ):
+        del residual, quant_format
+        assert post_residual_addition is None
+        self._assert_non_scattered()
+        if self.is_first_layer:
+            hidden_states = hc_expand(hidden_states, self.mhc.hc_mult)
+
+        hidden_states, residual = self.mhc.attn_split(
+            hidden_states, out_norm=self.input_layernorm
+        )
+        hidden_states = self._communicate_simple_fn(
+            hidden_states=hidden_states,
+            forward_batch=forward_batch,
+            context=self._context,
+        )
+        if self.qkv_latent_func is not None:
+            get_attn_tp_context().set_attn_inputs(
+                AttentionInputs(hidden_states, forward_batch, self.qkv_latent_func)
+            )
+        return hidden_states, residual
+
+    def prepare_mlp(
+        self,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor,
+        forward_batch: ForwardBatch,
+        cache=None,
+    ):
+        self._assert_non_scattered()
+        if cache is not None:
+            self._context.cache = cache
+        return self._communicate_with_all_reduce_and_layer_norm_fn(
+            hidden_states=hidden_states,
+            residual=residual,
+            forward_batch=forward_batch,
+            layernorm=self.post_attention_layernorm,
+            context=self._context,
+            mhc=self.mhc,
+        )
+
+    def postprocess_layer(
+        self,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor,
+        forward_batch: ForwardBatch,
+    ):
+        self._assert_non_scattered()
+        hidden_states, residual = self._communicate_summable_tensor_pair_fn(
+            hidden_states=hidden_states,
+            residual=residual,
+            forward_batch=forward_batch,
+            context=self._context,
+            allow_reduce_scatter=False,
+            mhc=self.mhc,
+            is_last_layer=self.is_last_layer,
+        )
+        self.mhc.reset_aux()
+        return hidden_states, residual
+
+    def should_fuse_mlp_allreduce_with_next_layer(
+        self, forward_batch: ForwardBatch
+    ) -> bool:
+        del forward_batch
+        return False
+
+    def should_use_reduce_scatter(self, forward_batch: ForwardBatch) -> bool:
+        del forward_batch
+        return False

--- a/python/sglang/srt/layers/communicator_mhc.py
+++ b/python/sglang/srt/layers/communicator_mhc.py
@@ -40,6 +40,7 @@ class MHCState:
     hc_attn_pre: Callable
     hc_ffn_pre: Callable
     hc_post: Callable
+    attn_all_reduce_output_dtype: Optional[torch.dtype] = None
     h_res: Optional[torch.Tensor] = None
     h_post: Optional[torch.Tensor] = None
 
@@ -75,6 +76,8 @@ class MHCState:
         out_norm: Optional[torch.nn.Module] = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         assert self.h_res is not None and self.h_post is not None
+        if self.attn_all_reduce_output_dtype is not None:
+            hidden_states = hidden_states.to(self.attn_all_reduce_output_dtype)
         hidden_states = self.hc_post(hidden_states, residual, self.h_res, self.h_post)
         residual = hidden_states
         out_norm_weight, out_norm_eps = self._resolve_out_norm(out_norm)
@@ -224,6 +227,7 @@ class MHCLayerCommunicator(LayerCommunicator):
         hc_attn_pre: Callable,
         hc_ffn_pre: Callable,
         hc_post: Callable,
+        attn_all_reduce_output_dtype: Optional[torch.dtype] = None,
     ):
         self.is_first_layer = is_first_layer
         self.mhc = MHCState(
@@ -231,6 +235,7 @@ class MHCLayerCommunicator(LayerCommunicator):
             hc_attn_pre=hc_attn_pre,
             hc_ffn_pre=hc_ffn_pre,
             hc_post=hc_post,
+            attn_all_reduce_output_dtype=attn_all_reduce_output_dtype,
         )
         super().__init__(
             layer_scatter_modes,

--- a/python/sglang/srt/layers/moe/fused_moe_triton/fused_moe.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/fused_moe.py
@@ -106,6 +106,7 @@ def inplace_fused_experts(
     gemm1_limit: Optional[float] = None,
     filter_expert: bool = True,
     swiglu_limit: Optional[float] = None,
+    glm5_next_hf_two_round_swiglu: bool = False,
 ) -> None:
     fused_experts_impl(
         hidden_states,
@@ -137,6 +138,7 @@ def inplace_fused_experts(
         gemm1_limit,
         filter_expert,
         swiglu_limit=swiglu_limit,
+        glm5_next_hf_two_round_swiglu=glm5_next_hf_two_round_swiglu,
     )
 
 
@@ -170,6 +172,7 @@ def outplace_fused_experts(
     gemm1_limit: Optional[float] = None,
     filter_expert: bool = True,
     swiglu_limit: Optional[float] = None,
+    glm5_next_hf_two_round_swiglu: bool = False,
 ) -> torch.Tensor:
     return fused_experts_impl(
         hidden_states,
@@ -201,6 +204,7 @@ def outplace_fused_experts(
         gemm1_limit=gemm1_limit,
         filter_expert=filter_expert,
         swiglu_limit=swiglu_limit,
+        glm5_next_hf_two_round_swiglu=glm5_next_hf_two_round_swiglu,
     )
 
 
@@ -260,6 +264,7 @@ def fused_experts(
             moe_runner_config.gemm1_clamp_limit,
             filter_expert,
             moe_runner_config.swiglu_limit,
+            moe_runner_config.glm5_next_hf_two_round_swiglu,
         )
         return hidden_states
     else:
@@ -292,6 +297,9 @@ def fused_experts(
             gemm1_limit=moe_runner_config.gemm1_clamp_limit,
             filter_expert=filter_expert,
             swiglu_limit=moe_runner_config.swiglu_limit,
+            glm5_next_hf_two_round_swiglu=(
+                moe_runner_config.glm5_next_hf_two_round_swiglu
+            ),
         )
 
 
@@ -365,6 +373,7 @@ def fused_experts_impl(
     gemm1_limit: Optional[float] = None,
     filter_expert: bool = True,
     swiglu_limit: Optional[float] = None,
+    glm5_next_hf_two_round_swiglu: bool = False,
 ):
     padded_size = padding_size
     if not (use_fp8_w8a8 or use_int8_w8a8) or block_shape is not None or _use_aiter:
@@ -519,7 +528,26 @@ def fused_experts_impl(
         if activation == "silu" and is_gated:
             # - gemm1_alpha != None: GPT-OSS-style swiglu(alpha, limit)
             # - gemm1_alpha == None and gemm1_limit != None: silu+clamp+mul(limit-only)
-            if gemm1_alpha is not None:
+            if glm5_next_hf_two_round_swiglu:
+                if gemm1_alpha is not None or gemm1_limit is not None:
+                    raise ValueError(
+                        "GLM-5-Next HF two-round SwiGLU is incompatible with "
+                        "gemm1_alpha/gemm1_limit"
+                    )
+                if swiglu_limit is None:
+                    raise ValueError(
+                        "GLM-5-Next HF two-round SwiGLU requires swiglu_limit"
+                    )
+                from sglang.srt.layers.moe.glm5_next_swiglu import (
+                    glm5_next_hf_two_round_swiglu as glm5_next_swiglu,
+                )
+
+                intermediate_cache2 = glm5_next_swiglu(
+                    intermediate_cache1.view(-1, N),
+                    swiglu_limit,
+                    output=intermediate_cache2,
+                )
+            elif gemm1_alpha is not None:
                 assert gemm1_limit is not None
                 intermediate_cache2 = _swiglu_gpt_oss_sigmoid_alpha(
                     intermediate_cache1.view(-1, N), gemm1_alpha, gemm1_limit

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -186,6 +186,7 @@ class FusedMoE(torch.nn.Module):
         gemm1_alpha: Optional[float] = None,
         gemm1_clamp_limit: Optional[float] = None,
         swiglu_limit: Optional[float] = None,
+        glm5_next_hf_two_round_swiglu: bool = False,
         use_weight_loader_fused: bool = False,
         with_bias=False,
         routing_method_type: Optional[RoutingMethodType] = None,
@@ -268,6 +269,7 @@ class FusedMoE(torch.nn.Module):
             gemm1_alpha=gemm1_alpha,
             gemm1_clamp_limit=gemm1_clamp_limit,
             swiglu_limit=swiglu_limit,
+            glm5_next_hf_two_round_swiglu=glm5_next_hf_two_round_swiglu,
             is_gated=is_gated,
             routing_method_type=routing_method_type,
         )

--- a/python/sglang/srt/layers/moe/glm5_next_swiglu.py
+++ b/python/sglang/srt/layers/moe/glm5_next_swiglu.py
@@ -1,0 +1,159 @@
+"""GLM-5-Next-private SwiGLU with the HF BF16 rounding contract."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+import torch.nn.functional as F
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _glm5_next_silu_to_bf16_kernel(
+    gate_up_ptr,
+    output_ptr,
+    numel,
+    HALF_WIDTH: tl.constexpr,
+    LIMIT: tl.constexpr,
+    HAS_LIMIT: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < numel
+    rows = offsets // HALF_WIDTH
+    columns = offsets - rows * HALF_WIDTH
+    gate_offsets = rows * (2 * HALF_WIDTH) + columns
+
+    gate = tl.load(gate_up_ptr + gate_offsets, mask=mask).to(tl.float32)
+    if HAS_LIMIT:
+        gate = tl.minimum(gate, LIMIT)
+    activated_gate = gate * tl.sigmoid(gate)
+
+    # output_ptr is BF16 for the exact GLM runtime.  This store is the first
+    # required rounding boundary and is intentionally consumed by a separate
+    # kernel below.
+    tl.store(output_ptr + offsets, activated_gate, mask=mask)
+
+
+@triton.jit
+def _glm5_next_bf16_mul_kernel(
+    gate_up_ptr,
+    output_ptr,
+    numel,
+    HALF_WIDTH: tl.constexpr,
+    LIMIT: tl.constexpr,
+    HAS_LIMIT: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < numel
+    rows = offsets // HALF_WIDTH
+    columns = offsets - rows * HALF_WIDTH
+    up_offsets = rows * (2 * HALF_WIDTH) + HALF_WIDTH + columns
+
+    # Reloading output_ptr observes the BF16 value materialized by stage one.
+    # The in-place store below is safe because every program owns its elements.
+    activated_gate = tl.load(output_ptr + offsets, mask=mask).to(tl.float32)
+    up = tl.load(gate_up_ptr + up_offsets, mask=mask).to(tl.float32)
+    if HAS_LIMIT:
+        up = tl.maximum(up, -LIMIT)
+        up = tl.minimum(up, LIMIT)
+    tl.store(output_ptr + offsets, activated_gate * up, mask=mask)
+
+
+def _reference_two_round_swiglu(
+    gate_up: torch.Tensor,
+    swiglu_limit: Optional[float],
+) -> torch.Tensor:
+    gate, up = gate_up.chunk(2, dim=-1)
+    if swiglu_limit is not None:
+        limit = float(swiglu_limit)
+        gate = gate.clamp(max=limit)
+        up = up.clamp(min=-limit, max=limit)
+    activated_gate = F.silu(gate)
+    return activated_gate * up
+
+
+def glm5_next_hf_two_round_swiglu(
+    gate_up: torch.Tensor,
+    swiglu_limit: Optional[float],
+    *,
+    output: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Apply GLM SwiGLU with a materialized BF16 SiLU intermediate.
+
+    The released Transformers model evaluates BF16 ``silu(gate)`` and then a
+    BF16 multiply.  A single fused pointwise kernel instead keeps SiLU in FP32
+    and rounds only after the multiply.  On CUDA BF16, these two fixed Triton
+    launches use ``output`` first as the SiLU materialization and then as the
+    final result, so no additional activation workspace is needed.  Other
+    devices and dtypes use the literal PyTorch expression.
+    """
+
+    if gate_up.shape[-1] % 2 != 0:
+        raise ValueError(
+            f"GLM-5-Next SwiGLU expects an even gate/up width, got {gate_up.shape[-1]}"
+        )
+
+    output_shape = (*gate_up.shape[:-1], gate_up.shape[-1] // 2)
+    if output is not None:
+        if output.shape != output_shape:
+            raise ValueError(
+                "GLM-5-Next SwiGLU output shape mismatch: expected "
+                f"{output_shape}, got {tuple(output.shape)}"
+            )
+        if output.device != gate_up.device or output.dtype != gate_up.dtype:
+            raise ValueError(
+                "GLM-5-Next SwiGLU output must match input device and dtype"
+            )
+
+    use_cuda_kernel = (
+        gate_up.is_cuda
+        and torch.version.hip is None
+        and gate_up.dtype == torch.bfloat16
+        and gate_up.is_contiguous()
+        and (output is None or output.is_contiguous())
+    )
+    if not use_cuda_kernel:
+        result = _reference_two_round_swiglu(gate_up, swiglu_limit)
+        if output is None:
+            return result
+        output.copy_(result)
+        return output
+
+    if output is None:
+        output = torch.empty(output_shape, dtype=gate_up.dtype, device=gate_up.device)
+    if output.numel() == 0:
+        return output
+
+    gate_up_2d = gate_up.view(-1, gate_up.shape[-1])
+    output_2d = output.view(-1, output.shape[-1])
+    half_width = output_2d.shape[-1]
+    numel = output_2d.numel()
+    limit = 0.0 if swiglu_limit is None else float(swiglu_limit)
+    grid = (triton.cdiv(numel, 256),)
+
+    _glm5_next_silu_to_bf16_kernel[grid](
+        gate_up_2d,
+        output_2d,
+        numel,
+        HALF_WIDTH=half_width,
+        LIMIT=limit,
+        HAS_LIMIT=swiglu_limit is not None,
+        BLOCK_SIZE=256,
+    )
+    _glm5_next_bf16_mul_kernel[grid](
+        gate_up_2d,
+        output_2d,
+        numel,
+        HALF_WIDTH=half_width,
+        LIMIT=limit,
+        HAS_LIMIT=swiglu_limit is not None,
+        BLOCK_SIZE=256,
+    )
+    return output
+
+
+__all__ = ["glm5_next_hf_two_round_swiglu"]

--- a/python/sglang/srt/layers/moe/kt_ep_wrapper.py
+++ b/python/sglang/srt/layers/moe/kt_ep_wrapper.py
@@ -5326,13 +5326,16 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
             if forward_mode_name not in ("EXTEND", "DECODE", "IDLE"):
                 raise RuntimeError(
                     "GLM-5-Next FP8 layerwise prefill supports only plain "
-                    "EXTEND (text layerwise or image hybrid) and bypasses "
+                    "EXTEND (text layerwise or multimodal hybrid) and bypasses "
                     "only DECODE/IDLE; got "
                     f"ForwardMode.{forward_mode_name}"
                 )
             if forward_mode_name == "EXTEND":
-                if bool(getattr(self, "_glm5_next_has_image_inputs", False)):
-                    # Keep the complete image EXTEND batch on the accepted
+                if bool(
+                    getattr(self, "_glm5_next_force_hybrid_prefill", False)
+                    or getattr(self, "_glm5_next_has_image_inputs", False)
+                ):
+                    # Keep the complete multimodal EXTEND batch on the accepted
                     # CPU/hybrid route; multimodal batches must not enter the
                     # text-only generic full-layer loader.
                     self._glm5_next_mm_hybrid_extend_count = (
@@ -5340,7 +5343,7 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
                     )
                     if self.tp_rank == 0 and self.kt_config.layer_idx in (3, 44):
                         logger.info(
-                            "GLM-5-Next image EXTEND bypasses FP8 layerwise "
+                            "GLM-5-Next multimodal EXTEND bypasses FP8 layerwise "
                             "prefill: layer=%d count=%d",
                             self.kt_config.layer_idx,
                             self._glm5_next_mm_hybrid_extend_count,

--- a/python/sglang/srt/layers/moe/kt_ep_wrapper.py
+++ b/python/sglang/srt/layers/moe/kt_ep_wrapper.py
@@ -25,6 +25,11 @@ Diagnostic / escape-hatch environment variables (KT-DEBUG-ONLY; not for prod):
         Force GPU-experts apply() to a zero return; routed expert output
         comes purely from the CPU side. "Plan-C" fallback for diagnosing
         whether a regression sits in the GPU MoE path or the merge math.
+
+    SGLANG_KT_GLM5_NEXT_FP8_TRANSPORT=auto|native|legacy
+        Select the exact GLM-5-Next TP4 block-FP8 layer transport. ``auto``
+        uses the native batch API when present and otherwise falls back before
+        the first load; a native runtime failure never falls back.
 """
 
 import bisect
@@ -36,6 +41,7 @@ import logging
 import os
 import time
 import uuid
+from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass, replace
 from multiprocessing import shared_memory
 from pathlib import Path
@@ -76,6 +82,45 @@ logger = logging.getLogger(__name__)
 
 # Global cache for GPU experts masks (initialized once per session)
 _KT_GPU_EXPERTS_MASKS: Optional[torch.Tensor] = None
+
+_GLM5_NEXT_FP8_TRANSPORT_ENV = "SGLANG_KT_GLM5_NEXT_FP8_TRANSPORT"
+_GLM5_NEXT_FP8_TRANSPORT_MODES = frozenset(("auto", "native", "legacy"))
+_GLM5_NEXT_FP8_CONTROL_BYTES = 4096
+_GLM5_NEXT_FP8_TRANSPORT_TIMEOUT_MS = 60_000
+_GLM5_NEXT_FP8_MOE_LAYER_INDICES = tuple(range(3, 45))
+
+
+def _glm5_next_fp8_transport_mode() -> str:
+    """Return the requested GLM transport without silently accepting typos."""
+
+    mode = os.environ.get(_GLM5_NEXT_FP8_TRANSPORT_ENV, "auto").strip().lower()
+    if mode not in _GLM5_NEXT_FP8_TRANSPORT_MODES:
+        raise ValueError(
+            f"{_GLM5_NEXT_FP8_TRANSPORT_ENV} must be one of "
+            f"{sorted(_GLM5_NEXT_FP8_TRANSPORT_MODES)}, got {mode!r}"
+        )
+    return mode
+
+
+def _load_glm5_next_fp8_native_transport_api():
+    """Feature-probe the optional native transport before allocating resources."""
+
+    try:
+        from kt_kernel import kt_kernel_ext
+    except ImportError as exc:
+        return None, f"kt_kernel_ext import failed: {exc}"
+
+    missing = [
+        name
+        for name in (
+            "initialize_fp8_layerwise_control",
+            "FP8LayerwiseTransport",
+        )
+        if not hasattr(kt_kernel_ext, name)
+    ]
+    if missing:
+        return None, "kt_kernel_ext is missing " + ", ".join(missing)
+    return kt_kernel_ext, None
 
 
 @dataclass
@@ -293,6 +338,11 @@ _SHARED_STAGING_BUFFER = None  # Global shared staging buffer for all MoE layers
 _MXFP4_PREFILL_LAYER_REGISTRY = {}
 _MXFP4_LAYERWISE_MANAGERS = {}
 _MXFP4_LAYERWISE_DISABLED_REASONS = {}
+# Exact GLM-5-Next block-FP8 has a deliberately separate registry/control
+# plane.  Registration is harmless for ``legacy`` transport, while manager
+# construction is hard-gated on the native TP4/gpu_experts=0 runtime below.
+_GLM5_NEXT_FP8_NATIVE_PREFETCH_LAYER_REGISTRY = {}
+_GLM5_NEXT_FP8_NATIVE_PREFETCH_MANAGERS = {}
 
 
 class SharedStagingBuffer:
@@ -787,6 +837,8 @@ class SharedFullContext:
     def _cleanup_cpu_buffers_after_failure(self) -> None:
         """Best-effort symmetric cleanup for a failed SHM setup phase."""
 
+        self._close_glm5_next_fp8_transport()
+
         if torch.cuda.is_available():
             for tensor in getattr(self, "_registered_host_buffers", []):
                 try:
@@ -818,6 +870,18 @@ class SharedFullContext:
             except Exception:
                 pass
         self.shm_handles = {}
+
+    def close(self) -> None:
+        """Stop native workers before releasing their Host-buffer mappings."""
+
+        self._cleanup_cpu_buffers_after_failure()
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            # Interpreter shutdown can tear down torch and logging first.
+            pass
 
     def _commit_cpu_buffer_phase(
         self, local_error: Optional[Exception], phase: str
@@ -1162,8 +1226,301 @@ class SharedFullContext:
         w13_p.set_(w13_p.view(num_experts, w13_k // 16, w13_n * (num_bits // 2)))
         w2_p.set_(w2_p.view(num_experts, w2_k // 16, w2_n * (num_bits // 2)))
 
-    def _initialize_glm5_next_fp8_transport(self) -> None:
-        """Create the exact-GLM transport resources once per shared context."""
+    def _close_glm5_next_fp8_transport(self) -> None:
+        """Best-effort teardown; native workers must stop before SHM closes."""
+
+        # A successor task may be blocked in an event fence or native
+        # join/run/wait.  It owns the last possible access to both the Host
+        # slots and transport handle, so join it before closing either.
+        prefetch_manager = getattr(
+            self, "_glm5_next_fp8_native_prefetch_manager", None
+        )
+        self._glm5_next_fp8_native_prefetch_manager = None
+        if prefetch_manager is not None:
+            try:
+                prefetch_manager.close()
+            except Exception:
+                pass
+
+        transport = getattr(self, "_glm5_next_fp8_native_transport", None)
+        self._glm5_next_fp8_native_transport = None
+        if transport is not None:
+            try:
+                transport.close()
+            except Exception:
+                pass
+
+        if getattr(self, "_glm5_next_fp8_transport_backend", None) == "legacy":
+            copy_stream = getattr(self, "_glm5_next_fp8_copy_stream", None)
+            if copy_stream is not None:
+                try:
+                    copy_stream.synchronize()
+                except Exception:
+                    pass
+
+        control_shm = getattr(self, "_glm5_next_fp8_control_shm", None)
+        self._glm5_next_fp8_control_shm = None
+        if control_shm is not None:
+            if getattr(self, "_glm5_next_fp8_control_owner", False):
+                try:
+                    control_shm.unlink()
+                except FileNotFoundError:
+                    pass
+                except Exception:
+                    pass
+            try:
+                control_shm.close()
+            except Exception:
+                pass
+
+        self._glm5_next_fp8_transport_initialized = False
+        self._glm5_next_fp8_transport_backend = None
+
+    @staticmethod
+    def _tp_all_gather_object(value):
+        if (
+            not dist.is_initialized()
+            or get_tensor_model_parallel_world_size() == 1
+        ):
+            return [value]
+        values = [None] * get_tensor_model_parallel_world_size()
+        dist.all_gather_object(
+            values, value, group=get_tp_group().cpu_group
+        )
+        return values
+
+    def _glm5_next_fp8_pointer_layout(self):
+        """Build the ABI-ordered raw pointer arrays consumed by native code."""
+
+        names = tuple(self.WEIGHT_NAMES_FP8)
+        tp_rank = get_tensor_model_parallel_rank()
+        tp_size = get_tensor_model_parallel_world_size()
+        expert_nbytes = [
+            self.cpu_buffers[name].numel()
+            // 2
+            * self.cpu_buffers[name].element_size()
+            for name in names
+        ]
+        local_host_ptrs = [
+            int(self.cpu_buffers[name].data_ptr() + slot * expert_nbytes[index])
+            for slot in range(2)
+            for index, name in enumerate(names)
+        ]
+        gpu_tensors = [getattr(self.gpu_layer, name) for name in names]
+        for index, (name, tensor) in enumerate(zip(names, gpu_tensors)):
+            if not tensor.is_contiguous():
+                raise RuntimeError(
+                    "GLM-5-Next native transport requires expert-major "
+                    f"contiguous GPU tensor {name}, got stride={tensor.stride()}"
+                )
+            if tensor.shape[0] != self.gpu_layer.num_experts:
+                raise RuntimeError(
+                    "GLM-5-Next native transport GPU tensor has an invalid "
+                    f"expert axis: {name} shape={tuple(tensor.shape)}"
+                )
+            expected_nbytes = expert_nbytes[index]
+            actual_nbytes = tensor.numel() // tensor.shape[0] * tensor.element_size()
+            if actual_nbytes != expected_nbytes:
+                raise RuntimeError(
+                    "GLM-5-Next native transport Host/GPU expert stride "
+                    f"mismatch for {name}: host={expected_nbytes}, gpu={actual_nbytes}"
+                )
+        local_gpu_ptrs = [int(tensor.data_ptr()) for tensor in gpu_tensors]
+        all_rank_host_ptrs = []
+        if tp_rank == 0:
+            all_rank_host_ptrs = [
+                int(
+                    self.all_rank_buffer_ptrs[name][rank]
+                    + slot * expert_nbytes[index]
+                )
+                for slot in range(2)
+                for rank in range(tp_size)
+                for index, name in enumerate(names)
+            ]
+
+        if len(local_host_ptrs) != 8 or len(local_gpu_ptrs) != 4:
+            raise RuntimeError("invalid GLM-5-Next native pointer layout")
+        if tp_rank == 0 and len(all_rank_host_ptrs) != 2 * tp_size * 4:
+            raise RuntimeError("invalid GLM-5-Next all-rank Host pointer layout")
+        if any(pointer <= 0 for pointer in local_host_ptrs + local_gpu_ptrs):
+            raise RuntimeError("GLM-5-Next native transport received a null pointer")
+        if tp_rank == 0 and any(pointer <= 0 for pointer in all_rank_host_ptrs):
+            raise RuntimeError(
+                "GLM-5-Next native transport could not map every TP Host slot"
+            )
+        return (
+            local_host_ptrs,
+            local_gpu_ptrs,
+            all_rank_host_ptrs,
+            expert_nbytes,
+        )
+
+    def _initialize_glm5_next_fp8_native_transport(self, kt_kernel_ext) -> None:
+        tp_rank = get_tensor_model_parallel_rank()
+        tp_size = get_tensor_model_parallel_world_size()
+        control_name = f"kt_glm5_next_fp8_ctrl_{self.shm_unique_id}"
+        self._glm5_next_fp8_control_shm = None
+        self._glm5_next_fp8_control_owner = tp_rank == 0
+        self._glm5_next_fp8_native_transport = None
+
+        create_error = None
+        if tp_rank == 0:
+            try:
+                control_shm = shared_memory.SharedMemory(
+                    name=control_name,
+                    create=True,
+                    size=_GLM5_NEXT_FP8_CONTROL_BYTES,
+                )
+                self._glm5_next_fp8_control_shm = control_shm
+                control_ptr = ctypes.addressof(
+                    ctypes.c_char.from_buffer(control_shm.buf)
+                )
+                kt_kernel_ext.initialize_fp8_layerwise_control(
+                    control_ptr,
+                    _GLM5_NEXT_FP8_CONTROL_BYTES,
+                    tp_size,
+                )
+            except Exception as exc:
+                create_error = exc
+        self._commit_cpu_buffer_phase(create_error, "native control creation")
+
+        map_error = None
+        if tp_rank != 0:
+            try:
+                self._glm5_next_fp8_control_shm = shared_memory.SharedMemory(
+                    name=control_name,
+                    create=False,
+                )
+            except Exception as exc:
+                map_error = exc
+        self._commit_cpu_buffer_phase(map_error, "native control mapping")
+
+        handle_error = None
+        try:
+            control_shm = self._glm5_next_fp8_control_shm
+            if control_shm is None:
+                raise RuntimeError("native control SHM is not mapped")
+            control_ptr = ctypes.addressof(
+                ctypes.c_char.from_buffer(control_shm.buf)
+            )
+            (
+                local_host_ptrs,
+                local_gpu_ptrs,
+                all_rank_host_ptrs,
+                expert_nbytes,
+            ) = self._glm5_next_fp8_pointer_layout()
+            device = self.gpu_layer.w13_weight.device
+            cuda_device = (
+                device.index
+                if device.index is not None
+                else torch.cuda.current_device()
+            )
+            self._glm5_next_fp8_native_transport = (
+                kt_kernel_ext.FP8LayerwiseTransport(
+                    control_ptr,
+                    _GLM5_NEXT_FP8_CONTROL_BYTES,
+                    tp_rank,
+                    tp_size,
+                    cuda_device,
+                    local_host_ptrs,
+                    local_gpu_ptrs,
+                    all_rank_host_ptrs,
+                    expert_nbytes,
+                    self.gpu_layer.num_experts,
+                    _GLM5_NEXT_FP8_TRANSPORT_TIMEOUT_MS,
+                )
+            )
+            # The native handle stores these destination addresses for its
+            # lifetime.  Exact-native loads reject any later rebind instead
+            # of silently writing an obsolete allocation.
+            self._glm5_next_fp8_native_gpu_ptrs = tuple(local_gpu_ptrs)
+        except Exception as exc:
+            handle_error = exc
+        self._commit_cpu_buffer_phase(handle_error, "native handle creation")
+
+        # Every process now owns a mapping. Remove the name immediately so a
+        # crashed server cannot strand a persistent control object in /dev/shm.
+        if tp_rank == 0:
+            try:
+                self._glm5_next_fp8_control_shm.unlink()
+            except FileNotFoundError:
+                pass
+        self._glm5_next_fp8_transport_epoch = 0
+        self._glm5_next_fp8_transport_poisoned = False
+        self._glm5_next_fp8_transport_backend = "native"
+        self._glm5_next_fp8_transport_initialized = True
+
+    def _initialize_glm5_next_fp8_transport(
+        self, wrapper=None, num_gpu_experts: int = 0
+    ) -> None:
+        """Select and initialize the exact-GLM transport once per context."""
+
+        if getattr(self, "_glm5_next_fp8_transport_initialized", False):
+            return
+        if get_tensor_model_parallel_world_size() != 4:
+            raise RuntimeError(
+                "GLM-5-Next layerwise prefill transport requires TP=4"
+            )
+        gpu_expert_counts = self._tp_all_gather_object(int(num_gpu_experts))
+        if any(count != gpu_expert_counts[0] for count in gpu_expert_counts):
+            raise RuntimeError(
+                "GLM-5-Next gpu_experts differs across TP ranks: "
+                f"{gpu_expert_counts}"
+            )
+        if gpu_expert_counts[0] != 0:
+            raise RuntimeError(
+                "GLM-5-Next layerwise prefill transport requires "
+                "gpu_experts=0"
+            )
+
+        raw_mode = os.environ.get(
+            _GLM5_NEXT_FP8_TRANSPORT_ENV, "auto"
+        ).strip().lower()
+        requested_modes = self._tp_all_gather_object(raw_mode)
+        if any(mode != requested_modes[0] for mode in requested_modes):
+            raise RuntimeError(
+                f"{_GLM5_NEXT_FP8_TRANSPORT_ENV} differs across TP ranks: "
+                f"{requested_modes}"
+            )
+        requested_mode = _glm5_next_fp8_transport_mode()
+
+        if requested_mode == "legacy":
+            self._initialize_glm5_next_fp8_legacy_transport()
+            return
+
+        kt_kernel_ext, missing_reason = (
+            _load_glm5_next_fp8_native_transport_api()
+        )
+        tp_rank = get_tensor_model_parallel_rank()
+        if tp_rank == 0 and not callable(
+            getattr(getattr(wrapper, "moe", None), "run_layerwise_fp8_batch", None)
+        ):
+            missing_reason = (
+                "KT FP8 writer is missing the direct native "
+                "moe.run_layerwise_fp8_batch API"
+            )
+        missing_reasons = self._tp_all_gather_object(missing_reason)
+        missing_reasons = [reason for reason in missing_reasons if reason]
+        if missing_reasons:
+            details = "; ".join(dict.fromkeys(missing_reasons))
+            if requested_mode == "native":
+                raise RuntimeError(
+                    "GLM-5-Next native FP8 transport was forced but is "
+                    f"unavailable: {details}"
+                )
+            if tp_rank == 0:
+                logger.warning(
+                    "KT GLM-5-Next native FP8 transport API is unavailable; "
+                    "falling back to legacy before the first layer load: %s",
+                    details,
+                )
+            self._initialize_glm5_next_fp8_legacy_transport()
+            return
+
+        self._initialize_glm5_next_fp8_native_transport(kt_kernel_ext)
+
+    def _initialize_glm5_next_fp8_legacy_transport(self) -> None:
+        """Create the legacy Python per-expert transport resources."""
 
         if getattr(self, "_glm5_next_fp8_transport_initialized", False):
             return
@@ -1179,10 +1536,12 @@ class SharedFullContext:
             if dist.is_initialized()
             else None
         )
+        self._glm5_next_fp8_transport_backend = "legacy"
+        self._glm5_next_fp8_transport_poisoned = False
         self._glm5_next_fp8_transport_initialized = True
 
-    def _prepare_weight_fp8_glm5_next(self, wrapper) -> None:
-        """Load one GLM layer with 2 Host expert slots and 1 GPU layer slot."""
+    def _prepare_weight_fp8_glm5_next_legacy(self, wrapper) -> None:
+        """Legacy Python per-expert writer/copy loop retained for A/B tests."""
 
         if not getattr(self, "_glm5_next_fp8_transport_initialized", False):
             raise RuntimeError(
@@ -1314,8 +1673,178 @@ class SharedFullContext:
 
         torch.cuda.current_stream(device).wait_stream(copy_stream)
 
-    def _prepare_weight_fp8(self, wrapper, original_layer=None, gpu_experts_mask=None,
-                            logical_to_gpu_index=None):
+    def _prepare_weight_fp8_glm5_next_native(
+        self, wrapper, layer_idx: int
+    ) -> None:
+        """Run one complete layer transport without a Python expert loop."""
+
+        if getattr(self, "_glm5_next_fp8_transport_poisoned", False):
+            raise RuntimeError(
+                "GLM-5-Next native FP8 transport is poisoned; restart the "
+                "server before retrying"
+            )
+        transport = getattr(self, "_glm5_next_fp8_native_transport", None)
+        if transport is None:
+            raise RuntimeError(
+                "GLM-5-Next native FP8 transport was not initialized"
+            )
+
+        tp_rank = get_tensor_model_parallel_rank()
+        expert_count = int(self.gpu_layer.num_experts)
+        epoch = int(self._glm5_next_fp8_transport_epoch) + 1
+        self._glm5_next_fp8_transport_epoch = epoch
+        try:
+            transport.join(epoch, int(layer_idx), expert_count)
+            if tp_rank == 0:
+                # The public NativeMoEWrapper helper drains the process-wide
+                # CPUInfer pool on every invocation.  The exact-native manager
+                # establishes that drain once before its first prime and then
+                # serializes all layer writers in one worker.  Calling the
+                # bound C++ MoE directly here therefore preserves the same
+                # non-reentrancy invariant without putting a process-wide
+                # CPUInfer drain back into every successor's hot path.
+                run_batch = getattr(
+                    getattr(wrapper, "moe", None),
+                    "run_layerwise_fp8_batch",
+                    None,
+                )
+                if not callable(run_batch):
+                    raise RuntimeError(
+                        "KT FP8 writer lost direct "
+                        "moe.run_layerwise_fp8_batch after native transport "
+                        "initialization"
+                    )
+                run_batch(transport, epoch, int(layer_idx), expert_count)
+            stats = dict(transport.wait(epoch) or {})
+
+            expected = {
+                "epoch": epoch,
+                "layer_id": int(layer_idx),
+                "expert_count": expert_count,
+            }
+            for name, value in expected.items():
+                if name in stats and int(stats[name]) != value:
+                    raise RuntimeError(
+                        f"native transport returned stale {name}: "
+                        f"expected={value}, got={stats[name]}"
+                    )
+            if bool(stats.get("poisoned", False)) or int(
+                stats.get("error_code", 0)
+            ) != 0:
+                raise RuntimeError(
+                    "native transport reported an error: "
+                    f"code={stats.get('error_code', 0)} "
+                    f"rank={stats.get('error_rank', -1)}"
+                )
+        except Exception as exc:
+            self._glm5_next_fp8_transport_poisoned = True
+            try:
+                transport.close()
+            except Exception:
+                pass
+            self._glm5_next_fp8_native_transport = None
+            raise RuntimeError(
+                "GLM-5-Next native FP8 layer transport failed for "
+                f"epoch={epoch}, layer={layer_idx}; runtime fallback is disabled"
+            ) from exc
+
+        logger.debug(
+            "KT GLM-5-Next native FP8 transport: epoch=%d layer=%d rank=%d "
+            "experts=%d writer=%.2f ms slot_wait=%.2f ms h2d=%.2f ms "
+            "transport=%.2f ms bytes=%d",
+            epoch,
+            layer_idx,
+            tp_rank,
+            expert_count,
+            float(stats.get("writer_ms", 0.0)),
+            float(stats.get("slot_wait_ms", 0.0)),
+            float(stats.get("h2d_ms", 0.0)),
+            float(stats.get("total_ms", 0.0)),
+            int(stats.get("bytes", 0)),
+        )
+
+    def _validate_glm5_next_fp8_native_gpu_slot(self) -> None:
+        """Keep the native pointer ABI bound to exactly one GPU layer slot."""
+
+        expected = getattr(self, "_glm5_next_fp8_native_gpu_ptrs", None)
+        actual = tuple(
+            int(getattr(self.gpu_layer, name).data_ptr())
+            for name in self.WEIGHT_NAMES_FP8
+        )
+        if expected is None or actual != tuple(expected):
+            raise RuntimeError(
+                "GLM-5-Next native FP8 full-layer GPU slot was rebound; "
+                "restart the server instead of writing stale native pointers"
+            )
+
+    def load_glm5_next_fp8_native(
+        self,
+        *,
+        layer_idx: int,
+        wrapper,
+        consumed_event=None,
+    ) -> None:
+        """Load one exact-GLM layer without a device-wide synchronization.
+
+        ``consumed_event`` is recorded immediately after the previous MoE's
+        GPU apply is enqueued.  Waiting for that single event fences the only
+        full-layer destination slot while still allowing the successor H2D
+        transport to overlap later attention kernels on the main stream.
+        The native wait returns only after its private H2D stream has finished,
+        so the acquiring main thread can safely enqueue the next MoE.
+        """
+
+        if getattr(self, "_glm5_next_fp8_transport_backend", None) != "native":
+            raise RuntimeError(
+                "exact-native GLM load requires the native FP8 transport"
+            )
+        if getattr(self, "_glm5_next_fp8_transport_poisoned", False):
+            raise RuntimeError(
+                "GLM-5-Next native FP8 transport is poisoned; runtime "
+                "fallback is disabled"
+            )
+
+        fence_error = None
+        if consumed_event is not None:
+            try:
+                consumed_event.synchronize()
+            except Exception as exc:
+                fence_error = exc
+            if fence_error is not None:
+                self._glm5_next_fp8_transport_poisoned = True
+                raise RuntimeError(
+                    "GLM-5-Next native FP8 local consumed-event fence failed; "
+                    "runtime fallback is disabled"
+                ) from fence_error
+
+        try:
+            self._validate_glm5_next_fp8_native_gpu_slot()
+            self._prepare_weight_fp8_glm5_next_native(wrapper, layer_idx)
+            self._validate_glm5_next_fp8_native_gpu_slot()
+        except Exception:
+            self._glm5_next_fp8_transport_poisoned = True
+            raise
+
+    def _prepare_weight_fp8_glm5_next(self, wrapper, layer_idx: int) -> None:
+        backend = getattr(self, "_glm5_next_fp8_transport_backend", None)
+        if backend == "native":
+            self._prepare_weight_fp8_glm5_next_native(wrapper, layer_idx)
+            return
+        if backend == "legacy":
+            self._prepare_weight_fp8_glm5_next_legacy(wrapper)
+            return
+        raise RuntimeError(
+            "GLM-5-Next FP8 transport resources were not initialized"
+        )
+
+    def _prepare_weight_fp8(
+        self,
+        wrapper,
+        original_layer=None,
+        gpu_experts_mask=None,
+        logical_to_gpu_index=None,
+        layer_idx: Optional[int] = None,
+    ):
         """Prepare FP8 block quant weights by writing from KT and copying to GPU.
 
         Pipeline: write(e+1) || copy(e) || postprocess(e-1)
@@ -1342,7 +1871,11 @@ class SharedFullContext:
                 False,
             )
         ):
-            self._prepare_weight_fp8_glm5_next(wrapper)
+            if layer_idx is None:
+                raise RuntimeError(
+                    "GLM-5-Next FP8 transport requires the logical layer index"
+                )
+            self._prepare_weight_fp8_glm5_next(wrapper, layer_idx)
             return
 
         # Bind Python thread to specific CPU core (last cores for each rank)
@@ -1949,8 +2482,13 @@ class SharedFullContext:
             # When the inference layer is Marlin-repacked (int32), the
             # raw fp8 context layer can't share GPU→GPU copies.
             # Disable Phase 1 shortcut by passing original_layer=None.
-            self._prepare_weight_fp8(wrapper, None, gpu_experts_mask,
-                                     logical_to_gpu_index)
+            self._prepare_weight_fp8(
+                wrapper,
+                None,
+                gpu_experts_mask,
+                logical_to_gpu_index,
+                layer_idx=layer_idx,
+            )
         elif self._is_fp8_channel_quant:
             self._prepare_weight_fp8_channel(wrapper, None, gpu_experts_mask,
                                              logical_to_gpu_index)
@@ -2963,18 +3501,38 @@ def _validate_glm5_next_fp8_shared_full_context(
             "GLM-5-Next layerwise prefill requires runtime TP=4; "
             f"got TP={tp_size}"
         )
-    slot_events = getattr(
-        context, "_glm5_next_fp8_host_slot_events", None
-    )
-    if (
-        not getattr(context, "_glm5_next_fp8_transport_initialized", False)
-        or slot_events is None
-        or len(slot_events) != 2
-        or getattr(context, "_glm5_next_fp8_copy_stream", None) is None
-    ):
+    if not getattr(context, "_glm5_next_fp8_transport_initialized", False):
         raise RuntimeError(
-            "GLM-5-Next layerwise prefill requires one persistent H2D "
-            "stream and exactly two Host-slot completion events"
+            "GLM-5-Next layerwise prefill transport is not initialized"
+        )
+    transport_backend = getattr(
+        context, "_glm5_next_fp8_transport_backend", "legacy"
+    )
+    if transport_backend == "native":
+        if (
+            getattr(context, "_glm5_next_fp8_native_transport", None) is None
+            or getattr(context, "_glm5_next_fp8_control_shm", None) is None
+        ):
+            raise RuntimeError(
+                "GLM-5-Next native layerwise prefill requires a persistent "
+                "native handle and mapped control SHM"
+            )
+    elif transport_backend == "legacy":
+        slot_events = getattr(
+            context, "_glm5_next_fp8_host_slot_events", None
+        )
+        if (
+            slot_events is None
+            or len(slot_events) != 2
+            or getattr(context, "_glm5_next_fp8_copy_stream", None) is None
+        ):
+            raise RuntimeError(
+                "GLM-5-Next legacy layerwise prefill requires one persistent "
+                "H2D stream and exactly two Host-slot completion events"
+            )
+    else:
+        raise RuntimeError(
+            f"unknown GLM-5-Next transport backend {transport_backend!r}"
         )
     layer = context.gpu_layer
     runner_config = getattr(layer, "moe_runner_config", None)
@@ -3061,6 +3619,477 @@ def _validate_glm5_next_fp8_shared_full_context(
 def _glm5_next_forward_mode_name(mode) -> str:
     name = getattr(mode, "name", None)
     return str(name if name is not None else mode).upper()
+
+
+def _glm5_next_fp8_native_prefetch_signature(method, layer) -> tuple:
+    device = next(layer.parameters()).device
+    return (
+        str(device),
+        method.kt_config.weight_path,
+        method.kt_config.num_layers,
+        method.global_num_experts,
+        method._full_init_args,
+    )
+
+
+def _register_glm5_next_fp8_native_prefetch_layer(method, layer) -> None:
+    """Register exact-GLM MoE order during model construction."""
+
+    if not _glm5_next_fp8_pipeline_requested(method):
+        return
+    signature = _glm5_next_fp8_native_prefetch_signature(method, layer)
+    method._glm5_next_fp8_native_prefetch_signature = signature
+    registry = _GLM5_NEXT_FP8_NATIVE_PREFETCH_LAYER_REGISTRY.setdefault(
+        signature, {}
+    )
+    layer_idx = int(method.kt_config.layer_idx)
+    existing = registry.get(layer_idx)
+    if existing is not None and (
+        existing[0] is not method or existing[1] is not layer
+    ):
+        raise RuntimeError(
+            "duplicate exact GLM-5-Next native prefetch registration for "
+            f"layer {layer_idx}"
+        )
+    registry[layer_idx] = (method, layer)
+
+
+def _glm5_next_fp8_native_prefetch_runtime_supported(
+    method, context: SharedFullContext
+) -> bool:
+    """Hard-gate the successor worker without changing legacy behavior."""
+
+    if not _glm5_next_fp8_pipeline_requested(method):
+        return False
+    if getattr(context, "_glm5_next_fp8_transport_backend", None) != "native":
+        return False
+    tp_size = get_tensor_model_parallel_world_size()
+    if tp_size != 4:
+        raise RuntimeError(
+            "exact GLM-5-Next native successor prefetch requires TP=4; "
+            f"got TP={tp_size}"
+        )
+    if int(method.num_gpu_experts) != 0:
+        raise RuntimeError(
+            "exact GLM-5-Next native successor prefetch requires "
+            "gpu_experts=0"
+        )
+    return True
+
+
+class _Glm5NextFp8NativeSingleSlotPrefetchManager:
+    """Overlap successor transport with attention using one GPU weight slot.
+
+    The manager deliberately owns no weight tensor.  ``context.gpu_layer`` is
+    the sole full-layer destination, protected by one consumed event.  A
+    single Python worker per TP rank executes only layer-granularity control;
+    the expert writer/H2D hot loop remains in the native transport.
+    """
+
+    def __init__(self, context: SharedFullContext, signature: tuple, registry):
+        self.context = context
+        self.signature = signature
+        self.registry = registry
+        self.layer_indices = tuple(sorted(registry))
+        if self.layer_indices != _GLM5_NEXT_FP8_MOE_LAYER_INDICES:
+            raise RuntimeError(
+                "exact GLM-5-Next native prefetch requires the complete MoE "
+                "registry for layers 3..44 before its first prime; got "
+                f"{self.layer_indices}"
+            )
+        for layer_idx, (method, _layer) in registry.items():
+            config = method.kt_config
+            if (
+                int(config.layer_idx) != layer_idx
+                or int(config.num_layers or 0) != 45
+                or not bool(config.is_glm5_next)
+                or (config.method or "").upper() != "FP8"
+            ):
+                raise RuntimeError(
+                    "exact GLM-5-Next native prefetch registry contains an "
+                    f"invalid layer entry for layer {layer_idx}"
+                )
+        self.first_layer_idx = self.layer_indices[0]
+        self.last_layer_idx = self.layer_indices[-1]
+        self._successors = {
+            layer_idx: (
+                self.layer_indices[index + 1]
+                if index + 1 < len(self.layer_indices)
+                else None
+            )
+            for index, layer_idx in enumerate(self.layer_indices)
+        }
+        self.device = context.gpu_layer.w13_weight.device
+        self.consumed_event = torch.cuda.Event()
+        self.executor = ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix=(
+                f"kt-glm5-fp8-prefetch-r{get_tensor_model_parallel_rank()}"
+            ),
+        )
+        self.future: Optional[Future] = None
+        self.future_layer_idx: Optional[int] = None
+        self.loaded_layer_idx: Optional[int] = None
+        self.last_acquired_layer_idx: Optional[int] = None
+        self.round_id = 0
+        self._cpu_infer_drained = False
+        self._poison_error: Optional[BaseException] = None
+        self._closed = False
+
+    def _mark_poisoned(self, error: BaseException) -> None:
+        if self._poison_error is None:
+            self._poison_error = error
+        self.context._glm5_next_fp8_transport_poisoned = True
+
+    def _raise_if_unusable(self) -> None:
+        if self._closed:
+            raise RuntimeError(
+                "GLM-5-Next native successor prefetch manager is closed"
+            )
+        if self._poison_error is not None or getattr(
+            self.context, "_glm5_next_fp8_transport_poisoned", False
+        ):
+            raise RuntimeError(
+                "GLM-5-Next native successor prefetch is poisoned; "
+                "runtime fallback is disabled"
+            ) from self._poison_error
+
+    def _commit_rank_local_error(
+        self, local_error: Optional[BaseException], phase: str
+    ) -> None:
+        if _all_tp_ranks_succeeded(local_error is None):
+            return
+        error = RuntimeError(
+            "GLM-5-Next native successor prefetch "
+            f"{phase} failed on at least one TP rank; runtime fallback is disabled"
+        )
+        self._mark_poisoned(error)
+        if local_error is not None:
+            raise error from local_error
+        raise error
+
+    def _drain_cpu_infer_once(self, method) -> None:
+        """Establish a clean writer boundary once, before the first epoch."""
+
+        if self._cpu_infer_drained:
+            return
+        local_error = None
+        if method.tp_rank == 0:
+            try:
+                cpu_infer = getattr(method.wrapper, "cpu_infer", None)
+                sync = getattr(cpu_infer, "sync", None)
+                if not callable(sync):
+                    raise RuntimeError(
+                        "exact GLM-5-Next native prime requires "
+                        "wrapper.cpu_infer.sync"
+                    )
+                sync()
+            except Exception as exc:
+                local_error = exc
+        self._commit_rank_local_error(local_error, "initial CPUInfer drain")
+        self._cpu_infer_drained = True
+
+    def _load_layer(
+        self, layer_idx: int, method, consumed_event
+    ) -> int:
+        self.context.load_glm5_next_fp8_native(
+            layer_idx=layer_idx,
+            wrapper=method.wrapper,
+            consumed_event=consumed_event,
+        )
+        return layer_idx
+
+    def _prime(self, layer_idx: int, method, consumed_event) -> None:
+        self._drain_cpu_infer_once(method)
+        self._load_layer(layer_idx, method, consumed_event)
+        self.loaded_layer_idx = layer_idx
+
+    def _finish_future(self, expected_layer_idx: int) -> None:
+        future = self.future
+        actual_expected = self.future_layer_idx
+        loaded_layer_idx = None
+        local_error = None
+        if future is None or actual_expected != expected_layer_idx:
+            local_error = RuntimeError(
+                "GLM-5-Next native successor prefetch acquired an invalid "
+                f"future: wanted layer={expected_layer_idx}, "
+                f"pending={actual_expected}"
+            )
+        else:
+            try:
+                loaded_layer_idx = int(future.result())
+            except Exception as exc:
+                local_error = exc
+        try:
+            if (
+                local_error is None
+                and loaded_layer_idx != expected_layer_idx
+            ):
+                local_error = RuntimeError(
+                    "GLM-5-Next native successor prefetch returned stale "
+                    f"weights: wanted layer={expected_layer_idx}, "
+                    f"got={loaded_layer_idx}"
+                )
+        finally:
+            self.future = None
+            self.future_layer_idx = None
+        # This consensus deliberately runs on the acquiring main thread, not
+        # inside the background worker.  It keeps torch.distributed control
+        # flow ordered with the model thread while propagating any rank-local
+        # event/native task failure before another successor is launched.
+        try:
+            self._commit_rank_local_error(
+                local_error, f"successor acquire for layer {expected_layer_idx}"
+            )
+        except Exception as exc:
+            self._mark_poisoned(exc)
+            raise
+        self.loaded_layer_idx = loaded_layer_idx
+
+    def _drain_interrupted_round(self) -> None:
+        if self.future is None:
+            return
+        expected = self.future_layer_idx
+        if expected is None:
+            error = RuntimeError(
+                "GLM-5-Next native successor prefetch lost its pending layer"
+            )
+            self._mark_poisoned(error)
+            raise error
+        # A canceled/short request can wrap before consuming the prefetched
+        # layer.  Finish that one writer first; one GPU slot cannot be
+        # overwritten by a second producer concurrently.
+        self._finish_future(expected)
+
+    def _acquire(self, method, layer) -> bool:
+        self._raise_if_unusable()
+        layer_idx = int(method.kt_config.layer_idx)
+        registered = self.registry.get(layer_idx)
+        if registered is None or registered[0] is not method or registered[1] is not layer:
+            error = RuntimeError(
+                "GLM-5-Next native successor prefetch received an "
+                f"unregistered layer {layer_idx}"
+            )
+            self._mark_poisoned(error)
+            raise error
+
+        is_wrap = (
+            self.last_acquired_layer_idx is not None
+            and layer_idx == self.first_layer_idx
+        )
+        if self.last_acquired_layer_idx is None:
+            if layer_idx != self.first_layer_idx:
+                error = RuntimeError(
+                    "GLM-5-Next native prefetch round must start at layer "
+                    f"{self.first_layer_idx}, got layer {layer_idx}"
+                )
+                self._mark_poisoned(error)
+                raise error
+            self.round_id = 1
+            self._prime(layer_idx, method, consumed_event=None)
+            prefetch_hit = False
+        elif is_wrap:
+            self._drain_interrupted_round()
+            self.round_id += 1
+            self.loaded_layer_idx = None
+            # The previous round's last (or last actually executed) MoE
+            # recorded this event.  Fence it before re-prime overwrites the
+            # sole layer slot; later attention remains free to overlap.
+            self._prime(layer_idx, method, self.consumed_event)
+            prefetch_hit = False
+        else:
+            expected = self._successors.get(self.last_acquired_layer_idx)
+            if expected != layer_idx:
+                error = RuntimeError(
+                    "GLM-5-Next native prefetch observed an out-of-order MoE: "
+                    f"after layer {self.last_acquired_layer_idx}, expected "
+                    f"{expected}, got {layer_idx}"
+                )
+                self._mark_poisoned(error)
+                raise error
+            self._finish_future(layer_idx)
+            prefetch_hit = True
+
+        if self.loaded_layer_idx != layer_idx:
+            error = RuntimeError(
+                "GLM-5-Next native prefetch did not acquire the requested "
+                f"layer: requested={layer_idx}, loaded={self.loaded_layer_idx}"
+            )
+            self._mark_poisoned(error)
+            raise error
+        self.last_acquired_layer_idx = layer_idx
+        return prefetch_hit
+
+    def _prefetch_successor(self, layer_idx: int) -> None:
+        successor_idx = self._successors[layer_idx]
+        if successor_idx is None:
+            # There is intentionally no speculative first-layer load here.
+            # The next chunk/request synchronously re-primes only after the
+            # last layer's consumed event has completed.
+            self.future = None
+            self.future_layer_idx = None
+            return
+        if self.future is not None:
+            error = RuntimeError(
+                "GLM-5-Next native successor prefetch already has a task in flight"
+            )
+            self._mark_poisoned(error)
+            raise error
+        successor_method, _ = self.registry[successor_idx]
+        self.future_layer_idx = successor_idx
+        try:
+            self.future = self.executor.submit(
+                self._load_layer,
+                successor_idx,
+                successor_method,
+                self.consumed_event,
+            )
+        except Exception as exc:
+            self.future_layer_idx = None
+            self._mark_poisoned(exc)
+            raise RuntimeError(
+                "GLM-5-Next native successor worker submission failed; "
+                "runtime fallback is disabled"
+            ) from exc
+
+    def apply(self, method, layer, dispatch_output):
+        layer_idx = int(method.kt_config.layer_idx)
+        prefetch_hit = self._acquire(method, layer)
+        main_stream = torch.cuda.current_stream(self.device)
+        result = None
+        compute_error = None
+        try:
+            process = getattr(
+                self.context.gpu_method, "process_weights_after_loading", None
+            )
+            if callable(process):
+                process(self.context.gpu_layer)
+            self.context._validate_glm5_next_fp8_native_gpu_slot()
+            result = self.context.gpu_method.apply(
+                self.context.gpu_layer, dispatch_output
+            )
+        except Exception as exc:
+            compute_error = exc
+        finally:
+            try:
+                # This event is the only overwrite fence for the one GPU slot.
+                # It is recorded after all weight-reading MoE work is enqueued,
+                # before the caller continues with postprocess/attention.
+                self.consumed_event.record(main_stream)
+            except Exception as exc:
+                if compute_error is None:
+                    compute_error = exc
+
+        try:
+            self._commit_rank_local_error(compute_error, "compute enqueue")
+        except Exception as exc:
+            self._mark_poisoned(exc)
+            raise
+        if compute_error is not None:
+            self._mark_poisoned(compute_error)
+            raise RuntimeError(
+                "GLM-5-Next native MoE compute enqueue failed; runtime "
+                "fallback is disabled"
+            ) from compute_error
+
+        # Submit only after every rank has published its consumed fence.  The
+        # main thread returns immediately; the single worker waits that event
+        # and runs native join/run/wait for the successor.
+        self._prefetch_successor(layer_idx)
+        if method.tp_rank == 0:
+            logger.debug(
+                "KT GLM-5-Next native single-slot prefetch: layer=%d "
+                "round=%d %s successor=%s",
+                layer_idx,
+                self.round_id,
+                "prefetch-hit" if prefetch_hit else "prime",
+                self._successors[layer_idx],
+            )
+        return result
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            if self.future is not None:
+                try:
+                    self.future.result()
+                except Exception as exc:
+                    self._mark_poisoned(exc)
+                finally:
+                    self.future = None
+                    self.future_layer_idx = None
+        finally:
+            self.executor.shutdown(wait=True, cancel_futures=False)
+            if (
+                _GLM5_NEXT_FP8_NATIVE_PREFETCH_MANAGERS.get(self.signature)
+                is self
+            ):
+                _GLM5_NEXT_FP8_NATIVE_PREFETCH_MANAGERS.pop(self.signature, None)
+
+
+def _get_or_initialize_glm5_next_fp8_native_prefetch_manager(
+    method, layer, context: SharedFullContext
+) -> _Glm5NextFp8NativeSingleSlotPrefetchManager:
+    if getattr(context, "_glm5_next_fp8_transport_poisoned", False):
+        raise RuntimeError(
+            "exact GLM-5-Next native prefetch context is poisoned; runtime "
+            "fallback is disabled"
+        )
+    signature = getattr(
+        method, "_glm5_next_fp8_native_prefetch_signature", None
+    )
+    if signature is None:
+        context._glm5_next_fp8_transport_poisoned = True
+        raise RuntimeError(
+            "exact GLM-5-Next native prefetch layer was not registered during "
+            "create_weights"
+        )
+    registry = _GLM5_NEXT_FP8_NATIVE_PREFETCH_LAYER_REGISTRY.get(signature)
+    if registry is None or registry.get(int(method.kt_config.layer_idx)) != (
+        method,
+        layer,
+    ):
+        context._glm5_next_fp8_transport_poisoned = True
+        raise RuntimeError(
+            "exact GLM-5-Next native prefetch registry is incomplete"
+        )
+
+    manager = _GLM5_NEXT_FP8_NATIVE_PREFETCH_MANAGERS.get(signature)
+    if manager is not None:
+        if manager.context is not context:
+            context._glm5_next_fp8_transport_poisoned = True
+            raise RuntimeError(
+                "exact GLM-5-Next native prefetch signature reused with a "
+                "different full-layer context"
+            )
+        return manager
+
+    manager = None
+    local_error = None
+    try:
+        manager = _Glm5NextFp8NativeSingleSlotPrefetchManager(
+            context, signature, registry
+        )
+    except Exception as exc:
+        local_error = exc
+    if not _all_tp_ranks_succeeded(local_error is None):
+        context._glm5_next_fp8_transport_poisoned = True
+        if manager is not None:
+            manager.close()
+        raise RuntimeError(
+            "exact GLM-5-Next native single-slot prefetch setup failed on at "
+            "least one TP rank"
+        ) from local_error
+    if manager is None:
+        context._glm5_next_fp8_transport_poisoned = True
+        raise RuntimeError(
+            "exact GLM-5-Next native single-slot prefetch setup returned no manager"
+        )
+    _GLM5_NEXT_FP8_NATIVE_PREFETCH_MANAGERS[signature] = manager
+    context._glm5_next_fp8_native_prefetch_manager = manager
+    return manager
 
 
 def generate_front_loading_masks(
@@ -4038,6 +5067,7 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
         # Registration happens during model construction, not on the first
         # request, so layer N can identify and prepare N+1 immediately.
         _register_mxfp4_prefill_layer(self, layer)
+        _register_glm5_next_fp8_native_prefetch_layer(self, layer)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         """Process weights after loading from checkpoint.
@@ -4438,6 +5468,14 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
             # serialized full-GPU fallback.
             ctx = self._build_full_context(layer)
 
+            if _glm5_next_fp8_native_prefetch_runtime_supported(self, ctx):
+                manager = (
+                    _get_or_initialize_glm5_next_fp8_native_prefetch_manager(
+                        self, layer, ctx
+                    )
+                )
+                return manager.apply(self, layer, dispatch_output)
+
             # Re-run quant post-processing on the full-expert gpu_layer
             # if supported (e.g. Marlin repack for Fp8MarlinMoEMethod).
             # The ctx.load() call writes raw fp8 weights; downstream apply()
@@ -4793,8 +5831,8 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
     def _build_full_context(self, layer: torch.nn.Module) -> "SharedFullContext":
         global _SHARED_FULL_CONTEXT
 
+        is_glm5_next_fp8 = _glm5_next_fp8_pipeline_requested(self)
         if _SHARED_FULL_CONTEXT is None:
-            is_glm5_next_fp8 = _glm5_next_fp8_pipeline_requested(self)
             if is_glm5_next_fp8:
                 # GPU tensors are allocated independently on each TP rank.
                 # Do not let a successful peer enter the Host-SHM collectives
@@ -4855,7 +5893,10 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
                 validation_result = None
                 validation_error = None
                 try:
-                    context._initialize_glm5_next_fp8_transport()
+                    context._initialize_glm5_next_fp8_transport(
+                        wrapper=self.wrapper,
+                        num_gpu_experts=self.num_gpu_experts,
+                    )
                     validation_result = (
                         _validate_glm5_next_fp8_shared_full_context(context)
                     )
@@ -4890,21 +5931,34 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
                     logger.info(
                         "KT GLM-5-Next FP8 layerwise prefill lazily allocated "
                         "generic SharedFullContext: gpu_full_layer_slots=1 "
-                        "host_expert_slots=2 gpu_slot_bytes=%d "
+                        "host_expert_slots=2 transport=%s gpu_slot_bytes=%d "
                         "host_buffer_bytes=%d device=%s",
+                        context._glm5_next_fp8_transport_backend,
                         gpu_slot_bytes,
                         host_buffer_bytes,
                         context.gpu_layer.w13_weight.device,
                     )
             _SHARED_FULL_CONTEXT = context
 
-        _SHARED_FULL_CONTEXT.load(
-            layer_idx=self.kt_config.layer_idx,
-            wrapper=self.wrapper,
-            original_layer=layer,
-            gpu_experts_mask=self.gpu_experts_mask,
-            logical_to_gpu_index=self.logical_to_gpu_index,
-        )
+        # Native exact GLM is loaded by its single-slot manager: synchronous
+        # prime for the first MoE, then event-fenced successor tasks.  Keeping
+        # it out of generic load() avoids both device-wide synchronizations.
+        if not (
+            is_glm5_next_fp8
+            and getattr(
+                _SHARED_FULL_CONTEXT,
+                "_glm5_next_fp8_transport_backend",
+                None,
+            )
+            == "native"
+        ):
+            _SHARED_FULL_CONTEXT.load(
+                layer_idx=self.kt_config.layer_idx,
+                wrapper=self.wrapper,
+                original_layer=layer,
+                gpu_experts_mask=self.gpu_experts_mask,
+                logical_to_gpu_index=self.logical_to_gpu_index,
+            )
         return _SHARED_FULL_CONTEXT
 
 

--- a/python/sglang/srt/layers/moe/kt_ep_wrapper.py
+++ b/python/sglang/srt/layers/moe/kt_ep_wrapper.py
@@ -95,6 +95,7 @@ class KTConfig:
         gpu_prefill_token_threshold: token threshold for enabling full GPU fallback
         kt_enable_dynamic_expert_update: Enable dynamic GPU expert updates based on runtime statistics
         expert_lora_path: Optional PEFT adapter directory for KT CPU expert LoRA
+        is_glm5_next: Whether the exact GLM-5-Next boundary is active
     """
 
     layer_idx: int
@@ -110,6 +111,7 @@ class KTConfig:
     gpu_prefill_token_threshold: Optional[int] = None
     kt_enable_dynamic_expert_update: bool = False
     expert_lora_path: Optional[str] = None
+    is_glm5_next: bool = False
 
 
 @dataclass
@@ -139,6 +141,15 @@ def _map_kt_method_to_sft_method(method: str) -> str:
     raise ValueError(
         f"--kt-expert-lora-path currently supports only AMX/BF16 SFT-compatible "
         f"KT methods {sorted(_KT_SFT_METHOD_BY_INFERENCE_METHOD)}, got {method!r}."
+    )
+
+
+def _kt_supports_swiglu_parameters(method: Optional[str], is_glm5_next: bool) -> bool:
+    """Keep block-FP8 clamp propagation isolated to the exact GLM runtime."""
+
+    normalized = (method or "").upper()
+    return normalized in ("MXFP4", "MXFP8") or (
+        normalized == "FP8" and is_glm5_next
     )
 
 
@@ -3200,6 +3211,7 @@ def create_kt_config_from_server_args(
         gpu_prefill_token_threshold=server_args.kt_gpu_prefill_token_threshold,
         kt_enable_dynamic_expert_update=server_args.kt_enable_dynamic_expert_update,
         expert_lora_path=getattr(server_args, "kt_expert_lora_path", None),
+        is_glm5_next=getattr(server_args, "_glm5_next_session_ab_active", False),
     )
 
 
@@ -3679,10 +3691,15 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
             _kt_swiglu_limit = float(
                 _cfg_clamp if _cfg_clamp is not None else (_cfg_swglim or 0.0)
             )
-            # kt-kernel guards swiglu_limit to MXFP4/MXFP8 only.
-            # Zero it out for other methods (AMXINT4, BF16, etc.)
-            # so V4-Flash + non-MXFP runs don't crash at init.
-            if (self.kt_config.method or "").upper() not in ("MXFP4", "MXFP8"):
+            # MXFP4/MXFP8 retain their existing clamp behavior.  Block-FP8
+            # carries the parameters only for the exact GLM boundary; this
+            # prevents the new low-level FP8 capability from changing legacy
+            # models that also select KT method=FP8.
+            supports_swiglu_params = _kt_supports_swiglu_parameters(
+                self.kt_config.method,
+                self.kt_config.is_glm5_next,
+            )
+            if not supports_swiglu_params:
                 _kt_swiglu_limit = 0.0
                 _kt_swiglu_alpha = 0.0
             common_wrapper_kwargs = dict(

--- a/python/sglang/srt/layers/moe/kt_ep_wrapper.py
+++ b/python/sglang/srt/layers/moe/kt_ep_wrapper.py
@@ -31,11 +31,9 @@ import bisect
 import copy
 import ctypes
 import gc
-import hashlib
 import json
 import logging
 import os
-import socket
 import time
 import uuid
 from dataclasses import dataclass, replace
@@ -295,12 +293,6 @@ _SHARED_STAGING_BUFFER = None  # Global shared staging buffer for all MoE layers
 _MXFP4_PREFILL_LAYER_REGISTRY = {}
 _MXFP4_LAYERWISE_MANAGERS = {}
 _MXFP4_LAYERWISE_DISABLED_REASONS = {}
-# GLM-5-Next block-FP8 uses its own registry and manager.  Do not merge this
-# state with the generic full-GPU fallback or MXFP4: the GLM path is required
-# (fail-closed), has no format conversion, and is eagerly allocated before KV
-# cache profiling.
-_GLM5_NEXT_FP8_PREFILL_LAYER_REGISTRY = {}
-_GLM5_NEXT_FP8_LAYERWISE_MANAGERS = {}
 
 
 class SharedStagingBuffer:
@@ -1170,6 +1162,158 @@ class SharedFullContext:
         w13_p.set_(w13_p.view(num_experts, w13_k // 16, w13_n * (num_bits // 2)))
         w2_p.set_(w2_p.view(num_experts, w2_k // 16, w2_n * (num_bits // 2)))
 
+    def _initialize_glm5_next_fp8_transport(self) -> None:
+        """Create the exact-GLM transport resources once per shared context."""
+
+        if getattr(self, "_glm5_next_fp8_transport_initialized", False):
+            return
+        device = self.gpu_layer.w13_weight.device
+        self._glm5_next_fp8_copy_stream = torch.cuda.Stream(device=device)
+        self._glm5_next_fp8_host_slot_events = (
+            torch.cuda.Event(),
+            torch.cuda.Event(),
+        )
+        self._glm5_next_fp8_host_slot_was_used = [False, False]
+        self._glm5_next_fp8_transport_status = (
+            torch.ones((1,), dtype=torch.int32, device=device)
+            if dist.is_initialized()
+            else None
+        )
+        self._glm5_next_fp8_transport_initialized = True
+
+    def _prepare_weight_fp8_glm5_next(self, wrapper) -> None:
+        """Load one GLM layer with 2 Host expert slots and 1 GPU layer slot."""
+
+        if not getattr(self, "_glm5_next_fp8_transport_initialized", False):
+            raise RuntimeError(
+                "GLM-5-Next FP8 transport resources were not initialized"
+            )
+        layer = self.gpu_layer
+        device = layer.w13_weight.device
+        num_experts = layer.num_experts
+        tp_rank = get_tensor_model_parallel_rank()
+        tp_world_size = get_tensor_model_parallel_world_size()
+        do_write = tp_rank == 0 and wrapper is not None
+        copy_stream = self._glm5_next_fp8_copy_stream
+        slot_events = self._glm5_next_fp8_host_slot_events
+        # load() globally synchronizes before entering this helper, so no
+        # event from the previous layer remains in flight.  Reset only the
+        # logical occupancy while retaining the two persistent CUDA events.
+        slot_was_used = [False, False]
+        self._glm5_next_fp8_host_slot_was_used = slot_was_used
+        transport_status = self._glm5_next_fp8_transport_status
+
+        weight_infos = [
+            (self.cpu_buffers[name], getattr(layer, name))
+            for name in self.WEIGHT_NAMES_FP8
+        ]
+        expert_nbytes = {
+            name: self.cpu_buffers[name].numel()
+            // 2
+            * self.cpu_buffers[name].element_size()
+            for name in self.WEIGHT_NAMES_FP8
+        }
+
+        def submit_write_expert(expert_id: int, slot: int) -> None:
+            pointers = {
+                name: [
+                    pointer + slot * expert_nbytes[name]
+                    for pointer in self.all_rank_buffer_ptrs[name]
+                ]
+                for name in self.WEIGHT_NAMES_FP8
+            }
+            wrapper.submit_write_weight_scale_to_buffer(
+                tp_world_size,
+                expert_id,
+                pointers["w13_weight"],
+                pointers["w13_weight_scale_inv"],
+                pointers["w2_weight"],
+                pointers["w2_weight_scale_inv"],
+            )
+
+        def all_ranks_succeeded(local_error: Optional[Exception]) -> bool:
+            if transport_status is None:
+                return local_error is None
+            transport_status.fill_(int(local_error is None))
+            dist.all_reduce(
+                transport_status,
+                op=dist.ReduceOp.MIN,
+                group=get_tp_group().device_group,
+            )
+            return bool(transport_status.item())
+
+        pending_error = (
+            RuntimeError(
+                "GLM-5-Next FP8 Host-slot transport has no KT writer on TP0"
+            )
+            if tp_rank == 0 and wrapper is None
+            else None
+        )
+        if do_write:
+            try:
+                submit_write_expert(0, 0)
+            except Exception as exc:
+                pending_error = exc
+
+        for expert_id in range(num_experts):
+            slot = expert_id % 2
+            local_error = pending_error
+            if do_write and local_error is None:
+                try:
+                    wrapper.sync_write_weight_scale_to_buffer()
+                except Exception as exc:
+                    local_error = exc
+
+            has_next = expert_id + 1 < num_experts
+            next_slot = (expert_id + 1) % 2
+            if has_next and slot_was_used[next_slot]:
+                try:
+                    slot_events[next_slot].synchronize()
+                except Exception as exc:
+                    if local_error is None:
+                        local_error = exc
+
+            if not all_ranks_succeeded(local_error):
+                raise RuntimeError(
+                    "GLM-5-Next FP8 Host-slot transport failed on at least "
+                    "one TP rank"
+                ) from local_error
+
+            pending_error = None
+            if do_write and has_next:
+                try:
+                    submit_write_expert(expert_id + 1, next_slot)
+                except Exception as exc:
+                    # Publish this TP0-only failure at the next expert's
+                    # status collective while peers finish copy(current).
+                    pending_error = exc
+
+            try:
+                with torch.cuda.stream(copy_stream):
+                    for cpu_buffer, gpu_tensor in weight_infos:
+                        gpu_tensor[expert_id].copy_(
+                            cpu_buffer[slot], non_blocking=True
+                        )
+                    slot_events[slot].record(copy_stream)
+                slot_was_used[slot] = True
+            except Exception as exc:
+                if pending_error is None:
+                    pending_error = exc
+
+        final_error = pending_error
+        try:
+            copy_stream.synchronize()
+        except Exception as exc:
+            if final_error is None:
+                final_error = exc
+        if not all_ranks_succeeded(final_error):
+            raise RuntimeError(
+                "GLM-5-Next FP8 final Host-to-GPU copy failed on at least "
+                "one TP rank"
+            ) from final_error
+
+        torch.cuda.current_stream(device).wait_stream(copy_stream)
+
     def _prepare_weight_fp8(self, wrapper, original_layer=None, gpu_experts_mask=None,
                             logical_to_gpu_index=None):
         """Prepare FP8 block quant weights by writing from KT and copying to GPU.
@@ -1190,13 +1334,23 @@ class SharedFullContext:
         already on GPU are copied directly (fast GPU-to-GPU), while CPU experts
         use the KT wrapper pipeline.
         """
+        layer = self.gpu_layer
+        if bool(
+            getattr(
+                getattr(layer, "moe_runner_config", None),
+                "glm5_next_hf_two_round_swiglu",
+                False,
+            )
+        ):
+            self._prepare_weight_fp8_glm5_next(wrapper)
+            return
+
         # Bind Python thread to specific CPU core (last cores for each rank)
         tp_rank = get_tensor_model_parallel_rank()
         num_cpus = os.cpu_count()
         target_cpu = num_cpus - 1 - tp_rank
         os.sched_setaffinity(0, {target_cpu})
 
-        layer = self.gpu_layer
         num_experts = layer.num_experts
         device = layer.w13_weight.device
 
@@ -2782,1173 +2936,6 @@ def _get_or_initialize_mxfp4_layerwise_manager(
     return _MXFP4_LAYERWISE_MANAGERS.get(signature)
 
 
-class _Glm5NextFp8PrefillSlot:
-    """One raw block-FP8 GLM-5-Next MoE layer image.
-
-    Unlike MXFP4 there is no prepared/repacked representation.  The Triton
-    runner consumes these E4M3 weights and FP32 block scales directly.
-    """
-
-    RAW_NAMES = (
-        "w13_weight",
-        "w13_weight_scale_inv",
-        "w2_weight",
-        "w2_weight_scale_inv",
-    )
-
-    def __init__(self, index: int, raw_tensors: Dict[str, torch.Tensor]):
-        self.index = index
-        for name in self.RAW_NAMES:
-            setattr(self, name, raw_tensors[name])
-
-        self.state = "EMPTY"
-        self.layer_idx: Optional[int] = None
-        self.epoch = -1
-        self.has_consumed_event = False
-        self.reuse_guard = None
-        self.ready_event = torch.cuda.Event()
-        self.consumed_event = torch.cuda.Event()
-        self.num_experts = self.w13_weight.shape[0]
-
-    def invalidate(self) -> None:
-        # Keep both the tensor storage and its last overwrite fence alive.
-        self.state = "EMPTY"
-        self.layer_idx = None
-        self.epoch = -1
-
-
-class _Glm5NextFp8LayerwisePrefillManager:
-    """Required two-slot raw block-FP8 scheduler for exact GLM-5-Next.
-
-    A positive ``--kt-gpu-prefill-token-threshold`` selects this path for
-    every plain EXTEND forward, including a final chunk smaller than the
-    configured value.  There is deliberately no hybrid/serialized fallback:
-    a transport, ordering, allocation, or coverage failure is fatal.
-    """
-
-    _CONTROL_CACHELINE_BYTES = 64
-    _CONTROL_TIMEOUT_SECONDS = 300.0
-    _ATOMIC_ACQUIRE = 2
-    _ATOMIC_RELEASE = 3
-    _SLOT_STATE_CODES = {"EMPTY": 0, "LOADING": 1, "READY": 2, "IN_USE": 3}
-    _REUSE_GUARD_CODES = {
-        None: 0,
-        "loading": 1,
-        "ready": 2,
-        "consumed": 3,
-        "synchronized": 4,
-        "poisoned": 5,
-    }
-
-    def __init__(
-        self,
-        context: SharedFullContext,
-        signature: tuple,
-        slot1_raw_tensors: Dict[str, torch.Tensor],
-    ):
-        self.context = context
-        self.signature = signature
-        self.device = context.gpu_layer.w13_weight.device
-        slot0_raw = {
-            name: getattr(context.gpu_layer, name)
-            for name in _Glm5NextFp8PrefillSlot.RAW_NAMES
-        }
-        self.slots = (
-            _Glm5NextFp8PrefillSlot(0, slot0_raw),
-            _Glm5NextFp8PrefillSlot(1, slot1_raw_tensors),
-        )
-        self.transfer_stream = torch.cuda.Stream(device=self.device)
-        self.host_slot_free_events = (torch.cuda.Event(), torch.cuda.Event())
-        self.host_slot_was_used = [False, False]
-        self.host_slot_generations = [0, 0]
-        self.host_write_status = torch.ones((1,), dtype=torch.int32, device="cpu")
-
-        # Initialized only after every TP rank has successfully allocated both
-        # GPU slots and its pinned weight SHM.  Each control word occupies its
-        # own cache line and is accessed through libatomic acquire/release
-        # operations; ordinary Python/torch SHM stores are not a publication
-        # primitive across processes.
-        self._atomic_lib = None
-        self._atomic_load_u64 = None
-        self._atomic_store_u64 = None
-        self._transport_control_shm = None
-        self._transport_control_anchor = None
-        self._transport_control_address = None
-        self._control_offsets = None
-        self.transport_generation = 0
-        self.transport_abandoned = False
-        self.contract_digest = None
-
-        self.epoch = -1
-        self.last_layer_position: Optional[int] = None
-        self.current_slot_index: Optional[int] = None
-        self.round_active = False
-        self.failure_reason: Optional[str] = None
-        self.visited_layer_indices: List[int] = []
-
-        # Acceptance counters.  fallback_count intentionally never changes;
-        # it is exported in logs to prove a 500K run did not silently fall
-        # through to hybrid or serialized prefill.
-        self.apply_count = 0
-        self.prime_count = 0
-        self.prefetch_hit_count = 0
-        self.completed_round_count = 0
-        self.fallback_count = 0
-        self.expert_layouts = {}
-        for layer_idx, (method, _layer) in self.registry.items():
-            gpu_ids = tuple(
-                expert_id
-                for expert_id in range(self.slots[0].num_experts)
-                if method.gpu_experts_mask[expert_id].item()
-            )
-            gpu_id_set = set(gpu_ids)
-            cpu_ids = tuple(
-                expert_id
-                for expert_id in range(self.slots[0].num_experts)
-                if expert_id not in gpu_id_set
-            )
-            self.expert_layouts[layer_idx] = (gpu_ids, cpu_ids)
-
-    @property
-    def registry(self):
-        return _GLM5_NEXT_FP8_PREFILL_LAYER_REGISTRY.get(self.signature, {})
-
-    @property
-    def layer_order(self) -> List[int]:
-        return sorted(self.registry)
-
-    @property
-    def allocated_bytes(self) -> int:
-        return sum(
-            getattr(slot, name).numel() * getattr(slot, name).element_size()
-            for slot in self.slots
-            for name in _Glm5NextFp8PrefillSlot.RAW_NAMES
-        )
-
-    @classmethod
-    def _build_control_offsets(cls, tp_size: int):
-        cursor = 0
-        offsets = {}
-
-        def allocate(name: str, count: int) -> None:
-            nonlocal cursor
-            offsets[name] = tuple(
-                (cursor + index) * cls._CONTROL_CACHELINE_BYTES
-                for index in range(count)
-            )
-            cursor += count
-
-        allocate("global_error", 1)
-        allocate("ready_generation", 2)
-        allocate("writer_ok", 2)
-        allocate("writer_layer", 2)
-        allocate("writer_expert", 2)
-        allocate("rank_error", tp_size)
-        allocate("free_generation", tp_size * 2)
-        return offsets, cursor * cls._CONTROL_CACHELINE_BYTES
-
-    def _configure_atomic_access(self, handle, tp_size: int) -> None:
-        atomic_lib = ctypes.CDLL("libatomic.so.1")
-        atomic_load = getattr(atomic_lib, "__atomic_load_8")
-        atomic_load.argtypes = [ctypes.c_void_p, ctypes.c_int]
-        atomic_load.restype = ctypes.c_uint64
-        atomic_store = getattr(atomic_lib, "__atomic_store_8")
-        atomic_store.argtypes = [
-            ctypes.c_void_p,
-            ctypes.c_uint64,
-            ctypes.c_int,
-        ]
-        atomic_store.restype = None
-        atomic_is_lock_free = getattr(atomic_lib, "__atomic_is_lock_free")
-        atomic_is_lock_free.argtypes = [ctypes.c_size_t, ctypes.c_void_p]
-        atomic_is_lock_free.restype = ctypes.c_bool
-
-        anchor = ctypes.c_char.from_buffer(handle.buf)
-        address = ctypes.addressof(anchor)
-        if address % self._CONTROL_CACHELINE_BYTES != 0:
-            raise RuntimeError(
-                "GLM-5-Next FP8 transport control is not cache-line aligned"
-            )
-        if not atomic_is_lock_free(8, ctypes.c_void_p(address)):
-            raise RuntimeError(
-                "GLM-5-Next FP8 transport requires lock-free shared uint64 atomics"
-            )
-
-        offsets, _ = self._build_control_offsets(tp_size)
-        self._atomic_lib = atomic_lib
-        self._atomic_load_u64 = atomic_load
-        self._atomic_store_u64 = atomic_store
-        self._transport_control_anchor = anchor
-        self._transport_control_address = address
-        self._control_offsets = offsets
-
-    def _atomic_load(self, offset: int) -> int:
-        return int(
-            self._atomic_load_u64(
-                ctypes.c_void_p(self._transport_control_address + offset),
-                self._ATOMIC_ACQUIRE,
-            )
-        )
-
-    def _atomic_store(self, offset: int, value: int) -> None:
-        if value < 0 or value >= 2**64:
-            raise OverflowError(f"invalid uint64 control value {value}")
-        self._atomic_store_u64(
-            ctypes.c_void_p(self._transport_control_address + offset),
-            ctypes.c_uint64(value),
-            self._ATOMIC_RELEASE,
-        )
-
-    def _control_offset(self, name: str, index: int = 0) -> int:
-        return self._control_offsets[name][index]
-
-    @staticmethod
-    def _open_transport_shared_memory(**kwargs):
-        """Open untracked control SHM when the Python runtime supports it.
-
-        Every TP rank keeps its own file descriptor and mmap alive for the
-        manager lifetime.  TP0 unlinks the name only after every rank has
-        opened and configured that mapping.  Disabling ``resource_tracker``
-        registration prevents an unrelated rank's tracker from attempting a
-        second unlink at process shutdown.  Python before 3.13 has no
-        ``track`` argument; immediate TP0 unlink still makes that fallback
-        safe because all mappings are already open.
-        """
-
-        try:
-            return shared_memory.SharedMemory(**kwargs, track=False)
-        except TypeError:
-            return shared_memory.SharedMemory(**kwargs)
-
-    def initialize_transport_control(self) -> None:
-        """Create a same-node acquire/release control plane for hot transport."""
-
-        tp_rank = get_tensor_model_parallel_rank()
-        tp_size = get_tensor_model_parallel_world_size()
-        _, control_nbytes = self._build_control_offsets(tp_size)
-        name_holder = [None]
-        local_error = None
-        handle = None
-        try:
-            if tp_rank == 0:
-                name_holder[0] = f"kt_glm5_fp8_ctrl_{uuid.uuid4().hex[:12]}"
-                handle = self._open_transport_shared_memory(
-                    name=name_holder[0],
-                    create=True,
-                    size=control_nbytes,
-                )
-                handle.buf[:] = bytes(control_nbytes)
-        except Exception as exc:
-            local_error = exc
-
-        if dist.is_initialized():
-            dist.broadcast_object_list(
-                name_holder,
-                src=get_tp_group().first_rank,
-                group=get_tp_group().cpu_group,
-            )
-
-        if tp_rank != 0 and local_error is None:
-            try:
-                if name_holder[0] is None:
-                    raise RuntimeError("TP0 did not publish a transport SHM name")
-                handle = self._open_transport_shared_memory(
-                    name=name_holder[0], create=False
-                )
-            except Exception as exc:
-                local_error = exc
-
-        if handle is not None and local_error is None:
-            try:
-                self._configure_atomic_access(handle, tp_size)
-            except Exception as exc:
-                local_error = exc
-
-        if not _all_tp_ranks_succeeded(local_error is None):
-            self._transport_control_anchor = None
-            if handle is not None:
-                try:
-                    handle.close()
-                except Exception:
-                    pass
-            if tp_rank == 0 and handle is not None:
-                try:
-                    handle.unlink()
-                except Exception:
-                    pass
-            message = (
-                "GLM-5-Next FP8 transport control SHM initialization failed "
-                "on at least one TP rank"
-            )
-            if local_error is not None:
-                raise RuntimeError(message) from local_error
-            raise RuntimeError(message)
-        if local_error is not None:
-            raise local_error
-        assert handle is not None
-
-        self._transport_control_shm = handle
-        if tp_rank == 0:
-            try:
-                handle.unlink()
-            except FileNotFoundError:
-                pass
-
-    def _mark_local_transport_failure(self) -> None:
-        if self._control_offsets is None:
-            return
-        try:
-            tp_rank = get_tensor_model_parallel_rank()
-            self._atomic_store(self._control_offset("rank_error", tp_rank), 1)
-            self._atomic_store(self._control_offset("global_error"), 1)
-        except Exception:
-            # Error publication is best-effort once the atomic control plane
-            # itself is broken.  Do not let it make one rank skip the fixed
-            # expert loop / layer-end consensus; the process-group watchdog
-            # remains the final guard for an unusable mapping or dead rank.
-            self.transport_abandoned = True
-
-    def _shared_transport_failed(self) -> bool:
-        return bool(
-            self._control_offsets is not None
-            and self._atomic_load(self._control_offset("global_error"))
-        )
-
-    def _wait_for_exact_control_value(
-        self, offset: int, expected: int, phase: str
-    ) -> None:
-        if self.transport_abandoned:
-            raise RuntimeError(
-                "GLM-5-Next FP8 transport control was abandoned after a "
-                "protocol failure"
-            )
-        deadline = time.monotonic() + self._CONTROL_TIMEOUT_SECONDS
-        while True:
-            observed = self._atomic_load(offset)
-            if observed == expected:
-                return
-            if observed > expected:
-                self.transport_abandoned = True
-                self._mark_local_transport_failure()
-                raise RuntimeError(
-                    "GLM-5-Next FP8 transport generation drift while waiting "
-                    f"for {phase}: expected {expected}, observed {observed}"
-                )
-            if self._shared_transport_failed():
-                self.transport_abandoned = True
-                raise RuntimeError(
-                    "GLM-5-Next FP8 atomic transport was aborted by another "
-                    f"TP rank while waiting for {phase}"
-                )
-            if time.monotonic() >= deadline:
-                self.transport_abandoned = True
-                self._mark_local_transport_failure()
-                raise RuntimeError(
-                    "GLM-5-Next FP8 atomic transport timed out while waiting "
-                    f"for {phase}"
-                )
-            time.sleep(0)
-
-    def _wait_until_all_ranks_release(
-        self, host_slot: int, generation: int
-    ) -> bool:
-        if generation == 0:
-            return not self._shared_transport_failed()
-        tp_size = get_tensor_model_parallel_world_size()
-        deadline = time.monotonic() + self._CONTROL_TIMEOUT_SECONDS
-        for rank in range(tp_size):
-            offset = self._control_offset("free_generation", rank * 2 + host_slot)
-            while True:
-                observed = self._atomic_load(offset)
-                if observed == generation:
-                    break
-                if observed > generation:
-                    self.transport_abandoned = True
-                    self._mark_local_transport_failure()
-                    raise RuntimeError(
-                        "GLM-5-Next FP8 host-slot release generation drift: "
-                        f"rank={rank} slot={host_slot} expected={generation} "
-                        f"observed={observed}"
-                    )
-                if self._shared_transport_failed():
-                    return False
-                if time.monotonic() >= deadline:
-                    self.transport_abandoned = True
-                    self._mark_local_transport_failure()
-                    raise RuntimeError(
-                        "GLM-5-Next FP8 timed out waiting for host-slot "
-                        f"{host_slot} generation {generation} release from "
-                        f"rank {rank}"
-                    )
-                time.sleep(0)
-        return not self._shared_transport_failed()
-
-    def _publish_writer_generation(
-        self,
-        host_slot: int,
-        generation: int,
-        layer_idx: int,
-        expert_id: int,
-        writer_ok: bool,
-    ) -> None:
-        self._atomic_store(
-            self._control_offset("writer_layer", host_slot), layer_idx
-        )
-        self._atomic_store(
-            self._control_offset("writer_expert", host_slot), expert_id
-        )
-        self._atomic_store(
-            self._control_offset("writer_ok", host_slot), int(writer_ok)
-        )
-        # Release-publish ready last.  Readers acquire-load it before reading
-        # the descriptor or the payload written by KT.
-        self._atomic_store(
-            self._control_offset("ready_generation", host_slot), generation
-        )
-
-    def _consume_writer_generation(
-        self,
-        host_slot: int,
-        generation: int,
-        layer_idx: int,
-        expert_id: int,
-    ) -> bool:
-        self._wait_for_exact_control_value(
-            self._control_offset("ready_generation", host_slot),
-            generation,
-            f"writer generation {generation}",
-        )
-        observed_layer = self._atomic_load(
-            self._control_offset("writer_layer", host_slot)
-        )
-        observed_expert = self._atomic_load(
-            self._control_offset("writer_expert", host_slot)
-        )
-        if observed_layer != layer_idx or observed_expert != expert_id:
-            self.transport_abandoned = True
-            self._mark_local_transport_failure()
-            raise RuntimeError(
-                "GLM-5-Next FP8 writer descriptor mismatch: expected "
-                f"layer={layer_idx}/expert={expert_id}, observed "
-                f"layer={observed_layer}/expert={observed_expert}"
-            )
-        return bool(
-            self._atomic_load(self._control_offset("writer_ok", host_slot))
-        )
-
-    def _publish_local_host_release(
-        self, host_slot: int, generation: int
-    ) -> None:
-        rank = get_tensor_model_parallel_rank()
-        self._atomic_store(
-            self._control_offset("free_generation", rank * 2 + host_slot),
-            generation,
-        )
-
-    def _entry_state_values(self, layer_idx: int) -> tuple:
-        values = (
-            layer_idx,
-            self.epoch,
-            -1 if self.last_layer_position is None else self.last_layer_position,
-            -1 if self.current_slot_index is None else self.current_slot_index,
-            int(self.round_active),
-            int(self.failure_reason is not None),
-            tuple(self.visited_layer_indices),
-            self.transport_generation,
-            tuple(self.host_slot_generations),
-        )
-        slots = []
-        for slot in self.slots:
-            slots.append(
-                (
-                    self._SLOT_STATE_CODES.get(slot.state, -1),
-                    -1 if slot.layer_idx is None else slot.layer_idx,
-                    slot.epoch,
-                    self._REUSE_GUARD_CODES.get(slot.reuse_guard, -1),
-                )
-            )
-        return values + (tuple(slots),)
-
-    def _synchronize_layer_entry(self, layer_idx: int) -> None:
-        """Fail every local TP rank before any rank chooses ready vs load."""
-
-        if not dist.is_initialized() or get_tensor_model_parallel_world_size() == 1:
-            return
-        local_error = None
-        state = None
-        try:
-            state = self._entry_state_values(layer_idx)
-        except Exception as exc:
-            local_error = exc
-        gathered = [None] * get_tensor_model_parallel_world_size()
-        dist.all_gather_object(
-            gathered,
-            (state, None if local_error is None else repr(local_error)),
-            group=get_tp_group().cpu_group,
-        )
-        if any(peer[1] is not None for peer in gathered) or any(
-            peer[0] != gathered[0][0] for peer in gathered[1:]
-        ):
-            message = (
-                "GLM-5-Next FP8 layerwise TP state diverged before transport "
-                f"for layer {layer_idx}: {gathered}"
-            )
-            if local_error is not None:
-                raise RuntimeError(message) from local_error
-            raise RuntimeError(message)
-
-    def validate_tp_contract(self) -> None:
-        """Validate all rank-invariant registry and expert layout metadata."""
-
-        local_error = None
-        digest = None
-        hostname = socket.gethostname()
-        try:
-            layers = []
-            raw_metadata = {
-                name: {
-                    "shape": list(getattr(self.slots[0], name).shape),
-                    "dtype": str(getattr(self.slots[0], name).dtype),
-                }
-                for name in _Glm5NextFp8PrefillSlot.RAW_NAMES
-            }
-            for layer_idx in self.layer_order:
-                method, original_layer = self.registry[layer_idx]
-                original_raw_metadata = {}
-                for name in _Glm5NextFp8PrefillSlot.RAW_NAMES:
-                    if not hasattr(original_layer, name):
-                        raise RuntimeError(
-                            "GLM-5-Next FP8 registered GPU layer is missing "
-                            f"raw tensor {name} at layer {layer_idx}"
-                        )
-                    tensor = getattr(original_layer, name)
-                    full_tensor = getattr(self.slots[0], name)
-                    expected_shape = (
-                        method.num_gpu_experts,
-                        *tuple(full_tensor.shape[1:]),
-                    )
-                    if tuple(tensor.shape) != expected_shape:
-                        raise RuntimeError(
-                            "GLM-5-Next FP8 registered GPU tensor shape "
-                            f"mismatch for {name} at layer {layer_idx}: "
-                            f"expected {expected_shape}, got "
-                            f"{tuple(tensor.shape)}"
-                        )
-                    if tensor.dtype != full_tensor.dtype:
-                        raise RuntimeError(
-                            "GLM-5-Next FP8 registered GPU tensor dtype "
-                            f"mismatch for {name} at layer {layer_idx}: "
-                            f"expected {full_tensor.dtype}, got {tensor.dtype}"
-                        )
-                    original_raw_metadata[name] = {
-                        "shape": list(tensor.shape),
-                        "dtype": str(tensor.dtype),
-                    }
-                layers.append(
-                    {
-                        "layer": layer_idx,
-                        "mask": method.gpu_experts_mask.to(torch.uint8).tolist(),
-                        "logical_to_gpu": method.logical_to_gpu_index.tolist(),
-                        "global_num_experts": method.global_num_experts,
-                        "full_init_args": [
-                            str(value) for value in method._full_init_args
-                        ],
-                        "weight_path": method.kt_config.weight_path,
-                        "original_raw": original_raw_metadata,
-                    }
-                )
-            contract = {
-                "kind": "glm5_next_block_fp8_layerwise_v1",
-                "tp_size": get_tensor_model_parallel_world_size(),
-                "device_type": self.device.type,
-                "layer_order": self.layer_order,
-                "raw": raw_metadata,
-                "layers": layers,
-            }
-            canonical = json.dumps(
-                contract, sort_keys=True, separators=(",", ":")
-            )
-            digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
-        except Exception as exc:
-            local_error = exc
-
-        self.contract_digest = digest
-        if not dist.is_initialized() or get_tensor_model_parallel_world_size() == 1:
-            if local_error is not None:
-                raise RuntimeError(
-                    "GLM-5-Next FP8 failed to build its TP contract"
-                ) from local_error
-            return
-
-        local = (
-            hostname,
-            digest,
-            self.device.type,
-            None if local_error is None else repr(local_error),
-        )
-        gathered = [None] * get_tensor_model_parallel_world_size()
-        dist.all_gather_object(
-            gathered, local, group=get_tp_group().cpu_group
-        )
-        if any(item[3] is not None for item in gathered):
-            message = (
-                "GLM-5-Next FP8 TP contract construction failed on at least "
-                f"one rank: {gathered}"
-            )
-            if local_error is not None:
-                raise RuntimeError(message) from local_error
-            raise RuntimeError(message)
-        if len({item[0] for item in gathered}) != 1:
-            raise RuntimeError(
-                "GLM-5-Next FP8 atomic host transport requires every TP rank "
-                f"on one host; got {gathered}"
-            )
-        if any(item[1:3] != gathered[0][1:3] for item in gathered[1:]):
-            raise RuntimeError(
-                "GLM-5-Next FP8 TP registry/mask/layout contract mismatch: "
-                f"{gathered}"
-            )
-
-    def _ensure_healthy(self) -> None:
-        if self.failure_reason is not None:
-            raise RuntimeError(
-                "GLM-5-Next FP8 layerwise prefill manager is poisoned after "
-                f"a required-path failure: {self.failure_reason}"
-            )
-
-    def _poison(self, exc: BaseException) -> None:
-        if self.failure_reason is None:
-            self.failure_reason = f"{type(exc).__name__}: {exc}"
-
-    def successor_layer_idx(self, layer_idx: int) -> Optional[int]:
-        order = self.layer_order
-        pos = bisect.bisect_right(order, layer_idx)
-        return order[pos] if pos < len(order) else None
-
-    def _advance_round(self, layer_idx: int) -> None:
-        self._ensure_healthy()
-        order = self.layer_order
-        pos = bisect.bisect_left(order, layer_idx)
-        if pos >= len(order) or order[pos] != layer_idx:
-            raise RuntimeError(
-                f"GLM-5-Next FP8 layerwise layer {layer_idx} is not "
-                f"registered; registered layers are {order}"
-            )
-
-        if not self.round_active:
-            if pos != 0:
-                raise RuntimeError(
-                    "GLM-5-Next FP8 layerwise EXTEND must start at MoE "
-                    f"layer {order[0]}, got layer {layer_idx}"
-                )
-            self.epoch += 1
-            self.round_active = True
-            self.last_layer_position = None
-            self.current_slot_index = None
-            self.visited_layer_indices = []
-            for slot in self.slots:
-                slot.invalidate()
-        elif self.last_layer_position is not None and pos != self.last_layer_position + 1:
-            raise RuntimeError(
-                "GLM-5-Next FP8 layerwise layer order mismatch in epoch "
-                f"{self.epoch}: expected {order[self.last_layer_position + 1]}, "
-                f"got {layer_idx}"
-            )
-        self.last_layer_position = pos
-
-    def _finish_round_if_complete(self, layer_idx: int) -> None:
-        order = self.layer_order
-        if layer_idx != order[-1]:
-            return
-        if self.visited_layer_indices != order:
-            raise RuntimeError(
-                "GLM-5-Next FP8 layerwise coverage mismatch in epoch "
-                f"{self.epoch}: expected {order}, got "
-                f"{self.visited_layer_indices}"
-            )
-        self.completed_round_count += 1
-        self.round_active = False
-        self.last_layer_position = None
-        self.current_slot_index = None
-
-    def _find_ready_slot(
-        self, layer_idx: int
-    ) -> Optional[_Glm5NextFp8PrefillSlot]:
-        for slot in self.slots:
-            if (
-                slot.state == "READY"
-                and slot.layer_idx == layer_idx
-                and slot.epoch == self.epoch
-            ):
-                return slot
-        return None
-
-    @staticmethod
-    def _record_raw_backing_on_stream(
-        slot: _Glm5NextFp8PrefillSlot, stream: torch.cuda.Stream
-    ) -> None:
-        for name in _Glm5NextFp8PrefillSlot.RAW_NAMES:
-            getattr(slot, name).record_stream(stream)
-
-    def _bind_slot(self, slot: _Glm5NextFp8PrefillSlot) -> None:
-        layer = self.context.gpu_layer
-        for name in _Glm5NextFp8PrefillSlot.RAW_NAMES:
-            # Slot tensors are stable Parameters.  Rebinding selects a slot;
-            # no tensor allocation or format conversion occurs in apply().
-            setattr(layer, name, getattr(slot, name))
-
-    def _tp_phase_succeeded(self, local_success: bool) -> bool:
-        if not dist.is_initialized() or get_tensor_model_parallel_world_size() == 1:
-            return local_success
-        try:
-            self.host_write_status.fill_(int(local_success))
-            dist.all_reduce(
-                self.host_write_status,
-                op=dist.ReduceOp.MIN,
-                group=get_tp_group().cpu_group,
-            )
-            return bool(self.host_write_status.item())
-        except Exception:
-            # This process can no longer prove that peers reached the same
-            # phase.  Poison the atomic transport before re-raising; an
-            # external process-group watchdog owns peer/rank death handling.
-            self.transport_abandoned = True
-            self._mark_local_transport_failure()
-            raise
-
-    def _commit_tp_runtime_phase(
-        self, local_error: Optional[BaseException], phase: str
-    ) -> None:
-        if self._tp_phase_succeeded(local_error is None):
-            return
-        message = f"GLM-5-Next FP8 {phase} failed on at least one TP rank"
-        if local_error is not None:
-            raise RuntimeError(message) from local_error
-        raise RuntimeError(message)
-
-    def _submit_host_write(self, method, expert_id: int, host_slot: int) -> None:
-        buffers = self.context.cpu_buffers
-        pointers = self.context.all_rank_buffer_ptrs
-
-        def expert_nbytes(name: str) -> int:
-            tensor = buffers[name]
-            return tensor.numel() // 2 * tensor.element_size()
-
-        offsets = {
-            name: host_slot * expert_nbytes(name)
-            for name in _Glm5NextFp8PrefillSlot.RAW_NAMES
-        }
-
-        def rank_pointers(name: str) -> List[int]:
-            return [ptr + offsets[name] for ptr in pointers[name]]
-
-        # Existing KT FP8 ABI writes raw E4M3 weights plus FP32 inverse
-        # scales.  No new C++ writer or conversion ABI is needed.
-        method.wrapper.submit_write_weight_scale_to_buffer(
-            get_tensor_model_parallel_world_size(),
-            expert_id,
-            rank_pointers("w13_weight"),
-            rank_pointers("w13_weight_scale_inv"),
-            rank_pointers("w2_weight"),
-            rank_pointers("w2_weight_scale_inv"),
-        )
-        method.wrapper.sync_write_weight_scale_to_buffer()
-
-    def _load_slot(
-        self,
-        slot: _Glm5NextFp8PrefillSlot,
-        layer_idx: int,
-        method,
-        original_layer: torch.nn.Module,
-    ) -> None:
-        if getattr(slot, "reuse_guard", None) == "poisoned":
-            raise RuntimeError(
-                f"GLM-5-Next FP8 slot {slot.index} cannot be reused after "
-                "its transfer stream failed to synchronize"
-            )
-        if slot.state == "LOADING":
-            raise RuntimeError(
-                f"GLM-5-Next FP8 slot {slot.index} is already loading "
-                f"layer {slot.layer_idx}"
-            )
-
-        reuse_guard = getattr(slot, "reuse_guard", None)
-        if reuse_guard is None and slot.has_consumed_event:
-            reuse_guard = "consumed"
-        slot.reuse_guard = "loading"
-        slot.state = "LOADING"
-        slot.layer_idx = layer_idx
-        slot.epoch = self.epoch
-
-        saved_affinity = None
-        local_error: Optional[BaseException] = None
-
-        def remember_error(exc: BaseException) -> None:
-            nonlocal local_error
-            if local_error is None:
-                local_error = exc
-            self._mark_local_transport_failure()
-
-        try:
-            try:
-                weight_infos = [
-                    (name, self.context.cpu_buffers[name], getattr(slot, name))
-                    for name in _Glm5NextFp8PrefillSlot.RAW_NAMES
-                ]
-                gpu_expert_ids, cpu_expert_ids = self.expert_layouts[layer_idx]
-
-                if hasattr(os, "sched_getaffinity"):
-                    saved_affinity = os.sched_getaffinity(0)
-                    available_cpus = sorted(saved_affinity)
-                    if available_cpus:
-                        target = available_cpus[
-                            -1 - (method.tp_rank % len(available_cpus))
-                        ]
-                        os.sched_setaffinity(0, {target})
-            except Exception as exc:
-                weight_infos = []
-                gpu_expert_ids, cpu_expert_ids = self.expert_layouts.get(
-                    layer_idx, ((), tuple(range(slot.num_experts)))
-                )
-                remember_error(exc)
-
-            try:
-                with torch.cuda.stream(self.transfer_stream):
-                    if reuse_guard == "consumed":
-                        self.transfer_stream.wait_event(slot.consumed_event)
-                    elif reuse_guard == "ready":
-                        self.transfer_stream.wait_event(slot.ready_event)
-                    if local_error is None:
-                        for expert_id in gpu_expert_ids:
-                            gpu_index = method.logical_to_gpu_index[
-                                expert_id
-                            ].item()
-                            for name, _, destination in weight_infos:
-                                source = getattr(original_layer, name)
-                                destination[expert_id].copy_(
-                                    source[gpu_index], non_blocking=True
-                                )
-            except Exception as exc:
-                remember_error(exc)
-
-            for position, expert_id in enumerate(cpu_expert_ids):
-                host_slot = position % 2
-                self.transport_generation += 1
-                generation = self.transport_generation
-                previous_generation = self.host_slot_generations[host_slot]
-
-                if self.host_slot_was_used[host_slot]:
-                    try:
-                        self.host_slot_free_events[host_slot].synchronize()
-                        self.host_slot_was_used[host_slot] = False
-                        self._publish_local_host_release(
-                            host_slot, previous_generation
-                        )
-                    except Exception as exc:
-                        remember_error(exc)
-
-                if method.tp_rank == 0:
-                    writer_ok = False
-                    try:
-                        can_write = self._wait_until_all_ranks_release(
-                            host_slot, previous_generation
-                        )
-                        if can_write and local_error is None:
-                            if method.wrapper is None:
-                                raise RuntimeError(
-                                    "GLM-5-Next FP8 TP0 has no KT wrapper for "
-                                    "host weight transport"
-                                )
-                            self._submit_host_write(method, expert_id, host_slot)
-                            writer_ok = True
-                    except Exception as exc:
-                        remember_error(exc)
-                    finally:
-                        try:
-                            self._publish_writer_generation(
-                                host_slot,
-                                generation,
-                                layer_idx,
-                                expert_id,
-                                writer_ok
-                                and not self._shared_transport_failed(),
-                            )
-                        except Exception as exc:
-                            # Continue the fixed expert loop.  Peers observe
-                            # global_error and abort their generation wait;
-                            # watchdog handles a fully broken atomic mapping.
-                            remember_error(exc)
-
-                writer_ok = False
-                try:
-                    writer_ok = self._consume_writer_generation(
-                        host_slot,
-                        generation,
-                        layer_idx,
-                        expert_id,
-                    )
-                except Exception as exc:
-                    remember_error(exc)
-                self.host_slot_generations[host_slot] = generation
-
-                if not writer_ok and local_error is None:
-                    remember_error(
-                        RuntimeError(
-                            "GLM-5-Next FP8 TP0 writer failed for "
-                            f"layer {layer_idx}, expert {expert_id}"
-                        )
-                    )
-
-                copied = False
-                transport_failed = True
-                try:
-                    transport_failed = self._shared_transport_failed()
-                except Exception as exc:
-                    remember_error(exc)
-                if writer_ok and local_error is None and not transport_failed:
-                    event_recorded = False
-                    try:
-                        with torch.cuda.stream(self.transfer_stream):
-                            try:
-                                for _, cpu_buffer, destination in weight_infos:
-                                    destination[expert_id].copy_(
-                                        cpu_buffer[host_slot], non_blocking=True
-                                    )
-                            finally:
-                                self.host_slot_free_events[host_slot].record(
-                                    self.transfer_stream
-                                )
-                                event_recorded = True
-                        self.host_slot_was_used[host_slot] = True
-                        copied = True
-                    except Exception as exc:
-                        remember_error(exc)
-                        if event_recorded:
-                            self.host_slot_was_used[host_slot] = True
-                        else:
-                            try:
-                                self.transfer_stream.synchronize()
-                                self.host_slot_was_used[host_slot] = False
-                            except Exception as fence_exc:
-                                remember_error(fence_exc)
-
-                if not copied and not self.host_slot_was_used[host_slot]:
-                    # This rank enqueued no DMA for the generation, so release
-                    # it immediately.  A rank with an unfenced prior DMA never
-                    # enters this branch and consequently cannot authorize an
-                    # overwrite after failure.
-                    try:
-                        self._publish_local_host_release(host_slot, generation)
-                    except Exception as exc:
-                        remember_error(exc)
-
-            fence_complete = False
-            try:
-                with torch.cuda.stream(self.transfer_stream):
-                    slot.ready_event.record(self.transfer_stream)
-                slot.ready_event.synchronize()
-                slot.reuse_guard = "ready"
-                fence_complete = True
-            except Exception as exc:
-                remember_error(exc)
-                try:
-                    self.transfer_stream.synchronize()
-                    slot.reuse_guard = "synchronized"
-                    fence_complete = True
-                except Exception as fence_exc:
-                    slot.reuse_guard = "poisoned"
-                    remember_error(fence_exc)
-
-            if fence_complete:
-                for host_slot in range(2):
-                    if self.host_slot_was_used[host_slot]:
-                        self.host_slot_was_used[host_slot] = False
-                        try:
-                            self._publish_local_host_release(
-                                host_slot,
-                                self.host_slot_generations[host_slot],
-                            )
-                        except Exception as exc:
-                            remember_error(exc)
-
-            if local_error is None:
-                try:
-                    if self._shared_transport_failed():
-                        local_error = RuntimeError(
-                            "another TP rank reported an atomic transport "
-                            "failure"
-                        )
-                except Exception as exc:
-                    remember_error(exc)
-            self._commit_tp_runtime_phase(
-                local_error, f"transport for layer {layer_idx}"
-            )
-            slot.state = "READY"
-        except Exception:
-            fence_error = None
-            if slot.reuse_guard not in ("ready", "synchronized", "poisoned"):
-                try:
-                    with torch.cuda.stream(self.transfer_stream):
-                        if reuse_guard == "consumed":
-                            self.transfer_stream.wait_event(slot.consumed_event)
-                        elif reuse_guard == "ready":
-                            self.transfer_stream.wait_event(slot.ready_event)
-                        slot.ready_event.record(self.transfer_stream)
-                    slot.reuse_guard = "ready"
-                except Exception:
-                    try:
-                        self.transfer_stream.synchronize()
-                        slot.reuse_guard = "synchronized"
-                    except Exception as exc:
-                        slot.reuse_guard = "poisoned"
-                        fence_error = exc
-            slot.invalidate()
-            if fence_error is not None:
-                raise RuntimeError(
-                    f"GLM-5-Next FP8 failed to fence slot {slot.index} "
-                    "after a transport error"
-                ) from fence_error
-            raise
-        finally:
-            if saved_affinity is not None:
-                try:
-                    os.sched_setaffinity(0, saved_affinity)
-                except Exception:
-                    logger.warning(
-                        "Failed to restore CPU affinity after GLM-5-Next "
-                        "FP8 transport",
-                        exc_info=True,
-                    )
-
-    def _acquire(self, layer_idx: int, method, layer: torch.nn.Module):
-        self._synchronize_layer_entry(layer_idx)
-        self._advance_round(layer_idx)
-        ready = self._find_ready_slot(layer_idx)
-        if ready is not None:
-            return ready, True
-
-        slot = (
-            self.slots[0]
-            if self.current_slot_index is None
-            else self.slots[1 - self.current_slot_index]
-        )
-        self._load_slot(slot, layer_idx, method, layer)
-        return slot, False
-
-    def _prefetch_successor(self, current: _Glm5NextFp8PrefillSlot) -> None:
-        successor_idx = self.successor_layer_idx(current.layer_idx)
-        if successor_idx is None:
-            return
-        entry = self.registry.get(successor_idx)
-        if entry is None:
-            raise RuntimeError(
-                f"GLM-5-Next FP8 successor layer {successor_idx} "
-                "disappeared from registry"
-            )
-        next_method, next_layer = entry
-        target = self.slots[1 - current.index]
-        if (
-            target.state == "READY"
-            and target.layer_idx == successor_idx
-            and target.epoch == self.epoch
-        ):
-            return
-        self._load_slot(target, successor_idx, next_method, next_layer)
-
-    def apply(self, method, layer, dispatch_output):
-        layer_idx = method.kt_config.layer_idx
-        try:
-            slot, prefetch_hit = self._acquire(layer_idx, method, layer)
-            if slot.layer_idx != layer_idx or slot.epoch != self.epoch:
-                raise RuntimeError(
-                    "GLM-5-Next FP8 layerwise acquired stale weights: "
-                    f"wanted layer={layer_idx}/epoch={self.epoch}, got "
-                    f"layer={slot.layer_idx}/epoch={slot.epoch}"
-                )
-
-            main_stream = None
-            result = None
-            compute_error = None
-            try:
-                main_stream = torch.cuda.current_stream(self.device)
-                main_stream.wait_event(slot.ready_event)
-                self._bind_slot(slot)
-                self._record_raw_backing_on_stream(slot, main_stream)
-                result = self.context.gpu_method.apply(
-                    self.context.gpu_layer, dispatch_output
-                )
-            except Exception as exc:
-                compute_error = exc
-            finally:
-                if main_stream is not None:
-                    try:
-                        slot.consumed_event.record(main_stream)
-                        slot.has_consumed_event = True
-                        slot.reuse_guard = "consumed"
-                        slot.state = "IN_USE"
-                        self.current_slot_index = slot.index
-                    except Exception as exc:
-                        if compute_error is None:
-                            compute_error = exc
-                        try:
-                            main_stream.synchronize()
-                            slot.reuse_guard = "synchronized"
-                            slot.state = "IN_USE"
-                            self.current_slot_index = slot.index
-                        except Exception:
-                            pass
-
-            self._commit_tp_runtime_phase(
-                compute_error, f"compute launch for layer {layer_idx}"
-            )
-            self.apply_count += 1
-            if prefetch_hit:
-                self.prefetch_hit_count += 1
-            else:
-                self.prime_count += 1
-            self.visited_layer_indices.append(layer_idx)
-
-            # Compute is already enqueued; prepare N+1 while it runs.
-            self._prefetch_successor(slot)
-            coverage_error = None
-            try:
-                self._finish_round_if_complete(layer_idx)
-            except Exception as exc:
-                coverage_error = exc
-            if layer_idx == self.layer_order[-1]:
-                # No rank may leave the final MoE layer after a rank-local
-                # coverage failure while peers proceed to later collectives.
-                self._commit_tp_runtime_phase(
-                    coverage_error, f"coverage for epoch {self.epoch}"
-                )
-            elif coverage_error is not None:
-                raise coverage_error
-            if method.tp_rank == 0:
-                log = (
-                    logger.info
-                    if layer_idx == self.layer_order[-1]
-                    else logger.debug
-                )
-                log(
-                    "KT GLM-5-Next FP8 layerwise prefill: layer=%d epoch=%d "
-                    "slot=%d %s apply_count=%d prime_count=%d "
-                    "prefetch_hit_count=%d completed_rounds=%d fallback_count=%d",
-                    layer_idx,
-                    self.epoch,
-                    slot.index,
-                    "prefetch-hit" if prefetch_hit else "prime",
-                    self.apply_count,
-                    self.prime_count,
-                    self.prefetch_hit_count,
-                    self.completed_round_count,
-                    self.fallback_count,
-                )
-            return result
-        except Exception as exc:
-            self._poison(exc)
-            raise
-
-
 def _glm5_next_fp8_pipeline_requested(method) -> bool:
     return (
         bool(getattr(method.kt_config, "is_glm5_next", False))
@@ -3957,145 +2944,60 @@ def _glm5_next_fp8_pipeline_requested(method) -> bool:
     )
 
 
-def _glm5_next_fp8_pipeline_signature(method, layer: torch.nn.Module) -> tuple:
-    device = next(layer.parameters()).device
-    return (
-        "glm5_next_block_fp8",
-        str(device),
-        method.kt_config.weight_path,
-        method.kt_config.num_layers,
-        method.global_num_experts,
-        method._full_init_args,
-    )
+_GLM5_NEXT_FP8_RAW_WEIGHT_NAMES = (
+    "w13_weight",
+    "w13_weight_scale_inv",
+    "w2_weight",
+    "w2_weight_scale_inv",
+)
 
 
-def _register_glm5_next_fp8_prefill_layer(method, layer: torch.nn.Module) -> None:
-    if not _glm5_next_fp8_pipeline_requested(method):
-        return
-    if method.kt_config.kt_enable_dynamic_expert_update:
-        raise ValueError(
-            "GLM-5-Next required FP8 layerwise prefill is incompatible with "
-            "--kt-enable-dynamic-expert-update"
+def _validate_glm5_next_fp8_shared_full_context(
+    context: SharedFullContext,
+) -> Tuple[int, int]:
+    """Validate the lazy generic context and return GPU/host storage bytes."""
+
+    tp_size = get_tensor_model_parallel_world_size()
+    if tp_size != 4:
+        raise RuntimeError(
+            "GLM-5-Next layerwise prefill requires runtime TP=4; "
+            f"got TP={tp_size}"
         )
-    signature = _glm5_next_fp8_pipeline_signature(method, layer)
-    method._glm5_next_fp8_pipeline_signature = signature
-    registry = _GLM5_NEXT_FP8_PREFILL_LAYER_REGISTRY.setdefault(signature, {})
-    layer_idx = method.kt_config.layer_idx
-    existing = registry.get(layer_idx)
-    if existing is not None and (
-        existing[0] is not method or existing[1] is not layer
+    slot_events = getattr(
+        context, "_glm5_next_fp8_host_slot_events", None
+    )
+    if (
+        not getattr(context, "_glm5_next_fp8_transport_initialized", False)
+        or slot_events is None
+        or len(slot_events) != 2
+        or getattr(context, "_glm5_next_fp8_copy_stream", None) is None
     ):
         raise RuntimeError(
-            "duplicate GLM-5-Next FP8 layerwise prefill registration for "
-            f"layer {layer_idx}"
+            "GLM-5-Next layerwise prefill requires one persistent H2D "
+            "stream and exactly two Host-slot completion events"
         )
-    registry[layer_idx] = (method, layer)
-
-
-def _validate_glm5_next_fp8_registry(signature: tuple, registry: dict) -> None:
-    order = sorted(registry)
-    expected_order = list(range(3, 45))
-    if order != expected_order:
-        raise RuntimeError(
-            "GLM-5-Next required FP8 layerwise registry must contain every "
-            f"MoE layer 3..44 exactly once; got {order}"
-        )
-    for layer_idx, (method, _layer) in registry.items():
-        if not _glm5_next_fp8_pipeline_requested(method):
-            raise RuntimeError(
-                f"GLM-5-Next FP8 registry {signature} contains an ineligible "
-                f"layer {layer_idx}"
-            )
-        if method.kt_config.num_layers != 45:
-            raise RuntimeError(
-                "GLM-5-Next FP8 layerwise requires num_layers=45; got "
-                f"{method.kt_config.num_layers} at layer {layer_idx}"
-            )
-        if method.kt_config.kt_enable_dynamic_expert_update:
-            raise RuntimeError(
-                "GLM-5-Next FP8 layerwise does not support dynamic expert update"
-            )
-        if getattr(method, "tp_rank", None) != get_tensor_model_parallel_rank():
-            raise RuntimeError(
-                "GLM-5-Next FP8 layerwise method/rank mismatch at layer "
-                f"{layer_idx}: method.tp_rank={getattr(method, 'tp_rank', None)}, "
-                f"runtime rank={get_tensor_model_parallel_rank()}"
-            )
-        if getattr(method, "global_num_experts", None) != 288:
-            raise RuntimeError(
-                "GLM-5-Next FP8 layerwise requires exactly 288 routed "
-                f"experts; got {getattr(method, 'global_num_experts', None)}"
-            )
-        full_init_args = getattr(method, "_full_init_args", ())
-        if len(full_init_args) < 2 or tuple(full_init_args[:2]) != (4096, 256):
-            raise RuntimeError(
-                "GLM-5-Next FP8 layerwise requires TP8 expert geometry "
-                "hidden=4096/intermediate_per_partition=256; got "
-                f"{full_init_args}"
-            )
-        mask = getattr(method, "gpu_experts_mask", None)
-        mapping = getattr(method, "logical_to_gpu_index", None)
-        if (
-            not isinstance(mask, torch.Tensor)
-            or mask.dtype != torch.bool
-            or tuple(mask.shape) != (288,)
-            or not isinstance(mapping, torch.Tensor)
-            or tuple(mapping.shape) != (288,)
-        ):
-            raise RuntimeError(
-                "GLM-5-Next FP8 layerwise requires [288] bool mask and "
-                f"logical mapping at layer {layer_idx}"
-            )
-        # Both tensors are model state and therefore normally live on the TP
-        # rank's CUDA device.  Build the invariant on that same device: a CPU
-        # reference here makes torch.equal fail during the required startup
-        # preflight before the layerwise slots can be allocated.
-        mapping_int32 = mapping.to(dtype=torch.int32)
-        mask_on_mapping_device = mask.to(device=mapping.device)
-        expected_mapping = torch.full(
-            (288,), -1, dtype=torch.int32, device=mapping.device
-        )
-        gpu_ids = torch.where(mask_on_mapping_device)[0]
-        expected_mapping[gpu_ids] = torch.arange(
-            gpu_ids.numel(), dtype=torch.int32, device=mapping.device
-        )
-        if not torch.equal(mapping_int32, expected_mapping):
-            raise RuntimeError(
-                "GLM-5-Next FP8 logical_to_gpu_index does not match its "
-                f"static mask at layer {layer_idx}"
-            )
-        if getattr(method, "num_gpu_experts", None) != gpu_ids.numel():
-            raise RuntimeError(
-                "GLM-5-Next FP8 num_gpu_experts does not match its static "
-                f"mask at layer {layer_idx}"
-            )
-
-
-def _validate_glm5_next_fp8_context(context: SharedFullContext) -> None:
-    runner_config = getattr(context.gpu_layer, "moe_runner_config", None)
+    layer = context.gpu_layer
+    runner_config = getattr(layer, "moe_runner_config", None)
     if not bool(
         getattr(runner_config, "glm5_next_hf_two_round_swiglu", False)
     ):
         raise RuntimeError(
-            "GLM-5-Next layerwise requires the private HF two-round "
+            "GLM-5-Next layerwise prefill requires the private HF two-round "
             "BF16 SwiGLU runner"
         )
     if not getattr(context, "_is_fp8_quant", False):
         raise RuntimeError(
-            "GLM-5-Next layerwise built a non-block-FP8 full context"
+            "GLM-5-Next layerwise prefill built a non-block-FP8 full context"
         )
     base_method = context._get_base_quant_method()
-    if not getattr(base_method, "block_quant", False):
+    if (
+        not getattr(base_method, "block_quant", False)
+        or getattr(base_method, "use_mxfp8", False)
+        or tuple(getattr(base_method, "weight_block_size", ())) != (128, 128)
+    ):
         raise RuntimeError(
-            "GLM-5-Next layerwise requires a block-quantized FP8 MoE method"
-        )
-    if getattr(base_method, "use_mxfp8", False):
-        raise RuntimeError(
-            "GLM-5-Next layerwise requires raw E4M3+FP32 block FP8, not MXFP8"
-        )
-    if tuple(getattr(base_method, "weight_block_size", ())) != (128, 128):
-        raise RuntimeError(
-            "GLM-5-Next layerwise requires FP8 weight_block_size=[128, 128]"
+            "GLM-5-Next layerwise prefill requires raw E4M3+FP32 "
+            "block-FP8 weights with weight_block_size=[128, 128]"
         )
     runner_backend = getattr(
         getattr(base_method, "runner", None), "runner_backend", None
@@ -4106,15 +3008,15 @@ def _validate_glm5_next_fp8_context(context: SharedFullContext) -> None:
         or not runner_backend.is_triton()
     ):
         raise RuntimeError(
-            "GLM-5-Next layerwise requires the raw block-FP8 Triton MoE runner"
+            "GLM-5-Next layerwise prefill requires the raw block-FP8 "
+            "Triton MoE runner"
         )
 
-    layer = context.gpu_layer
     expected_shapes = {
-        "w13_weight": (288, 512, 4096),
-        "w13_weight_scale_inv": (288, 4, 32),
-        "w2_weight": (288, 4096, 256),
-        "w2_weight_scale_inv": (288, 32, 2),
+        "w13_weight": (288, 1024, 4096),
+        "w13_weight_scale_inv": (288, 8, 32),
+        "w2_weight": (288, 4096, 512),
+        "w2_weight_scale_inv": (288, 32, 4),
     }
     expected_dtypes = {
         "w13_weight": getattr(torch, "float8_e4m3fn", None),
@@ -4122,245 +3024,38 @@ def _validate_glm5_next_fp8_context(context: SharedFullContext) -> None:
         "w2_weight": getattr(torch, "float8_e4m3fn", None),
         "w2_weight_scale_inv": torch.float32,
     }
-    for name in _Glm5NextFp8PrefillSlot.RAW_NAMES:
-        if not hasattr(layer, name):
+    gpu_slot_bytes = 0
+    host_buffer_bytes = 0
+    for name in _GLM5_NEXT_FP8_RAW_WEIGHT_NAMES:
+        gpu_tensor = getattr(layer, name, None)
+        if gpu_tensor is None or gpu_tensor.dtype != expected_dtypes[name]:
             raise RuntimeError(
-                f"GLM-5-Next FP8 full context is missing raw tensor {name}"
+                "GLM-5-Next generic full context has an invalid raw tensor "
+                f"{name}: expected dtype={expected_dtypes[name]}, "
+                f"got {getattr(gpu_tensor, 'dtype', None)}"
             )
-        tensor = getattr(layer, name)
-        if tuple(tensor.shape) != expected_shapes[name]:
+        if tuple(gpu_tensor.shape) != expected_shapes[name]:
             raise RuntimeError(
-                f"GLM-5-Next FP8 {name} shape mismatch: expected "
-                f"{expected_shapes[name]}, got {tuple(tensor.shape)}"
+                "GLM-5-Next TP4 generic full context has an invalid shape "
+                f"for {name}: expected={expected_shapes[name]}, "
+                f"got={tuple(gpu_tensor.shape)}"
             )
-        if tensor.dtype != expected_dtypes[name]:
+        gpu_slot_bytes += gpu_tensor.numel() * gpu_tensor.element_size()
+
+        host_buffer = context.cpu_buffers.get(name)
+        if host_buffer is None or host_buffer.shape[0] != 2:
             raise RuntimeError(
-                f"GLM-5-Next FP8 {name} dtype mismatch: expected "
-                f"{expected_dtypes[name]}, got {tensor.dtype}"
+                "GLM-5-Next generic layerwise prefill requires exactly two "
+                f"expert Host slots for {name}"
             )
-
-
-def _validate_glm5_next_fp8_writer_abi(registry: dict) -> None:
-    """Fail startup if TP0's installed KT binary lacks the FP8 writer ABI."""
-
-    if get_tensor_model_parallel_rank() != 0:
-        return
-    for layer_idx, (method, _layer) in registry.items():
-        wrapper = getattr(method, "wrapper", None)
-        if wrapper is None:
+        if tuple(host_buffer.shape[1:]) != tuple(gpu_tensor.shape[1:]):
             raise RuntimeError(
-                f"GLM-5-Next FP8 layer {layer_idx} has no TP0 KT wrapper"
+                f"GLM-5-Next Host/GPU expert shape mismatch for {name}: "
+                f"host={tuple(host_buffer.shape)}, gpu={tuple(gpu_tensor.shape)}"
             )
-        for name in (
-            "submit_write_weight_scale_to_buffer",
-            "sync_write_weight_scale_to_buffer",
-        ):
-            if not callable(getattr(wrapper, name, None)):
-                raise RuntimeError(
-                    "GLM-5-Next FP8 requires the installed KT writer ABI; "
-                    f"layer {layer_idx} is missing {name}"
-                )
-        moe = getattr(wrapper, "moe", None)
-        if moe is None or not hasattr(moe, "write_weight_scale_to_buffer_task"):
-            raise RuntimeError(
-                "GLM-5-Next FP8 requires a kt-kernel binary exposing "
-                "write_weight_scale_to_buffer_task; missing at layer "
-                f"{layer_idx}"
-            )
+        host_buffer_bytes += host_buffer.numel() * host_buffer.element_size()
 
-
-def _glm5_next_fp8_raw_slot_storage_nbytes(
-    *, num_experts: int, hidden_size: int, intermediate_size: int
-) -> int:
-    """Bytes in one raw E4M3 + FP32 [128, 128] full-expert slot."""
-
-    fp8_size = torch.tensor([], dtype=torch.float8_e4m3fn).element_size()
-    fp32_size = torch.tensor([], dtype=torch.float32).element_size()
-    hidden_blocks = (hidden_size + 127) // 128
-    intermediate_blocks = (intermediate_size + 127) // 128
-    return (
-        num_experts
-        * (2 * intermediate_size * hidden_size + hidden_size * intermediate_size)
-        * fp8_size
-        + num_experts
-        * (
-            2 * intermediate_blocks * hidden_blocks
-            + hidden_blocks * intermediate_blocks
-        )
-        * fp32_size
-    )
-
-
-def _allocate_glm5_next_fp8_slot_storage(
-    context: SharedFullContext,
-) -> Dict[str, torch.Tensor]:
-    return {
-        name: torch.nn.Parameter(
-            torch.empty_like(getattr(context.gpu_layer, name).data),
-            requires_grad=False,
-        )
-        for name in _Glm5NextFp8PrefillSlot.RAW_NAMES
-    }
-
-
-def _initialize_glm5_next_fp8_layerwise_pipeline(
-    signature: tuple, registry: dict
-) -> _Glm5NextFp8LayerwisePrefillManager:
-    existing = _GLM5_NEXT_FP8_LAYERWISE_MANAGERS.get(signature)
-    if existing is not None:
-        return existing
-
-    preflight_error = None
-    try:
-        _validate_glm5_next_fp8_registry(signature, registry)
-        if not torch.cuda.is_available():
-            raise RuntimeError(
-                "GLM-5-Next required FP8 layerwise prefill requires CUDA"
-            )
-        if get_tensor_model_parallel_world_size() != 8:
-            raise RuntimeError(
-                "GLM-5-Next required FP8 layerwise prefill is accepted only "
-                "for the TP=8 production topology"
-            )
-    except Exception as exc:
-        preflight_error = exc
-    if not _all_tp_ranks_succeeded(preflight_error is None):
-        message = (
-            "GLM-5-Next required FP8 layerwise preflight failed on at least "
-            "one TP rank"
-        )
-        if preflight_error is not None:
-            raise RuntimeError(message) from preflight_error
-        raise RuntimeError(message)
-    if preflight_error is not None:
-        raise preflight_error
-
-    first_layer_idx = min(registry)
-    method, layer = registry[first_layer_idx]
-    context = None
-    slot1_raw = None
-    manager = None
-    local_error = None
-    try:
-        context = SharedFullContext(
-            layer=layer,
-            init_args=method._full_init_args,
-            global_num_experts=method.global_num_experts,
-            moe_runner_config=method.moe_runner_config,
-            defer_cpu_buffers=True,
-        )
-        _validate_glm5_next_fp8_context(context)
-        slot1_raw = _allocate_glm5_next_fp8_slot_storage(context)
-        manager = _Glm5NextFp8LayerwisePrefillManager(
-            context, signature, slot1_raw
-        )
-        _validate_glm5_next_fp8_writer_abi(registry)
-    except Exception as exc:
-        local_error = exc
-
-    if not _all_tp_ranks_succeeded(local_error is None):
-        manager = None
-        slot1_raw = None
-        context = None
-        gc.collect()
-        if torch.cuda.is_available():
-            torch.cuda.empty_cache()
-        message = (
-            "GLM-5-Next required FP8 two-slot allocation failed on at least "
-            "one TP rank; refusing hybrid/serialized fallback"
-        )
-        if local_error is not None:
-            raise RuntimeError(message) from local_error
-        raise RuntimeError(message)
-    if local_error is not None:
-        raise local_error
-    assert context is not None and manager is not None
-
-    shm_error = None
-    try:
-        # The digest excludes rank-local CUDA indices, but covers the complete
-        # registry, raw tensor metadata, masks, and logical mappings.  Validate
-        # it before TP0 receives pointers into peer processes.
-        manager.validate_tp_contract()
-        # Allocate host transport only after both GPU slots exist on every TP
-        # rank, preventing an OOM peer from stranding SHM collectives.
-        context.initialize_cpu_buffers()
-        manager.initialize_transport_control()
-    except Exception as exc:
-        shm_error = exc
-    if not _all_tp_ranks_succeeded(shm_error is None):
-        message = (
-            "GLM-5-Next required FP8 host transport initialization failed "
-            "on at least one TP rank"
-        )
-        if shm_error is not None:
-            raise RuntimeError(message) from shm_error
-        raise RuntimeError(message)
-    if shm_error is not None:
-        raise shm_error
-
-    _GLM5_NEXT_FP8_LAYERWISE_MANAGERS[signature] = manager
-    if method.tp_rank == 0:
-        logger.info(
-            "KT GLM-5-Next FP8 layerwise prefill eagerly allocated two raw "
-            "E4M3+FP32 full-layer slots on %s before KV profiling "
-            "(total=%.2f GiB, contract=%s, fallback_count=0)",
-            manager.device,
-            manager.allocated_bytes / 1024**3,
-            manager.contract_digest,
-        )
-    return manager
-
-
-def initialize_glm5_next_fp8_layerwise_prefill() -> int:
-    """Eagerly allocate all required GLM managers before KV profiling.
-
-    Called only for the exact-model gate.  Returning allocated bytes makes the
-    startup reservation auditable; the memory profiler must not subtract it a
-    second time because the tensors are already resident.
-    """
-
-    registry_error = None
-    registry_count = len(_GLM5_NEXT_FP8_PREFILL_LAYER_REGISTRY)
-    if registry_count != 1:
-        registry_error = RuntimeError(
-            "GLM-5-Next required FP8 layerwise prefill needs exactly one "
-            "device-local MoE registry; got "
-            f"{registry_count}"
-        )
-    if not _all_tp_ranks_succeeded(registry_error is None):
-        message = (
-            "GLM-5-Next required FP8 layerwise registry count differs or is "
-            "invalid on at least one TP rank"
-        )
-        if registry_error is not None:
-            raise RuntimeError(message) from registry_error
-        raise RuntimeError(message)
-    if registry_error is not None:
-        raise registry_error
-
-    signature, registry = next(
-        iter(_GLM5_NEXT_FP8_PREFILL_LAYER_REGISTRY.items())
-    )
-    manager = _initialize_glm5_next_fp8_layerwise_pipeline(signature, registry)
-    return manager.allocated_bytes
-
-
-def _get_glm5_next_fp8_layerwise_manager(
-    method,
-) -> _Glm5NextFp8LayerwisePrefillManager:
-    signature = getattr(method, "_glm5_next_fp8_pipeline_signature", None)
-    if signature is None:
-        raise RuntimeError(
-            "GLM-5-Next required FP8 layerwise layer was not registered"
-        )
-    manager = _GLM5_NEXT_FP8_LAYERWISE_MANAGERS.get(signature)
-    if manager is None:
-        raise RuntimeError(
-            "GLM-5-Next required FP8 layerwise manager was not initialized "
-            "before KV-cache profiling; refusing fallback"
-        )
-    return manager
+    return gpu_slot_bytes, host_buffer_bytes
 
 
 def _glm5_next_forward_mode_name(mode) -> str:
@@ -5343,7 +4038,6 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
         # Registration happens during model construction, not on the first
         # request, so layer N can identify and prepare N+1 immediately.
         _register_mxfp4_prefill_layer(self, layer)
-        _register_glm5_next_fp8_prefill_layer(self, layer)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         """Process weights after loading from checkpoint.
@@ -5590,6 +4284,7 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
         topk_output = dispatch_output.topk_output
         num_tokens = int(x.shape[0]) if x.dim() > 0 else 0
         _glm5_next_fp8_required = _glm5_next_fp8_pipeline_requested(self)
+        _glm5_next_full_gpu_allowed = not _glm5_next_fp8_required
         if _glm5_next_fp8_required:
             forward_mode = getattr(self, "_glm5_next_forward_mode", None)
             if forward_mode is None:
@@ -5598,13 +4293,18 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
                     "ForwardMode metadata"
                 )
             forward_mode_name = _glm5_next_forward_mode_name(forward_mode)
+            if forward_mode_name not in ("EXTEND", "DECODE", "IDLE"):
+                raise RuntimeError(
+                    "GLM-5-Next FP8 layerwise prefill supports only plain "
+                    "EXTEND (text layerwise or image hybrid) and bypasses "
+                    "only DECODE/IDLE; got "
+                    f"ForwardMode.{forward_mode_name}"
+                )
             if forward_mode_name == "EXTEND":
                 if bool(getattr(self, "_glm5_next_has_image_inputs", False)):
-                    # Session D keeps the complete image EXTEND batch on the
-                    # already accepted CPU/hybrid expert route.  Keep
-                    # _glm5_next_fp8_required true so the generic full-GPU
-                    # threshold fallback below cannot accidentally select a
-                    # different image-prefill implementation.
+                    # Keep the complete image EXTEND batch on the accepted
+                    # CPU/hybrid route; multimodal batches must not enter the
+                    # text-only generic full-layer loader.
                     self._glm5_next_mm_hybrid_extend_count = (
                         getattr(self, "_glm5_next_mm_hybrid_extend_count", 0) + 1
                     )
@@ -5615,32 +4315,21 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
                             self.kt_config.layer_idx,
                             self._glm5_next_mm_hybrid_extend_count,
                         )
-                else:
-                    # The threshold is an enable switch for exact GLM, not a
-                    # per-chunk size cutoff.  This includes the final short
-                    # chunk of every pure-text EXTEND.
+                elif num_tokens >= self.gpu_prefill_token_threshold:
+                    # Exact GLM uses the same serialized SharedFullContext
+                    # loader as the generic block-FP8 path.  Short final
+                    # chunks remain hybrid instead of forcing another layer
+                    # image transfer.
+                    _glm5_next_full_gpu_allowed = True
                     self._glm5_next_layerwise_extend_count = (
                         getattr(self, "_glm5_next_layerwise_extend_count", 0) + 1
                     )
-                    return _get_glm5_next_fp8_layerwise_manager(self).apply(
-                        self, layer, dispatch_output
-                    )
-            if forward_mode_name not in ("EXTEND", "DECODE", "IDLE"):
-                raise RuntimeError(
-                    "GLM-5-Next required FP8 layerwise prefill supports only "
-                    "plain EXTEND (text layerwise or image hybrid) and bypasses "
-                    "only DECODE/IDLE; got "
-                    f"ForwardMode.{forward_mode_name}"
-                )
 
         from sglang.srt.eplb.expert_distribution import (
             get_global_expert_distribution_recorder,
         )
         from sglang.srt.layers.moe.token_dispatcher import StandardCombineInput
 
-        # The required exact-GLM EXTEND route above must happen before this
-        # TP0-only recorder.  A recorder exception on rank 0 must never leave
-        # peers entering layerwise transport collectives.
         if self.tp_rank == 0:
             recorder = get_global_expert_distribution_recorder()
             recorder.on_gpu_expert_mask(
@@ -5675,8 +4364,17 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
             or hasattr(layer, "w13_weight_packed")
             or getattr(layer, "_v4_tk_path", False)
         )
+        if (
+            _glm5_next_fp8_required
+            and _glm5_next_full_gpu_allowed
+            and not _full_gpu_fallback_supported
+        ):
+            raise RuntimeError(
+                "GLM-5-Next FP8 layerwise prefill requires raw block-FP8 "
+                "weight attributes for the generic SharedFullContext loader"
+            )
         _full_gpu_gate = (
-            not _glm5_next_fp8_required
+            _glm5_next_full_gpu_allowed
             and self.gpu_prefill_token_threshold > 0
             and num_tokens >= self.gpu_prefill_token_threshold
             and _full_gpu_fallback_supported
@@ -6096,12 +4794,109 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
         global _SHARED_FULL_CONTEXT
 
         if _SHARED_FULL_CONTEXT is None:
-            _SHARED_FULL_CONTEXT = SharedFullContext(
-                layer=layer,
-                init_args=self._full_init_args,
-                global_num_experts=self.global_num_experts,
-                moe_runner_config=self.moe_runner_config,
-            )
+            is_glm5_next_fp8 = _glm5_next_fp8_pipeline_requested(self)
+            if is_glm5_next_fp8:
+                # GPU tensors are allocated independently on each TP rank.
+                # Do not let a successful peer enter the Host-SHM collectives
+                # until every rank has finished that allocation: otherwise a
+                # single-rank OOM can strand the remaining ranks forever.
+                context = None
+                context_error = None
+                try:
+                    context = SharedFullContext(
+                        layer=layer,
+                        init_args=self._full_init_args,
+                        global_num_experts=self.global_num_experts,
+                        moe_runner_config=self.moe_runner_config,
+                        defer_cpu_buffers=True,
+                    )
+                except Exception as exc:
+                    context_error = exc
+
+                if not _all_tp_ranks_succeeded(context_error is None):
+                    any_oom = _any_tp_rank_true(
+                        isinstance(context_error, torch.cuda.OutOfMemoryError)
+                    )
+                    any_fatal = _any_tp_rank_true(
+                        context_error is not None
+                        and not isinstance(
+                            context_error, torch.cuda.OutOfMemoryError
+                        )
+                    )
+                    context = None
+                    gc.collect()
+                    if torch.cuda.is_available():
+                        torch.cuda.empty_cache()
+                    if any_fatal:
+                        message = (
+                            "GLM-5-Next full-layer GPU slot initialization "
+                            "failed on at least one TP rank"
+                        )
+                    elif any_oom:
+                        message = (
+                            "GLM-5-Next full-layer GPU slot CUDA out of memory "
+                            "on at least one TP rank"
+                        )
+                    else:
+                        message = (
+                            "GLM-5-Next full-layer GPU slot initialization "
+                            "failed without a rank-local exception"
+                        )
+                    raise RuntimeError(message) from context_error
+
+                if context is None:
+                    raise RuntimeError(
+                        "GLM-5-Next full-layer GPU slot initialization returned "
+                        "no context"
+                    )
+                # _create_cpu_buffers has phase-level TP consensus and cleanup.
+                context.initialize_cpu_buffers()
+
+                validation_result = None
+                validation_error = None
+                try:
+                    context._initialize_glm5_next_fp8_transport()
+                    validation_result = (
+                        _validate_glm5_next_fp8_shared_full_context(context)
+                    )
+                except Exception as exc:
+                    validation_error = exc
+                if not _all_tp_ranks_succeeded(validation_error is None):
+                    context._cleanup_cpu_buffers_after_failure()
+                    context = None
+                    gc.collect()
+                    if torch.cuda.is_available():
+                        torch.cuda.empty_cache()
+                    raise RuntimeError(
+                        "GLM-5-Next single-slot transport setup or context "
+                        "validation failed on at least one TP rank"
+                    ) from validation_error
+
+                if validation_result is None:
+                    raise RuntimeError(
+                        "GLM-5-Next single-slot validation returned no result"
+                    )
+                gpu_slot_bytes, host_buffer_bytes = validation_result
+            else:
+                context = SharedFullContext(
+                    layer=layer,
+                    init_args=self._full_init_args,
+                    global_num_experts=self.global_num_experts,
+                    moe_runner_config=self.moe_runner_config,
+                )
+
+            if is_glm5_next_fp8:
+                if self.tp_rank == 0:
+                    logger.info(
+                        "KT GLM-5-Next FP8 layerwise prefill lazily allocated "
+                        "generic SharedFullContext: gpu_full_layer_slots=1 "
+                        "host_expert_slots=2 gpu_slot_bytes=%d "
+                        "host_buffer_bytes=%d device=%s",
+                        gpu_slot_bytes,
+                        host_buffer_bytes,
+                        context.gpu_layer.w13_weight.device,
+                    )
+            _SHARED_FULL_CONTEXT = context
 
         _SHARED_FULL_CONTEXT.load(
             layer_idx=self.kt_config.layer_idx,

--- a/python/sglang/srt/layers/moe/kt_ep_wrapper.py
+++ b/python/sglang/srt/layers/moe/kt_ep_wrapper.py
@@ -27,7 +27,7 @@ Diagnostic / escape-hatch environment variables (KT-DEBUG-ONLY; not for prod):
         whether a regression sits in the GPU MoE path or the merge math.
 
     SGLANG_KT_GLM5_NEXT_FP8_TRANSPORT=auto|native|legacy
-        Select the exact GLM-5-Next TP4 block-FP8 layer transport. ``auto``
+        Select the exact GLM-5-Next block-FP8 layer transport. ``auto``
         uses the native batch API when present and otherwise falls back before
         the first load; a native runtime failure never falls back.
 """
@@ -55,6 +55,7 @@ from sglang.srt.distributed import (
     get_tensor_model_parallel_world_size,
     get_tp_group,
 )
+from sglang.srt.configs.glm5_next import GLM5_NEXT_SUPPORTED_TP_SIZES
 from sglang.srt.layers.quantization.base_config import FusedMoEMethodBase
 from sglang.srt.layers.quantization.marlin_utils import marlin_permute_scales
 from sglang.srt.utils import get_compiler_backend, is_cuda
@@ -85,7 +86,8 @@ _KT_GPU_EXPERTS_MASKS: Optional[torch.Tensor] = None
 
 _GLM5_NEXT_FP8_TRANSPORT_ENV = "SGLANG_KT_GLM5_NEXT_FP8_TRANSPORT"
 _GLM5_NEXT_FP8_TRANSPORT_MODES = frozenset(("auto", "native", "legacy"))
-_GLM5_NEXT_FP8_CONTROL_BYTES = 4096
+_GLM5_NEXT_FP8_LEGACY_CONTROL_BYTES = 4096
+_GLM5_NEXT_FP8_LEGACY_MAX_TP_SIZE = 4
 _GLM5_NEXT_FP8_TRANSPORT_TIMEOUT_MS = 60_000
 _GLM5_NEXT_FP8_MOE_LAYER_INDICES = tuple(range(3, 45))
 
@@ -121,6 +123,39 @@ def _load_glm5_next_fp8_native_transport_api():
     if missing:
         return None, "kt_kernel_ext is missing " + ", ".join(missing)
     return kt_kernel_ext, None
+
+
+def _glm5_next_fp8_native_transport_capabilities(kt_kernel_ext) -> Tuple[int, int]:
+    """Read the installed native transport ABI without duplicating its limits."""
+
+    max_tp_size = int(
+        getattr(
+            kt_kernel_ext,
+            "FP8_LAYERWISE_MAX_TP_SIZE",
+            _GLM5_NEXT_FP8_LEGACY_MAX_TP_SIZE,
+        )
+    )
+    control_bytes = int(
+        getattr(
+            kt_kernel_ext,
+            "FP8_LAYERWISE_CONTROL_BYTES",
+            _GLM5_NEXT_FP8_LEGACY_CONTROL_BYTES,
+        )
+    )
+    if max_tp_size <= 0 or control_bytes <= 0:
+        raise RuntimeError(
+            "kt_kernel_ext exposed invalid FP8 Layerwise transport capabilities: "
+            f"max_tp_size={max_tp_size}, control_bytes={control_bytes}"
+        )
+    return max_tp_size, control_bytes
+
+
+def _validate_glm5_next_tp_size(tp_size: int, *, context: str) -> None:
+    if tp_size not in GLM5_NEXT_SUPPORTED_TP_SIZES:
+        raise RuntimeError(
+            f"GLM-5-Next {context} supports TP sizes 1, 2, 4, and 8; "
+            f"got TP={tp_size}"
+        )
 
 
 @dataclass
@@ -340,7 +375,7 @@ _MXFP4_LAYERWISE_MANAGERS = {}
 _MXFP4_LAYERWISE_DISABLED_REASONS = {}
 # Exact GLM-5-Next block-FP8 has a deliberately separate registry/control
 # plane.  Registration is harmless for ``legacy`` transport, while manager
-# construction is hard-gated on the native TP4/gpu_experts=0 runtime below.
+# construction is hard-gated on the validated TP/gpu_experts=0 runtime below.
 _GLM5_NEXT_FP8_NATIVE_PREFETCH_LAYER_REGISTRY = {}
 _GLM5_NEXT_FP8_NATIVE_PREFETCH_MANAGERS = {}
 
@@ -409,6 +444,8 @@ class SharedFullContext:
         moe_runner_config: "MoeRunnerConfig",
         defer_cpu_buffers: bool = False,
     ):
+        self._full_init_args = init_args
+        self._global_num_experts = global_num_experts
         self._build_layers(layer, init_args, global_num_experts, moe_runner_config)
 
         # Capture original tensors to support restoration before loading
@@ -1275,6 +1312,7 @@ class SharedFullContext:
 
         self._glm5_next_fp8_transport_initialized = False
         self._glm5_next_fp8_transport_backend = None
+        self._glm5_next_fp8_native_control_bytes = None
 
     @staticmethod
     def _tp_all_gather_object(value):
@@ -1355,13 +1393,16 @@ class SharedFullContext:
             expert_nbytes,
         )
 
-    def _initialize_glm5_next_fp8_native_transport(self, kt_kernel_ext) -> None:
+    def _initialize_glm5_next_fp8_native_transport(
+        self, kt_kernel_ext, control_bytes: int
+    ) -> None:
         tp_rank = get_tensor_model_parallel_rank()
         tp_size = get_tensor_model_parallel_world_size()
         control_name = f"kt_glm5_next_fp8_ctrl_{self.shm_unique_id}"
         self._glm5_next_fp8_control_shm = None
         self._glm5_next_fp8_control_owner = tp_rank == 0
         self._glm5_next_fp8_native_transport = None
+        self._glm5_next_fp8_native_control_bytes = control_bytes
 
         create_error = None
         if tp_rank == 0:
@@ -1369,7 +1410,7 @@ class SharedFullContext:
                 control_shm = shared_memory.SharedMemory(
                     name=control_name,
                     create=True,
-                    size=_GLM5_NEXT_FP8_CONTROL_BYTES,
+                    size=control_bytes,
                 )
                 self._glm5_next_fp8_control_shm = control_shm
                 control_ptr = ctypes.addressof(
@@ -1377,7 +1418,7 @@ class SharedFullContext:
                 )
                 kt_kernel_ext.initialize_fp8_layerwise_control(
                     control_ptr,
-                    _GLM5_NEXT_FP8_CONTROL_BYTES,
+                    control_bytes,
                     tp_size,
                 )
             except Exception as exc:
@@ -1400,6 +1441,11 @@ class SharedFullContext:
             control_shm = self._glm5_next_fp8_control_shm
             if control_shm is None:
                 raise RuntimeError("native control SHM is not mapped")
+            if control_shm.size < control_bytes:
+                raise RuntimeError(
+                    "native control SHM is smaller than the installed transport ABI: "
+                    f"mapped={control_shm.size}, required={control_bytes}"
+                )
             control_ptr = ctypes.addressof(
                 ctypes.c_char.from_buffer(control_shm.buf)
             )
@@ -1418,7 +1464,7 @@ class SharedFullContext:
             self._glm5_next_fp8_native_transport = (
                 kt_kernel_ext.FP8LayerwiseTransport(
                     control_ptr,
-                    _GLM5_NEXT_FP8_CONTROL_BYTES,
+                    control_bytes,
                     tp_rank,
                     tp_size,
                     cuda_device,
@@ -1457,10 +1503,8 @@ class SharedFullContext:
 
         if getattr(self, "_glm5_next_fp8_transport_initialized", False):
             return
-        if get_tensor_model_parallel_world_size() != 4:
-            raise RuntimeError(
-                "GLM-5-Next layerwise prefill transport requires TP=4"
-            )
+        tp_size = get_tensor_model_parallel_world_size()
+        _validate_glm5_next_tp_size(tp_size, context="layerwise prefill transport")
         gpu_expert_counts = self._tp_all_gather_object(int(num_gpu_experts))
         if any(count != gpu_expert_counts[0] for count in gpu_expert_counts):
             raise RuntimeError(
@@ -1492,6 +1536,20 @@ class SharedFullContext:
             _load_glm5_next_fp8_native_transport_api()
         )
         tp_rank = get_tensor_model_parallel_rank()
+        native_capabilities = None
+        if kt_kernel_ext is not None:
+            try:
+                native_capabilities = _glm5_next_fp8_native_transport_capabilities(
+                    kt_kernel_ext
+                )
+                max_tp_size, _control_bytes = native_capabilities
+                if tp_size > max_tp_size:
+                    missing_reason = (
+                        "installed KT FP8 Layerwise transport supports at most "
+                        f"TP={max_tp_size}, requested TP={tp_size}"
+                    )
+            except Exception as exc:
+                missing_reason = str(exc)
         if tp_rank == 0 and not callable(
             getattr(getattr(wrapper, "moe", None), "run_layerwise_fp8_batch", None)
         ):
@@ -1517,7 +1575,16 @@ class SharedFullContext:
             self._initialize_glm5_next_fp8_legacy_transport()
             return
 
-        self._initialize_glm5_next_fp8_native_transport(kt_kernel_ext)
+        assert native_capabilities is not None
+        capability_values = self._tp_all_gather_object(native_capabilities)
+        if any(value != capability_values[0] for value in capability_values):
+            raise RuntimeError(
+                "FP8 Layerwise transport capabilities differ across TP ranks: "
+                f"{capability_values}"
+            )
+        self._initialize_glm5_next_fp8_native_transport(
+            kt_kernel_ext, native_capabilities[1]
+        )
 
     def _initialize_glm5_next_fp8_legacy_transport(self) -> None:
         """Create the legacy Python per-expert transport resources."""
@@ -3496,11 +3563,7 @@ def _validate_glm5_next_fp8_shared_full_context(
     """Validate the lazy generic context and return GPU/host storage bytes."""
 
     tp_size = get_tensor_model_parallel_world_size()
-    if tp_size != 4:
-        raise RuntimeError(
-            "GLM-5-Next layerwise prefill requires runtime TP=4; "
-            f"got TP={tp_size}"
-        )
+    _validate_glm5_next_tp_size(tp_size, context="layerwise prefill")
     if not getattr(context, "_glm5_next_fp8_transport_initialized", False):
         raise RuntimeError(
             "GLM-5-Next layerwise prefill transport is not initialized"
@@ -3570,11 +3633,47 @@ def _validate_glm5_next_fp8_shared_full_context(
             "Triton MoE runner"
         )
 
+    init_args = getattr(context, "_full_init_args", None)
+    if init_args is None or len(init_args) != 3:
+        raise RuntimeError(
+            "GLM-5-Next layerwise prefill is missing its runtime tensor geometry"
+        )
+    hidden_size, intermediate_size_per_partition, _params_dtype = init_args
+    num_experts = int(
+        getattr(context, "_global_num_experts", layer.num_experts)
+    )
+    hidden_size = int(hidden_size)
+    intermediate_size_per_partition = int(intermediate_size_per_partition)
+    if (
+        num_experts != 288
+        or hidden_size != 4096
+        or intermediate_size_per_partition * tp_size != 2048
+    ):
+        raise RuntimeError(
+            "GLM-5-Next layerwise prefill received incompatible runtime geometry: "
+            f"experts={num_experts}, hidden={hidden_size}, "
+            f"local_intermediate={intermediate_size_per_partition}, TP={tp_size}"
+        )
+
+    block_n, block_k = tuple(base_method.weight_block_size)
+    w13_n = 2 * intermediate_size_per_partition
     expected_shapes = {
-        "w13_weight": (288, 1024, 4096),
-        "w13_weight_scale_inv": (288, 8, 32),
-        "w2_weight": (288, 4096, 512),
-        "w2_weight_scale_inv": (288, 32, 4),
+        "w13_weight": (num_experts, w13_n, hidden_size),
+        "w13_weight_scale_inv": (
+            num_experts,
+            (w13_n + block_n - 1) // block_n,
+            (hidden_size + block_k - 1) // block_k,
+        ),
+        "w2_weight": (
+            num_experts,
+            hidden_size,
+            intermediate_size_per_partition,
+        ),
+        "w2_weight_scale_inv": (
+            num_experts,
+            (hidden_size + block_n - 1) // block_n,
+            (intermediate_size_per_partition + block_k - 1) // block_k,
+        ),
     }
     expected_dtypes = {
         "w13_weight": getattr(torch, "float8_e4m3fn", None),
@@ -3594,7 +3693,7 @@ def _validate_glm5_next_fp8_shared_full_context(
             )
         if tuple(gpu_tensor.shape) != expected_shapes[name]:
             raise RuntimeError(
-                "GLM-5-Next TP4 generic full context has an invalid shape "
+                f"GLM-5-Next TP{tp_size} generic full context has an invalid shape "
                 f"for {name}: expected={expected_shapes[name]}, "
                 f"got={tuple(gpu_tensor.shape)}"
             )
@@ -3664,11 +3763,7 @@ def _glm5_next_fp8_native_prefetch_runtime_supported(
     if getattr(context, "_glm5_next_fp8_transport_backend", None) != "native":
         return False
     tp_size = get_tensor_model_parallel_world_size()
-    if tp_size != 4:
-        raise RuntimeError(
-            "exact GLM-5-Next native successor prefetch requires TP=4; "
-            f"got TP={tp_size}"
-        )
+    _validate_glm5_next_tp_size(tp_size, context="native successor prefetch")
     if int(method.num_gpu_experts) != 0:
         raise RuntimeError(
             "exact GLM-5-Next native successor prefetch requires "

--- a/python/sglang/srt/layers/moe/kt_ep_wrapper.py
+++ b/python/sglang/srt/layers/moe/kt_ep_wrapper.py
@@ -5599,15 +5599,37 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
                 )
             forward_mode_name = _glm5_next_forward_mode_name(forward_mode)
             if forward_mode_name == "EXTEND":
-                # The threshold is an enable switch for exact GLM, not a
-                # per-chunk size cutoff.  This includes the final short chunk.
-                return _get_glm5_next_fp8_layerwise_manager(self).apply(
-                    self, layer, dispatch_output
-                )
-            if forward_mode_name not in ("DECODE", "IDLE"):
+                if bool(getattr(self, "_glm5_next_has_image_inputs", False)):
+                    # Session D keeps the complete image EXTEND batch on the
+                    # already accepted CPU/hybrid expert route.  Keep
+                    # _glm5_next_fp8_required true so the generic full-GPU
+                    # threshold fallback below cannot accidentally select a
+                    # different image-prefill implementation.
+                    self._glm5_next_mm_hybrid_extend_count = (
+                        getattr(self, "_glm5_next_mm_hybrid_extend_count", 0) + 1
+                    )
+                    if self.tp_rank == 0 and self.kt_config.layer_idx in (3, 44):
+                        logger.info(
+                            "GLM-5-Next image EXTEND bypasses FP8 layerwise "
+                            "prefill: layer=%d count=%d",
+                            self.kt_config.layer_idx,
+                            self._glm5_next_mm_hybrid_extend_count,
+                        )
+                else:
+                    # The threshold is an enable switch for exact GLM, not a
+                    # per-chunk size cutoff.  This includes the final short
+                    # chunk of every pure-text EXTEND.
+                    self._glm5_next_layerwise_extend_count = (
+                        getattr(self, "_glm5_next_layerwise_extend_count", 0) + 1
+                    )
+                    return _get_glm5_next_fp8_layerwise_manager(self).apply(
+                        self, layer, dispatch_output
+                    )
+            if forward_mode_name not in ("EXTEND", "DECODE", "IDLE"):
                 raise RuntimeError(
                     "GLM-5-Next required FP8 layerwise prefill supports only "
-                    "plain EXTEND and bypasses only DECODE/IDLE; got "
+                    "plain EXTEND (text layerwise or image hybrid) and bypasses "
+                    "only DECODE/IDLE; got "
                     f"ForwardMode.{forward_mode_name}"
                 )
 

--- a/python/sglang/srt/layers/moe/kt_ep_wrapper.py
+++ b/python/sglang/srt/layers/moe/kt_ep_wrapper.py
@@ -31,9 +31,11 @@ import bisect
 import copy
 import ctypes
 import gc
+import hashlib
 import json
 import logging
 import os
+import socket
 import time
 import uuid
 from dataclasses import dataclass, replace
@@ -293,6 +295,12 @@ _SHARED_STAGING_BUFFER = None  # Global shared staging buffer for all MoE layers
 _MXFP4_PREFILL_LAYER_REGISTRY = {}
 _MXFP4_LAYERWISE_MANAGERS = {}
 _MXFP4_LAYERWISE_DISABLED_REASONS = {}
+# GLM-5-Next block-FP8 uses its own registry and manager.  Do not merge this
+# state with the generic full-GPU fallback or MXFP4: the GLM path is required
+# (fail-closed), has no format conversion, and is eagerly allocated before KV
+# cache profiling.
+_GLM5_NEXT_FP8_PREFILL_LAYER_REGISTRY = {}
+_GLM5_NEXT_FP8_LAYERWISE_MANAGERS = {}
 
 
 class SharedStagingBuffer:
@@ -2774,6 +2782,1592 @@ def _get_or_initialize_mxfp4_layerwise_manager(
     return _MXFP4_LAYERWISE_MANAGERS.get(signature)
 
 
+class _Glm5NextFp8PrefillSlot:
+    """One raw block-FP8 GLM-5-Next MoE layer image.
+
+    Unlike MXFP4 there is no prepared/repacked representation.  The Triton
+    runner consumes these E4M3 weights and FP32 block scales directly.
+    """
+
+    RAW_NAMES = (
+        "w13_weight",
+        "w13_weight_scale_inv",
+        "w2_weight",
+        "w2_weight_scale_inv",
+    )
+
+    def __init__(self, index: int, raw_tensors: Dict[str, torch.Tensor]):
+        self.index = index
+        for name in self.RAW_NAMES:
+            setattr(self, name, raw_tensors[name])
+
+        self.state = "EMPTY"
+        self.layer_idx: Optional[int] = None
+        self.epoch = -1
+        self.has_consumed_event = False
+        self.reuse_guard = None
+        self.ready_event = torch.cuda.Event()
+        self.consumed_event = torch.cuda.Event()
+        self.num_experts = self.w13_weight.shape[0]
+
+    def invalidate(self) -> None:
+        # Keep both the tensor storage and its last overwrite fence alive.
+        self.state = "EMPTY"
+        self.layer_idx = None
+        self.epoch = -1
+
+
+class _Glm5NextFp8LayerwisePrefillManager:
+    """Required two-slot raw block-FP8 scheduler for exact GLM-5-Next.
+
+    A positive ``--kt-gpu-prefill-token-threshold`` selects this path for
+    every plain EXTEND forward, including a final chunk smaller than the
+    configured value.  There is deliberately no hybrid/serialized fallback:
+    a transport, ordering, allocation, or coverage failure is fatal.
+    """
+
+    _CONTROL_CACHELINE_BYTES = 64
+    _CONTROL_TIMEOUT_SECONDS = 300.0
+    _ATOMIC_ACQUIRE = 2
+    _ATOMIC_RELEASE = 3
+    _SLOT_STATE_CODES = {"EMPTY": 0, "LOADING": 1, "READY": 2, "IN_USE": 3}
+    _REUSE_GUARD_CODES = {
+        None: 0,
+        "loading": 1,
+        "ready": 2,
+        "consumed": 3,
+        "synchronized": 4,
+        "poisoned": 5,
+    }
+
+    def __init__(
+        self,
+        context: SharedFullContext,
+        signature: tuple,
+        slot1_raw_tensors: Dict[str, torch.Tensor],
+    ):
+        self.context = context
+        self.signature = signature
+        self.device = context.gpu_layer.w13_weight.device
+        slot0_raw = {
+            name: getattr(context.gpu_layer, name)
+            for name in _Glm5NextFp8PrefillSlot.RAW_NAMES
+        }
+        self.slots = (
+            _Glm5NextFp8PrefillSlot(0, slot0_raw),
+            _Glm5NextFp8PrefillSlot(1, slot1_raw_tensors),
+        )
+        self.transfer_stream = torch.cuda.Stream(device=self.device)
+        self.host_slot_free_events = (torch.cuda.Event(), torch.cuda.Event())
+        self.host_slot_was_used = [False, False]
+        self.host_slot_generations = [0, 0]
+        self.host_write_status = torch.ones((1,), dtype=torch.int32, device="cpu")
+
+        # Initialized only after every TP rank has successfully allocated both
+        # GPU slots and its pinned weight SHM.  Each control word occupies its
+        # own cache line and is accessed through libatomic acquire/release
+        # operations; ordinary Python/torch SHM stores are not a publication
+        # primitive across processes.
+        self._atomic_lib = None
+        self._atomic_load_u64 = None
+        self._atomic_store_u64 = None
+        self._transport_control_shm = None
+        self._transport_control_anchor = None
+        self._transport_control_address = None
+        self._control_offsets = None
+        self.transport_generation = 0
+        self.transport_abandoned = False
+        self.contract_digest = None
+
+        self.epoch = -1
+        self.last_layer_position: Optional[int] = None
+        self.current_slot_index: Optional[int] = None
+        self.round_active = False
+        self.failure_reason: Optional[str] = None
+        self.visited_layer_indices: List[int] = []
+
+        # Acceptance counters.  fallback_count intentionally never changes;
+        # it is exported in logs to prove a 500K run did not silently fall
+        # through to hybrid or serialized prefill.
+        self.apply_count = 0
+        self.prime_count = 0
+        self.prefetch_hit_count = 0
+        self.completed_round_count = 0
+        self.fallback_count = 0
+        self.expert_layouts = {}
+        for layer_idx, (method, _layer) in self.registry.items():
+            gpu_ids = tuple(
+                expert_id
+                for expert_id in range(self.slots[0].num_experts)
+                if method.gpu_experts_mask[expert_id].item()
+            )
+            gpu_id_set = set(gpu_ids)
+            cpu_ids = tuple(
+                expert_id
+                for expert_id in range(self.slots[0].num_experts)
+                if expert_id not in gpu_id_set
+            )
+            self.expert_layouts[layer_idx] = (gpu_ids, cpu_ids)
+
+    @property
+    def registry(self):
+        return _GLM5_NEXT_FP8_PREFILL_LAYER_REGISTRY.get(self.signature, {})
+
+    @property
+    def layer_order(self) -> List[int]:
+        return sorted(self.registry)
+
+    @property
+    def allocated_bytes(self) -> int:
+        return sum(
+            getattr(slot, name).numel() * getattr(slot, name).element_size()
+            for slot in self.slots
+            for name in _Glm5NextFp8PrefillSlot.RAW_NAMES
+        )
+
+    @classmethod
+    def _build_control_offsets(cls, tp_size: int):
+        cursor = 0
+        offsets = {}
+
+        def allocate(name: str, count: int) -> None:
+            nonlocal cursor
+            offsets[name] = tuple(
+                (cursor + index) * cls._CONTROL_CACHELINE_BYTES
+                for index in range(count)
+            )
+            cursor += count
+
+        allocate("global_error", 1)
+        allocate("ready_generation", 2)
+        allocate("writer_ok", 2)
+        allocate("writer_layer", 2)
+        allocate("writer_expert", 2)
+        allocate("rank_error", tp_size)
+        allocate("free_generation", tp_size * 2)
+        return offsets, cursor * cls._CONTROL_CACHELINE_BYTES
+
+    def _configure_atomic_access(self, handle, tp_size: int) -> None:
+        atomic_lib = ctypes.CDLL("libatomic.so.1")
+        atomic_load = getattr(atomic_lib, "__atomic_load_8")
+        atomic_load.argtypes = [ctypes.c_void_p, ctypes.c_int]
+        atomic_load.restype = ctypes.c_uint64
+        atomic_store = getattr(atomic_lib, "__atomic_store_8")
+        atomic_store.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_uint64,
+            ctypes.c_int,
+        ]
+        atomic_store.restype = None
+        atomic_is_lock_free = getattr(atomic_lib, "__atomic_is_lock_free")
+        atomic_is_lock_free.argtypes = [ctypes.c_size_t, ctypes.c_void_p]
+        atomic_is_lock_free.restype = ctypes.c_bool
+
+        anchor = ctypes.c_char.from_buffer(handle.buf)
+        address = ctypes.addressof(anchor)
+        if address % self._CONTROL_CACHELINE_BYTES != 0:
+            raise RuntimeError(
+                "GLM-5-Next FP8 transport control is not cache-line aligned"
+            )
+        if not atomic_is_lock_free(8, ctypes.c_void_p(address)):
+            raise RuntimeError(
+                "GLM-5-Next FP8 transport requires lock-free shared uint64 atomics"
+            )
+
+        offsets, _ = self._build_control_offsets(tp_size)
+        self._atomic_lib = atomic_lib
+        self._atomic_load_u64 = atomic_load
+        self._atomic_store_u64 = atomic_store
+        self._transport_control_anchor = anchor
+        self._transport_control_address = address
+        self._control_offsets = offsets
+
+    def _atomic_load(self, offset: int) -> int:
+        return int(
+            self._atomic_load_u64(
+                ctypes.c_void_p(self._transport_control_address + offset),
+                self._ATOMIC_ACQUIRE,
+            )
+        )
+
+    def _atomic_store(self, offset: int, value: int) -> None:
+        if value < 0 or value >= 2**64:
+            raise OverflowError(f"invalid uint64 control value {value}")
+        self._atomic_store_u64(
+            ctypes.c_void_p(self._transport_control_address + offset),
+            ctypes.c_uint64(value),
+            self._ATOMIC_RELEASE,
+        )
+
+    def _control_offset(self, name: str, index: int = 0) -> int:
+        return self._control_offsets[name][index]
+
+    @staticmethod
+    def _open_transport_shared_memory(**kwargs):
+        """Open untracked control SHM when the Python runtime supports it.
+
+        Every TP rank keeps its own file descriptor and mmap alive for the
+        manager lifetime.  TP0 unlinks the name only after every rank has
+        opened and configured that mapping.  Disabling ``resource_tracker``
+        registration prevents an unrelated rank's tracker from attempting a
+        second unlink at process shutdown.  Python before 3.13 has no
+        ``track`` argument; immediate TP0 unlink still makes that fallback
+        safe because all mappings are already open.
+        """
+
+        try:
+            return shared_memory.SharedMemory(**kwargs, track=False)
+        except TypeError:
+            return shared_memory.SharedMemory(**kwargs)
+
+    def initialize_transport_control(self) -> None:
+        """Create a same-node acquire/release control plane for hot transport."""
+
+        tp_rank = get_tensor_model_parallel_rank()
+        tp_size = get_tensor_model_parallel_world_size()
+        _, control_nbytes = self._build_control_offsets(tp_size)
+        name_holder = [None]
+        local_error = None
+        handle = None
+        try:
+            if tp_rank == 0:
+                name_holder[0] = f"kt_glm5_fp8_ctrl_{uuid.uuid4().hex[:12]}"
+                handle = self._open_transport_shared_memory(
+                    name=name_holder[0],
+                    create=True,
+                    size=control_nbytes,
+                )
+                handle.buf[:] = bytes(control_nbytes)
+        except Exception as exc:
+            local_error = exc
+
+        if dist.is_initialized():
+            dist.broadcast_object_list(
+                name_holder,
+                src=get_tp_group().first_rank,
+                group=get_tp_group().cpu_group,
+            )
+
+        if tp_rank != 0 and local_error is None:
+            try:
+                if name_holder[0] is None:
+                    raise RuntimeError("TP0 did not publish a transport SHM name")
+                handle = self._open_transport_shared_memory(
+                    name=name_holder[0], create=False
+                )
+            except Exception as exc:
+                local_error = exc
+
+        if handle is not None and local_error is None:
+            try:
+                self._configure_atomic_access(handle, tp_size)
+            except Exception as exc:
+                local_error = exc
+
+        if not _all_tp_ranks_succeeded(local_error is None):
+            self._transport_control_anchor = None
+            if handle is not None:
+                try:
+                    handle.close()
+                except Exception:
+                    pass
+            if tp_rank == 0 and handle is not None:
+                try:
+                    handle.unlink()
+                except Exception:
+                    pass
+            message = (
+                "GLM-5-Next FP8 transport control SHM initialization failed "
+                "on at least one TP rank"
+            )
+            if local_error is not None:
+                raise RuntimeError(message) from local_error
+            raise RuntimeError(message)
+        if local_error is not None:
+            raise local_error
+        assert handle is not None
+
+        self._transport_control_shm = handle
+        if tp_rank == 0:
+            try:
+                handle.unlink()
+            except FileNotFoundError:
+                pass
+
+    def _mark_local_transport_failure(self) -> None:
+        if self._control_offsets is None:
+            return
+        try:
+            tp_rank = get_tensor_model_parallel_rank()
+            self._atomic_store(self._control_offset("rank_error", tp_rank), 1)
+            self._atomic_store(self._control_offset("global_error"), 1)
+        except Exception:
+            # Error publication is best-effort once the atomic control plane
+            # itself is broken.  Do not let it make one rank skip the fixed
+            # expert loop / layer-end consensus; the process-group watchdog
+            # remains the final guard for an unusable mapping or dead rank.
+            self.transport_abandoned = True
+
+    def _shared_transport_failed(self) -> bool:
+        return bool(
+            self._control_offsets is not None
+            and self._atomic_load(self._control_offset("global_error"))
+        )
+
+    def _wait_for_exact_control_value(
+        self, offset: int, expected: int, phase: str
+    ) -> None:
+        if self.transport_abandoned:
+            raise RuntimeError(
+                "GLM-5-Next FP8 transport control was abandoned after a "
+                "protocol failure"
+            )
+        deadline = time.monotonic() + self._CONTROL_TIMEOUT_SECONDS
+        while True:
+            observed = self._atomic_load(offset)
+            if observed == expected:
+                return
+            if observed > expected:
+                self.transport_abandoned = True
+                self._mark_local_transport_failure()
+                raise RuntimeError(
+                    "GLM-5-Next FP8 transport generation drift while waiting "
+                    f"for {phase}: expected {expected}, observed {observed}"
+                )
+            if self._shared_transport_failed():
+                self.transport_abandoned = True
+                raise RuntimeError(
+                    "GLM-5-Next FP8 atomic transport was aborted by another "
+                    f"TP rank while waiting for {phase}"
+                )
+            if time.monotonic() >= deadline:
+                self.transport_abandoned = True
+                self._mark_local_transport_failure()
+                raise RuntimeError(
+                    "GLM-5-Next FP8 atomic transport timed out while waiting "
+                    f"for {phase}"
+                )
+            time.sleep(0)
+
+    def _wait_until_all_ranks_release(
+        self, host_slot: int, generation: int
+    ) -> bool:
+        if generation == 0:
+            return not self._shared_transport_failed()
+        tp_size = get_tensor_model_parallel_world_size()
+        deadline = time.monotonic() + self._CONTROL_TIMEOUT_SECONDS
+        for rank in range(tp_size):
+            offset = self._control_offset("free_generation", rank * 2 + host_slot)
+            while True:
+                observed = self._atomic_load(offset)
+                if observed == generation:
+                    break
+                if observed > generation:
+                    self.transport_abandoned = True
+                    self._mark_local_transport_failure()
+                    raise RuntimeError(
+                        "GLM-5-Next FP8 host-slot release generation drift: "
+                        f"rank={rank} slot={host_slot} expected={generation} "
+                        f"observed={observed}"
+                    )
+                if self._shared_transport_failed():
+                    return False
+                if time.monotonic() >= deadline:
+                    self.transport_abandoned = True
+                    self._mark_local_transport_failure()
+                    raise RuntimeError(
+                        "GLM-5-Next FP8 timed out waiting for host-slot "
+                        f"{host_slot} generation {generation} release from "
+                        f"rank {rank}"
+                    )
+                time.sleep(0)
+        return not self._shared_transport_failed()
+
+    def _publish_writer_generation(
+        self,
+        host_slot: int,
+        generation: int,
+        layer_idx: int,
+        expert_id: int,
+        writer_ok: bool,
+    ) -> None:
+        self._atomic_store(
+            self._control_offset("writer_layer", host_slot), layer_idx
+        )
+        self._atomic_store(
+            self._control_offset("writer_expert", host_slot), expert_id
+        )
+        self._atomic_store(
+            self._control_offset("writer_ok", host_slot), int(writer_ok)
+        )
+        # Release-publish ready last.  Readers acquire-load it before reading
+        # the descriptor or the payload written by KT.
+        self._atomic_store(
+            self._control_offset("ready_generation", host_slot), generation
+        )
+
+    def _consume_writer_generation(
+        self,
+        host_slot: int,
+        generation: int,
+        layer_idx: int,
+        expert_id: int,
+    ) -> bool:
+        self._wait_for_exact_control_value(
+            self._control_offset("ready_generation", host_slot),
+            generation,
+            f"writer generation {generation}",
+        )
+        observed_layer = self._atomic_load(
+            self._control_offset("writer_layer", host_slot)
+        )
+        observed_expert = self._atomic_load(
+            self._control_offset("writer_expert", host_slot)
+        )
+        if observed_layer != layer_idx or observed_expert != expert_id:
+            self.transport_abandoned = True
+            self._mark_local_transport_failure()
+            raise RuntimeError(
+                "GLM-5-Next FP8 writer descriptor mismatch: expected "
+                f"layer={layer_idx}/expert={expert_id}, observed "
+                f"layer={observed_layer}/expert={observed_expert}"
+            )
+        return bool(
+            self._atomic_load(self._control_offset("writer_ok", host_slot))
+        )
+
+    def _publish_local_host_release(
+        self, host_slot: int, generation: int
+    ) -> None:
+        rank = get_tensor_model_parallel_rank()
+        self._atomic_store(
+            self._control_offset("free_generation", rank * 2 + host_slot),
+            generation,
+        )
+
+    def _entry_state_values(self, layer_idx: int) -> tuple:
+        values = (
+            layer_idx,
+            self.epoch,
+            -1 if self.last_layer_position is None else self.last_layer_position,
+            -1 if self.current_slot_index is None else self.current_slot_index,
+            int(self.round_active),
+            int(self.failure_reason is not None),
+            tuple(self.visited_layer_indices),
+            self.transport_generation,
+            tuple(self.host_slot_generations),
+        )
+        slots = []
+        for slot in self.slots:
+            slots.append(
+                (
+                    self._SLOT_STATE_CODES.get(slot.state, -1),
+                    -1 if slot.layer_idx is None else slot.layer_idx,
+                    slot.epoch,
+                    self._REUSE_GUARD_CODES.get(slot.reuse_guard, -1),
+                )
+            )
+        return values + (tuple(slots),)
+
+    def _synchronize_layer_entry(self, layer_idx: int) -> None:
+        """Fail every local TP rank before any rank chooses ready vs load."""
+
+        if not dist.is_initialized() or get_tensor_model_parallel_world_size() == 1:
+            return
+        local_error = None
+        state = None
+        try:
+            state = self._entry_state_values(layer_idx)
+        except Exception as exc:
+            local_error = exc
+        gathered = [None] * get_tensor_model_parallel_world_size()
+        dist.all_gather_object(
+            gathered,
+            (state, None if local_error is None else repr(local_error)),
+            group=get_tp_group().cpu_group,
+        )
+        if any(peer[1] is not None for peer in gathered) or any(
+            peer[0] != gathered[0][0] for peer in gathered[1:]
+        ):
+            message = (
+                "GLM-5-Next FP8 layerwise TP state diverged before transport "
+                f"for layer {layer_idx}: {gathered}"
+            )
+            if local_error is not None:
+                raise RuntimeError(message) from local_error
+            raise RuntimeError(message)
+
+    def validate_tp_contract(self) -> None:
+        """Validate all rank-invariant registry and expert layout metadata."""
+
+        local_error = None
+        digest = None
+        hostname = socket.gethostname()
+        try:
+            layers = []
+            raw_metadata = {
+                name: {
+                    "shape": list(getattr(self.slots[0], name).shape),
+                    "dtype": str(getattr(self.slots[0], name).dtype),
+                }
+                for name in _Glm5NextFp8PrefillSlot.RAW_NAMES
+            }
+            for layer_idx in self.layer_order:
+                method, original_layer = self.registry[layer_idx]
+                original_raw_metadata = {}
+                for name in _Glm5NextFp8PrefillSlot.RAW_NAMES:
+                    if not hasattr(original_layer, name):
+                        raise RuntimeError(
+                            "GLM-5-Next FP8 registered GPU layer is missing "
+                            f"raw tensor {name} at layer {layer_idx}"
+                        )
+                    tensor = getattr(original_layer, name)
+                    full_tensor = getattr(self.slots[0], name)
+                    expected_shape = (
+                        method.num_gpu_experts,
+                        *tuple(full_tensor.shape[1:]),
+                    )
+                    if tuple(tensor.shape) != expected_shape:
+                        raise RuntimeError(
+                            "GLM-5-Next FP8 registered GPU tensor shape "
+                            f"mismatch for {name} at layer {layer_idx}: "
+                            f"expected {expected_shape}, got "
+                            f"{tuple(tensor.shape)}"
+                        )
+                    if tensor.dtype != full_tensor.dtype:
+                        raise RuntimeError(
+                            "GLM-5-Next FP8 registered GPU tensor dtype "
+                            f"mismatch for {name} at layer {layer_idx}: "
+                            f"expected {full_tensor.dtype}, got {tensor.dtype}"
+                        )
+                    original_raw_metadata[name] = {
+                        "shape": list(tensor.shape),
+                        "dtype": str(tensor.dtype),
+                    }
+                layers.append(
+                    {
+                        "layer": layer_idx,
+                        "mask": method.gpu_experts_mask.to(torch.uint8).tolist(),
+                        "logical_to_gpu": method.logical_to_gpu_index.tolist(),
+                        "global_num_experts": method.global_num_experts,
+                        "full_init_args": [
+                            str(value) for value in method._full_init_args
+                        ],
+                        "weight_path": method.kt_config.weight_path,
+                        "original_raw": original_raw_metadata,
+                    }
+                )
+            contract = {
+                "kind": "glm5_next_block_fp8_layerwise_v1",
+                "tp_size": get_tensor_model_parallel_world_size(),
+                "device_type": self.device.type,
+                "layer_order": self.layer_order,
+                "raw": raw_metadata,
+                "layers": layers,
+            }
+            canonical = json.dumps(
+                contract, sort_keys=True, separators=(",", ":")
+            )
+            digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+        except Exception as exc:
+            local_error = exc
+
+        self.contract_digest = digest
+        if not dist.is_initialized() or get_tensor_model_parallel_world_size() == 1:
+            if local_error is not None:
+                raise RuntimeError(
+                    "GLM-5-Next FP8 failed to build its TP contract"
+                ) from local_error
+            return
+
+        local = (
+            hostname,
+            digest,
+            self.device.type,
+            None if local_error is None else repr(local_error),
+        )
+        gathered = [None] * get_tensor_model_parallel_world_size()
+        dist.all_gather_object(
+            gathered, local, group=get_tp_group().cpu_group
+        )
+        if any(item[3] is not None for item in gathered):
+            message = (
+                "GLM-5-Next FP8 TP contract construction failed on at least "
+                f"one rank: {gathered}"
+            )
+            if local_error is not None:
+                raise RuntimeError(message) from local_error
+            raise RuntimeError(message)
+        if len({item[0] for item in gathered}) != 1:
+            raise RuntimeError(
+                "GLM-5-Next FP8 atomic host transport requires every TP rank "
+                f"on one host; got {gathered}"
+            )
+        if any(item[1:3] != gathered[0][1:3] for item in gathered[1:]):
+            raise RuntimeError(
+                "GLM-5-Next FP8 TP registry/mask/layout contract mismatch: "
+                f"{gathered}"
+            )
+
+    def _ensure_healthy(self) -> None:
+        if self.failure_reason is not None:
+            raise RuntimeError(
+                "GLM-5-Next FP8 layerwise prefill manager is poisoned after "
+                f"a required-path failure: {self.failure_reason}"
+            )
+
+    def _poison(self, exc: BaseException) -> None:
+        if self.failure_reason is None:
+            self.failure_reason = f"{type(exc).__name__}: {exc}"
+
+    def successor_layer_idx(self, layer_idx: int) -> Optional[int]:
+        order = self.layer_order
+        pos = bisect.bisect_right(order, layer_idx)
+        return order[pos] if pos < len(order) else None
+
+    def _advance_round(self, layer_idx: int) -> None:
+        self._ensure_healthy()
+        order = self.layer_order
+        pos = bisect.bisect_left(order, layer_idx)
+        if pos >= len(order) or order[pos] != layer_idx:
+            raise RuntimeError(
+                f"GLM-5-Next FP8 layerwise layer {layer_idx} is not "
+                f"registered; registered layers are {order}"
+            )
+
+        if not self.round_active:
+            if pos != 0:
+                raise RuntimeError(
+                    "GLM-5-Next FP8 layerwise EXTEND must start at MoE "
+                    f"layer {order[0]}, got layer {layer_idx}"
+                )
+            self.epoch += 1
+            self.round_active = True
+            self.last_layer_position = None
+            self.current_slot_index = None
+            self.visited_layer_indices = []
+            for slot in self.slots:
+                slot.invalidate()
+        elif self.last_layer_position is not None and pos != self.last_layer_position + 1:
+            raise RuntimeError(
+                "GLM-5-Next FP8 layerwise layer order mismatch in epoch "
+                f"{self.epoch}: expected {order[self.last_layer_position + 1]}, "
+                f"got {layer_idx}"
+            )
+        self.last_layer_position = pos
+
+    def _finish_round_if_complete(self, layer_idx: int) -> None:
+        order = self.layer_order
+        if layer_idx != order[-1]:
+            return
+        if self.visited_layer_indices != order:
+            raise RuntimeError(
+                "GLM-5-Next FP8 layerwise coverage mismatch in epoch "
+                f"{self.epoch}: expected {order}, got "
+                f"{self.visited_layer_indices}"
+            )
+        self.completed_round_count += 1
+        self.round_active = False
+        self.last_layer_position = None
+        self.current_slot_index = None
+
+    def _find_ready_slot(
+        self, layer_idx: int
+    ) -> Optional[_Glm5NextFp8PrefillSlot]:
+        for slot in self.slots:
+            if (
+                slot.state == "READY"
+                and slot.layer_idx == layer_idx
+                and slot.epoch == self.epoch
+            ):
+                return slot
+        return None
+
+    @staticmethod
+    def _record_raw_backing_on_stream(
+        slot: _Glm5NextFp8PrefillSlot, stream: torch.cuda.Stream
+    ) -> None:
+        for name in _Glm5NextFp8PrefillSlot.RAW_NAMES:
+            getattr(slot, name).record_stream(stream)
+
+    def _bind_slot(self, slot: _Glm5NextFp8PrefillSlot) -> None:
+        layer = self.context.gpu_layer
+        for name in _Glm5NextFp8PrefillSlot.RAW_NAMES:
+            # Slot tensors are stable Parameters.  Rebinding selects a slot;
+            # no tensor allocation or format conversion occurs in apply().
+            setattr(layer, name, getattr(slot, name))
+
+    def _tp_phase_succeeded(self, local_success: bool) -> bool:
+        if not dist.is_initialized() or get_tensor_model_parallel_world_size() == 1:
+            return local_success
+        try:
+            self.host_write_status.fill_(int(local_success))
+            dist.all_reduce(
+                self.host_write_status,
+                op=dist.ReduceOp.MIN,
+                group=get_tp_group().cpu_group,
+            )
+            return bool(self.host_write_status.item())
+        except Exception:
+            # This process can no longer prove that peers reached the same
+            # phase.  Poison the atomic transport before re-raising; an
+            # external process-group watchdog owns peer/rank death handling.
+            self.transport_abandoned = True
+            self._mark_local_transport_failure()
+            raise
+
+    def _commit_tp_runtime_phase(
+        self, local_error: Optional[BaseException], phase: str
+    ) -> None:
+        if self._tp_phase_succeeded(local_error is None):
+            return
+        message = f"GLM-5-Next FP8 {phase} failed on at least one TP rank"
+        if local_error is not None:
+            raise RuntimeError(message) from local_error
+        raise RuntimeError(message)
+
+    def _submit_host_write(self, method, expert_id: int, host_slot: int) -> None:
+        buffers = self.context.cpu_buffers
+        pointers = self.context.all_rank_buffer_ptrs
+
+        def expert_nbytes(name: str) -> int:
+            tensor = buffers[name]
+            return tensor.numel() // 2 * tensor.element_size()
+
+        offsets = {
+            name: host_slot * expert_nbytes(name)
+            for name in _Glm5NextFp8PrefillSlot.RAW_NAMES
+        }
+
+        def rank_pointers(name: str) -> List[int]:
+            return [ptr + offsets[name] for ptr in pointers[name]]
+
+        # Existing KT FP8 ABI writes raw E4M3 weights plus FP32 inverse
+        # scales.  No new C++ writer or conversion ABI is needed.
+        method.wrapper.submit_write_weight_scale_to_buffer(
+            get_tensor_model_parallel_world_size(),
+            expert_id,
+            rank_pointers("w13_weight"),
+            rank_pointers("w13_weight_scale_inv"),
+            rank_pointers("w2_weight"),
+            rank_pointers("w2_weight_scale_inv"),
+        )
+        method.wrapper.sync_write_weight_scale_to_buffer()
+
+    def _load_slot(
+        self,
+        slot: _Glm5NextFp8PrefillSlot,
+        layer_idx: int,
+        method,
+        original_layer: torch.nn.Module,
+    ) -> None:
+        if getattr(slot, "reuse_guard", None) == "poisoned":
+            raise RuntimeError(
+                f"GLM-5-Next FP8 slot {slot.index} cannot be reused after "
+                "its transfer stream failed to synchronize"
+            )
+        if slot.state == "LOADING":
+            raise RuntimeError(
+                f"GLM-5-Next FP8 slot {slot.index} is already loading "
+                f"layer {slot.layer_idx}"
+            )
+
+        reuse_guard = getattr(slot, "reuse_guard", None)
+        if reuse_guard is None and slot.has_consumed_event:
+            reuse_guard = "consumed"
+        slot.reuse_guard = "loading"
+        slot.state = "LOADING"
+        slot.layer_idx = layer_idx
+        slot.epoch = self.epoch
+
+        saved_affinity = None
+        local_error: Optional[BaseException] = None
+
+        def remember_error(exc: BaseException) -> None:
+            nonlocal local_error
+            if local_error is None:
+                local_error = exc
+            self._mark_local_transport_failure()
+
+        try:
+            try:
+                weight_infos = [
+                    (name, self.context.cpu_buffers[name], getattr(slot, name))
+                    for name in _Glm5NextFp8PrefillSlot.RAW_NAMES
+                ]
+                gpu_expert_ids, cpu_expert_ids = self.expert_layouts[layer_idx]
+
+                if hasattr(os, "sched_getaffinity"):
+                    saved_affinity = os.sched_getaffinity(0)
+                    available_cpus = sorted(saved_affinity)
+                    if available_cpus:
+                        target = available_cpus[
+                            -1 - (method.tp_rank % len(available_cpus))
+                        ]
+                        os.sched_setaffinity(0, {target})
+            except Exception as exc:
+                weight_infos = []
+                gpu_expert_ids, cpu_expert_ids = self.expert_layouts.get(
+                    layer_idx, ((), tuple(range(slot.num_experts)))
+                )
+                remember_error(exc)
+
+            try:
+                with torch.cuda.stream(self.transfer_stream):
+                    if reuse_guard == "consumed":
+                        self.transfer_stream.wait_event(slot.consumed_event)
+                    elif reuse_guard == "ready":
+                        self.transfer_stream.wait_event(slot.ready_event)
+                    if local_error is None:
+                        for expert_id in gpu_expert_ids:
+                            gpu_index = method.logical_to_gpu_index[
+                                expert_id
+                            ].item()
+                            for name, _, destination in weight_infos:
+                                source = getattr(original_layer, name)
+                                destination[expert_id].copy_(
+                                    source[gpu_index], non_blocking=True
+                                )
+            except Exception as exc:
+                remember_error(exc)
+
+            for position, expert_id in enumerate(cpu_expert_ids):
+                host_slot = position % 2
+                self.transport_generation += 1
+                generation = self.transport_generation
+                previous_generation = self.host_slot_generations[host_slot]
+
+                if self.host_slot_was_used[host_slot]:
+                    try:
+                        self.host_slot_free_events[host_slot].synchronize()
+                        self.host_slot_was_used[host_slot] = False
+                        self._publish_local_host_release(
+                            host_slot, previous_generation
+                        )
+                    except Exception as exc:
+                        remember_error(exc)
+
+                if method.tp_rank == 0:
+                    writer_ok = False
+                    try:
+                        can_write = self._wait_until_all_ranks_release(
+                            host_slot, previous_generation
+                        )
+                        if can_write and local_error is None:
+                            if method.wrapper is None:
+                                raise RuntimeError(
+                                    "GLM-5-Next FP8 TP0 has no KT wrapper for "
+                                    "host weight transport"
+                                )
+                            self._submit_host_write(method, expert_id, host_slot)
+                            writer_ok = True
+                    except Exception as exc:
+                        remember_error(exc)
+                    finally:
+                        try:
+                            self._publish_writer_generation(
+                                host_slot,
+                                generation,
+                                layer_idx,
+                                expert_id,
+                                writer_ok
+                                and not self._shared_transport_failed(),
+                            )
+                        except Exception as exc:
+                            # Continue the fixed expert loop.  Peers observe
+                            # global_error and abort their generation wait;
+                            # watchdog handles a fully broken atomic mapping.
+                            remember_error(exc)
+
+                writer_ok = False
+                try:
+                    writer_ok = self._consume_writer_generation(
+                        host_slot,
+                        generation,
+                        layer_idx,
+                        expert_id,
+                    )
+                except Exception as exc:
+                    remember_error(exc)
+                self.host_slot_generations[host_slot] = generation
+
+                if not writer_ok and local_error is None:
+                    remember_error(
+                        RuntimeError(
+                            "GLM-5-Next FP8 TP0 writer failed for "
+                            f"layer {layer_idx}, expert {expert_id}"
+                        )
+                    )
+
+                copied = False
+                transport_failed = True
+                try:
+                    transport_failed = self._shared_transport_failed()
+                except Exception as exc:
+                    remember_error(exc)
+                if writer_ok and local_error is None and not transport_failed:
+                    event_recorded = False
+                    try:
+                        with torch.cuda.stream(self.transfer_stream):
+                            try:
+                                for _, cpu_buffer, destination in weight_infos:
+                                    destination[expert_id].copy_(
+                                        cpu_buffer[host_slot], non_blocking=True
+                                    )
+                            finally:
+                                self.host_slot_free_events[host_slot].record(
+                                    self.transfer_stream
+                                )
+                                event_recorded = True
+                        self.host_slot_was_used[host_slot] = True
+                        copied = True
+                    except Exception as exc:
+                        remember_error(exc)
+                        if event_recorded:
+                            self.host_slot_was_used[host_slot] = True
+                        else:
+                            try:
+                                self.transfer_stream.synchronize()
+                                self.host_slot_was_used[host_slot] = False
+                            except Exception as fence_exc:
+                                remember_error(fence_exc)
+
+                if not copied and not self.host_slot_was_used[host_slot]:
+                    # This rank enqueued no DMA for the generation, so release
+                    # it immediately.  A rank with an unfenced prior DMA never
+                    # enters this branch and consequently cannot authorize an
+                    # overwrite after failure.
+                    try:
+                        self._publish_local_host_release(host_slot, generation)
+                    except Exception as exc:
+                        remember_error(exc)
+
+            fence_complete = False
+            try:
+                with torch.cuda.stream(self.transfer_stream):
+                    slot.ready_event.record(self.transfer_stream)
+                slot.ready_event.synchronize()
+                slot.reuse_guard = "ready"
+                fence_complete = True
+            except Exception as exc:
+                remember_error(exc)
+                try:
+                    self.transfer_stream.synchronize()
+                    slot.reuse_guard = "synchronized"
+                    fence_complete = True
+                except Exception as fence_exc:
+                    slot.reuse_guard = "poisoned"
+                    remember_error(fence_exc)
+
+            if fence_complete:
+                for host_slot in range(2):
+                    if self.host_slot_was_used[host_slot]:
+                        self.host_slot_was_used[host_slot] = False
+                        try:
+                            self._publish_local_host_release(
+                                host_slot,
+                                self.host_slot_generations[host_slot],
+                            )
+                        except Exception as exc:
+                            remember_error(exc)
+
+            if local_error is None:
+                try:
+                    if self._shared_transport_failed():
+                        local_error = RuntimeError(
+                            "another TP rank reported an atomic transport "
+                            "failure"
+                        )
+                except Exception as exc:
+                    remember_error(exc)
+            self._commit_tp_runtime_phase(
+                local_error, f"transport for layer {layer_idx}"
+            )
+            slot.state = "READY"
+        except Exception:
+            fence_error = None
+            if slot.reuse_guard not in ("ready", "synchronized", "poisoned"):
+                try:
+                    with torch.cuda.stream(self.transfer_stream):
+                        if reuse_guard == "consumed":
+                            self.transfer_stream.wait_event(slot.consumed_event)
+                        elif reuse_guard == "ready":
+                            self.transfer_stream.wait_event(slot.ready_event)
+                        slot.ready_event.record(self.transfer_stream)
+                    slot.reuse_guard = "ready"
+                except Exception:
+                    try:
+                        self.transfer_stream.synchronize()
+                        slot.reuse_guard = "synchronized"
+                    except Exception as exc:
+                        slot.reuse_guard = "poisoned"
+                        fence_error = exc
+            slot.invalidate()
+            if fence_error is not None:
+                raise RuntimeError(
+                    f"GLM-5-Next FP8 failed to fence slot {slot.index} "
+                    "after a transport error"
+                ) from fence_error
+            raise
+        finally:
+            if saved_affinity is not None:
+                try:
+                    os.sched_setaffinity(0, saved_affinity)
+                except Exception:
+                    logger.warning(
+                        "Failed to restore CPU affinity after GLM-5-Next "
+                        "FP8 transport",
+                        exc_info=True,
+                    )
+
+    def _acquire(self, layer_idx: int, method, layer: torch.nn.Module):
+        self._synchronize_layer_entry(layer_idx)
+        self._advance_round(layer_idx)
+        ready = self._find_ready_slot(layer_idx)
+        if ready is not None:
+            return ready, True
+
+        slot = (
+            self.slots[0]
+            if self.current_slot_index is None
+            else self.slots[1 - self.current_slot_index]
+        )
+        self._load_slot(slot, layer_idx, method, layer)
+        return slot, False
+
+    def _prefetch_successor(self, current: _Glm5NextFp8PrefillSlot) -> None:
+        successor_idx = self.successor_layer_idx(current.layer_idx)
+        if successor_idx is None:
+            return
+        entry = self.registry.get(successor_idx)
+        if entry is None:
+            raise RuntimeError(
+                f"GLM-5-Next FP8 successor layer {successor_idx} "
+                "disappeared from registry"
+            )
+        next_method, next_layer = entry
+        target = self.slots[1 - current.index]
+        if (
+            target.state == "READY"
+            and target.layer_idx == successor_idx
+            and target.epoch == self.epoch
+        ):
+            return
+        self._load_slot(target, successor_idx, next_method, next_layer)
+
+    def apply(self, method, layer, dispatch_output):
+        layer_idx = method.kt_config.layer_idx
+        try:
+            slot, prefetch_hit = self._acquire(layer_idx, method, layer)
+            if slot.layer_idx != layer_idx or slot.epoch != self.epoch:
+                raise RuntimeError(
+                    "GLM-5-Next FP8 layerwise acquired stale weights: "
+                    f"wanted layer={layer_idx}/epoch={self.epoch}, got "
+                    f"layer={slot.layer_idx}/epoch={slot.epoch}"
+                )
+
+            main_stream = None
+            result = None
+            compute_error = None
+            try:
+                main_stream = torch.cuda.current_stream(self.device)
+                main_stream.wait_event(slot.ready_event)
+                self._bind_slot(slot)
+                self._record_raw_backing_on_stream(slot, main_stream)
+                result = self.context.gpu_method.apply(
+                    self.context.gpu_layer, dispatch_output
+                )
+            except Exception as exc:
+                compute_error = exc
+            finally:
+                if main_stream is not None:
+                    try:
+                        slot.consumed_event.record(main_stream)
+                        slot.has_consumed_event = True
+                        slot.reuse_guard = "consumed"
+                        slot.state = "IN_USE"
+                        self.current_slot_index = slot.index
+                    except Exception as exc:
+                        if compute_error is None:
+                            compute_error = exc
+                        try:
+                            main_stream.synchronize()
+                            slot.reuse_guard = "synchronized"
+                            slot.state = "IN_USE"
+                            self.current_slot_index = slot.index
+                        except Exception:
+                            pass
+
+            self._commit_tp_runtime_phase(
+                compute_error, f"compute launch for layer {layer_idx}"
+            )
+            self.apply_count += 1
+            if prefetch_hit:
+                self.prefetch_hit_count += 1
+            else:
+                self.prime_count += 1
+            self.visited_layer_indices.append(layer_idx)
+
+            # Compute is already enqueued; prepare N+1 while it runs.
+            self._prefetch_successor(slot)
+            coverage_error = None
+            try:
+                self._finish_round_if_complete(layer_idx)
+            except Exception as exc:
+                coverage_error = exc
+            if layer_idx == self.layer_order[-1]:
+                # No rank may leave the final MoE layer after a rank-local
+                # coverage failure while peers proceed to later collectives.
+                self._commit_tp_runtime_phase(
+                    coverage_error, f"coverage for epoch {self.epoch}"
+                )
+            elif coverage_error is not None:
+                raise coverage_error
+            if method.tp_rank == 0:
+                log = (
+                    logger.info
+                    if layer_idx == self.layer_order[-1]
+                    else logger.debug
+                )
+                log(
+                    "KT GLM-5-Next FP8 layerwise prefill: layer=%d epoch=%d "
+                    "slot=%d %s apply_count=%d prime_count=%d "
+                    "prefetch_hit_count=%d completed_rounds=%d fallback_count=%d",
+                    layer_idx,
+                    self.epoch,
+                    slot.index,
+                    "prefetch-hit" if prefetch_hit else "prime",
+                    self.apply_count,
+                    self.prime_count,
+                    self.prefetch_hit_count,
+                    self.completed_round_count,
+                    self.fallback_count,
+                )
+            return result
+        except Exception as exc:
+            self._poison(exc)
+            raise
+
+
+def _glm5_next_fp8_pipeline_requested(method) -> bool:
+    return (
+        bool(getattr(method.kt_config, "is_glm5_next", False))
+        and method.gpu_prefill_token_threshold > 0
+        and (method.kt_config.method or "").upper() == "FP8"
+    )
+
+
+def _glm5_next_fp8_pipeline_signature(method, layer: torch.nn.Module) -> tuple:
+    device = next(layer.parameters()).device
+    return (
+        "glm5_next_block_fp8",
+        str(device),
+        method.kt_config.weight_path,
+        method.kt_config.num_layers,
+        method.global_num_experts,
+        method._full_init_args,
+    )
+
+
+def _register_glm5_next_fp8_prefill_layer(method, layer: torch.nn.Module) -> None:
+    if not _glm5_next_fp8_pipeline_requested(method):
+        return
+    if method.kt_config.kt_enable_dynamic_expert_update:
+        raise ValueError(
+            "GLM-5-Next required FP8 layerwise prefill is incompatible with "
+            "--kt-enable-dynamic-expert-update"
+        )
+    signature = _glm5_next_fp8_pipeline_signature(method, layer)
+    method._glm5_next_fp8_pipeline_signature = signature
+    registry = _GLM5_NEXT_FP8_PREFILL_LAYER_REGISTRY.setdefault(signature, {})
+    layer_idx = method.kt_config.layer_idx
+    existing = registry.get(layer_idx)
+    if existing is not None and (
+        existing[0] is not method or existing[1] is not layer
+    ):
+        raise RuntimeError(
+            "duplicate GLM-5-Next FP8 layerwise prefill registration for "
+            f"layer {layer_idx}"
+        )
+    registry[layer_idx] = (method, layer)
+
+
+def _validate_glm5_next_fp8_registry(signature: tuple, registry: dict) -> None:
+    order = sorted(registry)
+    expected_order = list(range(3, 45))
+    if order != expected_order:
+        raise RuntimeError(
+            "GLM-5-Next required FP8 layerwise registry must contain every "
+            f"MoE layer 3..44 exactly once; got {order}"
+        )
+    for layer_idx, (method, _layer) in registry.items():
+        if not _glm5_next_fp8_pipeline_requested(method):
+            raise RuntimeError(
+                f"GLM-5-Next FP8 registry {signature} contains an ineligible "
+                f"layer {layer_idx}"
+            )
+        if method.kt_config.num_layers != 45:
+            raise RuntimeError(
+                "GLM-5-Next FP8 layerwise requires num_layers=45; got "
+                f"{method.kt_config.num_layers} at layer {layer_idx}"
+            )
+        if method.kt_config.kt_enable_dynamic_expert_update:
+            raise RuntimeError(
+                "GLM-5-Next FP8 layerwise does not support dynamic expert update"
+            )
+        if getattr(method, "tp_rank", None) != get_tensor_model_parallel_rank():
+            raise RuntimeError(
+                "GLM-5-Next FP8 layerwise method/rank mismatch at layer "
+                f"{layer_idx}: method.tp_rank={getattr(method, 'tp_rank', None)}, "
+                f"runtime rank={get_tensor_model_parallel_rank()}"
+            )
+        if getattr(method, "global_num_experts", None) != 288:
+            raise RuntimeError(
+                "GLM-5-Next FP8 layerwise requires exactly 288 routed "
+                f"experts; got {getattr(method, 'global_num_experts', None)}"
+            )
+        full_init_args = getattr(method, "_full_init_args", ())
+        if len(full_init_args) < 2 or tuple(full_init_args[:2]) != (4096, 256):
+            raise RuntimeError(
+                "GLM-5-Next FP8 layerwise requires TP8 expert geometry "
+                "hidden=4096/intermediate_per_partition=256; got "
+                f"{full_init_args}"
+            )
+        mask = getattr(method, "gpu_experts_mask", None)
+        mapping = getattr(method, "logical_to_gpu_index", None)
+        if (
+            not isinstance(mask, torch.Tensor)
+            or mask.dtype != torch.bool
+            or tuple(mask.shape) != (288,)
+            or not isinstance(mapping, torch.Tensor)
+            or tuple(mapping.shape) != (288,)
+        ):
+            raise RuntimeError(
+                "GLM-5-Next FP8 layerwise requires [288] bool mask and "
+                f"logical mapping at layer {layer_idx}"
+            )
+        # Both tensors are model state and therefore normally live on the TP
+        # rank's CUDA device.  Build the invariant on that same device: a CPU
+        # reference here makes torch.equal fail during the required startup
+        # preflight before the layerwise slots can be allocated.
+        mapping_int32 = mapping.to(dtype=torch.int32)
+        mask_on_mapping_device = mask.to(device=mapping.device)
+        expected_mapping = torch.full(
+            (288,), -1, dtype=torch.int32, device=mapping.device
+        )
+        gpu_ids = torch.where(mask_on_mapping_device)[0]
+        expected_mapping[gpu_ids] = torch.arange(
+            gpu_ids.numel(), dtype=torch.int32, device=mapping.device
+        )
+        if not torch.equal(mapping_int32, expected_mapping):
+            raise RuntimeError(
+                "GLM-5-Next FP8 logical_to_gpu_index does not match its "
+                f"static mask at layer {layer_idx}"
+            )
+        if getattr(method, "num_gpu_experts", None) != gpu_ids.numel():
+            raise RuntimeError(
+                "GLM-5-Next FP8 num_gpu_experts does not match its static "
+                f"mask at layer {layer_idx}"
+            )
+
+
+def _validate_glm5_next_fp8_context(context: SharedFullContext) -> None:
+    runner_config = getattr(context.gpu_layer, "moe_runner_config", None)
+    if not bool(
+        getattr(runner_config, "glm5_next_hf_two_round_swiglu", False)
+    ):
+        raise RuntimeError(
+            "GLM-5-Next layerwise requires the private HF two-round "
+            "BF16 SwiGLU runner"
+        )
+    if not getattr(context, "_is_fp8_quant", False):
+        raise RuntimeError(
+            "GLM-5-Next layerwise built a non-block-FP8 full context"
+        )
+    base_method = context._get_base_quant_method()
+    if not getattr(base_method, "block_quant", False):
+        raise RuntimeError(
+            "GLM-5-Next layerwise requires a block-quantized FP8 MoE method"
+        )
+    if getattr(base_method, "use_mxfp8", False):
+        raise RuntimeError(
+            "GLM-5-Next layerwise requires raw E4M3+FP32 block FP8, not MXFP8"
+        )
+    if tuple(getattr(base_method, "weight_block_size", ())) != (128, 128):
+        raise RuntimeError(
+            "GLM-5-Next layerwise requires FP8 weight_block_size=[128, 128]"
+        )
+    runner_backend = getattr(
+        getattr(base_method, "runner", None), "runner_backend", None
+    )
+    if (
+        runner_backend is None
+        or not hasattr(runner_backend, "is_triton")
+        or not runner_backend.is_triton()
+    ):
+        raise RuntimeError(
+            "GLM-5-Next layerwise requires the raw block-FP8 Triton MoE runner"
+        )
+
+    layer = context.gpu_layer
+    expected_shapes = {
+        "w13_weight": (288, 512, 4096),
+        "w13_weight_scale_inv": (288, 4, 32),
+        "w2_weight": (288, 4096, 256),
+        "w2_weight_scale_inv": (288, 32, 2),
+    }
+    expected_dtypes = {
+        "w13_weight": getattr(torch, "float8_e4m3fn", None),
+        "w13_weight_scale_inv": torch.float32,
+        "w2_weight": getattr(torch, "float8_e4m3fn", None),
+        "w2_weight_scale_inv": torch.float32,
+    }
+    for name in _Glm5NextFp8PrefillSlot.RAW_NAMES:
+        if not hasattr(layer, name):
+            raise RuntimeError(
+                f"GLM-5-Next FP8 full context is missing raw tensor {name}"
+            )
+        tensor = getattr(layer, name)
+        if tuple(tensor.shape) != expected_shapes[name]:
+            raise RuntimeError(
+                f"GLM-5-Next FP8 {name} shape mismatch: expected "
+                f"{expected_shapes[name]}, got {tuple(tensor.shape)}"
+            )
+        if tensor.dtype != expected_dtypes[name]:
+            raise RuntimeError(
+                f"GLM-5-Next FP8 {name} dtype mismatch: expected "
+                f"{expected_dtypes[name]}, got {tensor.dtype}"
+            )
+
+
+def _validate_glm5_next_fp8_writer_abi(registry: dict) -> None:
+    """Fail startup if TP0's installed KT binary lacks the FP8 writer ABI."""
+
+    if get_tensor_model_parallel_rank() != 0:
+        return
+    for layer_idx, (method, _layer) in registry.items():
+        wrapper = getattr(method, "wrapper", None)
+        if wrapper is None:
+            raise RuntimeError(
+                f"GLM-5-Next FP8 layer {layer_idx} has no TP0 KT wrapper"
+            )
+        for name in (
+            "submit_write_weight_scale_to_buffer",
+            "sync_write_weight_scale_to_buffer",
+        ):
+            if not callable(getattr(wrapper, name, None)):
+                raise RuntimeError(
+                    "GLM-5-Next FP8 requires the installed KT writer ABI; "
+                    f"layer {layer_idx} is missing {name}"
+                )
+        moe = getattr(wrapper, "moe", None)
+        if moe is None or not hasattr(moe, "write_weight_scale_to_buffer_task"):
+            raise RuntimeError(
+                "GLM-5-Next FP8 requires a kt-kernel binary exposing "
+                "write_weight_scale_to_buffer_task; missing at layer "
+                f"{layer_idx}"
+            )
+
+
+def _glm5_next_fp8_raw_slot_storage_nbytes(
+    *, num_experts: int, hidden_size: int, intermediate_size: int
+) -> int:
+    """Bytes in one raw E4M3 + FP32 [128, 128] full-expert slot."""
+
+    fp8_size = torch.tensor([], dtype=torch.float8_e4m3fn).element_size()
+    fp32_size = torch.tensor([], dtype=torch.float32).element_size()
+    hidden_blocks = (hidden_size + 127) // 128
+    intermediate_blocks = (intermediate_size + 127) // 128
+    return (
+        num_experts
+        * (2 * intermediate_size * hidden_size + hidden_size * intermediate_size)
+        * fp8_size
+        + num_experts
+        * (
+            2 * intermediate_blocks * hidden_blocks
+            + hidden_blocks * intermediate_blocks
+        )
+        * fp32_size
+    )
+
+
+def _allocate_glm5_next_fp8_slot_storage(
+    context: SharedFullContext,
+) -> Dict[str, torch.Tensor]:
+    return {
+        name: torch.nn.Parameter(
+            torch.empty_like(getattr(context.gpu_layer, name).data),
+            requires_grad=False,
+        )
+        for name in _Glm5NextFp8PrefillSlot.RAW_NAMES
+    }
+
+
+def _initialize_glm5_next_fp8_layerwise_pipeline(
+    signature: tuple, registry: dict
+) -> _Glm5NextFp8LayerwisePrefillManager:
+    existing = _GLM5_NEXT_FP8_LAYERWISE_MANAGERS.get(signature)
+    if existing is not None:
+        return existing
+
+    preflight_error = None
+    try:
+        _validate_glm5_next_fp8_registry(signature, registry)
+        if not torch.cuda.is_available():
+            raise RuntimeError(
+                "GLM-5-Next required FP8 layerwise prefill requires CUDA"
+            )
+        if get_tensor_model_parallel_world_size() != 8:
+            raise RuntimeError(
+                "GLM-5-Next required FP8 layerwise prefill is accepted only "
+                "for the TP=8 production topology"
+            )
+    except Exception as exc:
+        preflight_error = exc
+    if not _all_tp_ranks_succeeded(preflight_error is None):
+        message = (
+            "GLM-5-Next required FP8 layerwise preflight failed on at least "
+            "one TP rank"
+        )
+        if preflight_error is not None:
+            raise RuntimeError(message) from preflight_error
+        raise RuntimeError(message)
+    if preflight_error is not None:
+        raise preflight_error
+
+    first_layer_idx = min(registry)
+    method, layer = registry[first_layer_idx]
+    context = None
+    slot1_raw = None
+    manager = None
+    local_error = None
+    try:
+        context = SharedFullContext(
+            layer=layer,
+            init_args=method._full_init_args,
+            global_num_experts=method.global_num_experts,
+            moe_runner_config=method.moe_runner_config,
+            defer_cpu_buffers=True,
+        )
+        _validate_glm5_next_fp8_context(context)
+        slot1_raw = _allocate_glm5_next_fp8_slot_storage(context)
+        manager = _Glm5NextFp8LayerwisePrefillManager(
+            context, signature, slot1_raw
+        )
+        _validate_glm5_next_fp8_writer_abi(registry)
+    except Exception as exc:
+        local_error = exc
+
+    if not _all_tp_ranks_succeeded(local_error is None):
+        manager = None
+        slot1_raw = None
+        context = None
+        gc.collect()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+        message = (
+            "GLM-5-Next required FP8 two-slot allocation failed on at least "
+            "one TP rank; refusing hybrid/serialized fallback"
+        )
+        if local_error is not None:
+            raise RuntimeError(message) from local_error
+        raise RuntimeError(message)
+    if local_error is not None:
+        raise local_error
+    assert context is not None and manager is not None
+
+    shm_error = None
+    try:
+        # The digest excludes rank-local CUDA indices, but covers the complete
+        # registry, raw tensor metadata, masks, and logical mappings.  Validate
+        # it before TP0 receives pointers into peer processes.
+        manager.validate_tp_contract()
+        # Allocate host transport only after both GPU slots exist on every TP
+        # rank, preventing an OOM peer from stranding SHM collectives.
+        context.initialize_cpu_buffers()
+        manager.initialize_transport_control()
+    except Exception as exc:
+        shm_error = exc
+    if not _all_tp_ranks_succeeded(shm_error is None):
+        message = (
+            "GLM-5-Next required FP8 host transport initialization failed "
+            "on at least one TP rank"
+        )
+        if shm_error is not None:
+            raise RuntimeError(message) from shm_error
+        raise RuntimeError(message)
+    if shm_error is not None:
+        raise shm_error
+
+    _GLM5_NEXT_FP8_LAYERWISE_MANAGERS[signature] = manager
+    if method.tp_rank == 0:
+        logger.info(
+            "KT GLM-5-Next FP8 layerwise prefill eagerly allocated two raw "
+            "E4M3+FP32 full-layer slots on %s before KV profiling "
+            "(total=%.2f GiB, contract=%s, fallback_count=0)",
+            manager.device,
+            manager.allocated_bytes / 1024**3,
+            manager.contract_digest,
+        )
+    return manager
+
+
+def initialize_glm5_next_fp8_layerwise_prefill() -> int:
+    """Eagerly allocate all required GLM managers before KV profiling.
+
+    Called only for the exact-model gate.  Returning allocated bytes makes the
+    startup reservation auditable; the memory profiler must not subtract it a
+    second time because the tensors are already resident.
+    """
+
+    registry_error = None
+    registry_count = len(_GLM5_NEXT_FP8_PREFILL_LAYER_REGISTRY)
+    if registry_count != 1:
+        registry_error = RuntimeError(
+            "GLM-5-Next required FP8 layerwise prefill needs exactly one "
+            "device-local MoE registry; got "
+            f"{registry_count}"
+        )
+    if not _all_tp_ranks_succeeded(registry_error is None):
+        message = (
+            "GLM-5-Next required FP8 layerwise registry count differs or is "
+            "invalid on at least one TP rank"
+        )
+        if registry_error is not None:
+            raise RuntimeError(message) from registry_error
+        raise RuntimeError(message)
+    if registry_error is not None:
+        raise registry_error
+
+    signature, registry = next(
+        iter(_GLM5_NEXT_FP8_PREFILL_LAYER_REGISTRY.items())
+    )
+    manager = _initialize_glm5_next_fp8_layerwise_pipeline(signature, registry)
+    return manager.allocated_bytes
+
+
+def _get_glm5_next_fp8_layerwise_manager(
+    method,
+) -> _Glm5NextFp8LayerwisePrefillManager:
+    signature = getattr(method, "_glm5_next_fp8_pipeline_signature", None)
+    if signature is None:
+        raise RuntimeError(
+            "GLM-5-Next required FP8 layerwise layer was not registered"
+        )
+    manager = _GLM5_NEXT_FP8_LAYERWISE_MANAGERS.get(signature)
+    if manager is None:
+        raise RuntimeError(
+            "GLM-5-Next required FP8 layerwise manager was not initialized "
+            "before KV-cache profiling; refusing fallback"
+        )
+    return manager
+
+
+def _glm5_next_forward_mode_name(mode) -> str:
+    name = getattr(mode, "name", None)
+    return str(name if name is not None else mode).upper()
+
+
 def generate_front_loading_masks(
     num_layers: int,
     num_experts: int,
@@ -3749,6 +5343,7 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
         # Registration happens during model construction, not on the first
         # request, so layer N can identify and prepare N+1 immediately.
         _register_mxfp4_prefill_layer(self, layer)
+        _register_glm5_next_fp8_prefill_layer(self, layer)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         """Process weights after loading from checkpoint.
@@ -3991,22 +5586,45 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
         Returns:
             Combined computation results from CPU and GPU experts
         """
+        x = dispatch_output.hidden_states
+        topk_output = dispatch_output.topk_output
+        num_tokens = int(x.shape[0]) if x.dim() > 0 else 0
+        _glm5_next_fp8_required = _glm5_next_fp8_pipeline_requested(self)
+        if _glm5_next_fp8_required:
+            forward_mode = getattr(self, "_glm5_next_forward_mode", None)
+            if forward_mode is None:
+                raise RuntimeError(
+                    "GLM-5-Next required FP8 layerwise routing has no "
+                    "ForwardMode metadata"
+                )
+            forward_mode_name = _glm5_next_forward_mode_name(forward_mode)
+            if forward_mode_name == "EXTEND":
+                # The threshold is an enable switch for exact GLM, not a
+                # per-chunk size cutoff.  This includes the final short chunk.
+                return _get_glm5_next_fp8_layerwise_manager(self).apply(
+                    self, layer, dispatch_output
+                )
+            if forward_mode_name not in ("DECODE", "IDLE"):
+                raise RuntimeError(
+                    "GLM-5-Next required FP8 layerwise prefill supports only "
+                    "plain EXTEND and bypasses only DECODE/IDLE; got "
+                    f"ForwardMode.{forward_mode_name}"
+                )
+
         from sglang.srt.eplb.expert_distribution import (
             get_global_expert_distribution_recorder,
         )
         from sglang.srt.layers.moe.token_dispatcher import StandardCombineInput
 
-        # Record GPU expert mask for distribution tracking (rank 0 only)
-        # Use gpu_experts_mask_cuda which is already on GPU for CUDA graph compatibility
+        # The required exact-GLM EXTEND route above must happen before this
+        # TP0-only recorder.  A recorder exception on rank 0 must never leave
+        # peers entering layerwise transport collectives.
         if self.tp_rank == 0:
             recorder = get_global_expert_distribution_recorder()
             recorder.on_gpu_expert_mask(
                 self.kt_config.layer_idx, self.gpu_experts_mask_cuda
             )
 
-        x = dispatch_output.hidden_states
-        topk_output = dispatch_output.topk_output
-        num_tokens = int(x.shape[0]) if x.dim() > 0 else 0
         _kt_timing = (
             os.environ.get("SGLANG_KT_HYBRID_TIMING") == "1"
             and self.tp_rank == 0
@@ -4036,7 +5654,8 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
             or getattr(layer, "_v4_tk_path", False)
         )
         _full_gpu_gate = (
-            self.gpu_prefill_token_threshold > 0
+            not _glm5_next_fp8_required
+            and self.gpu_prefill_token_threshold > 0
             and num_tokens >= self.gpu_prefill_token_threshold
             and _full_gpu_fallback_supported
         )

--- a/python/sglang/srt/layers/moe/moe_runner/base.py
+++ b/python/sglang/srt/layers/moe/moe_runner/base.py
@@ -49,6 +49,10 @@ class MoeRunnerConfig:
     gemm1_alpha: Optional[float] = None
     gemm1_clamp_limit: Optional[float] = None
     swiglu_limit: Optional[float] = None
+    # GLM-5-Next only: preserve the released HF model's BF16 SiLU
+    # materialization before the BF16 gate/up multiply.  Generic MoE runners
+    # retain their existing fused one-round activation by default.
+    glm5_next_hf_two_round_swiglu: bool = False
 
 
 @dataclass

--- a/python/sglang/srt/layers/moe/moe_runner/triton.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton.py
@@ -203,6 +203,9 @@ class TritonRunnerCore(MoeRunnerCore):
         inplace = self.config.inplace
         gemm1_alpha = self.config.gemm1_alpha
         gemm1_limit = self.config.gemm1_clamp_limit
+        glm5_next_hf_two_round_swiglu = (
+            self.config.glm5_next_hf_two_round_swiglu
+        )
         routed_scaling_factor = self.config.routed_scaling_factor
         apply_router_weight_on_input = self.config.apply_router_weight_on_input
 
@@ -252,7 +255,26 @@ class TritonRunnerCore(MoeRunnerCore):
         )
 
         if activation == "silu":
-            if gemm1_alpha is not None:
+            if glm5_next_hf_two_round_swiglu:
+                if gemm1_alpha is not None or gemm1_limit is not None:
+                    raise ValueError(
+                        "GLM-5-Next HF two-round SwiGLU is incompatible with "
+                        "gemm1_alpha/gemm1_limit"
+                    )
+                if self.config.swiglu_limit is None:
+                    raise ValueError(
+                        "GLM-5-Next HF two-round SwiGLU requires swiglu_limit"
+                    )
+                from sglang.srt.layers.moe.glm5_next_swiglu import (
+                    glm5_next_hf_two_round_swiglu as glm5_next_swiglu,
+                )
+
+                intermediate_cache2 = glm5_next_swiglu(
+                    intermediate_cache1.view(-1, N),
+                    self.config.swiglu_limit,
+                    output=intermediate_cache2,
+                )
+            elif gemm1_alpha is not None:
                 assert gemm1_limit is not None
                 # kvcache fork asserts interleaved=False (FusedMoE layer.py:199),
                 # so w13 output is concatenated gate||up. Use the chunk(2, dim=-1)

--- a/python/sglang/srt/managers/forward_hooks_registry.py
+++ b/python/sglang/srt/managers/forward_hooks_registry.py
@@ -14,7 +14,7 @@ hisparse_coordinator.py is imported (triggered via deepseek_v4.py
 side-effect).
 """
 
-from typing import Any, Callable, Dict, List
+from typing import Any, Dict, List
 
 
 _HOOKS: Dict[str, Any] = {}
@@ -47,6 +47,17 @@ def dispatch(event: str, *args: Any, **kwargs: Any) -> None:
         method = getattr(hook, event, None)
         if method is None:
             continue
+        method(*args, **kwargs)
+
+
+def dispatch_named(name: str, event: str, *args: Any, **kwargs: Any) -> None:
+    """Fire one registered hook without changing any other plugin's lifecycle."""
+
+    hook = _HOOKS.get(name)
+    if hook is None:
+        return
+    method = getattr(hook, event, None)
+    if method is not None:
         method(*args, **kwargs)
 
 

--- a/python/sglang/srt/managers/glm5_next_kpool_coordinator.py
+++ b/python/sglang/srt/managers/glm5_next_kpool_coordinator.py
@@ -1,0 +1,127 @@
+"""Request-row lifecycle for GLM-5-Next's live KPool compression tail."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Iterable, Optional
+
+import torch
+
+from sglang.srt.managers.coordinator_registry import register_request_coordinator
+from sglang.srt.managers.forward_hooks_registry import register_forward_hook
+
+if TYPE_CHECKING:
+    from sglang.srt.mem_cache.glm5_next_memory_pool import Glm5NextHybridKVPool
+
+
+class Glm5NextKPoolCoordinator:
+    """Own the boundary at which a request's live KPool tail is reusable.
+
+    ``prepare_kpool_request`` must run after a request row is allocated and
+    before its first prefill forward.  The existing SGLang
+    ``on_request_admit`` event fires *after* prefill, so it intentionally does
+    not clear state: doing so would erase the tail that prefill just produced.
+    Finish and retract events occur before request-row release and are safe
+    cleanup points.
+    """
+
+    def __init__(self, pool: "Glm5NextHybridKVPool") -> None:
+        if not getattr(pool, "is_glm5_next_kpool", False):
+            raise TypeError("Glm5NextKPoolCoordinator only accepts the exact GLM KPool")
+        self.pool = pool
+        self._prepared_rows: set[int] = set()
+
+    @staticmethod
+    def _as_cpu_rows(
+        req_pool_indices: int | Iterable[int] | torch.Tensor,
+    ) -> list[int]:
+        if isinstance(req_pool_indices, int):
+            return [req_pool_indices]
+        if isinstance(req_pool_indices, torch.Tensor):
+            return [int(row) for row in req_pool_indices.detach().cpu().reshape(-1)]
+        return [int(row) for row in req_pool_indices]
+
+    def prepare_kpool_request(
+        self, req_pool_indices: int | Iterable[int] | torch.Tensor
+    ) -> None:
+        """Clear freshly allocated rows immediately before first prefill."""
+
+        rows = self._as_cpu_rows(req_pool_indices)
+        if not rows:
+            return
+        self.pool.prepare_kpool_request(rows)
+        self._prepared_rows.update(rows)
+
+    def _release_request(self, req) -> None:
+        req_pool_idx = getattr(req, "req_pool_idx", None)
+        if req_pool_idx is None:
+            return
+        row = int(req_pool_idx)
+        self.pool.clear_compress_tail_rows(row)
+        self._prepared_rows.discard(row)
+
+    def on_request_admit(self, req) -> None:
+        """No-op: the current admit hook is post-prefill, not pre-forward."""
+
+        del req
+
+    def on_request_finished(self, req) -> None:
+        self._release_request(req)
+
+    def on_request_retract(self, req) -> None:
+        self._release_request(req)
+
+    def is_prepared(self, req_pool_idx: int) -> bool:
+        """Test/debug visibility; not used to skip mandatory row clearing."""
+
+        return req_pool_idx in self._prepared_rows
+
+
+class _Glm5NextKPoolHookAdapter:
+    """Global hook proxy; inert until the exact GLM pool factory attaches."""
+
+    _coordinator: Optional[Glm5NextKPoolCoordinator] = None
+
+    @classmethod
+    def attach(cls, coordinator: Optional[Glm5NextKPoolCoordinator]) -> None:
+        cls._coordinator = coordinator
+
+    def prepare_kpool_request(self, req_pool_indices) -> None:
+        if self._coordinator is not None:
+            self._coordinator.prepare_kpool_request(req_pool_indices)
+
+    def on_request_admit(self, req) -> None:
+        if self._coordinator is not None:
+            self._coordinator.on_request_admit(req)
+
+    def on_request_finished(self, req) -> None:
+        if self._coordinator is not None:
+            self._coordinator.on_request_finished(req)
+
+    def on_request_retract(self, req) -> None:
+        if self._coordinator is not None:
+            self._coordinator.on_request_retract(req)
+
+
+_GLM5_NEXT_KPOOL_HOOK = _Glm5NextKPoolHookAdapter()
+
+
+def attach_glm5_next_kpool_lifecycle(
+    pool: "Glm5NextHybridKVPool",
+) -> Glm5NextKPoolCoordinator:
+    coordinator = Glm5NextKPoolCoordinator(pool)
+    _Glm5NextKPoolHookAdapter.attach(coordinator)
+    return coordinator
+
+
+def detach_glm5_next_kpool_lifecycle() -> None:
+    """Detach process-global state for worker shutdown and isolation tests."""
+
+    _Glm5NextKPoolHookAdapter.attach(None)
+
+
+def get_glm5_next_kpool_coordinator() -> Optional[Glm5NextKPoolCoordinator]:
+    return _Glm5NextKPoolHookAdapter._coordinator
+
+
+register_request_coordinator("glm5_next_kpool", Glm5NextKPoolCoordinator)
+register_forward_hook("glm5_next_kpool", _GLM5_NEXT_KPOOL_HOOK)

--- a/python/sglang/srt/managers/glm5_next_kpool_coordinator.py
+++ b/python/sglang/srt/managers/glm5_next_kpool_coordinator.py
@@ -70,6 +70,14 @@ class Glm5NextKPoolCoordinator:
     def on_request_retract(self, req) -> None:
         self._release_request(req)
 
+    def reset(self) -> None:
+        """Clear all rows still owned by this coordinator during cache flush."""
+
+        rows = sorted(self._prepared_rows)
+        if rows:
+            self.pool.clear_compress_tail_rows(rows)
+        self._prepared_rows.clear()
+
     def is_prepared(self, req_pool_idx: int) -> bool:
         """Test/debug visibility; not used to skip mandatory row clearing."""
 
@@ -100,6 +108,10 @@ class _Glm5NextKPoolHookAdapter:
     def on_request_retract(self, req) -> None:
         if self._coordinator is not None:
             self._coordinator.on_request_retract(req)
+
+    def on_cache_flush(self) -> None:
+        if self._coordinator is not None:
+            self._coordinator.reset()
 
 
 _GLM5_NEXT_KPOOL_HOOK = _Glm5NextKPoolHookAdapter()

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1943,9 +1943,15 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         req = self.reqs[idx]
 
         if self.hisparse_coordinator is not None and not req.finished():
-            from sglang.srt.managers.forward_hooks_registry import dispatch
+            from sglang.srt.managers.forward_hooks_registry import dispatch_named
 
-            dispatch("on_request_retract", req)
+            dispatch_named("hisparse", "on_request_retract", req)
+        if not req.finished() and getattr(
+            server_args, "_glm5_next_session_ab_active", False
+        ):
+            from sglang.srt.managers.forward_hooks_registry import dispatch_named
+
+            dispatch_named("glm5_next_kpool", "on_request_retract", req)
 
         if server_args.disaggregation_mode == "decode":
             req.offload_kv_cache(

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1052,8 +1052,11 @@ class Req(ReqDllmMixin):
                 matched_eos |= token_id in self.eos_token_ids
             if self.tokenizer is not None:
                 matched_eos |= token_id == self.tokenizer.eos_token_id
-                if self.tokenizer.additional_stop_token_ids:
-                    matched_eos |= token_id in self.tokenizer.additional_stop_token_ids
+                additional_stop_token_ids = getattr(
+                    self.tokenizer, "additional_stop_token_ids", None
+                )
+                if additional_stop_token_ids:
+                    matched_eos |= token_id in additional_stop_token_ids
             if matched_eos:
                 self.finished_reason = FINISH_MATCHED_TOKEN(matched=token_id)
                 matched_pos = len(self.output_ids) - len(new_accepted_tokens) + i

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -356,6 +356,9 @@ class MultimodalProcessorOutput:
     # video
     video_token_id: Optional[int] = None
 
+    # GLM-5-Next multimodal prefill must stay on the ordinary hybrid path.
+    glm5_next_force_hybrid_prefill: bool = False
+
     # audio
     audio_token_id: Optional[int] = None
     audio_start_id: Optional[int] = None
@@ -392,6 +395,9 @@ class MultimodalInputs:
 
     # video
     video_token_id: Optional[int] = None
+
+    # Request-level routing policy retained across chunked prefill batches.
+    glm5_next_force_hybrid_prefill: bool = False
 
     # audio
     audio_token_id: Optional[int] = None
@@ -461,6 +467,7 @@ class MultimodalInputs:
             "audio_start_id",
             "audio_end_id",
             "audio_token_id",
+            "glm5_next_force_hybrid_prefill",
         ]
         for arg in optional_args:
             if arg in obj:
@@ -518,6 +525,9 @@ class MultimodalInputs:
                 # set token_ids
                 if getattr(self, key, None) is None:
                     setattr(self, key, getattr(other, key, None))
+        self.glm5_next_force_hybrid_prefill = bool(
+            self.glm5_next_force_hybrid_prefill or other.glm5_next_force_hybrid_prefill
+        )
         # other args would be kept intact
 
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2704,6 +2704,10 @@ class Scheduler(
             self.last_batch = None
             self.tree_cache.reset()
             self.req_to_token_pool.clear()
+            if getattr(self.model_config, "is_glm5_next", False):
+                from sglang.srt.managers.forward_hooks_registry import dispatch_named
+
+                dispatch_named("glm5_next_kpool", "on_cache_flush")
             self.token_to_kv_pool_allocator.clear()
             self.grammar_manager.clear()
             self.reset_metrics()

--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -185,6 +185,14 @@ class SchedulerOutputProcessorMixin:
                     if req.finished():
                         self.maybe_collect_routed_experts(req)
                         self.maybe_collect_indexer_topk(req)
+                        from sglang.srt.managers.forward_hooks_registry import (
+                            dispatch_named,
+                        )
+
+                        if getattr(self.model_config, "is_glm5_next", False):
+                            dispatch_named(
+                                "glm5_next_kpool", "on_request_finished", req
+                            )
                         release_kv_cache(req, self.tree_cache)
                         req.time_stats.set_completion_time()
                     elif not batch.decoding_reqs or req not in batch.decoding_reqs:
@@ -192,10 +200,10 @@ class SchedulerOutputProcessorMixin:
                         self.tree_cache.cache_unfinished_req(req)
                         if self.enable_hisparse:
                             from sglang.srt.managers.forward_hooks_registry import (
-                                dispatch,
+                                dispatch_named,
                             )
 
-                            dispatch("on_request_admit", req)
+                            dispatch_named("hisparse", "on_request_admit", req)
 
                     self.maybe_collect_customized_info(i, req, logits_output)
 
@@ -487,12 +495,16 @@ class SchedulerOutputProcessorMixin:
                     if not self.decode_offload_manager.offload_kv_cache(req):
                         release_kv_cache(req, self.tree_cache)
                 else:
-                    if self.enable_hisparse:
-                        from sglang.srt.managers.forward_hooks_registry import (
-                            dispatch,
-                        )
+                    from sglang.srt.managers.forward_hooks_registry import (
+                        dispatch_named,
+                    )
 
-                        dispatch("on_request_finished", req)
+                    if self.enable_hisparse:
+                        dispatch_named("hisparse", "on_request_finished", req)
+                    if getattr(self.model_config, "is_glm5_next", False):
+                        dispatch_named(
+                            "glm5_next_kpool", "on_request_finished", req
+                        )
                     release_kv_cache(req, self.tree_cache)
 
                 req.time_stats.set_completion_time()

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -695,6 +695,7 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
                 obj.video_data = [obj.video_data]
             if obj.audio_data is not None and not isinstance(obj.audio_data, list):
                 obj.audio_data = [obj.audio_data]
+            self._validate_glm5_next_mm_boundary(obj)
             self._validate_mm_limits(obj)
 
             mm_inputs = None
@@ -833,6 +834,33 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
                     raise ValueError(
                         f"{modality.capitalize()} count {count} exceeds limit {limit} per request."
                     )
+
+    def _validate_glm5_next_mm_boundary(
+        self, obj: Union[GenerateReqInput, EmbeddingReqInput]
+    ) -> None:
+        """Reject unsupported GLM media combinations before invoking Processor."""
+
+        if not getattr(self.model_config, "is_glm5_next", False):
+            return
+
+        def count(data) -> int:
+            return len(data) if isinstance(data, list) else int(data is not None)
+
+        image_count = count(obj.image_data)
+        video_count = count(obj.video_data)
+        audio_count = count(obj.audio_data)
+        if audio_count:
+            raise ValueError("GLM-5-Next does not support audio input.")
+        if image_count and video_count:
+            raise ValueError("GLM-5-Next requests cannot mix image and video content.")
+        if image_count > 8:
+            raise ValueError(
+                f"GLM-5-Next accepts at most 8 images per request; got {image_count}."
+            )
+        if video_count > 1:
+            raise ValueError(
+                f"GLM-5-Next accepts at most one video per request; got {video_count}."
+            )
 
     def _validate_for_matryoshka_dim(self, obj: EmbeddingReqInput) -> None:
         """Validate the request for Matryoshka dim if it has the field set."""

--- a/python/sglang/srt/mem_cache/glm5_next_memory_pool.py
+++ b/python/sglang/srt/mem_cache/glm5_next_memory_pool.py
@@ -124,6 +124,9 @@ class Glm5NextNSATokenToKVPool(NSATokenToKVPool):
             kv_cache_dim=kv_cache_dim,
             start_layer=start_layer,
             end_layer=end_layer,
+            index_cache_dtype=(
+                torch.bfloat16 if dtype == torch.bfloat16 else torch.float8_e4m3fn
+            ),
         )
 
         # The shared NSA pool selects its scaled FP8 layout when
@@ -134,6 +137,11 @@ class Glm5NextNSATokenToKVPool(NSATokenToKVPool):
         if dtype == torch.float8_e4m3fn:
             assert not self.nsa_kv_cache_store_fp8
             assert self.kv_cache_dim == kv_lora_rank
+        elif dtype != torch.bfloat16:
+            raise ValueError(
+                "GLM-5-Next consumer cache supports only BF16 or FP8 E4M3, "
+                f"got {dtype}"
+            )
 
         self.index_kpool = index_kpool
         self.index_kpool_compress = index_kpool_compress
@@ -413,6 +421,14 @@ class Glm5NextHybridKVPool(HybridLinearKVPool):
     @property
     def quant_block_size(self) -> int:
         return self.full_kv_pool.quant_block_size
+
+    @property
+    def index_cache_dtype(self) -> torch.dtype:
+        return self.full_kv_pool.index_cache_dtype
+
+    @property
+    def index_cache_is_bf16(self) -> bool:
+        return self.full_kv_pool.index_cache_is_bf16
 
     @property
     def index_kpool(self) -> int:

--- a/python/sglang/srt/mem_cache/glm5_next_memory_pool.py
+++ b/python/sglang/srt/mem_cache/glm5_next_memory_pool.py
@@ -29,6 +29,8 @@ if TYPE_CHECKING:
 GLM5_NEXT_INDEX_KPOOL = 4
 GLM5_NEXT_INDEX_HEAD_DIM = 128
 GLM5_NEXT_REAL_PAGE_SIZE = 64
+GLM5_NEXT_LATENT_SCALE_GROUP_SIZE = 128
+GLM5_NEXT_LATENT_SCALE_GROUPS = 4
 
 
 def _normalize_req_pool_indices(
@@ -149,6 +151,25 @@ class Glm5NextNSATokenToKVPool(NSATokenToKVPool):
             self.memory_saver_adapter.region(GPU_MEMORY_TYPE_KV_CACHE),
             allocation_context,
         ):
+            # Keep the 512-byte latent cache ABI consumed by TRTLLM/Triton and
+            # store its four per-128-channel descales in an exact-GLM sidecar.
+            # This mirrors NSA index-cache scale semantics without changing
+            # any shared MLA or DeepSeek cache layout.
+            self._latent_scale = (
+                [
+                    torch.zeros(
+                        (
+                            size + page_size,
+                            GLM5_NEXT_LATENT_SCALE_GROUPS,
+                        ),
+                        dtype=torch.float32,
+                        device=device,
+                    )
+                    for _ in range(layer_num)
+                ]
+                if dtype == torch.float8_e4m3fn
+                else []
+            )
             self._compress_tail_k = [
                 torch.zeros(
                     (req_pool_size, index_kpool, index_head_dim),
@@ -185,6 +206,43 @@ class Glm5NextNSATokenToKVPool(NSATokenToKVPool):
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         local_idx = self._local_layer_index(layer_id)
         return self._compress_tail_k[local_idx], self._compress_tail_score[local_idx]
+
+    def get_latent_scale_buffer(self, layer_id: int) -> Optional[torch.Tensor]:
+        """Return the physical-token block descales for one compact DSA layer."""
+
+        if not self._latent_scale:
+            return None
+        return self._latent_scale[self._local_layer_index(layer_id)]
+
+    def set_latent_scale_buffer(
+        self,
+        layer_id: int,
+        loc: torch.Tensor,
+        scale: torch.Tensor,
+    ) -> None:
+        """Write dynamic latent descales beside their FP8 cache rows."""
+
+        target = self.get_latent_scale_buffer(layer_id)
+        if target is None:
+            raise RuntimeError("latent scales are available only for GLM FP8 KV cache")
+        if scale.ndim == 3 and scale.shape[-2] == 1:
+            scale = scale.squeeze(-2)
+        expected = (loc.numel(), GLM5_NEXT_LATENT_SCALE_GROUPS)
+        if tuple(scale.shape) != expected:
+            raise ValueError(
+                f"GLM latent scale must have shape {expected}, got {tuple(scale.shape)}"
+            )
+        if scale.dtype != torch.float32:
+            raise TypeError(f"GLM latent scale must be FP32, got {scale.dtype}")
+        target[loc] = scale
+
+    def move_kv_cache(self, tgt_loc: torch.Tensor, src_loc: torch.Tensor) -> None:
+        """Fail closed for the speculative-only cache relocation contract."""
+
+        raise NotImplementedError(
+            "GLM-5-Next KV-cache relocation is outside the current boundary: "
+            "MTP/speculative decoding is not supported"
+        )
 
     def clear_compress_tail_rows(
         self, req_pool_indices: int | Iterable[int] | torch.Tensor
@@ -253,10 +311,12 @@ class Glm5NextNSATokenToKVPool(NSATokenToKVPool):
 
     def get_kv_size_bytes(self):
         size_bytes = super().get_kv_size_bytes()
+        latent_scale = getattr(self, "_latent_scale", ())
         tail_k = getattr(self, "_compress_tail_k", ())
         tail_score = getattr(self, "_compress_tail_score", ())
         return size_bytes + sum(
-            tensor.numel() * tensor.element_size() for tensor in (*tail_k, *tail_score)
+            tensor.numel() * tensor.element_size()
+            for tensor in (*latent_scale, *tail_k, *tail_score)
         )
 
 
@@ -264,6 +324,14 @@ class Glm5NextHybridKVPool(HybridLinearKVPool):
     """Hybrid wrapper mapping global DSA layer IDs to a compact NSA pool."""
 
     is_glm5_next_kpool = True
+
+    def move_kv_cache(self, tgt_loc: torch.Tensor, src_loc: torch.Tensor) -> None:
+        """Reject the speculative-only relocation API at the public pool seam."""
+
+        raise NotImplementedError(
+            "GLM-5-Next KV-cache relocation is outside the current boundary: "
+            "MTP/speculative decoding is not supported"
+        )
 
     def __init__(
         self,
@@ -416,6 +484,21 @@ class Glm5NextHybridKVPool(HybridLinearKVPool):
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         return self.full_kv_pool.get_compress_tail_buffers(
             self._transfer_full_attention_id(layer_id)
+        )
+
+    def get_latent_scale_buffer(self, layer_id: int) -> Optional[torch.Tensor]:
+        return self.full_kv_pool.get_latent_scale_buffer(
+            self._transfer_full_attention_id(layer_id)
+        )
+
+    def set_latent_scale_buffer(
+        self,
+        layer_id: int,
+        loc: torch.Tensor,
+        scale: torch.Tensor,
+    ) -> None:
+        self.full_kv_pool.set_latent_scale_buffer(
+            self._transfer_full_attention_id(layer_id), loc, scale
         )
 
     def clear_compress_tail_rows(

--- a/python/sglang/srt/mem_cache/glm5_next_memory_pool.py
+++ b/python/sglang/srt/mem_cache/glm5_next_memory_pool.py
@@ -1,0 +1,496 @@
+"""GLM-5-Next hybrid KDA/DSA KV cache.
+
+This module deliberately keeps the KPool=4 state behind an exact
+GLM-5-Next capability gate.  It does not add KPool fields to the shared NSA
+or hybrid pools, so existing Kimi and DeepSeek models retain their original
+allocation and indexing contracts.
+
+Only eager, non-speculative execution is part of the initial bring-up.  PD,
+MTP, CP, and CUDA-graph state transfer are intentionally not implemented
+here.
+"""
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+from typing import TYPE_CHECKING, Iterable, Optional, Tuple
+
+import torch
+
+from sglang.srt.configs.glm5_next import is_glm5_next, uses_kpool4_compress
+from sglang.srt.constants import GPU_MEMORY_TYPE_KV_CACHE
+from sglang.srt.mem_cache.memory_pool import HybridLinearKVPool, NSATokenToKVPool
+from sglang.srt.mem_cache.pool_registry import register_kv_pool_factory
+
+if TYPE_CHECKING:
+    from sglang.srt.model_executor.model_runner import ModelRunner
+
+
+GLM5_NEXT_INDEX_KPOOL = 4
+GLM5_NEXT_INDEX_HEAD_DIM = 128
+GLM5_NEXT_REAL_PAGE_SIZE = 64
+
+
+def _normalize_req_pool_indices(
+    req_pool_indices: int | Iterable[int] | torch.Tensor,
+    *,
+    device: torch.device,
+) -> torch.Tensor:
+    """Return unique, one-dimensional request rows on ``device``."""
+
+    if isinstance(req_pool_indices, int):
+        rows = torch.tensor([req_pool_indices], dtype=torch.long, device=device)
+    elif isinstance(req_pool_indices, torch.Tensor):
+        rows = req_pool_indices.to(device=device, dtype=torch.long).reshape(-1)
+    else:
+        rows = torch.tensor(
+            list(req_pool_indices), dtype=torch.long, device=device
+        ).reshape(-1)
+    return torch.unique(rows)
+
+
+class Glm5NextNSATokenToKVPool(NSATokenToKVPool):
+    """NSA latent/index cache plus the live four-token compression tail.
+
+    KPool's compression gate is vector-valued (one score per index-head
+    dimension), so both tail tensors use ``[request, 4, 128]``.  A scalar
+    ``[request, 4]`` score buffer is incompatible with the eager KPool Triton
+    kernels.
+    """
+
+    is_glm5_next_kpool = True
+
+    def __init__(
+        self,
+        *,
+        size: int,
+        page_size: int,
+        kv_lora_rank: int,
+        dtype: torch.dtype,
+        qk_rope_head_dim: int,
+        layer_num: int,
+        device: str,
+        index_head_dim: int,
+        enable_memory_saver: bool,
+        kv_cache_dim: int,
+        req_pool_size: int,
+        index_kpool: int = GLM5_NEXT_INDEX_KPOOL,
+        index_kpool_compress: bool = True,
+        index_kpool_always_select_tail: bool = True,
+        start_layer: Optional[int] = None,
+        end_layer: Optional[int] = None,
+    ) -> None:
+        if page_size != GLM5_NEXT_REAL_PAGE_SIZE:
+            raise ValueError(f"GLM-5-Next KPool requires page_size=64, got {page_size}")
+        if index_head_dim != GLM5_NEXT_INDEX_HEAD_DIM:
+            raise ValueError(
+                f"GLM-5-Next KPool requires index_head_dim=128, got {index_head_dim}"
+            )
+        if index_kpool != GLM5_NEXT_INDEX_KPOOL:
+            raise ValueError(
+                f"GLM-5-Next KPool requires index_kpool=4, got {index_kpool}"
+            )
+        if not index_kpool_compress or not index_kpool_always_select_tail:
+            raise ValueError(
+                "GLM-5-Next requires compressed KPool with an always-selected tail"
+            )
+        if req_pool_size <= 0:
+            raise ValueError(f"req_pool_size must be positive, got {req_pool_size}")
+        if qk_rope_head_dim != 0:
+            raise ValueError(
+                "GLM-5-Next requires the zero-RoPE MLA cache layout, "
+                f"got qk_rope_head_dim={qk_rope_head_dim}"
+            )
+        if dtype == torch.float8_e4m3fn and kv_cache_dim != kv_lora_rank:
+            raise ValueError(
+                "GLM-5-Next FP8 with zero-RoPE requires the TRTLLM raw KV "
+                f"layout ({kv_lora_rank} bytes/token), got kv_cache_dim="
+                f"{kv_cache_dim}. The scaled NSA layout is incompatible "
+                "with an empty RoPE component."
+            )
+
+        super().__init__(
+            size=size,
+            page_size=page_size,
+            kv_lora_rank=kv_lora_rank,
+            dtype=dtype,
+            qk_rope_head_dim=qk_rope_head_dim,
+            layer_num=layer_num,
+            device=device,
+            index_head_dim=index_head_dim,
+            enable_memory_saver=enable_memory_saver,
+            kv_cache_dim=kv_cache_dim,
+            start_layer=start_layer,
+            end_layer=end_layer,
+        )
+
+        # The shared NSA pool selects its scaled FP8 layout when
+        # ``override_kv_cache_dim`` is present.  GLM's TRTLLM path instead
+        # writes an already-quantized 512-wide key plus an empty RoPE tensor,
+        # so it must stay on the raw byte layout.  Keep this assertion local
+        # to GLM rather than changing the existing DeepSeek cache contract.
+        if dtype == torch.float8_e4m3fn:
+            assert not self.nsa_kv_cache_store_fp8
+            assert self.kv_cache_dim == kv_lora_rank
+
+        self.index_kpool = index_kpool
+        self.index_kpool_compress = index_kpool_compress
+        self.index_kpool_always_select_tail = index_kpool_always_select_tail
+        self.tail_extra_slots = 0
+        self.slots_per_page = self.page_size
+        self.req_pool_size = req_pool_size
+
+        allocation_context = (
+            torch.cuda.use_mem_pool(self.custom_mem_pool)
+            if self.custom_mem_pool is not None
+            else nullcontext()
+        )
+        with (
+            self.memory_saver_adapter.region(GPU_MEMORY_TYPE_KV_CACHE),
+            allocation_context,
+        ):
+            self._compress_tail_k = [
+                torch.zeros(
+                    (req_pool_size, index_kpool, index_head_dim),
+                    dtype=torch.bfloat16,
+                    device=device,
+                )
+                for _ in range(layer_num)
+            ]
+            self._compress_tail_score = [
+                torch.zeros(
+                    (req_pool_size, index_kpool, index_head_dim),
+                    dtype=torch.bfloat16,
+                    device=device,
+                )
+                for _ in range(layer_num)
+            ]
+
+        # NSATokenToKVPool finalizes its accounting before this subclass can
+        # allocate the tail.  Refresh the value without emitting a duplicate
+        # allocation log.
+        self.mem_usage = self.get_kv_size_bytes() / (1024**3)
+
+    def _local_layer_index(self, layer_id: int) -> int:
+        local_idx = layer_id - self.start_layer
+        if not 0 <= local_idx < self.layer_num:
+            raise ValueError(
+                f"layer_id={layer_id} is outside compact GLM DSA range "
+                f"[{self.start_layer}, {self.start_layer + self.layer_num})"
+            )
+        return local_idx
+
+    def get_compress_tail_buffers(
+        self, layer_id: int
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        local_idx = self._local_layer_index(layer_id)
+        return self._compress_tail_k[local_idx], self._compress_tail_score[local_idx]
+
+    def clear_compress_tail_rows(
+        self, req_pool_indices: int | Iterable[int] | torch.Tensor
+    ) -> None:
+        """Clear stale live-tail state before reuse or before releasing rows."""
+
+        if not self._compress_tail_k:
+            return
+        rows = _normalize_req_pool_indices(
+            req_pool_indices, device=self._compress_tail_k[0].device
+        )
+        if rows.numel() == 0:
+            return
+        if torch.any(rows < 0) or torch.any(rows >= self.req_pool_size):
+            raise IndexError(
+                f"request rows must be in [0, {self.req_pool_size}), got "
+                f"{rows.detach().cpu().tolist()}"
+            )
+        for tail_k, tail_score in zip(
+            self._compress_tail_k, self._compress_tail_score, strict=True
+        ):
+            tail_k.index_fill_(0, rows, 0)
+            tail_score.index_fill_(0, rows, 0)
+
+    def prepare_kpool_request(
+        self, req_pool_indices: int | Iterable[int] | torch.Tensor
+    ) -> None:
+        """Initialize newly allocated rows before their first prefill write."""
+
+        self.clear_compress_tail_rows(req_pool_indices)
+
+    def kpool_decode_update_index_cache(
+        self,
+        *,
+        layer_id: int,
+        key: torch.Tensor,
+        slot_score: torch.Tensor,
+        ape: torch.Tensor,
+        block_tables: torch.Tensor,
+        req_pool_indices: torch.Tensor,
+        positions: torch.Tensor,
+        seq_lens: torch.Tensor,
+        out_cache_loc: torch.Tensor,
+        round_scale: bool = False,
+    ) -> None:
+        from sglang.srt.layers.attention.nsa.kpool_fp8_index import (
+            kpool_decode_update_and_maybe_write_cache,
+        )
+
+        local_idx = self._local_layer_index(layer_id)
+        kpool_decode_update_and_maybe_write_cache(
+            pool=self,
+            buf=self.get_index_k_with_scale_buffer(layer_id),
+            tail_k=self._compress_tail_k[local_idx],
+            tail_score=self._compress_tail_score[local_idx],
+            key=key,
+            slot_score=slot_score,
+            ape=ape,
+            block_tables=block_tables,
+            req_pool_indices=req_pool_indices,
+            positions=positions,
+            seq_lens=seq_lens,
+            out_cache_loc=out_cache_loc,
+            round_scale=round_scale,
+        )
+
+    def get_kv_size_bytes(self):
+        size_bytes = super().get_kv_size_bytes()
+        tail_k = getattr(self, "_compress_tail_k", ())
+        tail_score = getattr(self, "_compress_tail_score", ())
+        return size_bytes + sum(
+            tensor.numel() * tensor.element_size() for tensor in (*tail_k, *tail_score)
+        )
+
+
+class Glm5NextHybridKVPool(HybridLinearKVPool):
+    """Hybrid wrapper mapping global DSA layer IDs to a compact NSA pool."""
+
+    is_glm5_next_kpool = True
+
+    def __init__(
+        self,
+        *,
+        size: int,
+        dtype: torch.dtype,
+        page_size: int,
+        head_num: int,
+        head_dim: int,
+        full_attention_layer_ids: Iterable[int],
+        device: str,
+        mamba_pool,
+        kv_lora_rank: int,
+        qk_rope_head_dim: int,
+        index_head_dim: int,
+        kv_cache_dim: int,
+        req_pool_size: int,
+        enable_memory_saver: bool = False,
+        index_kpool: int = GLM5_NEXT_INDEX_KPOOL,
+        index_kpool_compress: bool = True,
+        index_kpool_always_select_tail: bool = True,
+    ) -> None:
+        full_attention_layer_ids = list(full_attention_layer_ids)
+        if len(set(full_attention_layer_ids)) != len(full_attention_layer_ids):
+            raise ValueError("GLM DSA layer IDs must be unique")
+        if full_attention_layer_ids != sorted(full_attention_layer_ids):
+            raise ValueError("GLM DSA layer IDs must be sorted")
+
+        # HybridLinearKVPool cannot construct an NSA full-attention pool in
+        # this KT baseline, so initialize its stable wrapper state explicitly
+        # and inherit its MLA/mamba delegation methods.
+        self.size = size
+        self.dtype = dtype
+        self.device = device
+        self.full_layer_nums = len(full_attention_layer_ids)
+        self.page_size = page_size
+        self.start_layer = 0
+        self.head_num = head_num
+        self.head_dim = head_dim
+        self.mamba_pool = mamba_pool
+        self.use_mla = True
+        self.use_dsa = True
+        self.full_attention_layer_id_mapping = {
+            global_id: compact_id
+            for compact_id, global_id in enumerate(full_attention_layer_ids)
+        }
+        self.full_kv_pool = Glm5NextNSATokenToKVPool(
+            size=size,
+            page_size=page_size,
+            kv_lora_rank=kv_lora_rank,
+            dtype=dtype,
+            qk_rope_head_dim=qk_rope_head_dim,
+            layer_num=self.full_layer_nums,
+            device=device,
+            index_head_dim=index_head_dim,
+            enable_memory_saver=enable_memory_saver,
+            kv_cache_dim=kv_cache_dim,
+            req_pool_size=req_pool_size,
+            index_kpool=index_kpool,
+            index_kpool_compress=index_kpool_compress,
+            index_kpool_always_select_tail=index_kpool_always_select_tail,
+            start_layer=0,
+        )
+        self.mem_usage = self.full_kv_pool.mem_usage
+        self.kpool_lifecycle_coordinator = None
+
+    @property
+    def nsa_kv_cache_store_fp8(self) -> bool:
+        return self.full_kv_pool.nsa_kv_cache_store_fp8
+
+    @property
+    def kv_cache_dim(self) -> int:
+        return self.full_kv_pool.kv_cache_dim
+
+    @property
+    def index_head_dim(self) -> int:
+        return self.full_kv_pool.index_head_dim
+
+    @property
+    def quant_block_size(self) -> int:
+        return self.full_kv_pool.quant_block_size
+
+    @property
+    def index_kpool(self) -> int:
+        return self.full_kv_pool.index_kpool
+
+    @property
+    def index_kpool_compress(self) -> bool:
+        return self.full_kv_pool.index_kpool_compress
+
+    @property
+    def index_kpool_always_select_tail(self) -> bool:
+        return self.full_kv_pool.index_kpool_always_select_tail
+
+    @property
+    def tail_extra_slots(self) -> int:
+        return self.full_kv_pool.tail_extra_slots
+
+    @property
+    def slots_per_page(self) -> int:
+        return self.full_kv_pool.slots_per_page
+
+    def get_index_k_with_scale_buffer(self, layer_id: int) -> torch.Tensor:
+        return self.full_kv_pool.get_index_k_with_scale_buffer(
+            self._transfer_full_attention_id(layer_id)
+        )
+
+    def get_broadcastable_index_k_with_scale_buffer(
+        self, layer_id: int
+    ) -> torch.Tensor:
+        return self.get_index_k_with_scale_buffer(layer_id)
+
+    def get_index_k_continuous(
+        self, layer_id: int, seq_len: int, page_indices: torch.Tensor
+    ):
+        return self.full_kv_pool.get_index_k_continuous(
+            self._transfer_full_attention_id(layer_id), seq_len, page_indices
+        )
+
+    def get_index_k_scale_continuous(
+        self, layer_id: int, seq_len: int, page_indices: torch.Tensor
+    ):
+        return self.full_kv_pool.get_index_k_scale_continuous(
+            self._transfer_full_attention_id(layer_id), seq_len, page_indices
+        )
+
+    def get_index_k_scale_buffer(
+        self, layer_id: int, seq_len: int, page_indices: torch.Tensor
+    ):
+        return self.full_kv_pool.get_index_k_scale_buffer(
+            self._transfer_full_attention_id(layer_id), seq_len, page_indices
+        )
+
+    def set_index_k_scale_buffer(
+        self,
+        layer_id: int,
+        loc: torch.Tensor,
+        index_k: torch.Tensor,
+        index_k_scale: torch.Tensor,
+    ) -> None:
+        self.full_kv_pool.set_index_k_scale_buffer(
+            self._transfer_full_attention_id(layer_id),
+            loc,
+            index_k,
+            index_k_scale,
+        )
+
+    def get_compress_tail_buffers(
+        self, layer_id: int
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        return self.full_kv_pool.get_compress_tail_buffers(
+            self._transfer_full_attention_id(layer_id)
+        )
+
+    def clear_compress_tail_rows(
+        self, req_pool_indices: int | Iterable[int] | torch.Tensor
+    ) -> None:
+        self.full_kv_pool.clear_compress_tail_rows(req_pool_indices)
+
+    def prepare_kpool_request(
+        self, req_pool_indices: int | Iterable[int] | torch.Tensor
+    ) -> None:
+        self.full_kv_pool.prepare_kpool_request(req_pool_indices)
+
+    def kpool_decode_update_index_cache(self, *, layer_id: int, **kwargs) -> None:
+        self.full_kv_pool.kpool_decode_update_index_cache(
+            layer_id=self._transfer_full_attention_id(layer_id), **kwargs
+        )
+
+
+def _glm5_next_pool_predicate(model_config, server_args) -> bool:
+    del server_args
+    return is_glm5_next(model_config) and uses_kpool4_compress(model_config)
+
+
+def build_glm5_next_kv_pool(*, model_runner: "ModelRunner") -> Glm5NextHybridKVPool:
+    """ModelRunner-facing factory registered only for exact GLM-5-Next KPool4."""
+
+    model_config = model_runner.model_config
+    if not _glm5_next_pool_predicate(model_config, model_runner.server_args):
+        raise ValueError("GLM-5-Next KV pool factory received a non-GLM configuration")
+    if model_runner.is_draft_worker:
+        raise NotImplementedError("GLM-5-Next MTP/draft KV pools are out of scope")
+    if not model_runner.use_mla_backend:
+        raise ValueError("GLM-5-Next DSA requires the MLA backend")
+    if not hasattr(model_runner.req_to_token_pool, "mamba_pool"):
+        raise RuntimeError(
+            "GLM-5-Next requires HybridReqToTokenPool before constructing its KV pool"
+        )
+
+    text_config = model_config.hf_text_config
+    full_attention_layer_ids = [
+        layer_id
+        for layer_id in text_config.full_attention_layer_ids
+        if model_runner.start_layer <= layer_id < model_runner.end_layer
+    ]
+
+    from sglang.srt.layers.dp_attention import get_attention_tp_size
+
+    pool = Glm5NextHybridKVPool(
+        size=model_runner.max_total_num_tokens,
+        dtype=model_runner.kv_cache_dtype,
+        page_size=model_runner.page_size,
+        head_num=model_config.get_num_kv_heads(get_attention_tp_size()),
+        head_dim=model_config.head_dim,
+        full_attention_layer_ids=full_attention_layer_ids,
+        device=model_runner.device,
+        mamba_pool=model_runner.req_to_token_pool.mamba_pool,
+        kv_lora_rank=model_config.kv_lora_rank,
+        qk_rope_head_dim=model_config.qk_rope_head_dim,
+        index_head_dim=text_config.index_head_dim,
+        kv_cache_dim=model_runner.calculate_mla_kv_cache_dim(),
+        req_pool_size=model_runner.req_to_token_pool.size,
+        enable_memory_saver=model_runner.server_args.enable_memory_saver,
+        index_kpool=text_config.index_kpool,
+        index_kpool_compress=text_config.index_kpool_compress,
+        index_kpool_always_select_tail=(text_config.index_kpool_always_select_tail),
+    )
+
+    from sglang.srt.managers.glm5_next_kpool_coordinator import (
+        attach_glm5_next_kpool_lifecycle,
+    )
+
+    pool.kpool_lifecycle_coordinator = attach_glm5_next_kpool_lifecycle(pool)
+    return pool
+
+
+register_kv_pool_factory(
+    "glm5_next_kpool4", _glm5_next_pool_predicate, build_glm5_next_kv_pool
+)

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -1746,6 +1746,7 @@ class NSATokenToKVPool(MLATokenToKVPool):
         kv_cache_dim: int,
         start_layer: Optional[int] = None,
         end_layer: Optional[int] = None,
+        index_cache_dtype: Optional[torch.dtype] = None,
     ):
 
         override_dim = (
@@ -1769,6 +1770,13 @@ class NSATokenToKVPool(MLATokenToKVPool):
         # self.index_k_dtype = torch.float8_e4m3fn
         # self.index_k_scale_dtype = torch.float32
         self.index_head_dim = index_head_dim
+        self.index_cache_dtype = index_cache_dtype or torch.float8_e4m3fn
+        if self.index_cache_dtype not in (torch.float8_e4m3fn, torch.bfloat16):
+            raise ValueError(
+                "NSA index cache supports only FP8 E4M3 or BF16, got "
+                f"{self.index_cache_dtype}"
+            )
+        self.index_cache_is_bf16 = self.index_cache_dtype == torch.bfloat16
         # num head == 1 and head dim == 128 for index_k in NSA
         assert index_head_dim == 128
 
@@ -1793,10 +1801,17 @@ class NSATokenToKVPool(MLATokenToKVPool):
                         (size + page_size + 1) // self.page_size,
                         self.page_size
                         * (
-                            index_head_dim + index_head_dim // self.quant_block_size * 4
+                            index_head_dim
+                            if self.index_cache_is_bf16
+                            else index_head_dim
+                            + index_head_dim // self.quant_block_size * 4
                         ),
                     ),
-                    dtype=self.index_k_with_scale_buffer_dtype,
+                    dtype=(
+                        torch.bfloat16
+                        if self.index_cache_is_bf16
+                        else self.index_k_with_scale_buffer_dtype
+                    ),
                     device=device,
                 )
                 for _ in range(layer_num)
@@ -1815,6 +1830,10 @@ class NSATokenToKVPool(MLATokenToKVPool):
         page_indices: torch.Tensor,
     ):
         buf = self.index_k_with_scale_buffer[layer_id - self.start_layer]
+        if self.index_cache_is_bf16:
+            num_pages = (seq_len + self.page_size - 1) // self.page_size
+            pages = buf.index_select(0, page_indices[:num_pages].to(torch.int64))
+            return pages.view(-1, self.index_head_dim)[:seq_len]
         return index_buf_accessor.GetK.execute(
             self, buf, seq_len=seq_len, page_indices=page_indices
         )
@@ -1826,6 +1845,8 @@ class NSATokenToKVPool(MLATokenToKVPool):
         page_indices: torch.Tensor,
     ):
         buf = self.index_k_with_scale_buffer[layer_id - self.start_layer]
+        if self.index_cache_is_bf16:
+            return torch.ones((seq_len,), dtype=torch.float32, device=buf.device)
         return index_buf_accessor.GetS.execute(
             self, buf, seq_len=seq_len, page_indices=page_indices
         )
@@ -1848,6 +1869,11 @@ class NSATokenToKVPool(MLATokenToKVPool):
                  k_scale: (seq_len, 4), uint8
         """
         buf = self.index_k_with_scale_buffer[layer_id - self.start_layer]
+        if self.index_cache_is_bf16:
+            return (
+                self.get_index_k_continuous(layer_id, seq_len, page_indices),
+                torch.ones((seq_len,), dtype=torch.float32, device=buf.device),
+            )
         return index_buf_accessor.GetKAndS.execute(
             self, buf, seq_len=seq_len, page_indices=page_indices
         )
@@ -1860,6 +1886,18 @@ class NSATokenToKVPool(MLATokenToKVPool):
         index_k_scale: torch.Tensor,
     ) -> None:
         buf = self.index_k_with_scale_buffer[layer_id - self.start_layer]
+        if self.index_cache_is_bf16:
+            if index_k.shape != (loc.numel(), self.index_head_dim):
+                raise ValueError(
+                    "BF16 NSA index K must have shape "
+                    f"{(loc.numel(), self.index_head_dim)}, got {tuple(index_k.shape)}"
+                )
+            pages = torch.div(loc, self.page_size, rounding_mode="floor").to(torch.long)
+            offsets = torch.remainder(loc, self.page_size).to(torch.long)
+            buf.view(-1, self.page_size, self.index_head_dim)[pages, offsets] = (
+                index_k.to(torch.bfloat16)
+            )
+            return
         index_buf_accessor.SetKAndS.execute(
             pool=self, buf=buf, loc=loc, index_k=index_k, index_k_scale=index_k_scale
         )

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -62,6 +62,7 @@ from sglang.srt.model_executor.forward_batch_info import (
     compute_local_num_token_non_padded,
     enable_num_token_non_padded,
 )
+from sglang.srt.model_executor.forward_context import ForwardContext, forward_context
 from sglang.srt.model_executor.input_buffers import ForwardInputBuffers
 from sglang.srt.multiplex.pdmux_context import get_current_stream_idx, get_stream_groups
 from sglang.srt.utils import (
@@ -679,6 +680,12 @@ class CudaGraphRunner:
             profile_context = self._init_profile_context_and_memory_record()
 
         def _capture_one_stream(stream_idx: Optional[int] = None):
+            if stream_idx is None:
+                attn_backend = self.model_runner.attn_backend
+            else:
+                assert self.enable_pdmux
+                attn_backend = self.model_runner.decode_attn_backend_group[stream_idx]
+
             avail_mem = get_available_gpu_memory(
                 self.model_runner.device,
                 self.model_runner.gpu_id,
@@ -701,20 +708,31 @@ class CudaGraphRunner:
                         f"Capturing batches ({bs=} {avail_mem=:.2f} GB)"
                     )
 
-                with patch_model(
-                    self.model_runner.model,
-                    bs in self.compile_bs,
-                    num_tokens=bs * self.num_tokens_per_bs,
-                    tp_group=self.model_runner.tp_group,
-                ) as forward:
-                    (
-                        graph,
-                        output_buffers,
-                    ) = self.capture_one_batch_size(bs, forward, stream_idx)
-                    # For pd_multiplexing, we need to save the graph and output buffers
-                    key = bs if stream_idx is None else f"{stream_idx}_{bs}"
-                    self.graphs[key] = graph
-                    self.output_buffers[key] = output_buffers
+                # Exact GLM-5-Next KPool/DSA helpers resolve the selected
+                # backend through a per-forward context. Capture bypasses
+                # ModelRunner._forward_raw, so publish that context here while
+                # leaving every other model's legacy capture path unchanged.
+                if getattr(self.model_runner.model_config, "is_glm5_next", False):
+                    ctx_mgr = forward_context(
+                        ForwardContext(attn_backend=attn_backend)
+                    )
+                else:
+                    ctx_mgr = empty_context()
+                with ctx_mgr:
+                    with patch_model(
+                        self.model_runner.model,
+                        bs in self.compile_bs,
+                        num_tokens=bs * self.num_tokens_per_bs,
+                        tp_group=self.model_runner.tp_group,
+                    ) as forward:
+                        (
+                            graph,
+                            output_buffers,
+                        ) = self.capture_one_batch_size(bs, forward, stream_idx)
+                        # For pd_multiplexing, we need to save the graph and output buffers
+                        key = bs if stream_idx is None else f"{stream_idx}_{bs}"
+                        self.graphs[key] = graph
+                        self.output_buffers[key] = output_buffers
 
         # Trigger CUDA graph capture for specific shapes.
         # Capture the large shapes first so that the smaller shapes

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -302,6 +302,10 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
 
     # For multimodal
     mm_inputs: Optional[List[MultimodalInputs]] = None
+    # Exact GLM-5-Next keeps image EXTEND on the CPU/hybrid MoE path.  The
+    # model sets this for image EXTEND before general_mm_embed_routine clears
+    # ``mm_inputs``; retained decode metadata must leave it false.
+    glm5_next_has_image_inputs: bool = False
 
     # Encoder-decoder
     encoder_cached: Optional[List[bool]] = None

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -306,6 +306,10 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
     # model sets this for image EXTEND before general_mm_embed_routine clears
     # ``mm_inputs``; retained decode metadata must leave it false.
     glm5_next_has_image_inputs: bool = False
+    # Request-level marker propagated from MultimodalInputs.  Unlike the
+    # historical image-only marker, this remains true for every chunk of an
+    # image or video prefill and false for decode/CUDA-graph batches.
+    glm5_next_force_hybrid_prefill: bool = False
 
     # Encoder-decoder
     encoder_cached: Optional[List[bool]] = None
@@ -410,6 +414,14 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             mamba_track_mask=batch.mamba_track_mask,
             mamba_track_seqlens=batch.mamba_track_seqlens,
             mm_inputs=batch.multimodal_inputs,
+            glm5_next_force_hybrid_prefill=bool(
+                batch.forward_mode.is_extend()
+                and any(
+                    mm_input is not None
+                    and getattr(mm_input, "glm5_next_force_hybrid_prefill", False)
+                    for mm_input in (batch.multimodal_inputs or [])
+                )
+            ),
             encoder_cached=batch.encoder_cached,
             encoder_lens=batch.encoder_lens,
             encoder_lens_cpu=batch.encoder_lens_cpu,

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -128,6 +128,11 @@ from sglang.srt.model_executor.forward_batch_info import (
     ForwardMode,
     PPProxyTensors,
 )
+from sglang.srt.model_executor.forward_context import (
+    ForwardContext,
+    forward_context,
+    has_forward_context,
+)
 from sglang.srt.model_executor.hook_manager import register_forward_hooks
 from sglang.srt.model_executor.model_runner_kv_cache_mixin import (
     ModelRunnerKVCacheMixin,
@@ -584,6 +589,25 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
         # Deduce KV cache dtype
         self.configure_kv_cache_dtype()
+
+        # Exact GLM-5-Next treats a positive threshold as a required
+        # layerwise-prefill enable switch.  Materialize its two raw block-FP8
+        # slots before KV profiling so the profiler observes the real reserved
+        # VRAM and a startup OOM fails closed rather than surfacing on the first
+        # long request.
+        self.glm5_next_fp8_layerwise_prefill_allocated_bytes = 0
+        if (
+            getattr(server_args, "_glm5_next_session_ab_active", False)
+            and (server_args.kt_method or "").upper() == "FP8"
+            and (server_args.kt_gpu_prefill_token_threshold or 0) > 0
+        ):
+            from sglang.srt.layers.moe.kt_ep_wrapper import (
+                initialize_glm5_next_fp8_layerwise_prefill,
+            )
+
+            self.glm5_next_fp8_layerwise_prefill_allocated_bytes = (
+                initialize_glm5_next_fp8_layerwise_prefill()
+            )
 
         # Do not allocate the MXFP4 layerwise slots at startup.  Still account
         # for their future capacity before KV-cache profiling, otherwise the
@@ -2547,6 +2571,33 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         return output
 
     def _forward_raw(
+        self,
+        forward_batch: ForwardBatch,
+        skip_attn_backend_init: bool,
+        pp_proxy_tensors: Optional[PPProxyTensors],
+        reinit_attn_backend: bool = False,
+        split_forward_count: int = 1,
+    ) -> ModelRunnerOutput:
+        # Exact GLM-5-Next KPool/DSA resolves active attention/pool state
+        # through a per-forward context. Preserve an explicit caller override;
+        # otherwise publish this runner's backend only for that exact model so
+        # every other model keeps the pre-Session-C execution path.
+        if has_forward_context() or not getattr(
+            self.model_config, "is_glm5_next", False
+        ):
+            ctx_mgr = empty_context()
+        else:
+            ctx_mgr = forward_context(ForwardContext(attn_backend=self.attn_backend))
+        with ctx_mgr:
+            return self._forward_raw_with_context(
+                forward_batch,
+                skip_attn_backend_init,
+                pp_proxy_tensors,
+                reinit_attn_backend,
+                split_forward_count,
+            )
+
+    def _forward_raw_with_context(
         self,
         forward_batch: ForwardBatch,
         skip_attn_backend_init: bool,

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1709,10 +1709,24 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         return None
 
     @property
+    def glm5_next_linear_config(self):
+        """Return GLM-5-Next's text config for the hybrid linear runtime.
+
+        GLM-5-Next deliberately does not inherit ``KimiLinearConfig``.  Keep
+        the compatibility bridge here exact so no other multimodal or MLA
+        model is accidentally routed through the stateful KDA scheduler.
+        """
+
+        if getattr(self.model_config, "is_glm5_next", False):
+            return self.model_config.hf_text_config
+        return None
+
+    @property
     def mambaish_config(self):
         return (
             self.mamba2_config
             or self.hybrid_gdn_config
+            or self.glm5_next_linear_config
             or self.kimi_linear_config
             or self.hybrid_lightning_config
         )

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -590,25 +590,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         # Deduce KV cache dtype
         self.configure_kv_cache_dtype()
 
-        # Exact GLM-5-Next treats a positive threshold as a required
-        # layerwise-prefill enable switch.  Materialize its two raw block-FP8
-        # slots before KV profiling so the profiler observes the real reserved
-        # VRAM and a startup OOM fails closed rather than surfacing on the first
-        # long request.
-        self.glm5_next_fp8_layerwise_prefill_allocated_bytes = 0
-        if (
-            getattr(server_args, "_glm5_next_session_ab_active", False)
-            and (server_args.kt_method or "").upper() == "FP8"
-            and (server_args.kt_gpu_prefill_token_threshold or 0) > 0
-        ):
-            from sglang.srt.layers.moe.kt_ep_wrapper import (
-                initialize_glm5_next_fp8_layerwise_prefill,
-            )
-
-            self.glm5_next_fp8_layerwise_prefill_allocated_bytes = (
-                initialize_glm5_next_fp8_layerwise_prefill()
-            )
-
         # Do not allocate the MXFP4 layerwise slots at startup.  Still account
         # for their future capacity before KV-cache profiling, otherwise the
         # pool can consume the VRAM needed by the first long prefill request.

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -102,6 +102,14 @@ class ModelRunnerKVCacheMixin:
                 # exact layout selected by the pool factory; otherwise memory
                 # profiling overestimates token capacity by roughly 1.66x.
                 cell_size = self.calculate_mla_kv_cache_dim() * num_layers * kv_size
+                if self.kv_cache_dtype == torch.float8_e4m3fn:
+                    # Exact GLM keeps TRTLLM's 512-byte raw latent row and a
+                    # separate FP32 descale per 128 channels.  Count the
+                    # sidecar here so 500k profiling cannot overcommit memory.
+                    latent_scale_groups = self.model_config.kv_lora_rank // 128
+                    cell_size += (
+                        latent_scale_groups * torch.float32.itemsize * num_layers
+                    )
             else:
                 cell_size = (
                     (
@@ -363,9 +371,9 @@ class ModelRunnerKVCacheMixin:
         # kv_lora_rank + scale storage (kv_lora_rank // quant_block_size * 4 bytes) + rope dimension storage
         # Note: rope dimension is stored in original dtype (bf16), not quantized to fp8
         if kv_cache_dtype == torch.float8_e4m3fn:
-            assert (
-                kv_lora_rank % quant_block_size == 0
-            ), f"kv_lora_rank {kv_lora_rank} must be multiple of quant_block_size {quant_block_size}"
+            assert kv_lora_rank % quant_block_size == 0, (
+                f"kv_lora_rank {kv_lora_rank} must be multiple of quant_block_size {quant_block_size}"
+            )
 
             return (
                 kv_lora_rank
@@ -444,9 +452,9 @@ class ModelRunnerKVCacheMixin:
             full_per_token * full_layers_num
             + swa_full_tokens_ratio * swa_per_token * swa_layers_num
         )
-        assert (
-            denominator > 0
-        ), f"Invalid denominator={denominator} for memory-based allocation. full_per_token={full_per_token}, full_layers_num={full_layers_num}, swa_per_token={swa_per_token}, swa_layers_num={swa_layers_num}, swa_full_tokens_ratio={swa_full_tokens_ratio}"
+        assert denominator > 0, (
+            f"Invalid denominator={denominator} for memory-based allocation. full_per_token={full_per_token}, full_layers_num={full_layers_num}, swa_per_token={swa_per_token}, swa_layers_num={swa_layers_num}, swa_full_tokens_ratio={swa_full_tokens_ratio}"
+        )
 
         self.full_max_total_num_tokens = int(total_memory / denominator)
         self.swa_max_total_num_tokens = int(
@@ -472,15 +480,15 @@ class ModelRunnerKVCacheMixin:
         logger.info(f"DSv4 compressed attention: state_dtype={self.state_dtype}")
 
         page_size = self.server_args.page_size
-        assert (
-            page_size % 128 == 0
-        ), "page_size must be multiple of 128 for compressed attention"
+        assert page_size % 128 == 0, (
+            "page_size must be multiple of 128 for compressed attention"
+        )
 
         if not self.spec_algorithm.is_none() and self.is_draft_worker:
             config = getattr(self.server_args, "_draft_pool_config", None)
-            assert (
-                config is not None
-            ), "Draft worker requires target's pool config but _draft_pool_config is not set."
+            assert config is not None, (
+                "Draft worker requires target's pool config but _draft_pool_config is not set."
+            )
             self.full_max_total_num_tokens = config["full_max_total_num_tokens"]
             self.swa_max_total_num_tokens = config["swa_max_total_num_tokens"]
             self.c4_max_total_num_tokens = 0

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -92,14 +92,25 @@ class ModelRunnerKVCacheMixin:
                 )
                 cell_size += indexer_size_per_token * num_layers * element_size
         elif self.use_mla_backend:
-            cell_size = (
-                (
-                    self.model_config.qk_nope_head_dim
-                    + self.model_config.qk_rope_head_dim
-                )
-                * num_layers
-                * kv_size
+            is_glm5_next_kpool = bool(
+                getattr(self.model_config, "is_glm5_next", False)
+                and getattr(self.model_config, "uses_kpool4_compress", False)
             )
+            if is_glm5_next_kpool:
+                # GLM's absorbed query width (qk_nope_head_dim=256) is not
+                # its latent KV-cache width (kv_lora_rank=512).  Account the
+                # exact layout selected by the pool factory; otherwise memory
+                # profiling overestimates token capacity by roughly 1.66x.
+                cell_size = self.calculate_mla_kv_cache_dim() * num_layers * kv_size
+            else:
+                cell_size = (
+                    (
+                        self.model_config.qk_nope_head_dim
+                        + self.model_config.qk_rope_head_dim
+                    )
+                    * num_layers
+                    * kv_size
+                )
             if is_float4_e2m1fn_x2(self.kv_cache_dtype):
                 # kv_scale_buffer
                 scale_block_size = 16
@@ -115,9 +126,17 @@ class ModelRunnerKVCacheMixin:
                     * kv_size
                 )
 
-            # Add indexer KV cache overhead for NSA models (DeepSeek V3.2)
-            if is_deepseek_nsa(self.model_config.hf_config):
-                index_head_dim = get_nsa_index_head_dim(self.model_config.hf_config)
+            # Add indexer KV cache overhead for NSA models. GLM-5-Next is
+            # checked through its exact capability bit because its sparse
+            # fields live on the nested text config rather than the wrapper.
+            if is_deepseek_nsa(self.model_config.hf_config) or getattr(
+                self.model_config, "uses_kpool4_compress", False
+            ):
+                index_head_dim = (
+                    self.model_config.index_head_dim
+                    if getattr(self.model_config, "is_glm5_next", False)
+                    else get_nsa_index_head_dim(self.model_config.hf_config)
+                )
                 indexer_size_per_token = (
                     index_head_dim
                     + index_head_dim // NSATokenToKVPool.quant_block_size * 4
@@ -160,6 +179,64 @@ class ModelRunnerKVCacheMixin:
                     (n * k * num_layers * 2 * kv_size) // scale_block_size
                 )
         return cell_size
+
+    def _get_glm5_next_kpool_tail_size_bytes(
+        self: ModelRunner, *, num_layers: int, max_num_reqs: int
+    ) -> int:
+        """Return GLM's fixed per-request live-tail allocation.
+
+        This allocation is separate from the token-indexed latent/index KV
+        pools and therefore must not be folded into the per-token cell size.
+        Keep the capability gate exact so legacy NSA/KDA models retain their
+        historical profiling arithmetic.
+        """
+
+        if not (
+            getattr(self.model_config, "is_glm5_next", False)
+            and getattr(self.model_config, "uses_kpool4_compress", False)
+        ):
+            return 0
+
+        text_config = self.model_config.hf_text_config
+        index_kpool = int(text_config.index_kpool)
+        index_head_dim = int(text_config.index_head_dim)
+        assert index_kpool == 4
+        assert index_head_dim == 128
+        assert text_config.index_kpool_compress
+
+        # One BF16 key tail and one BF16 vector-score tail per request/layer.
+        return (
+            num_layers
+            * max_num_reqs
+            * index_kpool
+            * index_head_dim
+            * 2
+            * torch.bfloat16.itemsize
+        )
+
+    def _reserve_glm5_next_kpool_tail(
+        self: ModelRunner,
+        *,
+        max_total_num_tokens: int,
+        num_layers: int,
+        max_num_reqs: int,
+    ) -> int:
+        """Trade provisional token capacity for the fixed KPool tail bytes."""
+
+        tail_size_bytes = self._get_glm5_next_kpool_tail_size_bytes(
+            num_layers=num_layers, max_num_reqs=max_num_reqs
+        )
+        if tail_size_bytes == 0:
+            return max_total_num_tokens
+
+        cell_size = self.get_cell_size_per_token(num_layers)
+        reserved_tokens = (tail_size_bytes + cell_size - 1) // cell_size
+        logger.info(
+            "Reserve %.2f MiB (%d token slots) for GLM-5-Next KPool tails.",
+            tail_size_bytes / (1 << 20),
+            reserved_tokens,
+        )
+        return max(0, max_total_num_tokens - reserved_tokens)
 
     def profile_max_num_token(self: ModelRunner):
         available_gpu_memory = get_available_gpu_memory(
@@ -258,7 +335,9 @@ class ModelRunnerKVCacheMixin:
         return total_rest_memory - mamba_state_memory
 
     def calculate_mla_kv_cache_dim(self: ModelRunner) -> int:
-        is_nsa_model = is_deepseek_nsa(self.model_config.hf_config)
+        is_nsa_model = is_deepseek_nsa(self.model_config.hf_config) or getattr(
+            self.model_config, "uses_kpool4_compress", False
+        )
         kv_cache_dtype = self.kv_cache_dtype
         kv_lora_rank = self.model_config.kv_lora_rank
         qk_rope_head_dim = self.model_config.qk_rope_head_dim
@@ -504,6 +583,19 @@ class ModelRunnerKVCacheMixin:
                     max_num_reqs, self.server_args.max_running_requests // self.dp_size
                 )
 
+        if getattr(self.model_config, "is_glm5_next", False) and getattr(
+            self.model_config, "uses_kpool4_compress", False
+        ):
+            local_dsa_layers = sum(
+                self.start_layer <= layer_id < self.end_layer
+                for layer_id in self.model_config.hf_text_config.full_attention_layer_ids
+            )
+            self.max_total_num_tokens = self._reserve_glm5_next_kpool_tail(
+                max_total_num_tokens=self.max_total_num_tokens,
+                num_layers=local_dsa_layers,
+                max_num_reqs=max_num_reqs,
+            )
+
         if max_total_tokens_configured is not None:
             if max_total_tokens_configured > self.max_total_num_tokens:
                 logging.warning(
@@ -618,6 +710,7 @@ class ModelRunnerKVCacheMixin:
 
         # Initialize token_to_kv_pool
         is_nsa_model = is_deepseek_nsa(self.model_config.hf_config)
+        is_glm5_next_kpool = getattr(self.model_config, "uses_kpool4_compress", False)
         is_v4_model = is_deepseek_compressed(self.model_config.hf_config)
         if is_v4_model:
             # Resolve V4 KV pool factory via plugin registry.
@@ -708,6 +801,18 @@ class ModelRunnerKVCacheMixin:
                     start_layer=self.start_layer,
                     end_layer=self.end_layer,
                 )
+        elif self.use_mla_backend and is_glm5_next_kpool:
+            # Importing the exact GLM module registers its isolated factory.
+            import sglang.srt.mem_cache.glm5_next_memory_pool  # noqa: F401
+            from sglang.srt.mem_cache.pool_registry import resolve_kv_pool_factory
+
+            resolved = resolve_kv_pool_factory(self.model_config, self.server_args)
+            assert resolved is not None and resolved[0] == "glm5_next_kpool4", (
+                "GLM-5-Next KPool4 capability was selected but its exact KV "
+                "pool factory is unavailable."
+            )
+            _, factory = resolved
+            self.token_to_kv_pool = factory(model_runner=self)
         elif self.use_mla_backend and is_nsa_model:
             self.token_to_kv_pool = NSATokenToKVPool(
                 self.max_total_num_tokens,

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -145,13 +145,17 @@ class ModelRunnerKVCacheMixin:
                     if getattr(self.model_config, "is_glm5_next", False)
                     else get_nsa_index_head_dim(self.model_config.hf_config)
                 )
-                indexer_size_per_token = (
-                    index_head_dim
-                    + index_head_dim // NSATokenToKVPool.quant_block_size * 4
-                )
-                element_size = torch._utils._element_size(
-                    NSATokenToKVPool.index_k_with_scale_buffer_dtype
-                )
+                if is_glm5_next_kpool and self.kv_cache_dtype == torch.bfloat16:
+                    indexer_size_per_token = index_head_dim
+                    element_size = torch.bfloat16.itemsize
+                else:
+                    indexer_size_per_token = (
+                        index_head_dim
+                        + index_head_dim // NSATokenToKVPool.quant_block_size * 4
+                    )
+                    element_size = torch._utils._element_size(
+                        NSATokenToKVPool.index_k_with_scale_buffer_dtype
+                    )
                 cell_size += indexer_size_per_token * num_layers * element_size
         else:
             if self.model_config.is_hybrid_swa:

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -436,6 +436,7 @@ class DeepseekV2MoE(nn.Module):
         prefix: str = "",
         alt_stream: Optional[torch.cuda.Stream] = None,
         is_nextn: bool = False,
+        glm5_next_hf_two_round_swiglu: bool = False,
     ):
         super().__init__()
         self.tp_size = get_tensor_model_parallel_world_size()
@@ -505,6 +506,7 @@ class DeepseekV2MoE(nn.Module):
                 config, "routing_method_type", RoutingMethodType.DeepSeekV3
             ),
             swiglu_limit=getattr(config, "swiglu_limit", None),
+            glm5_next_hf_two_round_swiglu=glm5_next_hf_two_round_swiglu,
             prefix=add_prefix("experts", prefix),
         )
 

--- a/python/sglang/srt/models/glm5_next.py
+++ b/python/sglang/srt/models/glm5_next.py
@@ -20,6 +20,10 @@ from sglang.srt.configs.glm5_next import Glm5NextConfig, Glm5NextTextConfig
 from sglang.srt.distributed import (
     get_pp_group,
     get_tensor_model_parallel_world_size,
+    get_tp_group,
+)
+from sglang.srt.distributed.device_communicators.pynccl_allocator import (
+    use_symmetric_memory,
 )
 from sglang.srt.eplb.expert_distribution import (
     get_global_expert_distribution_recorder,
@@ -30,9 +34,14 @@ from sglang.srt.layers.communicator import (
     get_attn_tp_context,
 )
 from sglang.srt.layers.communicator_mhc import MHCLayerCommunicator
-from sglang.srt.layers.layernorm import RMSNorm
+from sglang.srt.layers.dp_attention import (
+    get_attention_tp_rank,
+    is_allocation_symmetric,
+)
+from sglang.srt.layers.linear import ReplicatedLinear, RowParallelLinear
 from sglang.srt.layers.logits_processor import LogitsProcessor
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.layers.quantization.unquant import UnquantizedLinearMethod
 from sglang.srt.layers.utils import PPMissingLayer
 from sglang.srt.layers.vocab_parallel_embedding import (
     ParallelLMHead,
@@ -49,6 +58,7 @@ from sglang.srt.models.kimi_linear import (
 )
 from sglang.srt.models.glm5_next_dsa import Glm5NextDSAAttention
 from sglang.srt.models.glm5_next_moe import Glm5NextMLP, Glm5NextMoE
+from sglang.srt.models.glm5_next_norm import Glm5NextRMSNorm
 from sglang.srt.models.transformers import maybe_prefix
 from sglang.srt.utils import make_layers
 from sglang.srt.utils.common import BumpAllocator
@@ -168,6 +178,87 @@ def _kda_construction_config(config: Glm5NextTextConfig) -> Glm5NextTextConfig:
     return kda_config
 
 
+def _glm5_next_hc_post(
+    hidden_states: torch.Tensor,
+    residual: torch.Tensor,
+    h_res: torch.Tensor,
+    h_post: torch.Tensor,
+    hc_mult: int,
+) -> torch.Tensor:
+    """Apply GLM's checkpoint-native BF16 hyper-connection update.
+
+    The learned mix metadata is kept in FP32 by ``hc_pre``, but the released
+    model casts it to the hidden-state dtype *before* the branch multiply and
+    residual matmul.  Keep this arithmetic model-local: the shared mHC helper
+    is also used by existing models whose historical FP32 accumulation must
+    remain unchanged.
+    """
+
+    if hidden_states.ndim != 2 or residual.ndim != 2:
+        raise ValueError("GLM-5-Next mHC post expects flat 2-D tensors")
+    tokens, hidden_size = hidden_states.shape
+    if residual.shape != (tokens, hc_mult * hidden_size):
+        raise ValueError(
+            "GLM-5-Next mHC residual has shape "
+            f"{tuple(residual.shape)}, expected {(tokens, hc_mult * hidden_size)}"
+        )
+    residual_streams = residual.reshape(tokens, hc_mult, hidden_size)
+    post = h_post.reshape(tokens, hc_mult).to(hidden_states.dtype)
+    comb = h_res.reshape(tokens, hc_mult, hc_mult).to(hidden_states.dtype)
+    output = post.unsqueeze(-1) * hidden_states.unsqueeze(1) + torch.matmul(
+        comb.transpose(-1, -2), residual_streams
+    )
+    return output.reshape(tokens, hc_mult * hidden_size)
+
+
+def _glm5_next_kda_can_use_fp32_o_proj(
+    o_proj: nn.Module,
+    hidden_states: torch.Tensor,
+) -> bool:
+    """Keep the higher-precision KDA partial behind a GLM-only contract."""
+
+    weight = getattr(o_proj, "weight", None)
+    return (
+        isinstance(o_proj, RowParallelLinear)
+        and isinstance(getattr(o_proj, "quant_method", None), UnquantizedLinearMethod)
+        and hidden_states.is_cuda
+        and hidden_states.dtype is torch.bfloat16
+        and weight is not None
+        and weight.is_cuda
+        and weight.device == hidden_states.device
+        and weight.dtype is torch.bfloat16
+        and getattr(o_proj, "bias", None) is None
+        and getattr(o_proj, "reduce_results", None) is False
+        and getattr(o_proj, "input_is_parallel", None) is True
+    )
+
+
+def _glm5_next_kda_o_proj(
+    o_proj: nn.Module,
+    hidden_states: torch.Tensor,
+) -> torch.Tensor:
+    """Evaluate one GLM KDA TP partial without an intermediate BF16 round."""
+
+    if not hidden_states.is_cuda:
+        return o_proj(hidden_states)[0]
+    if not _glm5_next_kda_can_use_fp32_o_proj(o_proj, hidden_states):
+        raise RuntimeError(
+            "GLM-5-Next CUDA KDA o_proj requires an unquantized BF16 "
+            "RowParallelLinear with no bias, input_is_parallel=True, and "
+            "reduce_results=False"
+        )
+
+    # Match RowParallelLinear's allocator contract so CUDA Graph capture and
+    # symmetric-allocation bookkeeping remain unchanged.  mHC performs the TP
+    # all-reduce and casts its result once before applying hc_post.
+    with use_symmetric_memory(get_tp_group(), disabled=not is_allocation_symmetric()):
+        return torch.mm(
+            hidden_states,
+            o_proj.weight.t(),
+            out_dtype=torch.float32,
+        )
+
+
 class Glm5NextLinearAttention(KimiDeltaAttention):
     """Phase-3 construction seam backed by KT's existing KDA module."""
 
@@ -193,6 +284,34 @@ class Glm5NextLinearAttention(KimiDeltaAttention):
         self.config = config
         self.attn.lower_bound = config.linear_attn_config["gate_lower_bound"]
 
+        # The released checkpoint keeps b_proj in BF16 and evaluates its full
+        # 64-output GEMM before slicing heads.  A ColumnParallelLinear instead
+        # evaluates eight independent 8-output GEMMs at TP=8.  Although the
+        # weights and input are identical, CUDA's BF16 GEMM choice changes at
+        # that output geometry and the beta logits are observably different.
+        # Keep this replacement GLM-local and tiny (64 * hidden_size BF16 per
+        # rank), then slice the exact full result to the local attention heads.
+        if not self.do_fuse_qkvbfg:
+            self.b_proj = ReplicatedLinear(
+                self.hidden_size,
+                self.num_heads,
+                bias=False,
+                quant_config=quant_config,
+                prefix=f"{prefix}.b_proj",
+            )
+            if self.num_heads % self.attn_tp_size != 0:
+                raise ValueError(
+                    "GLM-5-Next beta heads must divide attention TP size: "
+                    f"heads={self.num_heads}, attention_tp={self.attn_tp_size}"
+                )
+            self._beta_heads_per_rank = self.num_heads // self.attn_tp_size
+            self._beta_head_start = (
+                get_attention_tp_rank() * self._beta_heads_per_rank
+            )
+        else:
+            self._beta_heads_per_rank = self.local_num_heads
+            self._beta_head_start = 0
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -214,6 +333,11 @@ class Glm5NextLinearAttention(KimiDeltaAttention):
             mixed_qkv, beta, forget_gate, g_proj_states = self.forward_qkvbfg(
                 hidden_states
             )
+            beta = beta.narrow(
+                -1,
+                self._beta_head_start,
+                self._beta_heads_per_rank,
+            )
 
         # GLM applies neither fused_kda_gate nor sigmoid here.  Its dedicated
         # backend activates both raw tensors identically in prefill and decode.
@@ -230,7 +354,7 @@ class Glm5NextLinearAttention(KimiDeltaAttention):
         norm_gate = g_proj_states.unflatten(-1, (-1, self.head_dim))
         core_attn_out = self.o_norm(core_attn_out, norm_gate)
         core_attn_out = core_attn_out.squeeze(0).flatten(-2)
-        return self.o_proj(core_attn_out)[0]
+        return _glm5_next_kda_o_proj(self.o_proj, core_attn_out)
 
 
 def build_glm5_next_attention(
@@ -337,8 +461,10 @@ class Glm5NextDecoderLayer(KimiDecoderLayer):
                 swiglu_limit=config.swiglu_limit,
             )
 
-        self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self.post_attention_layernorm = RMSNorm(
+        self.input_layernorm = Glm5NextRMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+        self.post_attention_layernorm = Glm5NextRMSNorm(
             config.hidden_size, eps=config.rms_norm_eps
         )
 
@@ -401,6 +527,9 @@ class Glm5NextDecoderLayer(KimiDecoderLayer):
                 hc_attn_pre=self.hc_attn_pre,
                 hc_ffn_pre=self.hc_ffn_pre,
                 hc_post=self.hc_post,
+                attn_all_reduce_output_dtype=(
+                    torch.bfloat16 if config.is_kda_layer(layer_idx) else None
+                ),
             )
 
     def _is_layer_sparse(self, layer_idx: int) -> bool:
@@ -448,15 +577,13 @@ class Glm5NextDecoderLayer(KimiDecoderLayer):
         )
 
     def hc_post(self, hidden_states, residual, h_res, h_post):
-        from sglang.kernels.ops.layernorm.mhc import hc_post
-
         if not self.mhc_enabled:
             raise RuntimeError("hc_post is only valid when config.mhc is True")
-        return hc_post(
-            x=hidden_states,
+        return _glm5_next_hc_post(
+            hidden_states=hidden_states,
             residual=residual,
-            h_post=h_post,
             h_res=h_res,
+            h_post=h_post,
             hc_mult=self.config.hc_mult,
         )
 
@@ -569,7 +696,9 @@ class Glm5NextModel(KimiLinearModel):
         )
 
         if self.pp_group.is_last_rank:
-            self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+            self.norm = Glm5NextRMSNorm(
+                config.hidden_size, eps=config.rms_norm_eps
+            )
         else:
             self.norm = PPMissingLayer()
 

--- a/python/sglang/srt/models/glm5_next.py
+++ b/python/sglang/srt/models/glm5_next.py
@@ -1,0 +1,945 @@
+"""Text-only GLM-5-Next model skeleton.
+
+This module intentionally reuses the KT Kimi/DeepSeek building blocks.  The
+GLM-specific KDA, DSA/KPool, mHC, and vision implementations are wired through
+small seams so that those later integrations do not have to modify the shared
+Kimi model or loosen behavior for existing architectures.
+"""
+
+from __future__ import annotations
+
+import copy
+import re
+from collections.abc import Iterable, Iterator
+from typing import Optional
+
+import torch
+from torch import nn
+
+from sglang.srt.configs.glm5_next import Glm5NextConfig, Glm5NextTextConfig
+from sglang.srt.distributed import (
+    get_pp_group,
+    get_tensor_model_parallel_world_size,
+)
+from sglang.srt.eplb.expert_distribution import (
+    get_global_expert_distribution_recorder,
+)
+from sglang.srt.layers.communicator import (
+    LayerScatterModes,
+    ScatterMode,
+    get_attn_tp_context,
+)
+from sglang.srt.layers.communicator_mhc import MHCLayerCommunicator
+from sglang.srt.layers.layernorm import RMSNorm
+from sglang.srt.layers.logits_processor import LogitsProcessor
+from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.layers.utils import PPMissingLayer
+from sglang.srt.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
+from sglang.srt.models.deepseek_common.deepseek_weight_loader import (
+    DeepseekV2WeightLoaderMixin,
+)
+from sglang.srt.models.kimi_linear import (
+    KimiDecoderLayer,
+    KimiDeltaAttention,
+    KimiLinearModel,
+)
+from sglang.srt.models.glm5_next_dsa import Glm5NextDSAAttention
+from sglang.srt.models.glm5_next_moe import Glm5NextMLP, Glm5NextMoE
+from sglang.srt.models.transformers import maybe_prefix
+from sglang.srt.utils import make_layers
+from sglang.srt.utils.common import BumpAllocator
+
+
+# Vision support is scheduled for phase 7.  Keep this whitelist exact: a
+# substring check such as ``"visual" in name`` can accidentally discard a
+# future text parameter and hide a corrupt checkpoint.
+GLM5_NEXT_PHASE7_VISUAL_WEIGHT_PREFIXES = ("visual.", "model.visual.")
+
+_GLM5_NEXT_LAYER_WEIGHT_RE = re.compile(r"^model\.layers\.(\d+)\.")
+_GLM5_NEXT_EXPERT_PARAMETER_RE = re.compile(
+    r"^(?P<prefix>model\.layers\.\d+\.mlp\.experts)\."
+    r"(?P<kind>w13|w2)_(?P<leaf>.+)$"
+)
+_GLM5_NEXT_RUNTIME_KV_SCALE_RE = re.compile(
+    r"^model\.layers\.\d+\.self_attn\.attn_m(?:ha|qa)\.[kv]_scale$"
+)
+
+
+def _glm5_next_checkpoint_source_contract(
+    parameter_names: Iterable[str],
+    *,
+    num_experts: int,
+    packed_modules_mapping: dict[str, list[str]],
+) -> tuple[frozenset[str], frozenset[str]]:
+    """Reverse the runtime parameter namespace into required HF source names.
+
+    A target parameter is not always a complete checkpoint-loading unit.  For
+    example, ``qkv_proj.weight`` needs three checkpoint shards, and a routed
+    ``w13_weight`` needs gate/up shards for every logical expert.  Tracking the
+    target parameter name alone would therefore miss a truncated packed shard.
+
+    The returned sets are rank-local: PP constructs only the layers owned by
+    the current rank, while TP keeps the same names and lets each parameter's
+    loader validate and shard the source tensor shape.
+    """
+
+    expected_sources: set[str] = set()
+    runtime_defaults: set[str] = set()
+
+    for parameter_name in parameter_names:
+        if _GLM5_NEXT_RUNTIME_KV_SCALE_RE.fullmatch(parameter_name):
+            # BaseKVCacheMethod owns these scalar defaults.  The pinned FP8
+            # checkpoint intentionally has no serialized K/V cache scales.
+            runtime_defaults.add(parameter_name)
+            continue
+
+        expert_match = _GLM5_NEXT_EXPERT_PARAMETER_RE.fullmatch(parameter_name)
+        if expert_match is not None:
+            prefix = expert_match.group("prefix")
+            kind = expert_match.group("kind")
+            leaf = expert_match.group("leaf")
+            checkpoint_projections = (
+                ("gate_proj", "up_proj") if kind == "w13" else ("down_proj",)
+            )
+            for expert_id in range(num_experts):
+                for projection in checkpoint_projections:
+                    expected_sources.add(f"{prefix}.{expert_id}.{projection}.{leaf}")
+            continue
+
+        if ".mlp.experts." in parameter_name:
+            raise RuntimeError(
+                "GLM-5-Next Session AB encountered an unsupported routed-expert "
+                f"runtime parameter: {parameter_name!r}"
+            )
+
+        for packed_name, checkpoint_names in packed_modules_mapping.items():
+            packed_segment = f".{packed_name}."
+            if packed_segment not in parameter_name:
+                continue
+            expected_sources.update(
+                parameter_name.replace(
+                    packed_segment,
+                    f".{checkpoint_name}.",
+                )
+                for checkpoint_name in checkpoint_names
+            )
+            break
+        else:
+            expected_sources.add(parameter_name)
+
+    return frozenset(expected_sources), frozenset(runtime_defaults)
+
+
+def normalize_glm5_next_weight_name(name: str) -> Optional[str]:
+    """Map the HF wrapper prefix to the text-only SGLang module namespace.
+
+    ``None`` means that the tensor belongs to the explicitly deferred phase-7
+    vision tower.  No other unknown weight is classified as skippable here.
+    """
+
+    if name.startswith(GLM5_NEXT_PHASE7_VISUAL_WEIGHT_PREFIXES):
+        return None
+
+    if name.startswith("model.language_model."):
+        name = "model." + name.removeprefix("model.language_model.")
+    elif name.startswith("language_model."):
+        name = "model." + name.removeprefix("language_model.")
+
+    return name
+
+
+def _kda_construction_config(config: Glm5NextTextConfig) -> Glm5NextTextConfig:
+    """Return a non-mutating Kimi compatibility view for GLM KDA layers.
+
+    GLM uses 256-wide values in its DSA layers, while its KDA Q/K/V heads are
+    all 128-wide.  Kimi's current KDA constructor reads ``v_head_dim`` from the
+    common config, so passing the root config would incorrectly make only KDA
+    V 256-wide.  A shallow copy keeps the source HF config untouched.
+    """
+
+    kda_config = copy.copy(config)
+    kda_config.linear_num_heads = config.linear_attn_config["num_heads"]
+    kda_config.linear_head_dim = config.linear_attn_config["head_dim"]
+    kda_config.v_head_dim = config.linear_attn_config["head_dim"]
+    return kda_config
+
+
+class Glm5NextLinearAttention(KimiDeltaAttention):
+    """Phase-3 construction seam backed by KT's existing KDA module."""
+
+    def __init__(
+        self,
+        layer_idx: int,
+        hidden_size: int,
+        config: Glm5NextTextConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        construction_config = _kda_construction_config(config)
+        super().__init__(
+            layer_idx=layer_idx,
+            hidden_size=hidden_size,
+            config=construction_config,
+            quant_config=quant_config,
+            rms_norm_eps=config.rms_norm_eps,
+            prefix=prefix,
+        )
+        # Preserve the canonical config for capability checks and diagnostics;
+        # all dimensions consumed during construction are stored on the module.
+        self.config = config
+        self.attn.lower_bound = config.linear_attn_config["gate_lower_bound"]
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        zero_allocator: BumpAllocator,
+    ) -> torch.Tensor:
+        """Pass GLM's raw gate and beta logits to its dedicated backend."""
+
+        del positions, zero_allocator
+        if forward_batch.forward_mode.is_idle():
+            return hidden_states
+
+        if self.do_fuse_qkvbfg:
+            mixed_qkv, beta, forget_gate, g_proj_states = self.forward_qkvbfg_fused(
+                hidden_states
+            )
+        else:
+            mixed_qkv, beta, forget_gate, g_proj_states = self.forward_qkvbfg(
+                hidden_states
+            )
+
+        # GLM applies neither fused_kda_gate nor sigmoid here.  Its dedicated
+        # backend activates both raw tensors identically in prefill and decode.
+        if not forward_batch.forward_mode.is_decode():
+            forget_gate = forget_gate.unsqueeze(0)
+        beta = beta.unsqueeze(0)
+
+        core_attn_out = self.attn(
+            forward_batch,
+            mixed_qkv=mixed_qkv,
+            a=forget_gate,
+            b=beta,
+        )
+        norm_gate = g_proj_states.unflatten(-1, (-1, self.head_dim))
+        core_attn_out = self.o_norm(core_attn_out, norm_gate)
+        core_attn_out = core_attn_out.squeeze(0).flatten(-2)
+        return self.o_proj(core_attn_out)[0]
+
+
+def build_glm5_next_attention(
+    *,
+    config: Glm5NextTextConfig,
+    layer_idx: int,
+    quant_config: Optional[QuantizationConfig],
+    prefix: str,
+    alt_stream: Optional[torch.cuda.Stream] = None,
+) -> nn.Module:
+    """Build one attention layer through a GLM-only integration seam."""
+
+    if config.is_kda_layer(layer_idx):
+        return Glm5NextLinearAttention(
+            layer_idx=layer_idx,
+            hidden_size=config.hidden_size,
+            config=config,
+            quant_config=quant_config,
+            prefix=prefix,
+        )
+
+    return Glm5NextDSAAttention(
+        config=config,
+        layer_id=layer_idx,
+        hidden_size=config.hidden_size,
+        num_heads=config.num_attention_heads,
+        quant_config=quant_config,
+        prefix=prefix,
+        qk_nope_head_dim=config.qk_nope_head_dim,
+        qk_rope_head_dim=config.qk_rope_head_dim,
+        v_head_dim=config.v_head_dim,
+        q_lora_rank=config.q_lora_rank,
+        kv_lora_rank=config.kv_lora_rank,
+        rope_theta=config.rope_theta,
+        rope_scaling=config.rope_scaling,
+        max_position_embeddings=config.max_position_embeddings,
+        alt_stream=alt_stream,
+        skip_rope=True,
+    )
+
+
+class Glm5NextDecoderLayer(KimiDecoderLayer):
+    """GLM layer selection with an opt-in mHC residual state machine."""
+
+    def __init__(
+        self,
+        config: Glm5NextTextConfig,
+        layer_idx: int,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+        alt_stream: Optional[torch.cuda.Stream] = None,
+    ) -> None:
+        nn.Module.__init__(self)
+        if config.mhc is not True:
+            raise ValueError(
+                "GLM-5-Next Session AB requires the checkpoint-native mhc=True "
+                "execution path."
+            )
+        self.hidden_size = config.hidden_size
+        self.config = config
+        self.layer_idx = layer_idx
+        self.alt_stream = alt_stream
+        self.is_moe = config.is_moe
+        self.mhc_enabled = True
+
+        self.self_attn = build_glm5_next_attention(
+            config=config,
+            layer_idx=layer_idx,
+            quant_config=quant_config,
+            prefix=f"{prefix}.self_attn",
+            alt_stream=alt_stream,
+        )
+        if self.mhc_enabled:
+            # The mHC communicator owns the attention-output TP all-reduce.
+            # Changing the GLM instance leaves the shared attention factory and
+            # the historical non-mHC construction path untouched.
+            self.self_attn.o_proj.reduce_results = False
+
+        if (
+            self.is_moe
+            and config.num_experts is not None
+            and layer_idx >= config.first_k_dense_replace
+            and layer_idx % config.moe_layer_freq == 0
+        ):
+            # Register the sparse module only under ``mlp``.  Registering the
+            # same module first as ``block_sparse_moe`` makes
+            # ``named_parameters()`` keep that first namespace and prevents
+            # the DeepSeek loader from matching the checkpoint's ``mlp.*``
+            # tensors.
+            self.mlp = Glm5NextMoE(
+                config=config,
+                quant_config=quant_config,
+                layer_idx=layer_idx,
+                prefix=f"{prefix}.mlp",
+                alt_stream=alt_stream,
+            )
+        else:
+            self.mlp = Glm5NextMLP(
+                hidden_size=config.hidden_size,
+                intermediate_size=config.intermediate_size,
+                hidden_act=config.hidden_act,
+                quant_config=quant_config,
+                prefix=f"{prefix}.mlp",
+                swiglu_limit=config.swiglu_limit,
+            )
+
+        self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+
+        if self.mhc_enabled:
+            hc_mult = config.hc_mult
+            mix_hc = (2 + hc_mult) * hc_mult
+            hc_dim = hc_mult * config.hidden_size
+
+            # These names and FP32 shapes match the checkpoint verbatim.
+            self.hc_attn_base = nn.Parameter(torch.empty(mix_hc, dtype=torch.float32))
+            self.hc_attn_scale = nn.Parameter(torch.empty(3, dtype=torch.float32))
+            self.hc_attn_fn = nn.Parameter(
+                torch.empty(mix_hc, hc_dim, dtype=torch.float32)
+            )
+            self.hc_ffn_base = nn.Parameter(torch.empty(mix_hc, dtype=torch.float32))
+            self.hc_ffn_scale = nn.Parameter(torch.empty(3, dtype=torch.float32))
+            self.hc_ffn_fn = nn.Parameter(
+                torch.empty(mix_hc, hc_dim, dtype=torch.float32)
+            )
+
+            is_layer_sparse = self._is_layer_sparse(layer_idx)
+            layer_scatter_modes = LayerScatterModes.init_new(
+                layer_id=layer_idx,
+                num_layers=config.num_hidden_layers,
+                is_layer_sparse=is_layer_sparse,
+                is_previous_layer_sparse=self._is_layer_sparse(layer_idx - 1),
+                is_next_layer_sparse=self._is_layer_sparse(layer_idx + 1),
+            )
+            if any(
+                mode is ScatterMode.SCATTERED
+                for mode in (
+                    layer_scatter_modes.layer_input_mode,
+                    layer_scatter_modes.attn_mode,
+                    layer_scatter_modes.mlp_mode,
+                    layer_scatter_modes.middle_residual_mode,
+                    layer_scatter_modes.layer_output_mode,
+                )
+            ):
+                raise NotImplementedError(
+                    "GLM-5-Next mHC does not support scattered layer states"
+                )
+            self.layer_scatter_modes = layer_scatter_modes
+            self.layer_communicator = MHCLayerCommunicator(
+                layer_scatter_modes=layer_scatter_modes,
+                input_layernorm=self.input_layernorm,
+                post_attention_layernorm=self.post_attention_layernorm,
+                allow_reduce_scatter=False,
+                is_last_layer=(layer_idx == config.num_hidden_layers - 1),
+                # DSA's absorb path fetches its Q/KV latent through the
+                # attention-TP context after mHC has normalized the layer
+                # input.  KDA consumes the normalized input directly and must
+                # not install a stale DSA callback.
+                qkv_latent_func=(
+                    None
+                    if config.is_kda_layer(layer_idx)
+                    else self.self_attn.prepare_qkv_latent
+                ),
+                is_first_layer=(layer_idx == 0),
+                hc_mult=hc_mult,
+                hc_attn_pre=self.hc_attn_pre,
+                hc_ffn_pre=self.hc_ffn_pre,
+                hc_post=self.hc_post,
+            )
+
+    def _is_layer_sparse(self, layer_idx: int) -> bool:
+        return (
+            self.is_moe
+            and self.config.num_experts is not None
+            and layer_idx >= self.config.first_k_dense_replace
+            and layer_idx % self.config.moe_layer_freq == 0
+        )
+
+    def hc_attn_pre(self, hidden_states, out_norm_weight, out_norm_eps):
+        from sglang.kernels.ops.layernorm.mhc import hc_pre
+
+        return hc_pre(
+            x=hidden_states,
+            hc_fn=self.hc_attn_fn,
+            hc_scale=self.hc_attn_scale,
+            hc_base=self.hc_attn_base,
+            hc_mult=self.config.hc_mult,
+            rms_eps=self.config.rms_norm_eps,
+            hc_eps=self.config.hc_eps,
+            sinkhorn_iters=self.config.hc_sinkhorn_iters,
+            post_mult_value=2.0,
+            hc_norm_weight=None,
+            out_norm_weight=out_norm_weight,
+            out_norm_eps=out_norm_eps,
+        )
+
+    def hc_ffn_pre(self, hidden_states, out_norm_weight, out_norm_eps):
+        from sglang.kernels.ops.layernorm.mhc import hc_pre
+
+        return hc_pre(
+            x=hidden_states,
+            hc_fn=self.hc_ffn_fn,
+            hc_scale=self.hc_ffn_scale,
+            hc_base=self.hc_ffn_base,
+            hc_mult=self.config.hc_mult,
+            rms_eps=self.config.rms_norm_eps,
+            hc_eps=self.config.hc_eps,
+            sinkhorn_iters=self.config.hc_sinkhorn_iters,
+            post_mult_value=2.0,
+            hc_norm_weight=None,
+            out_norm_weight=out_norm_weight,
+            out_norm_eps=out_norm_eps,
+        )
+
+    def hc_post(self, hidden_states, residual, h_res, h_post):
+        from sglang.kernels.ops.layernorm.mhc import hc_post
+
+        if not self.mhc_enabled:
+            raise RuntimeError("hc_post is only valid when config.mhc is True")
+        return hc_post(
+            x=hidden_states,
+            residual=residual,
+            h_post=h_post,
+            h_res=h_res,
+            hc_mult=self.config.hc_mult,
+        )
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        forward_batch: ForwardBatch,
+        residual: Optional[torch.Tensor],
+        zero_allocator: BumpAllocator,
+    ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+        if not self.mhc_enabled:
+            return super().forward(
+                positions=positions,
+                hidden_states=hidden_states,
+                forward_batch=forward_batch,
+                residual=residual,
+                zero_allocator=zero_allocator,
+            )
+
+        if residual is not None:
+            raise RuntimeError(
+                "GLM-5-Next mHC expects its cross-layer residual state to be None"
+            )
+        expected_width = self.hidden_size * (
+            1 if self.layer_idx == 0 else self.config.hc_mult
+        )
+        if hidden_states.shape[-1] != expected_width:
+            raise RuntimeError(
+                "GLM-5-Next mHC layer input has width "
+                f"{hidden_states.shape[-1]}, expected {expected_width}"
+            )
+
+        hidden_states, residual = self.layer_communicator.prepare_attn(
+            hidden_states,
+            residual,
+            forward_batch,
+        )
+        hidden_states = self.self_attn(
+            hidden_states=hidden_states,
+            positions=positions,
+            forward_batch=forward_batch,
+            zero_allocator=zero_allocator,
+        )
+        hidden_states, residual = self.layer_communicator.prepare_mlp(
+            hidden_states,
+            residual,
+            forward_batch,
+        )
+        if isinstance(self.mlp, Glm5NextMoE):
+            hidden_states = self.mlp(
+                hidden_states,
+                forward_batch=forward_batch,
+            )
+        else:
+            hidden_states = self.mlp(hidden_states)
+        return self.layer_communicator.postprocess_layer(
+            hidden_states,
+            residual,
+            forward_batch,
+        )
+
+
+class Glm5NextModel(KimiLinearModel):
+    """45-layer text model containing 34 KDA and 11 DSA construction seams."""
+
+    def __init__(
+        self,
+        config: Glm5NextTextConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        nn.Module.__init__(self)
+        if config.mhc is not True:
+            raise ValueError(
+                "GLM-5-Next Session AB requires the checkpoint-native mhc=True "
+                "execution path."
+            )
+        self.config = config
+        self.padding_idx = config.pad_token_id
+        self.vocab_size = config.vocab_size
+        self.pp_group = get_pp_group()
+        self.layer_types = tuple(config.layer_types)
+
+        if self.pp_group.is_first_rank:
+            self.embed_tokens = VocabParallelEmbedding(
+                config.vocab_size,
+                config.hidden_size,
+                prefix=f"{prefix}.embed_tokens",
+            )
+        else:
+            self.embed_tokens = PPMissingLayer()
+
+        # Kimi currently assumes CUDA unconditionally.  Keeping the alternate
+        # stream optional makes config/model construction tests CPU-safe and
+        # matches the existing modules' Optional stream contract.
+        self.alt_stream = torch.cuda.Stream() if torch.cuda.is_available() else None
+        self.layers, self.start_layer, self.end_layer = make_layers(
+            config.num_hidden_layers,
+            lambda idx, prefix: Glm5NextDecoderLayer(
+                config=config,
+                layer_idx=idx,
+                quant_config=quant_config,
+                prefix=prefix,
+                alt_stream=self.alt_stream,
+            ),
+            pp_rank=self.pp_group.rank_in_group,
+            pp_size=self.pp_group.world_size,
+            prefix=f"{prefix}.layers",
+        )
+
+        if self.pp_group.is_last_rank:
+            self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        else:
+            self.norm = PPMissingLayer()
+
+        world_size = get_tensor_model_parallel_world_size()
+        assert config.num_attention_heads % world_size == 0
+
+    def get_input_embeddings(self) -> nn.Module:
+        return self.embed_tokens
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        inputs_embeds: torch.Tensor | None = None,
+        pp_proxy_tensors: Optional[PPProxyTensors] = None,
+    ) -> torch.Tensor:
+        if self.pp_group.is_first_rank:
+            hidden_states = (
+                inputs_embeds
+                if inputs_embeds is not None
+                else self.embed_tokens(input_ids)
+            )
+            residual = None
+        else:
+            if pp_proxy_tensors is None:
+                raise RuntimeError("mHC pipeline rank requires pp_proxy_tensors")
+            hidden_states = pp_proxy_tensors["hidden_states"]
+            residual = pp_proxy_tensors["residual"]
+            if residual is not None:
+                raise RuntimeError("mHC pipeline residual state must be None")
+
+        total_num_layers = self.end_layer - self.start_layer
+        zero_allocator = BumpAllocator(
+            buffer_size=total_num_layers * 2,
+            dtype=torch.float32,
+            device=hidden_states.device,
+        )
+        for layer_idx in range(self.start_layer, self.end_layer):
+            ctx = get_global_expert_distribution_recorder().with_current_layer(
+                layer_idx
+            )
+            with ctx:
+                hidden_states, residual = self.layers[layer_idx](
+                    positions=positions,
+                    hidden_states=hidden_states,
+                    forward_batch=forward_batch,
+                    residual=residual,
+                    zero_allocator=zero_allocator,
+                )
+
+        if not self.pp_group.is_last_rank:
+            return PPProxyTensors(
+                {
+                    "hidden_states": hidden_states,
+                    "residual": residual,
+                }
+            )
+
+        if residual is not None:
+            raise RuntimeError("final mHC residual state must be None")
+        if hidden_states.shape[0] != 0:
+            hidden_states = self.norm(hidden_states)
+        return hidden_states
+
+
+class Glm5NextForConditionalGeneration(nn.Module, DeepseekV2WeightLoaderMixin):
+    """GLM-5-Next text runtime; the vision tower remains deferred to phase 7."""
+
+    packed_modules_mapping = {
+        "fused_qkv_a_proj_with_mqa": ["q_a_proj", "kv_a_proj_with_mqa"],
+        "fused_qkvbfg_a_proj": [
+            "q_proj",
+            "k_proj",
+            "v_proj",
+            "b_proj",
+            "f_a_proj",
+            "g_a_proj",
+        ],
+        "fused_fg_b_proj": ["f_b_proj", "g_b_proj"],
+        "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+        "qkv_conv1d": ["q_conv1d", "k_conv1d", "v_conv1d"],
+        "gate_up_proj": ["gate_proj", "up_proj"],
+    }
+    fall_back_to_pt_during_load = False
+
+    def __init__(
+        self,
+        config: Glm5NextConfig | Glm5NextTextConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.mm_config = config if hasattr(config, "text_config") else None
+        self.vision_config = getattr(config, "vision_config", None)
+        self.visual = None
+
+        text_config = getattr(config, "text_config", config)
+        self.config = text_config
+        self.quant_config = quant_config
+        self.num_fused_shared_experts = 0
+        self.pp_group = get_pp_group()
+        self.model = Glm5NextModel(
+            text_config,
+            quant_config,
+            prefix=maybe_prefix(prefix, "model"),
+        )
+
+        if self.pp_group.is_last_rank:
+            if self.pp_group.world_size == 1 and text_config.tie_word_embeddings:
+                self.lm_head = self.model.embed_tokens
+            else:
+                self.lm_head = ParallelLMHead(
+                    text_config.vocab_size,
+                    text_config.hidden_size,
+                    quant_config=quant_config,
+                    prefix=maybe_prefix(prefix, "lm_head"),
+                )
+        else:
+            self.lm_head = PPMissingLayer()
+        self.logits_processor = LogitsProcessor(config=text_config)
+        self.skipped_phase7_visual_weights: tuple[str, ...] = ()
+        self.skipped_session_ab_mtp_weights: tuple[str, ...] = ()
+        self.skipped_pipeline_parallel_weight_count = 0
+        self.checkpoint_runtime_default_parameters: tuple[str, ...] = ()
+        self._checkpoint_expected_source_names: Optional[frozenset[str]] = None
+        self._checkpoint_runtime_default_parameter_names: Optional[frozenset[str]] = (
+            None
+        )
+        self._checkpoint_source_contract_complete = False
+
+        # GLM's DSA layers use the same latent hand-off contract as the NSA
+        # DeepSeek path.  NSA keeps scattered-input mode disabled, but the
+        # context still owns the per-forward latent lifetime.
+        get_attn_tp_context().init_context(text_config.q_lora_rank, True)
+
+    def get_input_embeddings(self) -> nn.Module:
+        return self.model.embed_tokens
+
+    @property
+    def start_layer(self) -> int:
+        return self.model.start_layer
+
+    @property
+    def end_layer(self) -> int:
+        return self.model.end_layer
+
+    @staticmethod
+    def _require_phase7_vision() -> None:
+        raise RuntimeError(
+            "GLM-5-Next vision inputs are intentionally unavailable in the "
+            "phase-3 text runtime; enable them after the phase-7 vision integration."
+        )
+
+    def get_image_feature(self, *args, **kwargs):
+        self._require_phase7_vision()
+
+    def get_video_feature(self, *args, **kwargs):
+        self._require_phase7_vision()
+
+    @torch.no_grad()
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_embeds: Optional[torch.Tensor] = None,
+        pp_proxy_tensors: Optional[PPProxyTensors] = None,
+    ) -> torch.Tensor:
+        contains_mm_inputs = getattr(forward_batch, "contains_mm_inputs", None)
+        if callable(contains_mm_inputs) and contains_mm_inputs():
+            self._require_phase7_vision()
+
+        with get_attn_tp_context().maybe_input_scattered(forward_batch):
+            hidden_states = self.model(
+                input_ids,
+                positions,
+                forward_batch,
+                input_embeds,
+                pp_proxy_tensors,
+            )
+        if self.pp_group.is_last_rank:
+            return self.logits_processor(
+                input_ids, hidden_states, self.lm_head, forward_batch
+            )
+        return hidden_states
+
+    def _load_kda_stacked_weight(
+        self,
+        name: str,
+        loaded_weight: torch.Tensor,
+        params_dict: dict[str, nn.Parameter],
+    ) -> bool:
+        """Load a KDA shard that maps onto a packed KT parameter."""
+
+        mappings = (
+            (".fused_qkvbfg_a_proj", ".q_proj", 0),
+            (".fused_qkvbfg_a_proj", ".k_proj", 1),
+            (".fused_qkvbfg_a_proj", ".v_proj", 2),
+            (".fused_qkvbfg_a_proj", ".b_proj", 3),
+            (".fused_qkvbfg_a_proj", ".f_a_proj", 4),
+            (".fused_qkvbfg_a_proj", ".g_a_proj", 5),
+            (".fused_fg_b_proj", ".f_b_proj", 0),
+            (".fused_fg_b_proj", ".g_b_proj", 1),
+            (".qkv_proj", ".q_proj", "q"),
+            (".qkv_proj", ".k_proj", "k"),
+            (".qkv_proj", ".v_proj", "v"),
+            (".qkv_conv1d", ".q_conv1d", 0),
+            (".qkv_conv1d", ".k_conv1d", 1),
+            (".qkv_conv1d", ".v_conv1d", 2),
+        )
+        for packed_name, checkpoint_name, shard_id in mappings:
+            if checkpoint_name not in name:
+                continue
+            candidate = name.replace(checkpoint_name, packed_name)
+            param = params_dict.get(candidate)
+            if param is None:
+                continue
+            weight_loader = getattr(param, "weight_loader", None)
+            if weight_loader is None:
+                continue
+            weight_loader(param, loaded_weight, shard_id)
+            return True
+        return False
+
+    def _normalized_text_weights(
+        self,
+        weights: Iterable[tuple[str, torch.Tensor]],
+        *,
+        require_complete: bool = True,
+    ) -> Iterator[tuple[str, torch.Tensor]]:
+        params_dict = dict(self.named_parameters())
+        expected_sources = getattr(self, "_checkpoint_expected_source_names", None)
+        runtime_defaults = getattr(
+            self,
+            "_checkpoint_runtime_default_parameter_names",
+            None,
+        )
+        if expected_sources is None or runtime_defaults is None:
+            expected_sources, runtime_defaults = _glm5_next_checkpoint_source_contract(
+                params_dict,
+                num_experts=self.config.n_routed_experts,
+                packed_modules_mapping=self.packed_modules_mapping,
+            )
+            self._checkpoint_expected_source_names = expected_sources
+            self._checkpoint_runtime_default_parameter_names = runtime_defaults
+        seen_sources: set[str] = set()
+        seen_normalized_names: set[str] = set()
+        skipped_visual: list[str] = []
+        skipped_mtp: list[str] = []
+        skipped_pp_count = 0
+
+        num_hidden_layers = self.config.num_hidden_layers
+        num_nextn_layers = getattr(self.config, "num_nextn_predict_layers", 0)
+
+        for source_name, loaded_weight in weights:
+            normalized_name = normalize_glm5_next_weight_name(source_name)
+            if normalized_name is None:
+                skipped_visual.append(source_name)
+                continue
+
+            if normalized_name in seen_normalized_names:
+                raise RuntimeError(
+                    "GLM-5-Next checkpoint source contract found a duplicate "
+                    f"normalized text tensor {normalized_name!r}; latest raw "
+                    f"name is {source_name!r}."
+                )
+            seen_normalized_names.add(normalized_name)
+
+            if normalized_name in expected_sources:
+                seen_sources.add(normalized_name)
+            else:
+                layer_match = _GLM5_NEXT_LAYER_WEIGHT_RE.match(normalized_name)
+                layer_id = int(layer_match.group(1)) if layer_match else None
+
+                # MTP is deliberately absent from the Session-AB runtime.  The
+                # only legal decoder-layer exclusion is the one configured
+                # appended layer (45 in the pinned checkpoint); a layer 46 or
+                # broader ``>= num_hidden_layers`` skip must fail closed.
+                if num_nextn_layers == 1 and layer_id == num_hidden_layers:
+                    skipped_mtp.append(source_name)
+                    continue
+
+                # Every in-range layer is checked by its owning PP rank.  A
+                # non-owner has a PPMissingLayer and must ignore that rank-local
+                # source without weakening the owner rank's strict check.
+                if (
+                    layer_id is not None
+                    and 0 <= layer_id < num_hidden_layers
+                    and not self.model.start_layer <= layer_id < self.model.end_layer
+                ):
+                    skipped_pp_count += 1
+                    continue
+
+                owned_by_another_pp_rank = (
+                    (
+                        normalized_name.startswith("model.embed_tokens.")
+                        and not self.pp_group.is_first_rank
+                    )
+                    or (
+                        normalized_name.startswith("model.norm.")
+                        and not self.pp_group.is_last_rank
+                    )
+                    or (
+                        normalized_name.startswith("lm_head.")
+                        and not self.pp_group.is_last_rank
+                    )
+                )
+                if owned_by_another_pp_rank:
+                    skipped_pp_count += 1
+                    continue
+
+                raise RuntimeError(
+                    "GLM-5-Next checkpoint source contract rejected an unknown "
+                    f"text tensor: raw={source_name!r}, "
+                    f"normalized={normalized_name!r}. Only current-rank runtime "
+                    "parameters, exact PP non-owner namespaces, the single "
+                    "configured MTP layer, and raw visual./model.visual. "
+                    "prefixes may be skipped."
+                )
+
+            if normalized_name.endswith(".A_log") and loaded_weight.dim() == 1:
+                loaded_weight = loaded_weight.view(1, 1, -1, 1)
+
+            if self._load_kda_stacked_weight(
+                normalized_name, loaded_weight, params_dict
+            ):
+                continue
+            yield normalized_name, loaded_weight
+
+        self.skipped_phase7_visual_weights = tuple(skipped_visual)
+        self.skipped_session_ab_mtp_weights = tuple(skipped_mtp)
+        self.skipped_pipeline_parallel_weight_count = skipped_pp_count
+        self.checkpoint_runtime_default_parameters = tuple(sorted(runtime_defaults))
+
+        if require_complete:
+            missing_sources = sorted(expected_sources - seen_sources)
+            if missing_sources:
+                examples = ", ".join(repr(name) for name in missing_sources[:16])
+                raise RuntimeError(
+                    "GLM-5-Next checkpoint source contract is missing "
+                    f"{len(missing_sources)} required current-rank tensor(s); "
+                    f"examples: {examples}"
+                )
+
+    def load_weights(
+        self,
+        weights: Iterable[tuple[str, torch.Tensor]],
+        is_nextn: bool = False,
+    ) -> None:
+        if is_nextn:
+            raise RuntimeError(
+                "GLM-5-Next MTP/NextN loading is outside the Session-AB boundary."
+            )
+
+        require_complete = not self._checkpoint_source_contract_complete
+        DeepseekV2WeightLoaderMixin.do_load_weights(
+            self,
+            self._normalized_text_weights(
+                weights,
+                require_complete=require_complete,
+            ),
+            is_nextn=False,
+        )
+        self._checkpoint_source_contract_complete = True
+
+    def post_load_weights(self, is_nextn: bool = False, weight_names=None) -> None:
+        DeepseekV2WeightLoaderMixin.post_load_weights(
+            self, is_nextn=is_nextn, weight_names=weight_names
+        )
+
+
+EntryClass = [Glm5NextForConditionalGeneration]

--- a/python/sglang/srt/models/glm5_next.py
+++ b/python/sglang/srt/models/glm5_next.py
@@ -824,7 +824,7 @@ class Glm5NextModel(KimiLinearModel):
 
 
 class Glm5NextForConditionalGeneration(nn.Module, DeepseekV2WeightLoaderMixin):
-    """GLM-5-Next text runtime with an isolated single-image vision path."""
+    """GLM-5-Next runtime with isolated multi-image and single-video paths."""
 
     packed_modules_mapping = {
         "fused_qkv_a_proj_with_mqa": ["q_a_proj", "kv_a_proj_with_mqa"],
@@ -999,9 +999,78 @@ class Glm5NextForConditionalGeneration(nn.Module, DeepseekV2WeightLoaderMixin):
             )
         return image_embeds
 
-    def get_video_feature(self, *args, **kwargs):
-        del args, kwargs
-        raise ValueError("GLM-5-Next Session D does not support video input.")
+    def get_video_feature(self, items) -> torch.Tensor:
+        """Run timestamped video frames through bounded vision microbatches."""
+
+        self._require_multimodal_enabled()
+        if not items:
+            raise ValueError("GLM-5-Next video feature extraction needs video items.")
+        pixel_values = torch.cat([item.feature for item in items], dim=0).to(
+            device=self.visual.device, dtype=self.visual.dtype
+        )
+        video_grids = torch.cat([item.video_grid_thw for item in items], dim=0).to(
+            device="cpu", dtype=torch.int32
+        )
+        if pixel_values.ndim != 2 or video_grids.ndim != 2:
+            raise ValueError(
+                "GLM-5-Next video vision expects 2-D pixel patches and video_grid_thw."
+            )
+
+        frame_grids = []
+        for grid in video_grids.tolist():
+            grid_t, grid_h, grid_w = (int(value) for value in grid)
+            if min(grid_t, grid_h, grid_w) <= 0:
+                raise ValueError(f"Invalid GLM-5-Next video grid: {grid!r}.")
+            frame_grids.extend([(1, grid_h, grid_w)] * grid_t)
+        expected_patch_rows = sum(t * h * w for t, h, w in frame_grids)
+        if pixel_values.shape[0] != expected_patch_rows:
+            raise RuntimeError(
+                "GLM-5-Next video patch/grid mismatch before vision: "
+                f"expected={expected_patch_rows}, got={pixel_values.shape[0]}."
+            )
+
+        # Bound the temporary vision activation footprint.  A spatial frame
+        # larger than the budget is kept intact and runs alone because the
+        # vision tower cannot split one grid without changing positional ids.
+        max_patch_rows = 32_768
+        embeddings = []
+        patch_cursor = 0
+        batch_start = 0
+        batch_rows = 0
+        for frame_index, (_, grid_h, grid_w) in enumerate(frame_grids):
+            frame_rows = grid_h * grid_w
+            if batch_rows and batch_rows + frame_rows > max_patch_rows:
+                batch_grid = torch.tensor(
+                    frame_grids[batch_start:frame_index], dtype=torch.int32
+                )
+                embeddings.append(
+                    self.visual(
+                        pixel_values[patch_cursor - batch_rows : patch_cursor],
+                        grid_thw=batch_grid,
+                    )
+                )
+                batch_start = frame_index
+                batch_rows = 0
+            batch_rows += frame_rows
+            patch_cursor += frame_rows
+        if batch_rows:
+            batch_grid = torch.tensor(frame_grids[batch_start:], dtype=torch.int32)
+            embeddings.append(
+                self.visual(
+                    pixel_values[patch_cursor - batch_rows : patch_cursor],
+                    grid_thw=batch_grid,
+                )
+            )
+
+        video_embeds = torch.cat(embeddings, dim=0)
+        merge_area = self.vision_config.spatial_merge_size**2
+        expected_embed_rows = sum(t * h * w // merge_area for t, h, w in frame_grids)
+        if video_embeds.ndim != 2 or video_embeds.shape[0] != expected_embed_rows:
+            raise RuntimeError(
+                "GLM-5-Next visual embedding rows do not match video placeholders: "
+                f"expected={expected_embed_rows}, got={tuple(video_embeds.shape)}."
+            )
+        return video_embeds
 
     @torch.no_grad()
     def forward(
@@ -1018,43 +1087,55 @@ class Glm5NextForConditionalGeneration(nn.Module, DeepseekV2WeightLoaderMixin):
         has_image_inputs = bool(
             callable(contains_image_inputs) and contains_image_inputs()
         )
+        contains_video_inputs = getattr(
+            forward_batch, "contains_video_inputs", None
+        )
+        has_video_inputs = bool(
+            callable(contains_video_inputs) and contains_video_inputs()
+        )
+        has_multimodal_inputs = has_image_inputs or has_video_inputs
         forward_mode_name = getattr(
             getattr(forward_batch, "forward_mode", None), "name", None
         )
-        is_image_extend = has_image_inputs and forward_mode_name == "EXTEND"
+        is_multimodal_extend = has_multimodal_inputs and forward_mode_name == "EXTEND"
         # Real scheduler batches expose this Session-D marker as a dataclass
         # field.  Keep the historical lightweight/unit-test forward contract
         # usable for text-only calls, while refusing to silently lose the
         # marker for an actual image batch.
         try:
-            forward_batch.glm5_next_has_image_inputs = is_image_extend
+            forward_batch.glm5_next_has_image_inputs = (
+                has_image_inputs and forward_mode_name == "EXTEND"
+            )
+            forward_batch.glm5_next_force_hybrid_prefill = bool(
+                is_multimodal_extend
+                or getattr(forward_batch, "glm5_next_force_hybrid_prefill", False)
+            )
         except (AttributeError, TypeError):
-            if is_image_extend:
+            if is_multimodal_extend:
                 raise RuntimeError(
-                    "GLM-5-Next image dispatch requires a mutable ForwardBatch "
+                    "GLM-5-Next multimodal dispatch requires a mutable ForwardBatch "
                     "with the multimodal scheduling marker."
                 )
 
-        contains_video_inputs = getattr(
-            forward_batch, "contains_video_inputs", None
-        )
-        if callable(contains_video_inputs) and contains_video_inputs():
-            raise ValueError("GLM-5-Next Session D does not support video input.")
         contains_audio_inputs = getattr(
             forward_batch, "contains_audio_inputs", None
         )
         if callable(contains_audio_inputs) and contains_audio_inputs():
-            raise ValueError("GLM-5-Next Session D does not support audio input.")
+            raise ValueError("GLM-5-Next does not support audio input.")
 
-        if has_image_inputs and not self.multimodal_enabled:
+        if has_multimodal_inputs and not self.multimodal_enabled:
             self._require_multimodal_enabled()
-        if has_image_inputs and forward_mode_name not in ("EXTEND", "DECODE", "IDLE"):
+        if has_multimodal_inputs and forward_mode_name not in (
+            "EXTEND",
+            "DECODE",
+            "IDLE",
+        ):
             raise RuntimeError(
-                "GLM-5-Next Session D accepts image data only in plain EXTEND; "
+                "GLM-5-Next accepts multimodal data only in plain EXTEND; "
                 f"got ForwardMode.{forward_mode_name}."
             )
         with get_attn_tp_context().maybe_input_scattered(forward_batch):
-            if self.multimodal_enabled and is_image_extend:
+            if self.multimodal_enabled and is_multimodal_extend:
                 from sglang.srt.managers.mm_utils import general_mm_embed_routine
 
                 hidden_states = general_mm_embed_routine(

--- a/python/sglang/srt/models/glm5_next.py
+++ b/python/sglang/srt/models/glm5_next.py
@@ -9,6 +9,7 @@ behavior for existing architectures.
 from __future__ import annotations
 
 import copy
+import logging
 import re
 from collections.abc import Iterable, Iterator
 from typing import Optional
@@ -62,6 +63,9 @@ from sglang.srt.models.glm5_next_norm import Glm5NextRMSNorm
 from sglang.srt.models.transformers import maybe_prefix
 from sglang.srt.utils import make_layers
 from sglang.srt.utils.common import BumpAllocator
+
+
+logger = logging.getLogger(__name__)
 
 
 # This historical constant name is retained for compatibility with Session AB
@@ -714,7 +718,13 @@ class Glm5NextModel(KimiLinearModel):
         self.padding_idx = config.pad_token_id
         self.vocab_size = config.vocab_size
         self.pp_group = get_pp_group()
-        self.layer_types = tuple(config.layer_types)
+        self.layer_types = tuple(
+            getattr(
+                config,
+                "_glm5_next_checkpoint_layer_types",
+                config.layer_types,
+            )
+        )
 
         if self.pp_group.is_first_rank:
             self.embed_tokens = VocabParallelEmbedding(
@@ -1366,6 +1376,13 @@ class Glm5NextForConditionalGeneration(nn.Module, DeepseekV2WeightLoaderMixin):
         self._checkpoint_visual_source_contract_complete = bool(
             self.multimodal_enabled
         )
+        if require_complete and self.multimodal_enabled:
+            logger.info(
+                "GLM-5-Next visual checkpoint source contract complete: "
+                "loaded=%d expected=%d dtype=BF16",
+                len(self._checkpoint_seen_visual_source_names),
+                len(self._checkpoint_expected_visual_source_names or ()),
+            )
 
     def post_load_weights(self, is_nextn: bool = False, weight_names=None) -> None:
         DeepseekV2WeightLoaderMixin.post_load_weights(

--- a/python/sglang/srt/models/glm5_next.py
+++ b/python/sglang/srt/models/glm5_next.py
@@ -1,9 +1,9 @@
-"""Text-only GLM-5-Next model skeleton.
+"""GLM-5-Next text runtime with an isolated single-image vision path.
 
 This module intentionally reuses the KT Kimi/DeepSeek building blocks.  The
 GLM-specific KDA, DSA/KPool, mHC, and vision implementations are wired through
-small seams so that those later integrations do not have to modify the shared
-Kimi model or loosen behavior for existing architectures.
+small seams so the integration does not modify the shared Kimi model or loosen
+behavior for existing architectures.
 """
 
 from __future__ import annotations
@@ -64,10 +64,17 @@ from sglang.srt.utils import make_layers
 from sglang.srt.utils.common import BumpAllocator
 
 
-# Vision support is scheduled for phase 7.  Keep this whitelist exact: a
-# substring check such as ``"visual" in name`` can accidentally discard a
-# future text parameter and hide a corrupt checkpoint.
+# This historical constant name is retained for compatibility with Session AB
+# loader tests.  Session D now consumes the same exact prefixes when vision is
+# enabled and skips them only in the explicit text-only fallback.  A substring
+# check such as ``"visual" in name`` could discard a future text parameter and
+# hide a corrupt checkpoint.
 GLM5_NEXT_PHASE7_VISUAL_WEIGHT_PREFIXES = ("visual.", "model.visual.")
+GLM5_NEXT_PINNED_VISION_SOURCE_TENSOR_COUNT = 347
+_GLM5_NEXT_DEAD_VISION_RUNTIME_PREFIXES = (
+    "visual.embeddings.",
+    "visual.post_conv_layernorm.",
+)
 
 _GLM5_NEXT_LAYER_WEIGHT_RE = re.compile(r"^model\.layers\.(\d+)\.")
 _GLM5_NEXT_EXPERT_PARAMETER_RE = re.compile(
@@ -145,10 +152,12 @@ def _glm5_next_checkpoint_source_contract(
 
 
 def normalize_glm5_next_weight_name(name: str) -> Optional[str]:
-    """Map the HF wrapper prefix to the text-only SGLang module namespace.
+    """Map the HF wrapper prefix to the SGLang text-module namespace.
 
-    ``None`` means that the tensor belongs to the explicitly deferred phase-7
-    vision tower.  No other unknown weight is classified as skippable here.
+    Visual sources are handled by the strict Session D loader before this
+    helper when multimodal mode is active.  ``None`` therefore means either an
+    already-classified visual source or a visual tensor skipped by the explicit
+    text-only fallback.  No other unknown weight is classified as skippable.
     """
 
     if name.startswith(GLM5_NEXT_PHASE7_VISUAL_WEIGHT_PREFIXES):
@@ -160,6 +169,45 @@ def normalize_glm5_next_weight_name(name: str) -> Optional[str]:
         name = "model." + name.removeprefix("language_model.")
 
     return name
+
+
+def _canonical_glm5_next_visual_source_name(name: str) -> Optional[str]:
+    if name.startswith("model.visual."):
+        return name
+    if name.startswith("visual."):
+        return "model." + name
+    return None
+
+
+def _glm5_next_vision_checkpoint_source_contract(
+    parameter_names: Iterable[str],
+) -> frozenset[str]:
+    """Reverse live GLM vision parameters into checkpoint source names."""
+
+    expected_sources: set[str] = set()
+    for parameter_name in parameter_names:
+        if not parameter_name.startswith("visual."):
+            continue
+        if parameter_name.startswith(_GLM5_NEXT_DEAD_VISION_RUNTIME_PREFIXES):
+            # GlmOcrVisionModel inherits these GLM4V modules, but its forward
+            # never reads them and the GLM5 checkpoint intentionally omits them.
+            continue
+
+        source_name = "model." + parameter_name
+        if ".attn.qkv_proj." in source_name:
+            expected_sources.add(
+                source_name.replace(".attn.qkv_proj.", ".attn.qkv.")
+            )
+        elif ".gate_up_proj." in source_name:
+            expected_sources.add(
+                source_name.replace(".gate_up_proj.", ".gate_proj.")
+            )
+            expected_sources.add(
+                source_name.replace(".gate_up_proj.", ".up_proj.")
+            )
+        else:
+            expected_sources.add(source_name)
+    return frozenset(expected_sources)
 
 
 def _kda_construction_config(config: Glm5NextTextConfig) -> Glm5NextTextConfig:
@@ -713,13 +761,13 @@ class Glm5NextModel(KimiLinearModel):
         input_ids: torch.Tensor | None,
         positions: torch.Tensor,
         forward_batch: ForwardBatch,
-        inputs_embeds: torch.Tensor | None = None,
+        input_embeds: torch.Tensor | None = None,
         pp_proxy_tensors: Optional[PPProxyTensors] = None,
     ) -> torch.Tensor:
         if self.pp_group.is_first_rank:
             hidden_states = (
-                inputs_embeds
-                if inputs_embeds is not None
+                input_embeds
+                if input_embeds is not None
                 else self.embed_tokens(input_ids)
             )
             residual = None
@@ -766,7 +814,7 @@ class Glm5NextModel(KimiLinearModel):
 
 
 class Glm5NextForConditionalGeneration(nn.Module, DeepseekV2WeightLoaderMixin):
-    """GLM-5-Next text runtime; the vision tower remains deferred to phase 7."""
+    """GLM-5-Next text runtime with an isolated single-image vision path."""
 
     packed_modules_mapping = {
         "fused_qkv_a_proj_with_mqa": ["q_a_proj", "kv_a_proj_with_mqa"],
@@ -794,10 +842,42 @@ class Glm5NextForConditionalGeneration(nn.Module, DeepseekV2WeightLoaderMixin):
         super().__init__()
         self.mm_config = config if hasattr(config, "text_config") else None
         self.vision_config = getattr(config, "vision_config", None)
+        self.multimodal_enabled = bool(
+            getattr(config, "_glm5_next_multimodal_active", False)
+        )
         self.visual = None
+
+        if self.multimodal_enabled:
+            if self.mm_config is None or self.vision_config is None:
+                raise ValueError(
+                    "GLM-5-Next multimodal mode requires the root config and "
+                    "its vision_config."
+                )
+            # Keep imports and the ~1 GiB allocation out of the explicit
+            # programmatic text-only path.
+            from sglang.srt.layers.attention import vision_utils
+            from sglang.srt.models.glm_ocr import GlmOcrVisionModel
+
+            vision_utils.update_vit_attn_dummy_heads_config(config)
+            self.visual = GlmOcrVisionModel(
+                self.vision_config,
+                quant_config=None,
+                prefix=maybe_prefix(prefix, "visual"),
+                use_data_parallel=False,
+                num_dummy_heads=getattr(self.vision_config, "num_dummy_heads", 0),
+                merger_context_dim=self.vision_config.projection_intermediate_size,
+            )
 
         text_config = getattr(config, "text_config", config)
         self.config = text_config
+        # The processor/scheduler may retain GLM4V-style MRoPE metadata, but
+        # this pinned checkpoint has qk_rope_head_dim=0.  KT's DSA KPool uses
+        # the 1-D scheduler positions for cache/index updates, so forward must
+        # not replace them with the [3, N] metadata tensor used by the generic
+        # upstream VLM path (which would also break CUDA-graph batch size 4).
+        self.is_mrope_enabled = "mrope_section" in (
+            getattr(self.config, "rope_scaling", None) or {}
+        )
         self.quant_config = quant_config
         self.num_fused_shared_experts = 0
         self.pp_group = get_pp_group()
@@ -829,6 +909,22 @@ class Glm5NextForConditionalGeneration(nn.Module, DeepseekV2WeightLoaderMixin):
             None
         )
         self._checkpoint_source_contract_complete = False
+        self._checkpoint_expected_visual_source_names: Optional[
+            frozenset[str]
+        ] = None
+        self._checkpoint_seen_visual_source_names: frozenset[str] = frozenset()
+        self._checkpoint_visual_source_contract_complete = False
+        if self.multimodal_enabled:
+            visual_sources = _glm5_next_vision_checkpoint_source_contract(
+                name for name, _ in self.named_parameters()
+            )
+            if len(visual_sources) != GLM5_NEXT_PINNED_VISION_SOURCE_TENSOR_COUNT:
+                raise RuntimeError(
+                    "GLM-5-Next pinned vision runtime must reverse-map to "
+                    f"{GLM5_NEXT_PINNED_VISION_SOURCE_TENSOR_COUNT} checkpoint "
+                    f"tensors; got {len(visual_sources)}."
+                )
+            self._checkpoint_expected_visual_source_names = visual_sources
 
         # GLM's DSA layers use the same latent hand-off contract as the NSA
         # DeepSeek path.  NSA keeps scattered-input mode disabled, but the
@@ -846,18 +942,56 @@ class Glm5NextForConditionalGeneration(nn.Module, DeepseekV2WeightLoaderMixin):
     def end_layer(self) -> int:
         return self.model.end_layer
 
-    @staticmethod
-    def _require_phase7_vision() -> None:
+    def _require_multimodal_enabled(self) -> None:
+        if self.multimodal_enabled and self.visual is not None:
+            return
         raise RuntimeError(
-            "GLM-5-Next vision inputs are intentionally unavailable in the "
-            "phase-3 text runtime; enable them after the phase-7 vision integration."
+            "GLM-5-Next received vision input while multimodal support is disabled."
         )
 
-    def get_image_feature(self, *args, **kwargs):
-        self._require_phase7_vision()
+    def pad_input_ids(self, input_ids, mm_inputs):
+        self._require_multimodal_enabled()
+        from sglang.srt.managers.mm_utils import (
+            MultiModalityDataPaddingPatternMultimodalTokens,
+        )
+
+        pattern = MultiModalityDataPaddingPatternMultimodalTokens()
+        return pattern.pad_input_tokens(input_ids, mm_inputs)
+
+    def get_image_feature(self, items) -> torch.Tensor:
+        self._require_multimodal_enabled()
+        if not items:
+            raise ValueError("GLM-5-Next image feature extraction needs image items.")
+        pixel_values = torch.cat([item.feature for item in items], dim=0).to(
+            device=self.visual.device, dtype=self.visual.dtype
+        )
+        # GLM4V/GLM-OCR build the spatial index with CPU ``torch.arange`` and
+        # move only the resulting position ids into the vision tower.  Keep
+        # the tiny grid descriptor on CPU; placing it on CUDA would mix device
+        # scalars with those CPU allocations before the explicit transfer.
+        image_grid_thw = torch.cat(
+            [item.image_grid_thw for item in items], dim=0
+        ).to(device="cpu", dtype=torch.int32)
+        if pixel_values.ndim != 2 or image_grid_thw.ndim != 2:
+            raise ValueError(
+                "GLM-5-Next vision expects 2-D pixel patches and image_grid_thw."
+            )
+        image_embeds = self.visual(pixel_values, grid_thw=image_grid_thw)
+        expected_rows = sum(
+            int(grid.prod().item())
+            // (self.vision_config.spatial_merge_size**2)
+            for grid in image_grid_thw
+        )
+        if image_embeds.ndim != 2 or image_embeds.shape[0] != expected_rows:
+            raise RuntimeError(
+                "GLM-5-Next visual embedding rows do not match image placeholders: "
+                f"expected {expected_rows}, got {tuple(image_embeds.shape)}."
+            )
+        return image_embeds
 
     def get_video_feature(self, *args, **kwargs):
-        self._require_phase7_vision()
+        del args, kwargs
+        raise ValueError("GLM-5-Next Session D does not support video input.")
 
     @torch.no_grad()
     def forward(
@@ -868,18 +1002,72 @@ class Glm5NextForConditionalGeneration(nn.Module, DeepseekV2WeightLoaderMixin):
         input_embeds: Optional[torch.Tensor] = None,
         pp_proxy_tensors: Optional[PPProxyTensors] = None,
     ) -> torch.Tensor:
-        contains_mm_inputs = getattr(forward_batch, "contains_mm_inputs", None)
-        if callable(contains_mm_inputs) and contains_mm_inputs():
-            self._require_phase7_vision()
+        contains_image_inputs = getattr(
+            forward_batch, "contains_image_inputs", None
+        )
+        has_image_inputs = bool(
+            callable(contains_image_inputs) and contains_image_inputs()
+        )
+        forward_mode_name = getattr(
+            getattr(forward_batch, "forward_mode", None), "name", None
+        )
+        is_image_extend = has_image_inputs and forward_mode_name == "EXTEND"
+        # Real scheduler batches expose this Session-D marker as a dataclass
+        # field.  Keep the historical lightweight/unit-test forward contract
+        # usable for text-only calls, while refusing to silently lose the
+        # marker for an actual image batch.
+        try:
+            forward_batch.glm5_next_has_image_inputs = is_image_extend
+        except (AttributeError, TypeError):
+            if is_image_extend:
+                raise RuntimeError(
+                    "GLM-5-Next image dispatch requires a mutable ForwardBatch "
+                    "with the multimodal scheduling marker."
+                )
 
-        with get_attn_tp_context().maybe_input_scattered(forward_batch):
-            hidden_states = self.model(
-                input_ids,
-                positions,
-                forward_batch,
-                input_embeds,
-                pp_proxy_tensors,
+        contains_video_inputs = getattr(
+            forward_batch, "contains_video_inputs", None
+        )
+        if callable(contains_video_inputs) and contains_video_inputs():
+            raise ValueError("GLM-5-Next Session D does not support video input.")
+        contains_audio_inputs = getattr(
+            forward_batch, "contains_audio_inputs", None
+        )
+        if callable(contains_audio_inputs) and contains_audio_inputs():
+            raise ValueError("GLM-5-Next Session D does not support audio input.")
+
+        if has_image_inputs and not self.multimodal_enabled:
+            self._require_multimodal_enabled()
+        if has_image_inputs and forward_mode_name not in ("EXTEND", "DECODE", "IDLE"):
+            raise RuntimeError(
+                "GLM-5-Next Session D accepts image data only in plain EXTEND; "
+                f"got ForwardMode.{forward_mode_name}."
             )
+        with get_attn_tp_context().maybe_input_scattered(forward_batch):
+            if self.multimodal_enabled and is_image_extend:
+                from sglang.srt.managers.mm_utils import general_mm_embed_routine
+
+                hidden_states = general_mm_embed_routine(
+                    input_ids=input_ids,
+                    forward_batch=forward_batch,
+                    language_model=self.model,
+                    multimodal_model=self,
+                    positions=positions,
+                    pp_proxy_tensors=pp_proxy_tensors,
+                )
+            else:
+                # Preserve the Session-C text/decode call shape exactly.  In
+                # particular, pure text must not be forced through the generic
+                # multimodal embedding routine merely because the vision tower
+                # was enabled at startup; this also keeps its CUDA-graph and
+                # layerwise-prefill behavior isolated from Session D.
+                hidden_states = self.model(
+                    input_ids,
+                    positions,
+                    forward_batch,
+                    input_embeds,
+                    pp_proxy_tensors,
+                )
         if self.pp_group.is_last_rank:
             return self.logits_processor(
                 input_ids, hidden_states, self.lm_head, forward_batch
@@ -924,13 +1112,71 @@ class Glm5NextForConditionalGeneration(nn.Module, DeepseekV2WeightLoaderMixin):
             return True
         return False
 
+    def _load_visual_weight(
+        self,
+        canonical_source_name: str,
+        loaded_weight: torch.Tensor,
+        params_dict: dict[str, nn.Parameter],
+    ) -> None:
+        """Load one canonical visual source without buffering checkpoint data."""
+
+        if loaded_weight.dtype is not torch.bfloat16:
+            raise RuntimeError(
+                "GLM-5-Next pinned visual tensors must be BF16; "
+                f"{canonical_source_name!r} has dtype {loaded_weight.dtype}."
+            )
+
+        runtime_name = canonical_source_name.removeprefix("model.")
+        shard_id = None
+        if ".attn.qkv." in runtime_name:
+            runtime_name = runtime_name.replace(
+                ".attn.qkv.", ".attn.qkv_proj."
+            )
+        elif ".gate_proj." in runtime_name:
+            runtime_name = runtime_name.replace(
+                ".gate_proj.", ".gate_up_proj."
+            )
+            shard_id = 0
+        elif ".up_proj." in runtime_name:
+            runtime_name = runtime_name.replace(
+                ".up_proj.", ".gate_up_proj."
+            )
+            shard_id = 1
+
+        param = params_dict.get(runtime_name)
+        if param is None or runtime_name.startswith(
+            _GLM5_NEXT_DEAD_VISION_RUNTIME_PREFIXES
+        ):
+            raise RuntimeError(
+                "GLM-5-Next visual checkpoint source mapped to an unknown or "
+                f"dead runtime parameter: source={canonical_source_name!r}, "
+                f"runtime={runtime_name!r}."
+            )
+
+        from sglang.srt.layers.attention import vision_utils
+        from sglang.srt.model_loader.weight_utils import default_weight_loader
+
+        loaded_weight = vision_utils.pad_vit_attn_dummy_heads(
+            self.mm_config, runtime_name, loaded_weight
+        )
+        weight_loader = getattr(param, "weight_loader", default_weight_loader)
+        if shard_id is None:
+            weight_loader(param, loaded_weight)
+        else:
+            weight_loader(param, loaded_weight, shard_id)
+
     def _normalized_text_weights(
         self,
         weights: Iterable[tuple[str, torch.Tensor]],
         *,
         require_complete: bool = True,
     ) -> Iterator[tuple[str, torch.Tensor]]:
-        params_dict = dict(self.named_parameters())
+        all_params_dict = dict(self.named_parameters())
+        params_dict = {
+            name: parameter
+            for name, parameter in all_params_dict.items()
+            if not name.startswith("visual.")
+        }
         expected_sources = getattr(self, "_checkpoint_expected_source_names", None)
         runtime_defaults = getattr(
             self,
@@ -950,13 +1196,52 @@ class Glm5NextForConditionalGeneration(nn.Module, DeepseekV2WeightLoaderMixin):
         skipped_visual: list[str] = []
         skipped_mtp: list[str] = []
         skipped_pp_count = 0
+        multimodal_enabled = bool(getattr(self, "multimodal_enabled", False))
+        expected_visual_sources = getattr(
+            self, "_checkpoint_expected_visual_source_names", None
+        )
+        if multimodal_enabled and expected_visual_sources is None:
+            expected_visual_sources = _glm5_next_vision_checkpoint_source_contract(
+                all_params_dict
+            )
+            self._checkpoint_expected_visual_source_names = expected_visual_sources
+        # Duplicate detection is scoped to one load transaction, matching the
+        # text-source contract above.  The first complete startup load remains
+        # strict, while later online weight updates may legally present the
+        # same visual names again (or update only a subset).
+        seen_visual_sources: set[str] = set()
 
         num_hidden_layers = self.config.num_hidden_layers
         num_nextn_layers = getattr(self.config, "num_nextn_predict_layers", 0)
 
         for source_name, loaded_weight in weights:
+            visual_source_name = _canonical_glm5_next_visual_source_name(source_name)
+            if visual_source_name is not None:
+                if not multimodal_enabled:
+                    skipped_visual.append(source_name)
+                    continue
+                if visual_source_name in seen_visual_sources:
+                    raise RuntimeError(
+                        "GLM-5-Next visual checkpoint source contract found a "
+                        f"duplicate tensor {visual_source_name!r}; latest raw "
+                        f"name is {source_name!r}."
+                    )
+                if visual_source_name not in expected_visual_sources:
+                    raise RuntimeError(
+                        "GLM-5-Next visual checkpoint source contract rejected "
+                        f"unknown tensor: raw={source_name!r}, "
+                        f"canonical={visual_source_name!r}."
+                    )
+                self._load_visual_weight(
+                    visual_source_name, loaded_weight, all_params_dict
+                )
+                seen_visual_sources.add(visual_source_name)
+                continue
+
             normalized_name = normalize_glm5_next_weight_name(source_name)
             if normalized_name is None:
+                # All exact visual prefixes were handled above.  Retain this
+                # defensive branch for direct calls to the historical helper.
                 skipped_visual.append(source_name)
                 continue
 
@@ -1033,6 +1318,7 @@ class Glm5NextForConditionalGeneration(nn.Module, DeepseekV2WeightLoaderMixin):
         self.skipped_session_ab_mtp_weights = tuple(skipped_mtp)
         self.skipped_pipeline_parallel_weight_count = skipped_pp_count
         self.checkpoint_runtime_default_parameters = tuple(sorted(runtime_defaults))
+        self._checkpoint_seen_visual_source_names = frozenset(seen_visual_sources)
 
         if require_complete:
             missing_sources = sorted(expected_sources - seen_sources)
@@ -1043,6 +1329,19 @@ class Glm5NextForConditionalGeneration(nn.Module, DeepseekV2WeightLoaderMixin):
                     f"{len(missing_sources)} required current-rank tensor(s); "
                     f"examples: {examples}"
                 )
+            if multimodal_enabled:
+                missing_visual_sources = sorted(
+                    expected_visual_sources - seen_visual_sources
+                )
+                if missing_visual_sources:
+                    examples = ", ".join(
+                        repr(name) for name in missing_visual_sources[:16]
+                    )
+                    raise RuntimeError(
+                        "GLM-5-Next visual checkpoint source contract is missing "
+                        f"{len(missing_visual_sources)} required tensor(s); "
+                        f"examples: {examples}"
+                    )
 
     def load_weights(
         self,
@@ -1064,6 +1363,9 @@ class Glm5NextForConditionalGeneration(nn.Module, DeepseekV2WeightLoaderMixin):
             is_nextn=False,
         )
         self._checkpoint_source_contract_complete = True
+        self._checkpoint_visual_source_contract_complete = bool(
+            self.multimodal_enabled
+        )
 
     def post_load_weights(self, is_nextn: bool = False, weight_names=None) -> None:
         DeepseekV2WeightLoaderMixin.post_load_weights(

--- a/python/sglang/srt/models/glm5_next_dsa.py
+++ b/python/sglang/srt/models/glm5_next_dsa.py
@@ -1,0 +1,224 @@
+"""GLM-5-Next's zero-RoPE DSA attention boundary.
+
+Keep the KPool-specific construction out of the shared DeepSeek attention
+class.  This lets GLM opt in to its 4-token pooled index while the existing
+DeepSeek/Kimi models keep their current indexer and checkpoint namespaces.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Dict, Optional
+
+import torch
+
+from sglang.srt.configs.glm5_next import Glm5NextTextConfig
+from sglang.srt.layers.attention.nsa.nsa_indexer_kpool import IndexerKPool
+from sglang.srt.layers.attention.nsa.utils import is_nsa_enable_prefill_cp
+from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.models.deepseek_v2 import DeepseekV2AttentionMLA
+from sglang.srt.utils import add_prefix
+
+
+def is_glm5_next_dsa_config(config: Any) -> bool:
+    """Return whether ``config`` is the canonical GLM-5-Next text config."""
+
+    return isinstance(config, Glm5NextTextConfig) and (
+        getattr(config, "model_type", None) == Glm5NextTextConfig.model_type
+    )
+
+
+def _resolve_config_value(config: Glm5NextTextConfig, name: str, value: Any) -> Any:
+    """Use the canonical config value and reject a divergent factory input."""
+
+    expected = getattr(config, name)
+    if value is None:
+        return expected
+    if value != expected:
+        raise ValueError(f"GLM-5-Next DSA requires {name}={expected!r}, got {value!r}")
+    return value
+
+
+def _validate_glm5_next_dsa_config(config: Glm5NextTextConfig) -> None:
+    if not is_glm5_next_dsa_config(config):
+        raise TypeError(
+            "Glm5NextDSAAttention only accepts Glm5NextTextConfig; "
+            f"got {type(config).__name__}"
+        )
+
+    # These are checkpoint-format invariants, not tunable runtime options.
+    assert config.index_kpool == 4, (
+        f"GLM-5-Next requires index_kpool=4, got {config.index_kpool}"
+    )
+    assert config.index_kpool_compress is True, (
+        "GLM-5-Next requires index_kpool_compress=True"
+    )
+    assert config.index_kpool_always_select_tail is True, (
+        "GLM-5-Next requires index_kpool_always_select_tail=True"
+    )
+
+    if config.index_topk is None or config.index_topk <= 0:
+        raise ValueError("GLM-5-Next DSA requires a positive index_topk")
+    if config.index_topk % config.index_kpool != 0:
+        raise ValueError(
+            "GLM-5-Next index_topk must be divisible by index_kpool, got "
+            f"{config.index_topk} and {config.index_kpool}"
+        )
+    if config.q_lora_rank is None:
+        raise ValueError("GLM-5-Next KPool requires q_lora_rank")
+    if config.qk_rope_head_dim != 0:
+        raise ValueError("GLM-5-Next DSA is zero-RoPE and requires qk_rope_head_dim=0")
+
+    # KPool's CP/MTP and cross-layer top-k reuse contracts are deliberately
+    # not enabled yet.  Refuse those modes instead of silently entering the
+    # generic DeepSeek paths with a wider (index_topk + 3) index tensor.
+    if config.index_topk_freq != 1:
+        raise ValueError("GLM-5-Next KPool does not support index_topk_freq != 1")
+    if config.index_topk_pattern is not None:
+        raise ValueError("GLM-5-Next KPool does not support index_topk_pattern")
+    if config.index_skip_topk_offset is not None:
+        raise ValueError("GLM-5-Next KPool does not support index_skip_topk_offset")
+    if config.index_share_for_mtp_iteration is not False:
+        raise ValueError("GLM-5-Next KPool does not support index sharing for MTP")
+
+
+class Glm5NextDSAAttention(DeepseekV2AttentionMLA):
+    """DeepSeek MLA tensor layout with GLM's KPool4 DSA indexer."""
+
+    def _fuse_rope_for_trtllm_mla(self, forward_batch) -> bool:
+        """Keep zero-RoPE GLM out of the base fused-RoPE metadata path.
+
+        The KT DeepSeek base enables fused RoPE whenever the NSA TRTLLM
+        backend stores FP8 KV.  GLM deliberately has no rotary embedding, so
+        that generic branch would dereference ``self.rotary_emb`` even though
+        the query/key RoPE width is zero.  Returning false still lets the NSA
+        backend quantize the native 512-wide latent cache; it only suppresses
+        nonexistent cosine/sine metadata.
+        """
+
+        del forward_batch
+        return False
+
+    def __init__(
+        self,
+        config: Glm5NextTextConfig,
+        hidden_size: Optional[int] = None,
+        num_heads: Optional[int] = None,
+        qk_nope_head_dim: Optional[int] = None,
+        qk_rope_head_dim: Optional[int] = None,
+        v_head_dim: Optional[int] = None,
+        q_lora_rank: Optional[int] = None,
+        kv_lora_rank: Optional[int] = None,
+        rope_theta: Optional[float] = None,
+        rope_scaling: Optional[Dict[str, Any]] = None,
+        max_position_embeddings: Optional[int] = None,
+        quant_config: Optional[QuantizationConfig] = None,
+        reduce_results: bool = True,
+        layer_id: Optional[int] = None,
+        prefix: str = "",
+        alt_stream: Optional[torch.cuda.Stream] = None,
+        skip_rope: bool = True,
+        is_nextn: bool = False,
+    ) -> None:
+        _validate_glm5_next_dsa_config(config)
+        if is_nsa_enable_prefill_cp():
+            raise NotImplementedError(
+                "GLM-5-Next KPool does not support NSA prefill context parallel"
+            )
+        if is_nextn:
+            raise NotImplementedError("GLM-5-Next KPool does not support MTP layers")
+        if not skip_rope:
+            raise ValueError("GLM-5-Next DSA requires skip_rope=True")
+        if layer_id is None:
+            raise ValueError("GLM-5-Next DSA requires a concrete layer_id")
+
+        hidden_size = _resolve_config_value(config, "hidden_size", hidden_size)
+        num_heads = _resolve_config_value(config, "num_attention_heads", num_heads)
+        qk_nope_head_dim = _resolve_config_value(
+            config, "qk_nope_head_dim", qk_nope_head_dim
+        )
+        qk_rope_head_dim = _resolve_config_value(
+            config, "qk_rope_head_dim", qk_rope_head_dim
+        )
+        v_head_dim = _resolve_config_value(config, "v_head_dim", v_head_dim)
+        q_lora_rank = _resolve_config_value(config, "q_lora_rank", q_lora_rank)
+        kv_lora_rank = _resolve_config_value(config, "kv_lora_rank", kv_lora_rank)
+        rope_theta = _resolve_config_value(config, "rope_theta", rope_theta)
+        max_position_embeddings = _resolve_config_value(
+            config, "max_position_embeddings", max_position_embeddings
+        )
+        if rope_scaling is None:
+            rope_scaling = config.rope_scaling
+        elif rope_scaling != config.rope_scaling:
+            raise ValueError("GLM-5-Next DSA rope_scaling must match the text config")
+
+        # The subclass owns indexer construction.  Suppress the generic NSA
+        # branch without mutating the real text config or allocating a
+        # temporary DeepSeek Indexer; every other base forward dependency is
+        # still initialized by DeepseekV2AttentionMLA.
+        base_config = copy.copy(config)
+        base_config.index_topk = None
+        base_rope_scaling = copy.deepcopy(rope_scaling)
+        super().__init__(
+            config=base_config,
+            hidden_size=hidden_size,
+            num_heads=num_heads,
+            qk_nope_head_dim=qk_nope_head_dim,
+            qk_rope_head_dim=qk_rope_head_dim,
+            v_head_dim=v_head_dim,
+            q_lora_rank=q_lora_rank,
+            kv_lora_rank=kv_lora_rank,
+            rope_theta=rope_theta,
+            rope_scaling=base_rope_scaling,
+            max_position_embeddings=max_position_embeddings,
+            quant_config=quant_config,
+            reduce_results=reduce_results,
+            layer_id=layer_id,
+            prefix=prefix,
+            alt_stream=alt_stream,
+            skip_rope=True,
+            is_nextn=False,
+        )
+
+        self.config = config
+        self.use_nsa = True
+        self.nsa_enable_prefill_cp = False
+        self.is_nextn = False
+        self.skip_rope = True
+        self.rotary_emb = None
+
+        # GLM computes top-k independently in every DSA layer.  Keeping these
+        # attributes explicit is required by the inherited absorb forward.
+        self.index_topk_freq = 1
+        self.index_topk_pattern = None
+        self.index_skip_topk_offset = None
+        self.skip_topk = False
+        self.next_skip_topk = False
+
+        self.indexer = IndexerKPool(
+            hidden_size=hidden_size,
+            index_n_heads=config.index_n_heads,
+            index_head_dim=config.index_head_dim,
+            rope_head_dim=qk_rope_head_dim,
+            index_topk=config.index_topk,
+            q_lora_rank=q_lora_rank,
+            max_position_embeddings=max_position_embeddings,
+            rope_theta=rope_theta,
+            scale_fmt="ue8m0",
+            block_size=128,
+            rope_scaling=copy.deepcopy(rope_scaling),
+            is_neox_style=not config.indexer_rope_interleave,
+            prefix=add_prefix("indexer", prefix),
+            quant_config=quant_config,
+            layer_id=layer_id,
+            alt_stream=alt_stream,
+            skip_rope=True,
+            config=config,
+        )
+
+        # KPool always reserves three tail slots in addition to the 2048
+        # pooled-history choices in the released GLM config.
+        self.index_topk_output_width = config.index_topk + config.index_kpool - 1
+
+
+__all__ = ["Glm5NextDSAAttention", "is_glm5_next_dsa_config"]

--- a/python/sglang/srt/models/glm5_next_dsa.py
+++ b/python/sglang/srt/models/glm5_next_dsa.py
@@ -17,6 +17,7 @@ from sglang.srt.layers.attention.nsa.nsa_indexer_kpool import IndexerKPool
 from sglang.srt.layers.attention.nsa.utils import is_nsa_enable_prefill_cp
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.models.deepseek_v2 import DeepseekV2AttentionMLA
+from sglang.srt.models.glm5_next_norm import Glm5NextRMSNorm
 from sglang.srt.utils import add_prefix
 
 
@@ -181,6 +182,17 @@ class Glm5NextDSAAttention(DeepseekV2AttentionMLA):
         )
 
         self.config = config
+        # The inherited DeepSeek modules use the shared optimized RMSNorm,
+        # whose CUDA path rounds after the weight multiply.  GLM's checkpoint
+        # semantics round the normalized activation to BF16 first.  Replace
+        # only these two model-local latent norms before weight loading; their
+        # parameter names remain q_a_layernorm/kv_a_layernorm.
+        self.q_a_layernorm = Glm5NextRMSNorm(
+            q_lora_rank, eps=config.rms_norm_eps
+        )
+        self.kv_a_layernorm = Glm5NextRMSNorm(
+            kv_lora_rank, eps=config.rms_norm_eps
+        )
         self.use_nsa = True
         self.nsa_enable_prefill_cp = False
         self.is_nextn = False

--- a/python/sglang/srt/models/glm5_next_moe.py
+++ b/python/sglang/srt/models/glm5_next_moe.py
@@ -39,47 +39,34 @@ def glm5_next_swiglu(
         limit = float(swiglu_limit)
         gate = gate.clamp(max=limit)
         up = up.clamp(min=-limit, max=limit)
-    return F.silu(gate) * up
+    # Keep the activation as a named tensor.  For BF16 checkpoints this is a
+    # real model semantic: Transformers materializes the BF16 SiLU result
+    # before the BF16 multiply.  The generic fused CUDA kernel computes both
+    # operations in FP32 and rounds only once, which measurably changes GLM's
+    # hidden states even when given identical inputs.
+    activated_gate = F.silu(gate)
+    return activated_gate * up
 
 
 class Glm5NextSiluAndMul(nn.Module):
-    """Clamp-aware SwiGLU with the existing KT CUDA kernel as its fast path."""
+    """Clamp-aware SwiGLU preserving GLM's BF16 intermediate rounding."""
 
     def __init__(self, swiglu_limit: Optional[float]) -> None:
         super().__init__()
         self.swiglu_limit = swiglu_limit
 
     def forward(self, gate_up: torch.Tensor) -> torch.Tensor:
-        if gate_up.shape[-1] % 2 != 0:
-            raise ValueError(
-                "GLM-5-Next SwiGLU expects an even gate/up width, got "
-                f"{gate_up.shape[-1]}"
-            )
-
-        # The in-tree JIT kernel is NVIDIA-only and currently instantiates
-        # kernels for fp16/bf16.  Keep CPU, ROCm, and unusual dtypes on the
-        # device-agnostic reference path instead of importing CUDA code at
-        # module import time.
-        use_cuda_kernel = (
-            self.swiglu_limit is not None
-            and gate_up.is_cuda
-            and torch.version.hip is None
-            and gate_up.dtype in (torch.float16, torch.bfloat16)
-        )
-        if not use_cuda_kernel:
+        if not gate_up.is_cuda:
             return glm5_next_swiglu(gate_up, self.swiglu_limit)
 
-        from sglang.jit_kernel.deepseek_v4 import silu_and_mul_clamp
-
-        original_shape = gate_up.shape
-        gate_up_2d = gate_up.reshape(-1, original_shape[-1])
-        output_2d = gate_up.new_empty((gate_up_2d.shape[0], gate_up_2d.shape[1] // 2))
-        silu_and_mul_clamp(
-            gate_up_2d,
-            output_2d,
-            float(self.swiglu_limit),
+        from sglang.srt.layers.moe.glm5_next_swiglu import (
+            glm5_next_hf_two_round_swiglu,
         )
-        return output_2d.view(*original_shape[:-1], original_shape[-1] // 2)
+
+        # Dense and non-fused shared experts use the same private primitive as
+        # routed experts.  It materializes HF's BF16 SiLU boundary while
+        # leaving every generic activation kernel unchanged.
+        return glm5_next_hf_two_round_swiglu(gate_up, self.swiglu_limit)
 
 
 class Glm5NextMLP(DeepseekV2MLP):
@@ -146,6 +133,7 @@ class Glm5NextMoE(DeepseekV2MoE):
             prefix=prefix,
             alt_stream=alt_stream,
             is_nextn=is_nextn,
+            glm5_next_hf_two_round_swiglu=True,
         )
         self.layer_idx = layer_id
         self.swiglu_limit = getattr(config, "swiglu_limit", None)
@@ -204,7 +192,43 @@ class Glm5NextMoE(DeepseekV2MoE):
                 "sgl_kernel.fused_experts_cpu and sgl_kernel.shared_expert_cpu; "
                 "their current AMX ABI has no swiglu_limit argument"
             )
-        return super().forward(hidden_states, *args, **kwargs)
+
+        # DeepseekV2MoE.forward does not pass ForwardBatch through its normal
+        # (non-A2A) dispatcher ABI.  Expose only the mode, temporarily and only
+        # to the exact GLM KT wrapper, so it can route plain EXTEND through the
+        # required layerwise pipeline while CUDA-graph DECODE/IDLE bypass it.
+        quant_method = getattr(self.experts, "quant_method", None)
+        kt_config = getattr(quant_method, "kt_config", None)
+        layerwise_required = (
+            kt_config is not None
+            and bool(getattr(kt_config, "is_glm5_next", False))
+            and (getattr(kt_config, "method", "") or "").upper() == "FP8"
+            and (getattr(kt_config, "gpu_prefill_token_threshold", 0) or 0) > 0
+        )
+        if not layerwise_required:
+            return super().forward(hidden_states, *args, **kwargs)
+
+        forward_batch = kwargs.get("forward_batch")
+        if forward_batch is None and args:
+            forward_batch = args[0]
+        if forward_batch is None or not hasattr(forward_batch, "forward_mode"):
+            raise RuntimeError(
+                "GLM-5-Next required FP8 layerwise routing needs "
+                "ForwardBatch.forward_mode"
+            )
+
+        missing = object()
+        previous_mode = getattr(
+            quant_method, "_glm5_next_forward_mode", missing
+        )
+        quant_method._glm5_next_forward_mode = forward_batch.forward_mode
+        try:
+            return super().forward(hidden_states, *args, **kwargs)
+        finally:
+            if previous_mode is missing:
+                delattr(quant_method, "_glm5_next_forward_mode")
+            else:
+                quant_method._glm5_next_forward_mode = previous_mode
 
 
 __all__ = [

--- a/python/sglang/srt/models/glm5_next_moe.py
+++ b/python/sglang/srt/models/glm5_next_moe.py
@@ -226,9 +226,15 @@ class Glm5NextMoE(DeepseekV2MoE):
         previous_image_marker = getattr(
             quant_method, "_glm5_next_has_image_inputs", missing
         )
+        previous_hybrid_marker = getattr(
+            quant_method, "_glm5_next_force_hybrid_prefill", missing
+        )
         quant_method._glm5_next_forward_mode = forward_batch.forward_mode
         quant_method._glm5_next_has_image_inputs = bool(
             getattr(forward_batch, "glm5_next_has_image_inputs", False)
+        )
+        quant_method._glm5_next_force_hybrid_prefill = bool(
+            getattr(forward_batch, "glm5_next_force_hybrid_prefill", False)
         )
         try:
             return super().forward(hidden_states, *args, **kwargs)
@@ -241,6 +247,10 @@ class Glm5NextMoE(DeepseekV2MoE):
                 delattr(quant_method, "_glm5_next_has_image_inputs")
             else:
                 quant_method._glm5_next_has_image_inputs = previous_image_marker
+            if previous_hybrid_marker is missing:
+                delattr(quant_method, "_glm5_next_force_hybrid_prefill")
+            else:
+                quant_method._glm5_next_force_hybrid_prefill = previous_hybrid_marker
 
 
 __all__ = [

--- a/python/sglang/srt/models/glm5_next_moe.py
+++ b/python/sglang/srt/models/glm5_next_moe.py
@@ -1,0 +1,215 @@
+"""GLM-5-Next MLP and MoE specializations.
+
+GLM-5-Next uses the DeepSeek-style packed MLP/checkpoint layout, but its
+SwiGLU activation clamps the gate and up projections *before* applying SiLU.
+Keeping that small semantic difference here lets the model reuse the mature
+DeepSeek TP/EP, FP8, shared-expert, and weight-loading paths without changing
+their behavior for existing models.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.models.deepseek_v2 import DeepseekV2MLP, DeepseekV2MoE
+
+
+def glm5_next_swiglu(
+    gate_up: torch.Tensor, swiglu_limit: Optional[float]
+) -> torch.Tensor:
+    """Reference GLM-5-Next SwiGLU, usable on every torch device.
+
+    The checkpoint contract is ``silu(min(gate, limit)) * clamp(up, -limit,
+    limit)``.  In particular, the gate has no lower clamp and the clamp is
+    applied before SiLU.  ``None`` retains ordinary SwiGLU semantics.
+    """
+
+    if gate_up.shape[-1] % 2 != 0:
+        raise ValueError(
+            f"GLM-5-Next SwiGLU expects an even gate/up width, got {gate_up.shape[-1]}"
+        )
+
+    gate, up = gate_up.chunk(2, dim=-1)
+    if swiglu_limit is not None:
+        limit = float(swiglu_limit)
+        gate = gate.clamp(max=limit)
+        up = up.clamp(min=-limit, max=limit)
+    return F.silu(gate) * up
+
+
+class Glm5NextSiluAndMul(nn.Module):
+    """Clamp-aware SwiGLU with the existing KT CUDA kernel as its fast path."""
+
+    def __init__(self, swiglu_limit: Optional[float]) -> None:
+        super().__init__()
+        self.swiglu_limit = swiglu_limit
+
+    def forward(self, gate_up: torch.Tensor) -> torch.Tensor:
+        if gate_up.shape[-1] % 2 != 0:
+            raise ValueError(
+                "GLM-5-Next SwiGLU expects an even gate/up width, got "
+                f"{gate_up.shape[-1]}"
+            )
+
+        # The in-tree JIT kernel is NVIDIA-only and currently instantiates
+        # kernels for fp16/bf16.  Keep CPU, ROCm, and unusual dtypes on the
+        # device-agnostic reference path instead of importing CUDA code at
+        # module import time.
+        use_cuda_kernel = (
+            self.swiglu_limit is not None
+            and gate_up.is_cuda
+            and torch.version.hip is None
+            and gate_up.dtype in (torch.float16, torch.bfloat16)
+        )
+        if not use_cuda_kernel:
+            return glm5_next_swiglu(gate_up, self.swiglu_limit)
+
+        from sglang.jit_kernel.deepseek_v4 import silu_and_mul_clamp
+
+        original_shape = gate_up.shape
+        gate_up_2d = gate_up.reshape(-1, original_shape[-1])
+        output_2d = gate_up.new_empty((gate_up_2d.shape[0], gate_up_2d.shape[1] // 2))
+        silu_and_mul_clamp(
+            gate_up_2d,
+            output_2d,
+            float(self.swiglu_limit),
+        )
+        return output_2d.view(*original_shape[:-1], original_shape[-1] // 2)
+
+
+class Glm5NextMLP(DeepseekV2MLP):
+    """DeepSeek packed/parallel MLP with GLM's clamp-aware activation."""
+
+    def __init__(
+        self,
+        hidden_size: int,
+        intermediate_size: int,
+        hidden_act: str,
+        quant_config: Optional[QuantizationConfig] = None,
+        reduce_results: bool = True,
+        prefix: str = "",
+        tp_rank: Optional[int] = None,
+        tp_size: Optional[int] = None,
+        swiglu_limit: Optional[float] = None,
+    ) -> None:
+        super().__init__(
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            hidden_act=hidden_act,
+            quant_config=quant_config,
+            reduce_results=reduce_results,
+            prefix=prefix,
+            tp_rank=tp_rank,
+            tp_size=tp_size,
+        )
+        self.swiglu_limit = swiglu_limit
+        self.act_fn = Glm5NextSiluAndMul(swiglu_limit)
+
+
+class Glm5NextMoE(DeepseekV2MoE):
+    """GLM routing/activation semantics on the existing DeepSeek MoE stack.
+
+    ``layer_idx`` is accepted as a compatibility alias for the current GLM
+    decoder factory; upstream-style callers can use ``layer_id``.
+    """
+
+    def __init__(
+        self,
+        config,
+        layer_id: Optional[int] = None,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+        alt_stream: Optional[torch.cuda.Stream] = None,
+        is_nextn: bool = False,
+        *,
+        layer_idx: Optional[int] = None,
+    ) -> None:
+        if layer_id is None:
+            layer_id = layer_idx
+        elif layer_idx is not None and layer_idx != layer_id:
+            raise ValueError(
+                f"Conflicting GLM MoE layer ids: layer_id={layer_id}, "
+                f"layer_idx={layer_idx}"
+            )
+        if layer_id is None:
+            raise TypeError("Glm5NextMoE requires layer_id (or layer_idx)")
+
+        super().__init__(
+            config=config,
+            layer_id=layer_id,
+            quant_config=quant_config,
+            prefix=prefix,
+            alt_stream=alt_stream,
+            is_nextn=is_nextn,
+        )
+        self.layer_idx = layer_id
+        self.swiglu_limit = getattr(config, "swiglu_limit", None)
+        self._validate_kt_cpu_expert_activation()
+
+        # Official GLM uses grouped noaux_tc routing even when n_group and
+        # topk_group are both one.  The target DeepSeek base otherwise changes
+        # this to the ungrouped path for 1/1, so restore the exact contract in
+        # the model-local subclass.
+        if not self.is_hash:
+            self.use_grouped_topk = True
+            self.topk.topk_config.use_grouped_topk = True
+
+        # Routed (and fused shared) experts already receive swiglu_limit from
+        # DeepseekV2MoE.  Only the non-fused shared-expert MLP needs its
+        # activation specialized; its projections, prefixes, FP8 state, and TP
+        # settings remain untouched.
+        if hasattr(self, "shared_experts"):
+            self.shared_experts.swiglu_limit = self.swiglu_limit
+            self.shared_experts.act_fn = Glm5NextSiluAndMul(self.swiglu_limit)
+
+    def _validate_kt_cpu_expert_activation(self) -> None:
+        """Reject KT CPU formats whose kernel ABI discards swiglu_limit."""
+
+        if self.swiglu_limit is None:
+            return
+        quant_method = getattr(self.experts, "quant_method", None)
+        kt_config = getattr(quant_method, "kt_config", None)
+        if kt_config is None:
+            return
+
+        method = (getattr(kt_config, "method", None) or "").upper()
+        gpu_experts_mask = getattr(quant_method, "gpu_experts_mask", None)
+        if gpu_experts_mask is not None:
+            if isinstance(gpu_experts_mask, torch.Tensor):
+                all_experts_on_gpu = bool(gpu_experts_mask.all().item())
+            else:
+                all_experts_on_gpu = all(bool(value) for value in gpu_experts_mask)
+            if all_experts_on_gpu:
+                return
+
+        if method == "FP8":
+            return
+
+        raise NotImplementedError(
+            "GLM-5-Next KT CPU experts require --kt-method FP8 for the "
+            "checkpoint's block-E4M3 weights and FP32 [128, 128] scales; "
+            f"the current {method or 'unspecified'} KT kernel discards "
+            "swiglu_limit and would produce incorrect activations"
+        )
+
+    def forward(self, hidden_states: torch.Tensor, *args, **kwargs) -> torch.Tensor:
+        if hidden_states.device.type == "cpu" and self.swiglu_limit is not None:
+            raise NotImplementedError(
+                "GLM-5-Next CPU MoE requires clamp-before-SiLU support in both "
+                "sgl_kernel.fused_experts_cpu and sgl_kernel.shared_expert_cpu; "
+                "their current AMX ABI has no swiglu_limit argument"
+            )
+        return super().forward(hidden_states, *args, **kwargs)
+
+
+__all__ = [
+    "Glm5NextMLP",
+    "Glm5NextMoE",
+    "Glm5NextSiluAndMul",
+    "glm5_next_swiglu",
+]

--- a/python/sglang/srt/models/glm5_next_moe.py
+++ b/python/sglang/srt/models/glm5_next_moe.py
@@ -194,9 +194,11 @@ class Glm5NextMoE(DeepseekV2MoE):
             )
 
         # DeepseekV2MoE.forward does not pass ForwardBatch through its normal
-        # (non-A2A) dispatcher ABI.  Expose only the mode, temporarily and only
-        # to the exact GLM KT wrapper, so it can route plain EXTEND through the
-        # required layerwise pipeline while CUDA-graph DECODE/IDLE bypass it.
+        # (non-A2A) dispatcher ABI.  Expose only the mode and the exact GLM
+        # image marker, temporarily and only to the KT wrapper.  Text EXTEND
+        # uses the required layerwise pipeline, while image EXTEND deliberately
+        # uses the existing CPU/hybrid path and CUDA-graph DECODE/IDLE bypasses
+        # both prefill routes.
         quant_method = getattr(self.experts, "quant_method", None)
         kt_config = getattr(quant_method, "kt_config", None)
         layerwise_required = (
@@ -221,7 +223,13 @@ class Glm5NextMoE(DeepseekV2MoE):
         previous_mode = getattr(
             quant_method, "_glm5_next_forward_mode", missing
         )
+        previous_image_marker = getattr(
+            quant_method, "_glm5_next_has_image_inputs", missing
+        )
         quant_method._glm5_next_forward_mode = forward_batch.forward_mode
+        quant_method._glm5_next_has_image_inputs = bool(
+            getattr(forward_batch, "glm5_next_has_image_inputs", False)
+        )
         try:
             return super().forward(hidden_states, *args, **kwargs)
         finally:
@@ -229,6 +237,10 @@ class Glm5NextMoE(DeepseekV2MoE):
                 delattr(quant_method, "_glm5_next_forward_mode")
             else:
                 quant_method._glm5_next_forward_mode = previous_mode
+            if previous_image_marker is missing:
+                delattr(quant_method, "_glm5_next_has_image_inputs")
+            else:
+                quant_method._glm5_next_has_image_inputs = previous_image_marker
 
 
 __all__ = [

--- a/python/sglang/srt/models/glm5_next_norm.py
+++ b/python/sglang/srt/models/glm5_next_norm.py
@@ -1,0 +1,32 @@
+"""GLM-5-Next checkpoint-native RMSNorm arithmetic."""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+
+class Glm5NextRMSNorm(nn.Module):
+    """Apply the exact BF16 rounding boundary used by the released model.
+
+    The checkpoint implementation casts the FP32-normalized activation back
+    to the model dtype before multiplying by the learned weight.  SGLang's
+    shared optimized RMSNorm multiplies first and casts the product, which is
+    a real BF16 numerical difference.  This implementation stays GLM-local so
+    existing KT model paths retain their established numerics.
+    """
+
+    def __init__(self, hidden_size: int, eps: float = 1e-6) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.variance_epsilon = eps
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        input_dtype = hidden_states.dtype
+        hidden_states_fp32 = hidden_states.to(torch.float32)
+        variance = hidden_states_fp32.pow(2).mean(-1, keepdim=True)
+        normalized = hidden_states_fp32 * torch.rsqrt(variance + self.variance_epsilon)
+        return self.weight * normalized.to(input_dtype)
+
+
+__all__ = ["Glm5NextRMSNorm"]

--- a/python/sglang/srt/models/glm_ocr.py
+++ b/python/sglang/srt/models/glm_ocr.py
@@ -154,6 +154,8 @@ class GlmOcrVisionModel(Glm4vVisionModel):
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
         use_data_parallel: bool = False,
+        num_dummy_heads: int = 0,
+        merger_context_dim: Optional[int] = None,
     ) -> None:
         super().__init__(vision_config, quant_config, prefix, use_data_parallel)
 
@@ -196,14 +198,23 @@ class GlmOcrVisionModel(Glm4vVisionModel):
                     prefix=add_prefix(f"blocks.{layer_idx}", prefix),
                     rms_norm_eps=vision_config.rms_norm_eps,
                     attn_qkv_bias=vision_config.attention_bias,
+                    # Keep the shared GLM-OCR constructor's historical
+                    # behavior.  Exact GLM5 passes this explicitly after its
+                    # TP-aware config update, so a reused/mutated GLM-OCR
+                    # config cannot accidentally change old-model behavior.
+                    num_dummy_heads=num_dummy_heads,
                     use_data_parallel=use_data_parallel,
                 )
                 for layer_idx in range(depth)
             ]
         )
+        if merger_context_dim is None:
+            merger_context_dim = (
+                vision_config.out_hidden_size * vision_config.in_channels
+            )
         self.merger = GlmOcrVisionPatchMerger(
             d_model=vision_config.out_hidden_size,
-            context_dim=vision_config.out_hidden_size * vision_config.in_channels,
+            context_dim=merger_context_dim,
             quant_config=quant_config,
             bias=False,
             prefix=add_prefix("merger", prefix),

--- a/python/sglang/srt/multimodal/processors/glm5_next.py
+++ b/python/sglang/srt/multimodal/processors/glm5_next.py
@@ -1,213 +1,52 @@
-"""Self-contained image processor for GLM-5-Next.
+"""Strict image/video request adapter for GLM-5-Next.
 
-The pinned transformers-kt wheel has the reusable GLM-4.6V tokenizer and
-patchifier, but it does not register the checkpoint's Glmga image processor.
-Keep the small GLM-5 resize difference here instead of requiring a patched
-Transformers checkout at runtime.
+The checkpoint processor lives in transformers-kt.  SGLang owns only the
+request boundary, scheduler metadata, and the invariants needed by its vision
+embedding path; patchification and temporal sampling have one source of truth.
 """
 
 from __future__ import annotations
 
-from typing import Any
+import base64
+import binascii
+import os
+import tempfile
+from contextlib import contextmanager
+from urllib.parse import unquote, urlparse
 
+import requests
 import torch
-from transformers.image_transforms import group_images_by_shape, reorder_images
-from transformers.image_utils import SizeDict
-from transformers.models.glm46v.image_processing_glm46v import (
-    Glm46VImageProcessor,
-    smart_resize,
+from transformers.models.glm5_next.image_processing_glm5_next import (
+    Glm5NextImageProcessor,
 )
-from transformers.models.glm46v.processing_glm46v import Glm46VProcessor
+from transformers.models.glm5_next.processing_glm5_next import Glm5NextProcessor
+from transformers.models.glm5_next.video_processing_glm5_next import (
+    Glm5NextVideoProcessor,
+)
 
 from sglang.srt.layers.rotary_embedding import MRotaryEmbedding
 from sglang.srt.models.glm5_next import Glm5NextForConditionalGeneration
-from sglang.srt.multimodal.processors.base_processor import MultimodalSpecialTokens
+from sglang.srt.multimodal.processors.base_processor import (
+    BaseMultiModalProcessorOutput,
+    MultimodalSpecialTokens,
+)
 from sglang.srt.multimodal.processors.glm4v import Glm4vImageProcessor
 
 
 GLM5_NEXT_MIN_PIXELS = 12_544
-GLM5_NEXT_DEFAULT_MAX_PIXELS = 1_254_400
-GLM5_NEXT_CHECKPOINT_MAX_PIXELS = 9_633_792
-GLM5_NEXT_PATCH_EXPAND_FACTOR = 2
-_GLM5_NEXT_IMAGE_CONFIG_KEYS = frozenset(
-    {
-        "do_rescale",
-        "image_mean",
-        "image_processor_type",
-        "image_std",
-        "merge_size",
-        "patch_size",
-        "patch_expand_factor",
-        "size",
-        "temporal_patch_size",
-    }
-)
-_GLM5_NEXT_IMAGE_CONFIG_VALUES = {
-    "do_rescale": True,
-    "image_mean": [0.48145466, 0.4578275, 0.40821073],
-    "image_processor_type": "GlmgaImageProcessor",
-    "image_std": [0.26862954, 0.26130258, 0.27577711],
-    "merge_size": 2,
-    "patch_size": 14,
-    "patch_expand_factor": GLM5_NEXT_PATCH_EXPAND_FACTOR,
-    "temporal_patch_size": 2,
-}
-
-
-class Glm5NextImageProcessor(Glm46VImageProcessor):
-    """GLM-4.6V patchification with GLM-5's expanded resize factor."""
-
-    size = {
-        "shortest_edge": GLM5_NEXT_MIN_PIXELS,
-        "longest_edge": GLM5_NEXT_DEFAULT_MAX_PIXELS,
-    }
-    patch_expand_factor = GLM5_NEXT_PATCH_EXPAND_FACTOR
-
-    def __init__(self, patch_expand_factor: int = 2, **kwargs) -> None:
-        if patch_expand_factor != GLM5_NEXT_PATCH_EXPAND_FACTOR:
-            raise ValueError(
-                "GLM-5-Next requires patch_expand_factor=2; "
-                f"got {patch_expand_factor!r}."
-            )
-        self.patch_expand_factor = patch_expand_factor
-        super().__init__(**kwargs)
-
-    @classmethod
-    def from_checkpoint_config(cls, image_config: dict[str, Any]):
-        config = dict(image_config)
-        actual_keys = set(config)
-        missing_keys = sorted(_GLM5_NEXT_IMAGE_CONFIG_KEYS - actual_keys)
-        unknown_keys = sorted(actual_keys - _GLM5_NEXT_IMAGE_CONFIG_KEYS)
-        if missing_keys or unknown_keys:
-            raise ValueError(
-                "GLM-5-Next pinned image processor metadata keys changed: "
-                f"missing={missing_keys}, unknown={unknown_keys}."
-            )
-        for key, expected in _GLM5_NEXT_IMAGE_CONFIG_VALUES.items():
-            actual = config[key]
-            if actual != expected:
-                raise ValueError(
-                    f"GLM-5-Next pinned processor requires {key}={expected!r}; "
-                    f"got {actual!r}."
-                )
-
-        checkpoint_size = config["size"]
-        if not isinstance(checkpoint_size, dict) or checkpoint_size != {
-            "shortest_edge": GLM5_NEXT_MIN_PIXELS,
-            "longest_edge": GLM5_NEXT_CHECKPOINT_MAX_PIXELS,
-        }:
-            raise ValueError(
-                "GLM-5-Next checkpoint processor size metadata changed: "
-                f"got {checkpoint_size!r}."
-            )
-        config.pop("image_processor_type")
-        config["size"] = {
-            "shortest_edge": GLM5_NEXT_MIN_PIXELS,
-            "longest_edge": GLM5_NEXT_DEFAULT_MAX_PIXELS,
-        }
-        return cls(**config)
-
-    def _preprocess(
-        self,
-        images,
-        do_resize,
-        size,
-        resample,
-        do_rescale,
-        rescale_factor,
-        do_normalize,
-        image_mean,
-        image_std,
-        patch_size,
-        temporal_patch_size,
-        merge_size,
-        disable_grouping,
-        return_tensors,
-        **kwargs,
-    ):
-        if do_resize:
-            grouped_images, grouped_images_index = group_images_by_shape(
-                images, disable_grouping=disable_grouping
-            )
-            resized_images_grouped = {}
-            for shape, stacked_images in grouped_images.items():
-                height, width = stacked_images.shape[-2:]
-                resized_height, resized_width = smart_resize(
-                    num_frames=temporal_patch_size,
-                    height=height,
-                    width=width,
-                    temporal_factor=temporal_patch_size,
-                    factor=patch_size * merge_size * self.patch_expand_factor,
-                    min_pixels=size.shortest_edge,
-                    max_pixels=size.longest_edge,
-                )
-                resized_images_grouped[shape] = self.resize(
-                    stacked_images,
-                    size=SizeDict(height=resized_height, width=resized_width),
-                    resample=resample,
-                )
-            images = reorder_images(resized_images_grouped, grouped_images_index)
-
-        return super()._preprocess(
-            images=images,
-            do_resize=False,
-            size=size,
-            resample=resample,
-            do_rescale=do_rescale,
-            rescale_factor=rescale_factor,
-            do_normalize=do_normalize,
-            image_mean=image_mean,
-            image_std=image_std,
-            patch_size=patch_size,
-            temporal_patch_size=temporal_patch_size,
-            merge_size=merge_size,
-            disable_grouping=disable_grouping,
-            return_tensors=return_tensors,
-            **kwargs,
-        )
-
-    def get_number_of_image_patches(
-        self, height: int, width: int, images_kwargs=None
-    ) -> int:
-        images_kwargs = images_kwargs or {}
-        patch_size = images_kwargs.get("patch_size", self.patch_size)
-        merge_size = images_kwargs.get("merge_size", self.merge_size)
-        size = images_kwargs.get("size", self.size)
-        min_pixels = (
-            size["shortest_edge"] if isinstance(size, dict) else size.shortest_edge
-        )
-        max_pixels = (
-            size["longest_edge"] if isinstance(size, dict) else size.longest_edge
-        )
-        resized_height, resized_width = smart_resize(
-            num_frames=self.temporal_patch_size,
-            height=height,
-            width=width,
-            temporal_factor=self.temporal_patch_size,
-            factor=patch_size * merge_size * self.patch_expand_factor,
-            min_pixels=min_pixels,
-            max_pixels=max_pixels,
-        )
-        return (resized_height // patch_size) * (resized_width // patch_size)
-
-
-class Glm5NextProcessor(Glm46VProcessor):
-    """Image-only facade over the pinned GLM-4.6V token expansion logic."""
-
-    def __call__(self, images=None, text=None, videos=None, **kwargs):
-        if videos is not None:
-            raise ValueError("GLM-5-Next Session D does not support video input.")
-        return super().__call__(images=images, text=text, videos=None, **kwargs)
+GLM5_NEXT_DEFAULT_MAX_PIXELS = 8000 * 14**2 * 2**2
+GLM5_NEXT_CHECKPOINT_MAX_PIXELS = GLM5_NEXT_DEFAULT_MAX_PIXELS
+GLM5_NEXT_PATCH_EXPAND_FACTOR = 1
 
 
 class Glm5NextSGLangProcessor(Glm4vImageProcessor):
-    """Strict image-only request adapter registered only for GLM-5-Next."""
+    """Strict text+images or text+one-video adapter for GLM-5-Next."""
 
     models = [Glm5NextForConditionalGeneration]
 
     def __init__(self, hf_config, server_args, _processor, *args, **kwargs):
         super().__init__(hf_config, server_args, _processor, *args, **kwargs)
-        self.IMAGE_FACTOR = 56
+        self.IMAGE_FACTOR = 28
         self.MIN_PIXELS = GLM5_NEXT_MIN_PIXELS
         self.MAX_PIXELS = self._resolve_max_pixels(server_args.mm_process_config)
 
@@ -217,6 +56,11 @@ class Glm5NextSGLangProcessor(Glm4vImageProcessor):
                 "GLM-5-Next requires the built-in Glm5NextImageProcessor; "
                 f"got {type(image_processor).__name__}."
             )
+        if image_processor.patch_expand_factor != GLM5_NEXT_PATCH_EXPAND_FACTOR:
+            raise ValueError(
+                "GLM-5-Next requires image patch_expand_factor=1; "
+                f"got {image_processor.patch_expand_factor!r}."
+            )
         if isinstance(image_processor.size, dict):
             image_processor.size["shortest_edge"] = self.MIN_PIXELS
             image_processor.size["longest_edge"] = self.MAX_PIXELS
@@ -224,11 +68,30 @@ class Glm5NextSGLangProcessor(Glm4vImageProcessor):
             image_processor.size.shortest_edge = self.MIN_PIXELS
             image_processor.size.longest_edge = self.MAX_PIXELS
 
-        # Rebuild after the GLM4V initializer so only the image modality is
-        # advertised by this exact-model processor.
+        video_processor = getattr(_processor, "video_processor", None)
+        if not isinstance(video_processor, Glm5NextVideoProcessor):
+            raise TypeError(
+                "GLM-5-Next requires Glm5NextVideoProcessor; "
+                f"got {type(video_processor).__name__}."
+            )
+        if video_processor.patch_expand_factor != GLM5_NEXT_PATCH_EXPAND_FACTOR:
+            raise ValueError(
+                "GLM-5-Next requires video patch_expand_factor=1; "
+                f"got {video_processor.patch_expand_factor!r}."
+            )
+        if video_processor.fps != 2:
+            raise ValueError(
+                f"GLM-5-Next requires the checkpoint video fps=2; got {video_processor.fps!r}."
+            )
+
+        # GLM expands video frames to the image placeholder id.  Keep the
+        # source token distinct but advertise the post-tokenization id used by
+        # the scheduler and embedding scatter.
         self.mm_tokens = MultimodalSpecialTokens(
             image_token=self.IMAGE_TOKEN,
             image_token_id=self.IM_TOKEN_ID,
+            video_token=self.VIDEO_TOKEN,
+            video_token_id=self.IM_TOKEN_ID,
         ).build(_processor)
 
     @staticmethod
@@ -239,7 +102,7 @@ class Glm5NextSGLangProcessor(Glm4vImageProcessor):
         unknown_root = set(config) - {"image"}
         if unknown_root:
             raise ValueError(
-                "GLM-5-Next Session D accepts only the image processor config; "
+                "GLM-5-Next accepts only the image processor override; "
                 f"unsupported keys: {sorted(unknown_root)}."
             )
         image_config = config.get("image", {})
@@ -262,16 +125,106 @@ class Glm5NextSGLangProcessor(Glm4vImageProcessor):
             )
         return max_pixels
 
-    def _count_image_placeholders(self, input_text) -> int:
+    def _count_placeholders(self, input_text) -> tuple[int, int]:
         if isinstance(input_text, str):
-            if self.VIDEO_TOKEN in input_text:
-                raise ValueError("GLM-5-Next Session D does not support video input.")
-            return input_text.count(self.IMAGE_TOKEN)
+            return (
+                input_text.count(self.IMAGE_TOKEN),
+                input_text.count(self.VIDEO_TOKEN),
+            )
         if isinstance(input_text, (list, tuple)):
-            if self.VIDEO_TOKEN_ID in input_text:
-                raise ValueError("GLM-5-Next Session D does not support video input.")
-            return input_text.count(self.IM_TOKEN_ID)
+            return (
+                input_text.count(self.IM_TOKEN_ID),
+                input_text.count(self.VIDEO_TOKEN_ID),
+            )
         raise TypeError("GLM-5-Next multimodal prompt must be text or token ids.")
+
+    @staticmethod
+    @contextmanager
+    def _materialize_video(video):
+        """Yield one seekable local file for transformers/PyAV and clean it up."""
+
+        max_bytes = int(
+            os.environ.get("SGLANG_GLM5_NEXT_MAX_VIDEO_BYTES", 2 * 1024**3)
+        )
+        if max_bytes <= 0:
+            raise ValueError("SGLANG_GLM5_NEXT_MAX_VIDEO_BYTES must be positive.")
+        temporary_path = None
+        try:
+            if isinstance(video, str):
+                parsed = urlparse(video)
+                if parsed.scheme == "file":
+                    local_path = unquote(parsed.path)
+                    if not os.path.isfile(local_path):
+                        raise ValueError(f"GLM-5-Next video file not found: {local_path}")
+                    yield local_path
+                    return
+                if parsed.scheme in ("", None) and os.path.isfile(video):
+                    yield video
+                    return
+
+            payload = None
+            if isinstance(video, bytes):
+                payload = video
+            elif isinstance(video, str) and video.startswith(("http://", "https://")):
+                timeout = int(os.environ.get("REQUEST_TIMEOUT", "10"))
+                response = requests.get(video, stream=True, timeout=timeout)
+                try:
+                    response.raise_for_status()
+                    content_length = response.headers.get("content-length")
+                    if content_length and int(content_length) > max_bytes:
+                        raise ValueError(
+                            "GLM-5-Next video exceeds the configured byte limit: "
+                            f"content_length={content_length}, limit={max_bytes}."
+                        )
+                    with tempfile.NamedTemporaryFile(
+                        delete=False, suffix=".mp4"
+                    ) as temporary:
+                        temporary_path = temporary.name
+                        downloaded = 0
+                        for chunk in response.iter_content(chunk_size=1024 * 1024):
+                            if not chunk:
+                                continue
+                            downloaded += len(chunk)
+                            if downloaded > max_bytes:
+                                raise ValueError(
+                                    "GLM-5-Next video exceeds the configured byte "
+                                    f"limit of {max_bytes} bytes."
+                                )
+                            temporary.write(chunk)
+                finally:
+                    response.close()
+                if downloaded == 0:
+                    raise ValueError("GLM-5-Next downloaded an empty video.")
+                yield temporary_path
+                return
+            elif isinstance(video, str):
+                encoded = video.split(",", 1)[1] if video.startswith("data:") else video
+                try:
+                    payload = base64.b64decode(encoded, validate=True)
+                except (binascii.Error, ValueError) as error:
+                    raise ValueError(
+                        "GLM-5-Next video must be a local path, HTTP(S) URL, "
+                        "bytes, data URL, or valid base64."
+                    ) from error
+            else:
+                raise ValueError(
+                    f"Unsupported GLM-5-Next video input type: {type(video).__name__}."
+                )
+
+            if not payload:
+                raise ValueError("GLM-5-Next video payload is empty.")
+            if len(payload) > max_bytes:
+                raise ValueError(
+                    "GLM-5-Next video exceeds the configured byte limit: "
+                    f"size={len(payload)}, limit={max_bytes}."
+                )
+            with tempfile.NamedTemporaryFile(delete=False, suffix=".mp4") as temporary:
+                temporary_path = temporary.name
+                temporary.write(payload)
+            yield temporary_path
+        finally:
+            if temporary_path and os.path.exists(temporary_path):
+                os.unlink(temporary_path)
 
     def _get_multi_image_mrope(
         self,
@@ -426,9 +379,20 @@ class Glm5NextSGLangProcessor(Glm4vImageProcessor):
     ):
         del args, kwargs
         if audio_data:
-            raise ValueError("GLM-5-Next Session D does not support audio input.")
-        if getattr(request_obj, "video_data", None):
-            raise ValueError("GLM-5-Next Session D does not support video input.")
+            raise ValueError("GLM-5-Next does not support audio input.")
+        video_data = getattr(request_obj, "video_data", None) or []
+        image_data = image_data or []
+        if image_data and video_data:
+            raise ValueError(
+                "GLM-5-Next does not allow image and video content in one request."
+            )
+        if image_data:
+            return self._process_image_data(image_data, input_text)
+        if video_data:
+            return self._process_video_data(video_data, input_text)
+        raise ValueError("GLM-5-Next multimodal request contains no media data.")
+
+    def _process_image_data(self, image_data, input_text):
         if not isinstance(image_data, list) or not image_data:
             count = len(image_data) if isinstance(image_data, list) else 0
             raise ValueError(
@@ -436,16 +400,24 @@ class Glm5NextSGLangProcessor(Glm4vImageProcessor):
                 f"got {count}."
             )
         image_count = len(image_data)
+        if image_count > 8:
+            raise ValueError(
+                f"GLM-5-Next accepts at most 8 images per request; got {image_count}."
+            )
         if any(isinstance(image, dict) for image in image_data):
             raise ValueError(
                 "GLM-5-Next does not accept processor_output or "
                 "precomputed_embedding image inputs."
             )
-        placeholder_count = self._count_image_placeholders(input_text)
-        if placeholder_count != image_count:
+        image_placeholders, video_placeholders = self._count_placeholders(input_text)
+        if video_placeholders:
+            raise ValueError(
+                "GLM-5-Next image request unexpectedly contains a video placeholder."
+            )
+        if image_placeholders != image_count:
             raise ValueError(
                 "GLM-5-Next image count/placeholder count mismatch: "
-                f"images={image_count}, placeholders={placeholder_count}."
+                f"images={image_count}, placeholders={image_placeholders}."
             )
 
         # load_mm_data is synchronous: it submits image I/O to the processor's
@@ -599,9 +571,215 @@ class Glm5NextSGLangProcessor(Glm4vImageProcessor):
             "im_token_id": self.IM_TOKEN_ID,
             "im_start_id": self.IMAGE_START_TOKEN_ID,
             "im_end_id": self.IMAGE_END_TOKEN_ID,
-            "video_token_id": self.VIDEO_TOKEN_ID,
+            "video_token_id": self.IM_TOKEN_ID,
             "mrope_positions": mrope_positions,
             "mrope_position_delta": mrope_position_delta,
+            "glm5_next_force_hybrid_prefill": True,
+        }
+
+    def _process_video_data(self, video_data, input_text):
+        if not isinstance(video_data, list) or len(video_data) != 1:
+            count = len(video_data) if isinstance(video_data, list) else 0
+            raise ValueError(
+                f"GLM-5-Next accepts exactly one video per video request; got {count}."
+            )
+        if isinstance(video_data[0], dict):
+            raise ValueError(
+                "GLM-5-Next does not accept processor_output or "
+                "precomputed_embedding video inputs."
+            )
+
+        image_placeholders, video_placeholders = self._count_placeholders(input_text)
+        if image_placeholders:
+            raise ValueError(
+                "GLM-5-Next video request unexpectedly contains an image placeholder."
+            )
+        if video_placeholders != 1:
+            raise ValueError(
+                "GLM-5-Next video count/placeholder count mismatch: "
+                f"videos=1, placeholders={video_placeholders}."
+            )
+
+        if isinstance(input_text, (list, tuple)):
+            input_text = self._processor.tokenizer.decode(input_text)
+        # Do not send videos through SGLang's Decord loader and then decode a
+        # second time.  The transformers-kt video processor owns PyAV sampling
+        # and returns the metadata used to build timestamp tokens.
+        with self._materialize_video(video_data[0]) as video_path:
+            base_output = BaseMultiModalProcessorOutput(
+                input_text=input_text,
+                images=[],
+                videos=[video_path],
+                audios=[],
+            )
+            mm_items, input_ids, ret = self.process_and_combine_mm_data(
+                base_output, self.mm_tokens, return_metadata=True
+            )
+        video_grid_thw = getattr(ret, "video_grid_thw", None)
+        if video_grid_thw is None and isinstance(ret, dict):
+            video_grid_thw = ret.get("video_grid_thw")
+        if video_grid_thw is None or tuple(video_grid_thw.shape) != (1, 3):
+            actual_shape = (
+                None if video_grid_thw is None else tuple(video_grid_thw.shape)
+            )
+            raise RuntimeError(
+                "GLM-5-Next processor returned an invalid video_grid_thw shape: "
+                f"expected=(1, 3), got={actual_shape}."
+            )
+        grid_t, grid_h, grid_w = (int(value) for value in video_grid_thw[0].tolist())
+        if min(grid_t, grid_h, grid_w) <= 0:
+            raise RuntimeError(
+                "GLM-5-Next video grid dimensions must be positive; "
+                f"got {(grid_t, grid_h, grid_w)}."
+            )
+        merge_size = int(self.spatial_merge_size)
+        if grid_h % merge_size or grid_w % merge_size:
+            raise RuntimeError(
+                "GLM-5-Next video grid is not divisible by the spatial merge "
+                f"size: grid={(grid_t, grid_h, grid_w)}, merge_size={merge_size}."
+            )
+        if len(mm_items) != 1 or not mm_items[0].is_video():
+            raise RuntimeError("GLM-5-Next processor must return one video item.")
+
+        expected_feature_rows = grid_t * grid_h * grid_w
+        feature = mm_items[0].feature
+        feature_shape = getattr(feature, "shape", None)
+        if feature_shape is None:
+            feature_shape = getattr(getattr(feature, "info_data", None), "shape", None)
+        if (
+            feature_shape is None
+            or len(feature_shape) != 2
+            or int(feature_shape[0]) != expected_feature_rows
+        ):
+            raise RuntimeError(
+                "GLM-5-Next video feature/grid mismatch: "
+                f"expected_rows={expected_feature_rows}, "
+                f"feature_shape={None if feature_shape is None else tuple(feature_shape)}."
+            )
+
+        tokens_per_frame = grid_h * grid_w // (merge_size**2)
+        expected_video_tokens = grid_t * tokens_per_frame
+        video_token_positions = (
+            (input_ids == self.IM_TOKEN_ID).nonzero(as_tuple=True)[0].tolist()
+        )
+        if len(video_token_positions) != expected_video_tokens:
+            raise RuntimeError(
+                "GLM-5-Next video placeholder/feature mismatch: "
+                f"expected={expected_video_tokens}, got={len(video_token_positions)}."
+            )
+        offsets = mm_items[0].offsets or []
+        if len(offsets) != grid_t:
+            raise RuntimeError(
+                "GLM-5-Next video must expose one image-token block per temporal "
+                f"grid row: expected={grid_t}, got={len(offsets)}."
+            )
+        covered_positions = []
+        for frame_index, (start, end) in enumerate(offsets):
+            start, end = int(start), int(end)
+            if end - start + 1 != tokens_per_frame:
+                raise RuntimeError(
+                    "GLM-5-Next video frame token block length mismatch at frame "
+                    f"{frame_index}: expected={tokens_per_frame}, got={end - start + 1}."
+                )
+            covered_positions.extend(range(start, end + 1))
+        if covered_positions != video_token_positions:
+            raise RuntimeError(
+                "GLM-5-Next video offsets do not cover exactly the expanded frame tokens."
+            )
+
+        video_start_positions = (
+            (input_ids == self.VIDEO_START_TOKEN_ID).nonzero(as_tuple=True)[0].tolist()
+        )
+        video_end_positions = (
+            (input_ids == self.VIDEO_END_TOKEN_ID).nonzero(as_tuple=True)[0].tolist()
+        )
+        if (
+            len(video_start_positions) != 1
+            or len(video_end_positions) != 1
+            or video_start_positions[0] >= video_end_positions[0]
+        ):
+            raise RuntimeError(
+                "GLM-5-Next video prompt must contain one ordered begin/end boundary."
+            )
+        video_start, video_end = video_start_positions[0], video_end_positions[0]
+        image_starts = (
+            (input_ids[video_start + 1 : video_end] == self.IMAGE_START_TOKEN_ID)
+            .nonzero(as_tuple=True)[0]
+            .tolist()
+        )
+        image_ends = (
+            (input_ids[video_start + 1 : video_end] == self.IMAGE_END_TOKEN_ID)
+            .nonzero(as_tuple=True)[0]
+            .tolist()
+        )
+        if len(image_starts) != grid_t or len(image_ends) != grid_t:
+            raise RuntimeError(
+                "GLM-5-Next video frame boundaries/grid mismatch: "
+                f"grid_t={grid_t}, starts={len(image_starts)}, ends={len(image_ends)}."
+            )
+        if any(start >= end for start, end in zip(image_starts, image_ends)):
+            raise RuntimeError("GLM-5-Next video frame boundaries are not ordered.")
+
+        video_metadata = getattr(ret, "video_metadata", None)
+        if video_metadata is None and isinstance(ret, dict):
+            video_metadata = ret.get("video_metadata")
+        if not isinstance(video_metadata, list) or len(video_metadata) != 1:
+            raise RuntimeError(
+                "GLM-5-Next video processor must return exactly one metadata record."
+            )
+        metadata = video_metadata[0]
+        timestamps = list(metadata.timestamps[::2])[:grid_t]
+        while len(timestamps) < grid_t:
+            timestamps.append(timestamps[-1] if timestamps else 0.0)
+        if len(timestamps) != grid_t or any(
+            not torch.isfinite(torch.tensor(timestamp)) for timestamp in timestamps
+        ):
+            raise RuntimeError("GLM-5-Next video timestamps are invalid.")
+        if any(right < left for left, right in zip(timestamps, timestamps[1:])):
+            raise RuntimeError("GLM-5-Next video timestamps must be monotonic.")
+
+        expected_frame_text = "".join(
+            self._processor.replace_frame_token_id(timestamp)
+            for timestamp in timestamps
+        )
+        expected_frame_ids = self._processor.tokenizer.encode(
+            expected_frame_text, add_special_tokens=False
+        )
+        actual_frame_ids = input_ids[video_start + 1 : video_end].tolist()
+        if actual_frame_ids != expected_frame_ids:
+            raise RuntimeError(
+                "GLM-5-Next timestamped video token expansion changed unexpectedly."
+            )
+
+        attention_mask = getattr(ret, "attention_mask", None)
+        if attention_mask is None and isinstance(ret, dict):
+            attention_mask = ret.get("attention_mask")
+        mrope_positions, mrope_position_delta = MRotaryEmbedding.get_rope_index_glm4v(
+            input_ids=input_ids.unsqueeze(0),
+            hf_config=self.hf_config,
+            image_grid_thw=None,
+            video_grid_thw=video_grid_thw,
+            attention_mask=attention_mask,
+        )
+        mrope_positions = mrope_positions.squeeze(1)
+        if mrope_positions.ndim != 2 or tuple(mrope_positions.shape) != (
+            3,
+            input_ids.numel(),
+        ):
+            raise RuntimeError(
+                "GLM-5-Next video MRoPE positions must have shape (3, sequence_length)."
+            )
+
+        return {
+            "input_ids": input_ids.tolist(),
+            "mm_items": mm_items,
+            "im_token_id": self.IM_TOKEN_ID,
+            "im_start_id": self.IMAGE_START_TOKEN_ID,
+            "im_end_id": self.IMAGE_END_TOKEN_ID,
+            "video_token_id": self.IM_TOKEN_ID,
+            "mrope_positions": mrope_positions,
+            "mrope_position_delta": mrope_position_delta,
+            "glm5_next_force_hybrid_prefill": True,
         }
 
 
@@ -609,4 +787,5 @@ __all__ = [
     "Glm5NextImageProcessor",
     "Glm5NextProcessor",
     "Glm5NextSGLangProcessor",
+    "Glm5NextVideoProcessor",
 ]

--- a/python/sglang/srt/multimodal/processors/glm5_next.py
+++ b/python/sglang/srt/multimodal/processors/glm5_next.py
@@ -200,7 +200,7 @@ class Glm5NextProcessor(Glm46VProcessor):
 
 
 class Glm5NextSGLangProcessor(Glm4vImageProcessor):
-    """Strict one-image request adapter registered only for GLM-5-Next."""
+    """Strict image-only request adapter registered only for GLM-5-Next."""
 
     models = [Glm5NextForConditionalGeneration]
 
@@ -286,22 +286,23 @@ class Glm5NextSGLangProcessor(Glm4vImageProcessor):
             raise ValueError("GLM-5-Next Session D does not support audio input.")
         if getattr(request_obj, "video_data", None):
             raise ValueError("GLM-5-Next Session D does not support video input.")
-        if not isinstance(image_data, list) or len(image_data) != 1:
+        if not isinstance(image_data, list) or not image_data:
             count = len(image_data) if isinstance(image_data, list) else 0
             raise ValueError(
-                "GLM-5-Next Session D requires exactly one image per request; "
+                "GLM-5-Next requires at least one image per image request; "
                 f"got {count}."
             )
-        if isinstance(image_data[0], dict):
+        image_count = len(image_data)
+        if any(isinstance(image, dict) for image in image_data):
             raise ValueError(
-                "GLM-5-Next Session D does not accept processor_output or "
+                "GLM-5-Next does not accept processor_output or "
                 "precomputed_embedding image inputs."
             )
         placeholder_count = self._count_image_placeholders(input_text)
-        if placeholder_count != 1:
+        if placeholder_count != image_count:
             raise ValueError(
-                "GLM-5-Next Session D requires exactly one image placeholder; "
-                f"got {placeholder_count}."
+                "GLM-5-Next image count/placeholder count mismatch: "
+                f"images={image_count}, placeholders={placeholder_count}."
             )
 
         # load_mm_data is synchronous: it submits image I/O to the processor's
@@ -313,9 +314,14 @@ class Glm5NextSGLangProcessor(Glm4vImageProcessor):
             video_data=None,
             multimodal_tokens=self.mm_tokens,
         )
-        if len(base_output.images) != 1 or base_output.videos or base_output.audios:
+        if (
+            len(base_output.images) != image_count
+            or base_output.videos
+            or base_output.audios
+        ):
             raise ValueError(
-                "GLM-5-Next image loading must produce exactly one still image."
+                "GLM-5-Next image loading changed the request cardinality: "
+                f"expected={image_count}, loaded={len(base_output.images)}."
             )
 
         mm_items, input_ids, ret = self.process_and_combine_mm_data(
@@ -324,26 +330,95 @@ class Glm5NextSGLangProcessor(Glm4vImageProcessor):
         image_grid_thw = getattr(ret, "image_grid_thw", None)
         if image_grid_thw is None and isinstance(ret, dict):
             image_grid_thw = ret.get("image_grid_thw")
-        if image_grid_thw is None or tuple(image_grid_thw.shape) != (1, 3):
+        expected_grid_shape = (image_count, 3)
+        if image_grid_thw is None or tuple(image_grid_thw.shape) != expected_grid_shape:
+            actual_grid_shape = (
+                None if image_grid_thw is None else tuple(image_grid_thw.shape)
+            )
             raise RuntimeError(
-                "GLM-5-Next processor must return image_grid_thw with shape (1, 3)."
+                "GLM-5-Next processor returned an invalid image_grid_thw shape: "
+                f"expected={expected_grid_shape}, got={actual_grid_shape}."
             )
         if len(mm_items) != 1 or not mm_items[0].is_image():
             raise RuntimeError(
-                "GLM-5-Next processor must return exactly one image item."
+                "GLM-5-Next processor must return one bundled image item."
             )
-        expected_tokens = int(image_grid_thw[0].prod().item()) // (
-            self.spatial_merge_size**2
-        )
+
+        merge_area = self.spatial_merge_size**2
+        patch_counts = [int(grid.prod().item()) for grid in image_grid_thw]
+        if any(patch_count % merge_area for patch_count in patch_counts):
+            raise RuntimeError(
+                "GLM-5-Next image patch counts must be divisible by the spatial "
+                f"merge area {merge_area}; got {patch_counts}."
+            )
+        expected_tokens_per_image = [
+            patch_count // merge_area for patch_count in patch_counts
+        ]
+        expected_tokens = sum(expected_tokens_per_image)
         actual_tokens = int((input_ids == self.IM_TOKEN_ID).sum().item())
         if actual_tokens != expected_tokens:
             raise RuntimeError(
                 "GLM-5-Next image placeholder/feature mismatch: "
                 f"expected {expected_tokens} image tokens, got {actual_tokens}."
             )
-        if len(mm_items[0].offsets) != 1:
+
+        source_offsets = mm_items[0].offsets or []
+        covered_positions = []
+        for start, end in source_offsets:
+            start, end = int(start), int(end)
+            if end < start:
+                raise RuntimeError(
+                    "GLM-5-Next processor returned an inverted image offset: "
+                    f"start={start}, end={end}."
+                )
+            covered_positions.extend(range(start, end + 1))
+        image_token_positions = (
+            (input_ids == self.IM_TOKEN_ID).nonzero(as_tuple=True)[0].tolist()
+        )
+        if covered_positions != image_token_positions:
             raise RuntimeError(
-                "GLM-5-Next processor must return one contiguous image offset."
+                "GLM-5-Next processor image offsets do not cover exactly the "
+                "expanded image tokens."
+            )
+
+        # Adjacent placeholders form one token run in the generic processor.
+        # Split by the per-image grid sizes so the scheduler still receives one
+        # ordered offset per source image.
+        normalized_offsets = []
+        token_cursor = 0
+        for image_index, expected_tokens_for_image in enumerate(
+            expected_tokens_per_image
+        ):
+            positions = image_token_positions[
+                token_cursor : token_cursor + expected_tokens_for_image
+            ]
+            token_cursor += expected_tokens_for_image
+            is_contiguous = len(positions) == expected_tokens_for_image and all(
+                right == left + 1 for left, right in zip(positions, positions[1:])
+            )
+            if not is_contiguous:
+                raise RuntimeError(
+                    "GLM-5-Next image offset/token mismatch at image "
+                    f"{image_index}: expected={expected_tokens_for_image}, "
+                    f"positions={positions}."
+                )
+            normalized_offsets.append((positions[0], positions[-1]))
+        mm_items[0].offsets = normalized_offsets
+
+        feature = mm_items[0].feature
+        feature_shape = getattr(feature, "shape", None)
+        if feature_shape is None:
+            feature_shape = getattr(getattr(feature, "info_data", None), "shape", None)
+        expected_feature_rows = sum(patch_counts)
+        if (
+            feature_shape is None
+            or len(feature_shape) == 0
+            or int(feature_shape[0]) != expected_feature_rows
+        ):
+            raise RuntimeError(
+                "GLM-5-Next image feature/grid mismatch: "
+                f"expected_rows={expected_feature_rows}, "
+                f"feature_shape={None if feature_shape is None else tuple(feature_shape)}."
             )
 
         attention_mask = getattr(ret, "attention_mask", None)

--- a/python/sglang/srt/multimodal/processors/glm5_next.py
+++ b/python/sglang/srt/multimodal/processors/glm5_next.py
@@ -723,7 +723,10 @@ class Glm5NextSGLangProcessor(Glm4vImageProcessor):
         video_metadata = getattr(ret, "video_metadata", None)
         if video_metadata is None and isinstance(ret, dict):
             video_metadata = ret.get("video_metadata")
-        if not isinstance(video_metadata, list) or len(video_metadata) != 1:
+        # BatchFeature normalizes non-tensor metadata to a tuple on the
+        # transformers-kt 5.6 release line, while newer releases preserve a
+        # list. Both representations carry the same ordered request metadata.
+        if not isinstance(video_metadata, (list, tuple)) or len(video_metadata) != 1:
             raise RuntimeError(
                 "GLM-5-Next video processor must return exactly one metadata record."
             )

--- a/python/sglang/srt/multimodal/processors/glm5_next.py
+++ b/python/sglang/srt/multimodal/processors/glm5_next.py
@@ -1,4 +1,4 @@
-"""Self-contained single-image processor for GLM-5-Next.
+"""Self-contained image processor for GLM-5-Next.
 
 The pinned transformers-kt wheel has the reusable GLM-4.6V tokenizer and
 patchifier, but it does not register the checkpoint's Glmga image processor.
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import torch
 from transformers.image_transforms import group_images_by_shape, reorder_images
 from transformers.image_utils import SizeDict
 from transformers.models.glm46v.image_processing_glm46v import (
@@ -272,6 +273,148 @@ class Glm5NextSGLangProcessor(Glm4vImageProcessor):
             return input_text.count(self.IM_TOKEN_ID)
         raise TypeError("GLM-5-Next multimodal prompt must be text or token ids.")
 
+    def _get_multi_image_mrope(
+        self,
+        input_ids,
+        image_grid_thw,
+        image_offsets,
+        attention_mask,
+    ):
+        """Build GLM MRoPE positions while preserving adjacent image boundaries.
+
+        The shared GLM4V helper discovers modality segments by grouping adjacent
+        image-token IDs.  Two adjacent source placeholders therefore look like
+        one image and consume only the first grid.  The request adapter already
+        has one validated offset and one grid per source image, so use those
+        explicit boundaries for the multi-image case.
+        """
+
+        if input_ids.ndim != 1:
+            raise RuntimeError(
+                "GLM-5-Next multi-image MRoPE expects one token sequence; "
+                f"got shape={tuple(input_ids.shape)}."
+            )
+        sequence_length = int(input_ids.shape[0])
+        if attention_mask is None:
+            active_mask = torch.ones_like(input_ids, dtype=torch.bool)
+        else:
+            active_mask = attention_mask.reshape(-1).to(
+                device=input_ids.device, dtype=torch.bool
+            )
+            if active_mask.numel() != sequence_length:
+                raise RuntimeError(
+                    "GLM-5-Next multi-image attention mask length changed: "
+                    f"tokens={sequence_length}, mask={active_mask.numel()}."
+                )
+
+        active_indices = active_mask.nonzero(as_tuple=True)[0]
+        position_pieces = []
+        assignment_pieces = []
+        next_position = 0
+        token_cursor = 0
+
+        def append_text(indices):
+            nonlocal next_position
+            text_length = int(indices.numel())
+            if text_length == 0:
+                return
+            text_positions = torch.arange(
+                text_length, device=input_ids.device, dtype=input_ids.dtype
+            )
+            text_positions = text_positions.view(1, -1).expand(3, -1)
+            text_positions = text_positions + next_position
+            position_pieces.append(text_positions)
+            assignment_pieces.append(indices)
+            next_position = int(text_positions.max().item()) + 1
+
+        for image_index, ((start, end), grid) in enumerate(
+            zip(image_offsets, image_grid_thw)
+        ):
+            start, end = int(start), int(end)
+            if start < token_cursor or end < start or end >= sequence_length:
+                raise RuntimeError(
+                    "GLM-5-Next multi-image offsets are not ordered in bounds at "
+                    f"image {image_index}: start={start}, end={end}, "
+                    f"cursor={token_cursor}, sequence_length={sequence_length}."
+                )
+
+            text_indices = active_indices[
+                (active_indices >= token_cursor) & (active_indices < start)
+            ]
+            append_text(text_indices)
+
+            image_indices = active_indices[
+                (active_indices >= start) & (active_indices <= end)
+            ]
+            t, h, w = (int(value) for value in grid)
+            merge_size = int(self.spatial_merge_size)
+            if h % merge_size or w % merge_size:
+                raise RuntimeError(
+                    "GLM-5-Next image grid is not divisible by the spatial "
+                    f"merge size at image {image_index}: grid={(t, h, w)}, "
+                    f"merge_size={merge_size}."
+                )
+            grid_h, grid_w = h // merge_size, w // merge_size
+            image_token_count = t * grid_h * grid_w
+            if int(image_indices.numel()) != image_token_count:
+                raise RuntimeError(
+                    "GLM-5-Next multi-image offset/grid mismatch at image "
+                    f"{image_index}: offset_tokens={image_indices.numel()}, "
+                    f"grid_tokens={image_token_count}."
+                )
+
+            t_index = (
+                torch.arange(t, device=input_ids.device, dtype=input_ids.dtype)
+                .view(-1, 1)
+                .expand(t, grid_h * grid_w)
+                .reshape(-1)
+            )
+            h_index = (
+                torch.arange(grid_h, device=input_ids.device, dtype=input_ids.dtype)
+                .view(1, -1, 1)
+                .expand(t, grid_h, grid_w)
+                .reshape(-1)
+            )
+            w_index = (
+                torch.arange(grid_w, device=input_ids.device, dtype=input_ids.dtype)
+                .view(1, 1, -1)
+                .expand(t, grid_h, grid_w)
+                .reshape(-1)
+            )
+            image_positions = torch.stack((t_index, h_index, w_index)) + next_position
+            position_pieces.append(image_positions)
+            assignment_pieces.append(image_indices)
+            next_position = int(image_positions.max().item()) + 1
+            token_cursor = end + 1
+
+        append_text(active_indices[active_indices >= token_cursor])
+        assigned_indices = torch.cat(assignment_pieces)
+        if not torch.equal(assigned_indices, active_indices):
+            raise RuntimeError(
+                "GLM-5-Next multi-image MRoPE segments do not cover exactly the "
+                "active token sequence."
+            )
+        active_positions = torch.cat(position_pieces, dim=1)
+        if active_positions.shape[1] != active_indices.numel():
+            raise RuntimeError(
+                "GLM-5-Next multi-image MRoPE position length changed: "
+                f"positions={active_positions.shape[1]}, "
+                f"active_tokens={active_indices.numel()}."
+            )
+
+        position_ids = torch.ones(
+            (3, sequence_length),
+            dtype=input_ids.dtype,
+            device=input_ids.device,
+        )
+        position_ids[:, active_indices] = active_positions
+        position_delta = torch.tensor(
+            [[next_position - sequence_length]],
+            dtype=input_ids.dtype,
+            device=input_ids.device,
+        )
+        return position_ids, position_delta
+
     async def process_mm_data_async(
         self,
         image_data,
@@ -424,14 +567,24 @@ class Glm5NextSGLangProcessor(Glm4vImageProcessor):
         attention_mask = getattr(ret, "attention_mask", None)
         if attention_mask is None and isinstance(ret, dict):
             attention_mask = ret.get("attention_mask")
-        mrope_positions, mrope_position_delta = MRotaryEmbedding.get_rope_index_glm4v(
-            input_ids=input_ids.unsqueeze(0),
-            hf_config=self.hf_config,
-            image_grid_thw=image_grid_thw,
-            video_grid_thw=None,
-            attention_mask=attention_mask,
-        )
-        mrope_positions = mrope_positions.squeeze(1)
+        if image_count == 1:
+            mrope_positions, mrope_position_delta = (
+                MRotaryEmbedding.get_rope_index_glm4v(
+                    input_ids=input_ids.unsqueeze(0),
+                    hf_config=self.hf_config,
+                    image_grid_thw=image_grid_thw,
+                    video_grid_thw=None,
+                    attention_mask=attention_mask,
+                )
+            )
+            mrope_positions = mrope_positions.squeeze(1)
+        else:
+            mrope_positions, mrope_position_delta = self._get_multi_image_mrope(
+                input_ids=input_ids,
+                image_grid_thw=image_grid_thw,
+                image_offsets=normalized_offsets,
+                attention_mask=attention_mask,
+            )
         if mrope_positions.ndim != 2 or mrope_positions.shape[0] != 3:
             raise RuntimeError(
                 "GLM-5-Next MRoPE positions must have shape (3, sequence_length)."

--- a/python/sglang/srt/multimodal/processors/glm5_next.py
+++ b/python/sglang/srt/multimodal/processors/glm5_next.py
@@ -742,7 +742,11 @@ class Glm5NextSGLangProcessor(Glm4vImageProcessor):
             raise RuntimeError("GLM-5-Next video timestamps must be monotonic.")
 
         expected_frame_text = "".join(
-            self._processor.replace_frame_token_id(timestamp)
+            self._processor.replace_frame_token_id(timestamp).replace(
+                self._processor.image_token,
+                self._processor.image_token * tokens_per_frame,
+                1,
+            )
             for timestamp in timestamps
         )
         expected_frame_ids = self._processor.tokenizer.encode(

--- a/python/sglang/srt/multimodal/processors/glm5_next.py
+++ b/python/sglang/srt/multimodal/processors/glm5_next.py
@@ -1,0 +1,384 @@
+"""Self-contained single-image processor for GLM-5-Next.
+
+The pinned transformers-kt wheel has the reusable GLM-4.6V tokenizer and
+patchifier, but it does not register the checkpoint's Glmga image processor.
+Keep the small GLM-5 resize difference here instead of requiring a patched
+Transformers checkout at runtime.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from transformers.image_transforms import group_images_by_shape, reorder_images
+from transformers.image_utils import SizeDict
+from transformers.models.glm46v.image_processing_glm46v import (
+    Glm46VImageProcessor,
+    smart_resize,
+)
+from transformers.models.glm46v.processing_glm46v import Glm46VProcessor
+
+from sglang.srt.layers.rotary_embedding import MRotaryEmbedding
+from sglang.srt.models.glm5_next import Glm5NextForConditionalGeneration
+from sglang.srt.multimodal.processors.base_processor import MultimodalSpecialTokens
+from sglang.srt.multimodal.processors.glm4v import Glm4vImageProcessor
+
+
+GLM5_NEXT_MIN_PIXELS = 12_544
+GLM5_NEXT_DEFAULT_MAX_PIXELS = 1_254_400
+GLM5_NEXT_CHECKPOINT_MAX_PIXELS = 9_633_792
+GLM5_NEXT_PATCH_EXPAND_FACTOR = 2
+_GLM5_NEXT_IMAGE_CONFIG_KEYS = frozenset(
+    {
+        "do_rescale",
+        "image_mean",
+        "image_processor_type",
+        "image_std",
+        "merge_size",
+        "patch_size",
+        "patch_expand_factor",
+        "size",
+        "temporal_patch_size",
+    }
+)
+_GLM5_NEXT_IMAGE_CONFIG_VALUES = {
+    "do_rescale": True,
+    "image_mean": [0.48145466, 0.4578275, 0.40821073],
+    "image_processor_type": "GlmgaImageProcessor",
+    "image_std": [0.26862954, 0.26130258, 0.27577711],
+    "merge_size": 2,
+    "patch_size": 14,
+    "patch_expand_factor": GLM5_NEXT_PATCH_EXPAND_FACTOR,
+    "temporal_patch_size": 2,
+}
+
+
+class Glm5NextImageProcessor(Glm46VImageProcessor):
+    """GLM-4.6V patchification with GLM-5's expanded resize factor."""
+
+    size = {
+        "shortest_edge": GLM5_NEXT_MIN_PIXELS,
+        "longest_edge": GLM5_NEXT_DEFAULT_MAX_PIXELS,
+    }
+    patch_expand_factor = GLM5_NEXT_PATCH_EXPAND_FACTOR
+
+    def __init__(self, patch_expand_factor: int = 2, **kwargs) -> None:
+        if patch_expand_factor != GLM5_NEXT_PATCH_EXPAND_FACTOR:
+            raise ValueError(
+                "GLM-5-Next requires patch_expand_factor=2; "
+                f"got {patch_expand_factor!r}."
+            )
+        self.patch_expand_factor = patch_expand_factor
+        super().__init__(**kwargs)
+
+    @classmethod
+    def from_checkpoint_config(cls, image_config: dict[str, Any]):
+        config = dict(image_config)
+        actual_keys = set(config)
+        missing_keys = sorted(_GLM5_NEXT_IMAGE_CONFIG_KEYS - actual_keys)
+        unknown_keys = sorted(actual_keys - _GLM5_NEXT_IMAGE_CONFIG_KEYS)
+        if missing_keys or unknown_keys:
+            raise ValueError(
+                "GLM-5-Next pinned image processor metadata keys changed: "
+                f"missing={missing_keys}, unknown={unknown_keys}."
+            )
+        for key, expected in _GLM5_NEXT_IMAGE_CONFIG_VALUES.items():
+            actual = config[key]
+            if actual != expected:
+                raise ValueError(
+                    f"GLM-5-Next pinned processor requires {key}={expected!r}; "
+                    f"got {actual!r}."
+                )
+
+        checkpoint_size = config["size"]
+        if not isinstance(checkpoint_size, dict) or checkpoint_size != {
+            "shortest_edge": GLM5_NEXT_MIN_PIXELS,
+            "longest_edge": GLM5_NEXT_CHECKPOINT_MAX_PIXELS,
+        }:
+            raise ValueError(
+                "GLM-5-Next checkpoint processor size metadata changed: "
+                f"got {checkpoint_size!r}."
+            )
+        config.pop("image_processor_type")
+        config["size"] = {
+            "shortest_edge": GLM5_NEXT_MIN_PIXELS,
+            "longest_edge": GLM5_NEXT_DEFAULT_MAX_PIXELS,
+        }
+        return cls(**config)
+
+    def _preprocess(
+        self,
+        images,
+        do_resize,
+        size,
+        resample,
+        do_rescale,
+        rescale_factor,
+        do_normalize,
+        image_mean,
+        image_std,
+        patch_size,
+        temporal_patch_size,
+        merge_size,
+        disable_grouping,
+        return_tensors,
+        **kwargs,
+    ):
+        if do_resize:
+            grouped_images, grouped_images_index = group_images_by_shape(
+                images, disable_grouping=disable_grouping
+            )
+            resized_images_grouped = {}
+            for shape, stacked_images in grouped_images.items():
+                height, width = stacked_images.shape[-2:]
+                resized_height, resized_width = smart_resize(
+                    num_frames=temporal_patch_size,
+                    height=height,
+                    width=width,
+                    temporal_factor=temporal_patch_size,
+                    factor=patch_size * merge_size * self.patch_expand_factor,
+                    min_pixels=size.shortest_edge,
+                    max_pixels=size.longest_edge,
+                )
+                resized_images_grouped[shape] = self.resize(
+                    stacked_images,
+                    size=SizeDict(height=resized_height, width=resized_width),
+                    resample=resample,
+                )
+            images = reorder_images(resized_images_grouped, grouped_images_index)
+
+        return super()._preprocess(
+            images=images,
+            do_resize=False,
+            size=size,
+            resample=resample,
+            do_rescale=do_rescale,
+            rescale_factor=rescale_factor,
+            do_normalize=do_normalize,
+            image_mean=image_mean,
+            image_std=image_std,
+            patch_size=patch_size,
+            temporal_patch_size=temporal_patch_size,
+            merge_size=merge_size,
+            disable_grouping=disable_grouping,
+            return_tensors=return_tensors,
+            **kwargs,
+        )
+
+    def get_number_of_image_patches(
+        self, height: int, width: int, images_kwargs=None
+    ) -> int:
+        images_kwargs = images_kwargs or {}
+        patch_size = images_kwargs.get("patch_size", self.patch_size)
+        merge_size = images_kwargs.get("merge_size", self.merge_size)
+        size = images_kwargs.get("size", self.size)
+        min_pixels = (
+            size["shortest_edge"] if isinstance(size, dict) else size.shortest_edge
+        )
+        max_pixels = (
+            size["longest_edge"] if isinstance(size, dict) else size.longest_edge
+        )
+        resized_height, resized_width = smart_resize(
+            num_frames=self.temporal_patch_size,
+            height=height,
+            width=width,
+            temporal_factor=self.temporal_patch_size,
+            factor=patch_size * merge_size * self.patch_expand_factor,
+            min_pixels=min_pixels,
+            max_pixels=max_pixels,
+        )
+        return (resized_height // patch_size) * (resized_width // patch_size)
+
+
+class Glm5NextProcessor(Glm46VProcessor):
+    """Image-only facade over the pinned GLM-4.6V token expansion logic."""
+
+    def __call__(self, images=None, text=None, videos=None, **kwargs):
+        if videos is not None:
+            raise ValueError("GLM-5-Next Session D does not support video input.")
+        return super().__call__(images=images, text=text, videos=None, **kwargs)
+
+
+class Glm5NextSGLangProcessor(Glm4vImageProcessor):
+    """Strict one-image request adapter registered only for GLM-5-Next."""
+
+    models = [Glm5NextForConditionalGeneration]
+
+    def __init__(self, hf_config, server_args, _processor, *args, **kwargs):
+        super().__init__(hf_config, server_args, _processor, *args, **kwargs)
+        self.IMAGE_FACTOR = 56
+        self.MIN_PIXELS = GLM5_NEXT_MIN_PIXELS
+        self.MAX_PIXELS = self._resolve_max_pixels(server_args.mm_process_config)
+
+        image_processor = getattr(_processor, "image_processor", None)
+        if not isinstance(image_processor, Glm5NextImageProcessor):
+            raise TypeError(
+                "GLM-5-Next requires the built-in Glm5NextImageProcessor; "
+                f"got {type(image_processor).__name__}."
+            )
+        if isinstance(image_processor.size, dict):
+            image_processor.size["shortest_edge"] = self.MIN_PIXELS
+            image_processor.size["longest_edge"] = self.MAX_PIXELS
+        else:
+            image_processor.size.shortest_edge = self.MIN_PIXELS
+            image_processor.size.longest_edge = self.MAX_PIXELS
+
+        # Rebuild after the GLM4V initializer so only the image modality is
+        # advertised by this exact-model processor.
+        self.mm_tokens = MultimodalSpecialTokens(
+            image_token=self.IMAGE_TOKEN,
+            image_token_id=self.IM_TOKEN_ID,
+        ).build(_processor)
+
+    @staticmethod
+    def _resolve_max_pixels(mm_process_config) -> int:
+        config = {} if mm_process_config is None else mm_process_config
+        if not isinstance(config, dict):
+            raise ValueError("GLM-5-Next --mm-process-config must be a JSON object.")
+        unknown_root = set(config) - {"image"}
+        if unknown_root:
+            raise ValueError(
+                "GLM-5-Next Session D accepts only the image processor config; "
+                f"unsupported keys: {sorted(unknown_root)}."
+            )
+        image_config = config.get("image", {})
+        if not isinstance(image_config, dict):
+            raise ValueError("GLM-5-Next mm-process-config.image must be an object.")
+        unknown_image = set(image_config) - {"max_pixels"}
+        if unknown_image:
+            raise ValueError(
+                "GLM-5-Next accepts only image.max_pixels; unsupported keys: "
+                f"{sorted(unknown_image)}."
+            )
+        max_pixels = image_config.get("max_pixels", GLM5_NEXT_DEFAULT_MAX_PIXELS)
+        if isinstance(max_pixels, bool) or not isinstance(max_pixels, int):
+            raise ValueError("GLM-5-Next image.max_pixels must be an integer.")
+        if not GLM5_NEXT_MIN_PIXELS <= max_pixels <= GLM5_NEXT_CHECKPOINT_MAX_PIXELS:
+            raise ValueError(
+                "GLM-5-Next image.max_pixels must be within "
+                f"[{GLM5_NEXT_MIN_PIXELS}, {GLM5_NEXT_CHECKPOINT_MAX_PIXELS}]; "
+                f"got {max_pixels}."
+            )
+        return max_pixels
+
+    def _count_image_placeholders(self, input_text) -> int:
+        if isinstance(input_text, str):
+            if self.VIDEO_TOKEN in input_text:
+                raise ValueError("GLM-5-Next Session D does not support video input.")
+            return input_text.count(self.IMAGE_TOKEN)
+        if isinstance(input_text, (list, tuple)):
+            if self.VIDEO_TOKEN_ID in input_text:
+                raise ValueError("GLM-5-Next Session D does not support video input.")
+            return input_text.count(self.IM_TOKEN_ID)
+        raise TypeError("GLM-5-Next multimodal prompt must be text or token ids.")
+
+    async def process_mm_data_async(
+        self,
+        image_data,
+        audio_data,
+        input_text,
+        request_obj,
+        *args,
+        **kwargs,
+    ):
+        del args, kwargs
+        if audio_data:
+            raise ValueError("GLM-5-Next Session D does not support audio input.")
+        if getattr(request_obj, "video_data", None):
+            raise ValueError("GLM-5-Next Session D does not support video input.")
+        if not isinstance(image_data, list) or len(image_data) != 1:
+            count = len(image_data) if isinstance(image_data, list) else 0
+            raise ValueError(
+                "GLM-5-Next Session D requires exactly one image per request; "
+                f"got {count}."
+            )
+        if isinstance(image_data[0], dict):
+            raise ValueError(
+                "GLM-5-Next Session D does not accept processor_output or "
+                "precomputed_embedding image inputs."
+            )
+        placeholder_count = self._count_image_placeholders(input_text)
+        if placeholder_count != 1:
+            raise ValueError(
+                "GLM-5-Next Session D requires exactly one image placeholder; "
+                f"got {placeholder_count}."
+            )
+
+        # load_mm_data is synchronous: it submits image I/O to the processor's
+        # executors and joins those futures before returning the organized
+        # request payload.
+        base_output = self.load_mm_data(
+            prompt=input_text,
+            image_data=image_data,
+            video_data=None,
+            multimodal_tokens=self.mm_tokens,
+        )
+        if len(base_output.images) != 1 or base_output.videos or base_output.audios:
+            raise ValueError(
+                "GLM-5-Next image loading must produce exactly one still image."
+            )
+
+        mm_items, input_ids, ret = self.process_and_combine_mm_data(
+            base_output, self.mm_tokens
+        )
+        image_grid_thw = getattr(ret, "image_grid_thw", None)
+        if image_grid_thw is None and isinstance(ret, dict):
+            image_grid_thw = ret.get("image_grid_thw")
+        if image_grid_thw is None or tuple(image_grid_thw.shape) != (1, 3):
+            raise RuntimeError(
+                "GLM-5-Next processor must return image_grid_thw with shape (1, 3)."
+            )
+        if len(mm_items) != 1 or not mm_items[0].is_image():
+            raise RuntimeError(
+                "GLM-5-Next processor must return exactly one image item."
+            )
+        expected_tokens = int(image_grid_thw[0].prod().item()) // (
+            self.spatial_merge_size**2
+        )
+        actual_tokens = int((input_ids == self.IM_TOKEN_ID).sum().item())
+        if actual_tokens != expected_tokens:
+            raise RuntimeError(
+                "GLM-5-Next image placeholder/feature mismatch: "
+                f"expected {expected_tokens} image tokens, got {actual_tokens}."
+            )
+        if len(mm_items[0].offsets) != 1:
+            raise RuntimeError(
+                "GLM-5-Next processor must return one contiguous image offset."
+            )
+
+        attention_mask = getattr(ret, "attention_mask", None)
+        if attention_mask is None and isinstance(ret, dict):
+            attention_mask = ret.get("attention_mask")
+        mrope_positions, mrope_position_delta = MRotaryEmbedding.get_rope_index_glm4v(
+            input_ids=input_ids.unsqueeze(0),
+            hf_config=self.hf_config,
+            image_grid_thw=image_grid_thw,
+            video_grid_thw=None,
+            attention_mask=attention_mask,
+        )
+        mrope_positions = mrope_positions.squeeze(1)
+        if mrope_positions.ndim != 2 or mrope_positions.shape[0] != 3:
+            raise RuntimeError(
+                "GLM-5-Next MRoPE positions must have shape (3, sequence_length)."
+            )
+
+        # TokenizerManager currently consumes the processor result as a
+        # mapping (membership checks and subscription), matching GLM4V's
+        # established contract in this branch.
+        return {
+            "input_ids": input_ids.tolist(),
+            "mm_items": mm_items,
+            "im_token_id": self.IM_TOKEN_ID,
+            "im_start_id": self.IMAGE_START_TOKEN_ID,
+            "im_end_id": self.IMAGE_END_TOKEN_ID,
+            "video_token_id": self.VIDEO_TOKEN_ID,
+            "mrope_positions": mrope_positions,
+            "mrope_position_delta": mrope_position_delta,
+        }
+
+
+__all__ = [
+    "Glm5NextImageProcessor",
+    "Glm5NextProcessor",
+    "Glm5NextSGLangProcessor",
+]

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1332,7 +1332,7 @@ class ServerArgs:
         return capture_sizes
 
     def _validate_glm5_next_session_ab_boundary(self) -> None:
-        """Keep exact GLM-5-Next on the isolated Session AB surface."""
+        """Keep exact GLM-5-Next on the isolated Session D surface."""
 
         if self.enable_hierarchical_cache:
             raise ValueError(
@@ -1349,10 +1349,32 @@ class ServerArgs:
                 "GLM-5-Next Session AB does not support HiSparse; "
                 "--enable-hisparse must remain disabled."
             )
-        if self.enable_multimodal is True:
+        if self.mm_enable_dp_encoder:
             raise ValueError(
-                "GLM-5-Next multimodal input is deferred to Session D; "
-                "--enable-multimodal must remain disabled in Session AB."
+                "GLM-5-Next Session D does not support "
+                "--mm-enable-dp-encoder; the vision tower is TP-only."
+            )
+        if self.encoder_only or self.language_only or self.encoder_urls:
+            raise ValueError(
+                "GLM-5-Next Session D does not support encoder/language "
+                "disaggregation; --encoder-only, --language-only, and "
+                "--encoder-urls must remain unset."
+            )
+        unsupported_mm_options = {
+            "enable_broadcast_mm_inputs_process": self.enable_broadcast_mm_inputs_process,
+            "enable_prefix_mm_cache": self.enable_prefix_mm_cache,
+            "enable_mm_global_cache": self.enable_mm_global_cache,
+            "keep_mm_feature_on_device": self.keep_mm_feature_on_device,
+            "mm_attention_backend": self.mm_attention_backend is not None,
+        }
+        enabled_unsupported_mm_options = [
+            name for name, enabled in unsupported_mm_options.items() if enabled
+        ]
+        if enabled_unsupported_mm_options:
+            raise ValueError(
+                "GLM-5-Next Session D does not support these multimodal "
+                "execution/cache options: "
+                f"{enabled_unsupported_mm_options}."
             )
         if self.is_embedding:
             raise ValueError(
@@ -1430,6 +1452,11 @@ class ServerArgs:
             raise ValueError(
                 "GLM-5-Next Session AB does not support "
                 "--enable-two-batch-overlap."
+            )
+        if self.enable_mixed_chunk:
+            raise ValueError(
+                "GLM-5-Next Session D supports plain EXTEND prefill only and "
+                "does not support --enable-mixed-chunk."
             )
         if self.enable_piecewise_cuda_graph:
             raise ValueError(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1393,15 +1393,13 @@ class ServerArgs:
                 f"FP8 weight format; got quantization={self.quantization!r}."
             )
 
-        # Session AB accepts TP=1 for structural/component validation and TP=8
-        # for the pinned production checkpoint.  Intermediate TP widths and
-        # alternate PP/DP/CP/EP topologies have no acceptance evidence, and
-        # the mHC communicator intentionally rejects the scattered states
-        # produced by A2A MoE and dense fully-DP modes.
-        if self.tp_size not in (1, 8):
+        # Session AB accepts only the TP=4 runtime layout.  Other TP widths and
+        # alternate PP/DP/CP/EP topologies are deliberately outside the
+        # released boundary.  The mHC communicator intentionally rejects the
+        # scattered states produced by A2A MoE and dense fully-DP modes.
+        if self.tp_size != 4:
             raise ValueError(
-                "GLM-5-Next Session AB accepts only TP=1 structural validation "
-                "or the TP=8 production topology; "
+                "GLM-5-Next Session AB accepts only TP=4; "
                 f"got tp_size={self.tp_size}."
             )
 
@@ -1485,19 +1483,17 @@ class ServerArgs:
                 )
 
             # The positive threshold enables GLM's layerwise full-GPU prefill
-            # route.  Its two-slot FP8 pipeline is accepted only for the TP=8
-            # production layout.  Dynamic expert replacement mutates the
-            # resident set behind those slots and is deliberately excluded.
+            # route.  It is supported only by the TP=4 runtime layout.
+            # Dynamic expert replacement mutates the resident set behind the
+            # shared context and is deliberately excluded.
             prefill_threshold = getattr(
                 self, "kt_gpu_prefill_token_threshold", None
             )
             if prefill_threshold is not None and prefill_threshold > 0:
-                if self.tp_size != 8:
+                if self.tp_size != 4:
                     raise ValueError(
                         "GLM-5-Next KT layerwise prefill "
-                        "(--kt-gpu-prefill-token-threshold > 0) requires TP=8; "
-                        "TP=1 is structural-test-only and must keep the "
-                        "threshold unset or <= 0."
+                        "(--kt-gpu-prefill-token-threshold > 0) requires TP=4."
                     )
                 if getattr(self, "kt_enable_dynamic_expert_update", False):
                     raise ValueError(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1331,6 +1331,185 @@ class ServerArgs:
 
         return capture_sizes
 
+    def _validate_glm5_next_session_ab_boundary(self) -> None:
+        """Keep exact GLM-5-Next on the isolated Session AB surface."""
+
+        if self.enable_hierarchical_cache:
+            raise ValueError(
+                "GLM-5-Next Session AB does not support HiCache; "
+                "--enable-hierarchical-cache must remain disabled."
+            )
+        if self.enable_lmcache:
+            raise ValueError(
+                "GLM-5-Next Session AB does not support LMCache; "
+                "--enable-lmcache must remain disabled."
+            )
+        if self.enable_hisparse:
+            raise ValueError(
+                "GLM-5-Next Session AB does not support HiSparse; "
+                "--enable-hisparse must remain disabled."
+            )
+        if self.enable_multimodal is True:
+            raise ValueError(
+                "GLM-5-Next multimodal input is deferred to Session D; "
+                "--enable-multimodal must remain disabled in Session AB."
+            )
+        if self.is_embedding:
+            raise ValueError(
+                "GLM-5-Next Session AB accepts text generation only; "
+                "--is-embedding is outside the request-lifecycle boundary."
+            )
+        if self.dllm_algorithm is not None or self.dllm_algorithm_config is not None:
+            raise ValueError(
+                "GLM-5-Next diffusion-LLM inference is outside the Session AB "
+                "request-lifecycle boundary; --dllm-algorithm and its config "
+                "must remain unset."
+            )
+        if self.quantization != "fp8":
+            raise ValueError(
+                "GLM-5-Next Session AB accepts only the checkpoint-native "
+                f"FP8 weight format; got quantization={self.quantization!r}."
+            )
+
+        # Session AB accepts TP=1 for structural/component validation and TP=8
+        # for the pinned production checkpoint.  Intermediate TP widths and
+        # alternate PP/DP/CP/EP topologies have no acceptance evidence, and
+        # the mHC communicator intentionally rejects the scattered states
+        # produced by A2A MoE and dense fully-DP modes.
+        if self.tp_size not in (1, 8):
+            raise ValueError(
+                "GLM-5-Next Session AB accepts only TP=1 structural validation "
+                "or the TP=8 production topology; "
+                f"got tp_size={self.tp_size}."
+            )
+
+        topology = {
+            "pp_size": self.pp_size,
+            "dp_size": self.dp_size,
+            "moe_dp_size": self.moe_dp_size,
+            "attn_cp_size": self.attn_cp_size,
+            "ep_size": self.ep_size,
+            "moe_a2a_backend": self.moe_a2a_backend,
+            "moe_dense_tp_size": self.moe_dense_tp_size,
+        }
+        if topology != {
+            "pp_size": 1,
+            "dp_size": 1,
+            "moe_dp_size": 1,
+            "attn_cp_size": 1,
+            "ep_size": 1,
+            "moe_a2a_backend": "none",
+            "moe_dense_tp_size": None,
+        }:
+            raise ValueError(
+                "GLM-5-Next Session AB supports tensor parallelism only; "
+                "PP, DP/DCP, EP/A2A, and dense fully-DP MoE are outside the "
+                f"accepted topology. Got {topology}."
+            )
+
+        if self.speculative_algorithm is not None:
+            raise ValueError(
+                "GLM-5-Next MTP/speculative decoding is outside the current "
+                "Session AB adaptation boundary."
+            )
+        if self.enable_nsa_prefill_context_parallel:
+            raise ValueError(
+                "GLM-5-Next context-parallel prefill is outside the current "
+                "Session AB adaptation boundary."
+            )
+        if self.disaggregation_mode != "null":
+            raise ValueError(
+                "GLM-5-Next Session AB does not support PD/disaggregation; "
+                "--disaggregation-mode must be 'null'."
+            )
+        if self.enable_dp_attention:
+            raise ValueError(
+                "GLM-5-Next Session AB does not support --enable-dp-attention."
+            )
+        if self.enable_two_batch_overlap:
+            raise ValueError(
+                "GLM-5-Next Session AB does not support "
+                "--enable-two-batch-overlap."
+            )
+        if self.enable_piecewise_cuda_graph:
+            raise ValueError(
+                "GLM-5-Next Session AB requires eager execution and does not "
+                "support --enable-piecewise-cuda-graph."
+            )
+
+        if self.moe_runner_backend == "auto":
+            self.moe_runner_backend = "triton"
+        elif self.moe_runner_backend != "triton":
+            raise ValueError(
+                "GLM-5-Next Session AB requires --moe-runner-backend=triton; "
+                f"got {self.moe_runner_backend!r}. Cutlass, FlashInfer TRTLLM, "
+                "DeepGemm, and other MoE runners have not been verified to "
+                "propagate GLM's swiglu_limit correctly."
+            )
+
+        if self.kt_weight_path is not None:
+            kt_method = (self.kt_method or "").upper()
+            if kt_method != "FP8":
+                raise ValueError(
+                    "GLM-5-Next Session AB KT expert offload requires "
+                    "--kt-method FP8 so the block-E4M3 checkpoint layout is "
+                    "preserved and swiglu_limit reaches the "
+                    f"CPU expert kernel; got {self.kt_method!r}."
+                )
+
+        # The shared-expert fusion path has not been accepted for GLM's
+        # clamp-before-SiLU contract.  The top-level unfused shared expert has
+        # the exact model-local activation and is the Session AB oracle.
+        self.disable_shared_experts_fusion = True
+
+        # CUDA graph support is a later, separately accepted stage.
+        self.disable_cuda_graph = True
+
+        # GLM's KPool live tail is request-local and Session AB does not yet
+        # restore it from a reused prefix.  Force the safe no-prefix-cache
+        # route even though radix cache is enabled by default for other models.
+        self.disable_radix_cache = True
+
+        # Remember the exact-model gate so later generic normalization can
+        # revalidate without loading or inspecting configs for other models.
+        self._glm5_next_session_ab_active = True
+
+    def _configure_glm5_next_session_ab_nsa(self, major: int) -> None:
+        if major < 10:
+            raise ValueError(
+                "GLM-5-Next Session AB requires an NVIDIA Blackwell GPU "
+                "(compute capability major >= 10) for the validated FP8 "
+                "KPool4 path; "
+                f"got compute capability major {major}."
+            )
+        if self.kv_cache_dtype != "fp8_e4m3":
+            raise ValueError(
+                "GLM-5-Next Session AB requires --kv-cache-dtype=fp8_e4m3; "
+                f"got {self.kv_cache_dtype!r}. BF16 and other KV-cache "
+                "precisions are outside the accepted boundary."
+            )
+
+        if self.nsa_prefill_backend is None:
+            self.nsa_prefill_backend = "trtllm"
+        if self.nsa_decode_backend is None:
+            self.nsa_decode_backend = "trtllm"
+        if (
+            self.nsa_prefill_backend != "trtllm"
+            or self.nsa_decode_backend != "trtllm"
+        ):
+            raise ValueError(
+                "GLM-5-Next Session AB FP8 KPool4 requires trtllm for both "
+                "NSA prefill and decode; got "
+                f"prefill={self.nsa_prefill_backend!r}, "
+                f"decode={self.nsa_decode_backend!r}."
+            )
+
+        logger.warning(
+            "Set GLM-5-Next KPool4 NSA dispatcher paths to trtllm for FP8 KV "
+            "cache on Blackwell; Session AB uses the model-local eager sparse "
+            "MLA correctness fallback."
+        )
+
     def _set_default_nsa_kv_cache_dtype(self, major: int) -> str:
         user_set_prefill = self.nsa_prefill_backend is not None
         user_set_decode = self.nsa_decode_backend is not None
@@ -1392,6 +1571,13 @@ class ServerArgs:
 
         hf_config = self.get_model_config().hf_config
         model_arch = hf_config.architectures[0]
+        is_glm5_next = (
+            model_arch == "Glm5NextForConditionalGeneration"
+            and getattr(hf_config, "model_type", None) == "glm5_next"
+        )
+        sparse_hf_config = (
+            hf_config.get_text_config() if is_glm5_next else hf_config
+        )
 
         if model_arch in [
             "MistralLarge3ForCausalLM",
@@ -1457,9 +1643,20 @@ class ServerArgs:
             "MistralLarge3ForCausalLM",
             "PixtralForConditionalGeneration",
             "GlmMoeDsaForCausalLM",
+            "Glm5NextForConditionalGeneration",
         ]:
             # Set attention backend for DeepSeek
-            if is_deepseek_nsa(hf_config):  # DeepSeek 3.2, GlmMoeDsaForCausalLM
+            if is_deepseek_nsa(hf_config) or is_glm5_next:
+                if is_glm5_next:
+                    if self.quantization is None:
+                        self.quantization = get_quantization_config(hf_config)
+                    self._validate_glm5_next_session_ab_boundary()
+                    if not is_cuda() or is_hip() or is_npu():
+                        raise ValueError(
+                            "GLM-5-Next Session AB supports NVIDIA CUDA only; "
+                            "CPU, ROCm, and NPU execution are outside the "
+                            "accepted boundary."
+                        )
                 if model_arch == "GlmMoeDsaForCausalLM" and is_blackwell_supported():
                     envs.SGLANG_NSA_FORCE_MLA.set(True)
                     logger.warning(
@@ -1469,8 +1666,10 @@ class ServerArgs:
                     self.attention_backend = "nsa"
                     logger.info("Use nsa attention backend for DeepSeek with DSA.")
 
-                index_topk_freq = getattr(hf_config, "index_topk_freq", 1)
-                index_topk_pattern = getattr(hf_config, "index_topk_pattern", None)
+                index_topk_freq = getattr(sparse_hf_config, "index_topk_freq", 1)
+                index_topk_pattern = getattr(
+                    sparse_hf_config, "index_topk_pattern", None
+                )
                 if self.enable_two_batch_overlap and (
                     index_topk_freq > 1
                     or (index_topk_pattern is not None and "S" in index_topk_pattern)
@@ -1534,7 +1733,10 @@ class ServerArgs:
 
                     major, _ = torch.cuda.get_device_capability()
                     self._set_default_nsa_kv_cache_dtype(major)
-                    self._set_default_nsa_backends(self.kv_cache_dtype, major)
+                    if is_glm5_next:
+                        self._configure_glm5_next_session_ab_nsa(major)
+                    else:
+                        self._set_default_nsa_backends(self.kv_cache_dtype, major)
 
                 if self.enable_nsa_prefill_context_parallel:
                     assert (
@@ -2573,6 +2775,14 @@ class ServerArgs:
                 "mxfp8",
             ], "cutlass MoE is only supported with fp8/mxfp8 quantization"
             self.moe_runner_backend = "cutlass"
+
+        # Model-specific adjustment runs before this generic normalization.
+        # Revalidate exact GLM after all backend rewrites so MXFP8 defaults or
+        # the legacy Cutlass environment switch cannot silently leave the
+        # correctness-first Triton boundary.
+        if getattr(self, "_glm5_next_session_ab_active", False):
+            self._validate_glm5_next_session_ab_boundary()
+
         if self.moe_runner_backend == "cutlass" and self.quantization in [
             "fp8",
             "mxfp8",

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -31,6 +31,7 @@ from typing import Any, Callable, Dict, List, Literal, Optional, Union
 
 import orjson
 
+from sglang.srt.configs.glm5_next import GLM5_NEXT_SUPPORTED_TP_SIZES
 from sglang.srt.connector import ConnectorType
 from sglang.srt.environ import envs
 from sglang.srt.function_call.function_call_parser import FunctionCallParser
@@ -1393,13 +1394,11 @@ class ServerArgs:
                 f"FP8 weight format; got quantization={self.quantization!r}."
             )
 
-        # Session AB accepts only the TP=4 runtime layout.  Other TP widths and
-        # alternate PP/DP/CP/EP topologies are deliberately outside the
-        # released boundary.  The mHC communicator intentionally rejects the
-        # scattered states produced by A2A MoE and dense fully-DP modes.
-        if self.tp_size != 4:
+        # Keep the released GLM topology narrow while accepting every TP width
+        # validated by the model and its dedicated Layerwise transport.
+        if self.tp_size not in GLM5_NEXT_SUPPORTED_TP_SIZES:
             raise ValueError(
-                "GLM-5-Next Session AB accepts only TP=4; "
+                "GLM-5-Next Session AB supports TP sizes 1, 2, 4, and 8; "
                 f"got tp_size={self.tp_size}."
             )
 
@@ -1483,18 +1482,20 @@ class ServerArgs:
                 )
 
             # The positive threshold enables GLM's layerwise full-GPU prefill
-            # route.  It is supported only by the TP=4 runtime layout.
-            # Dynamic expert replacement mutates the resident set behind the
-            # shared context and is deliberately excluded.
+            # route.  Its single full-layer slot cannot coexist with resident
+            # GPU experts. Normalize those placement options before expert
+            # masks or GPU weights are allocated. This fallback is deliberately
+            # silent so existing launch scripts keep working unchanged.
             prefill_threshold = getattr(
                 self, "kt_gpu_prefill_token_threshold", None
             )
             if prefill_threshold is not None and prefill_threshold > 0:
-                if self.tp_size != 4:
-                    raise ValueError(
-                        "GLM-5-Next KT layerwise prefill "
-                        "(--kt-gpu-prefill-token-threshold > 0) requires TP=4."
-                    )
+                if (
+                    (getattr(self, "kt_num_gpu_experts", None) or 0) > 0
+                    or (getattr(self, "kt_gpu_experts_ratio", None) or 0) > 0
+                ):
+                    self.kt_num_gpu_experts = 0
+                    self.kt_gpu_experts_ratio = None
                 if getattr(self, "kt_enable_dynamic_expert_update", False):
                     raise ValueError(
                         "GLM-5-Next KT layerwise prefill requires "
@@ -1568,21 +1569,13 @@ class ServerArgs:
 
         prefill_threshold = getattr(self, "kt_gpu_prefill_token_threshold", None)
         if (
-            profile.is_consumer_gpu
+            capability == (8, 6)
             and prefill_threshold is not None
             and prefill_threshold > 0
         ):
             raise ValueError(
-                "GLM-5-Next layerwise prefill is not adapted for SM86/SM89; "
+                "GLM-5-Next layerwise prefill is not adapted for SM86; "
                 "set --kt-gpu-prefill-token-threshold=0."
-            )
-
-        if profile.is_consumer_gpu and bool(
-            getattr(self, "enable_multimodal", False)
-        ):
-            raise ValueError(
-                "GLM-5-Next SM86/SM89 acceptance covers text inference only; "
-                "--enable-multimodal must remain disabled."
             )
 
     def _set_default_nsa_kv_cache_dtype(self, major: int) -> str:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1433,8 +1433,8 @@ class ServerArgs:
             )
         if self.enable_piecewise_cuda_graph:
             raise ValueError(
-                "GLM-5-Next Session AB requires eager execution and does not "
-                "support --enable-piecewise-cuda-graph."
+                "GLM-5-Next Session C supports decode CUDA graphs only and does "
+                "not support --enable-piecewise-cuda-graph."
             )
 
         if self.moe_runner_backend == "auto":
@@ -1457,13 +1457,39 @@ class ServerArgs:
                     f"CPU expert kernel; got {self.kt_method!r}."
                 )
 
+            # The positive threshold enables GLM's layerwise full-GPU prefill
+            # route.  Its two-slot FP8 pipeline is accepted only for the TP=8
+            # production layout.  Dynamic expert replacement mutates the
+            # resident set behind those slots and is deliberately excluded.
+            prefill_threshold = getattr(
+                self, "kt_gpu_prefill_token_threshold", None
+            )
+            if prefill_threshold is not None and prefill_threshold > 0:
+                if self.tp_size != 8:
+                    raise ValueError(
+                        "GLM-5-Next KT layerwise prefill "
+                        "(--kt-gpu-prefill-token-threshold > 0) requires TP=8; "
+                        "TP=1 is structural-test-only and must keep the "
+                        "threshold unset or <= 0."
+                    )
+                if getattr(self, "kt_enable_dynamic_expert_update", False):
+                    raise ValueError(
+                        "GLM-5-Next KT layerwise prefill requires "
+                        "--kt-enable-dynamic-expert-update to remain disabled."
+                    )
+
         # The shared-expert fusion path has not been accepted for GLM's
         # clamp-before-SiLU contract.  The top-level unfused shared expert has
         # the exact model-local activation and is the Session AB oracle.
         self.disable_shared_experts_fusion = True
 
-        # CUDA graph support is a later, separately accepted stage.
-        self.disable_cuda_graph = True
+        # Session C captures normal decode only.  Fixed small graph batches
+        # bound the wide 1M-context NSA page-table and activation reservation;
+        # all unsupported graph modes are rejected above.  This exact-model
+        # override intentionally does not change any non-GLM defaults.
+        if not self.disable_cuda_graph:
+            self.cuda_graph_bs = [1, 2, 4]
+            self.cuda_graph_max_bs = 4
 
         # GLM's KPool live tail is request-local and Session AB does not yet
         # restore it from a reused prefix.  Force the safe no-prefix-cache
@@ -1506,8 +1532,8 @@ class ServerArgs:
 
         logger.warning(
             "Set GLM-5-Next KPool4 NSA dispatcher paths to trtllm for FP8 KV "
-            "cache on Blackwell; Session AB uses the model-local eager sparse "
-            "MLA correctness fallback."
+            "cache on Blackwell; Session C uses the model-local graph-safe "
+            "SM120 indexer and sparse-MLA kernels."
         )
 
     def _set_default_nsa_kv_cache_dtype(self, major: int) -> str:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1523,19 +1523,22 @@ class ServerArgs:
         # revalidate without loading or inspecting configs for other models.
         self._glm5_next_session_ab_active = True
 
-    def _configure_glm5_next_session_ab_nsa(self, major: int) -> None:
-        if major < 10:
+    def _configure_glm5_next_session_ab_nsa(
+        self, capability: tuple[int, int]
+    ) -> None:
+        from sglang.srt.configs.glm5_next import get_glm5_next_gpu_profile
+
+        profile = get_glm5_next_gpu_profile(capability)
+        if self.kv_cache_dtype == "auto":
+            self.kv_cache_dtype = profile.kv_cache_dtype
+        elif self.kv_cache_dtype == "bf16":
+            self.kv_cache_dtype = "bfloat16"
+
+        if self.kv_cache_dtype != profile.kv_cache_dtype:
             raise ValueError(
-                "GLM-5-Next Session AB requires an NVIDIA Blackwell GPU "
-                "(compute capability major >= 10) for the validated FP8 "
-                "KPool4 path; "
-                f"got compute capability major {major}."
-            )
-        if self.kv_cache_dtype != "fp8_e4m3":
-            raise ValueError(
-                "GLM-5-Next Session AB requires --kv-cache-dtype=fp8_e4m3; "
-                f"got {self.kv_cache_dtype!r}. BF16 and other KV-cache "
-                "precisions are outside the accepted boundary."
+                f"GLM-5-Next {profile.value} requires "
+                f"--kv-cache-dtype={profile.kv_cache_dtype}; got "
+                f"{self.kv_cache_dtype!r}."
             )
 
         if self.nsa_prefill_backend is None:
@@ -1547,17 +1550,40 @@ class ServerArgs:
             or self.nsa_decode_backend != "trtllm"
         ):
             raise ValueError(
-                "GLM-5-Next Session AB FP8 KPool4 requires trtllm for both "
+                "GLM-5-Next KPool4 requires the model-local trtllm dispatcher "
+                "for both "
                 "NSA prefill and decode; got "
                 f"prefill={self.nsa_prefill_backend!r}, "
                 f"decode={self.nsa_decode_backend!r}."
             )
 
         logger.warning(
-            "Set GLM-5-Next KPool4 NSA dispatcher paths to trtllm for FP8 KV "
-            "cache on Blackwell; Session C uses the model-local graph-safe "
-            "SM120 indexer and sparse-MLA kernels."
+            "Set GLM-5-Next GPU profile=%s, KV cache=%s, KPool cache=%s, "
+            "NSA dispatcher=trtllm; the dispatcher selects model-local "
+            "graph-safe kernels on SM86/SM89/SM120.",
+            profile.value,
+            profile.kv_cache_dtype,
+            profile.index_cache_dtype,
         )
+
+        prefill_threshold = getattr(self, "kt_gpu_prefill_token_threshold", None)
+        if (
+            profile.is_consumer_gpu
+            and prefill_threshold is not None
+            and prefill_threshold > 0
+        ):
+            raise ValueError(
+                "GLM-5-Next layerwise prefill is not adapted for SM86/SM89; "
+                "set --kt-gpu-prefill-token-threshold=0."
+            )
+
+        if profile.is_consumer_gpu and bool(
+            getattr(self, "enable_multimodal", False)
+        ):
+            raise ValueError(
+                "GLM-5-Next SM86/SM89 acceptance covers text inference only; "
+                "--enable-multimodal must remain disabled."
+            )
 
     def _set_default_nsa_kv_cache_dtype(self, major: int) -> str:
         user_set_prefill = self.nsa_prefill_backend is not None
@@ -1780,11 +1806,12 @@ class ServerArgs:
 
                     import torch
 
-                    major, _ = torch.cuda.get_device_capability()
-                    self._set_default_nsa_kv_cache_dtype(major)
+                    capability = torch.cuda.get_device_capability()
+                    major, _ = capability
                     if is_glm5_next:
-                        self._configure_glm5_next_session_ab_nsa(major)
+                        self._configure_glm5_next_session_ab_nsa(capability)
                     else:
+                        self._set_default_nsa_kv_cache_dtype(major)
                         self._set_default_nsa_backends(self.kv_cache_dtype, major)
 
                 if self.enable_nsa_prefill_context_parallel:

--- a/python/sglang/srt/utils/hf_transformers_utils.py
+++ b/python/sglang/srt/utils/hf_transformers_utils.py
@@ -740,85 +740,46 @@ def get_processor(
     if config.model_type == "glm5_next":
         if use_fast is False:
             raise ValueError(
-                "GLM-5-Next Session D requires the built-in torchvision image "
-                "processor; the slow image processor is not supported."
+                "GLM-5-Next requires the transformers-kt fast image/video "
+                "processors; slow processors are not supported."
             )
-
-        # transformers-kt 5.6.0.post1 has Glm46VProcessor, but no AutoProcessor
-        # or AutoImageProcessor registration for the checkpoint's Glmga class.
-        # Read the standard inline processor config and assemble the supported
-        # components directly, without importing a patched Transformers tree.
-        from transformers.models.glm46v.processing_glm46v import Glm46VProcessor
-        from transformers.models.glm46v.video_processing_glm46v import (
-            Glm46VVideoProcessor,
-        )
-
-        from sglang.srt.multimodal.processors.glm5_next import (
+        from transformers.models.glm5_next.image_processing_glm5_next import (
             Glm5NextImageProcessor,
+        )
+        from transformers.models.glm5_next.processing_glm5_next import (
             Glm5NextProcessor,
         )
+        from transformers.models.glm5_next.video_processing_glm5_next import (
+            Glm5NextVideoProcessor,
+        )
 
-        processor_lookup_kwargs = {
-            key: value
-            for key, value in kwargs.items()
-            if key
-            in {
-                "cache_dir",
-                "force_download",
-                "local_files_only",
-                "proxies",
-                "token",
-                "subfolder",
-            }
-        }
-        processor_dict, _ = Glm46VProcessor.get_processor_dict(
-            tokenizer_name,
-            revision=revision,
-            **processor_lookup_kwargs,
-        )
-        processor_class = processor_dict.get("processor_class")
-        if processor_class != "Glm46VProcessor":
-            raise ValueError(
-                "GLM-5-Next expected processor_class='Glm46VProcessor'; "
-                f"got {processor_class!r}."
-            )
-        image_config = processor_dict.get("image_processor")
-        if not isinstance(image_config, dict):
-            raise ValueError(
-                "GLM-5-Next processor_config.json must contain an inline "
-                "image_processor object."
-            )
-        image_processor = Glm5NextImageProcessor.from_checkpoint_config(
-            image_config
-        )
-        video_config = processor_dict.get("video_processor")
-        if not isinstance(video_config, dict) or video_config.get(
-            "video_processor_type"
-        ) != "Glm5NextVideoProcessor":
-            raise ValueError(
-                "GLM-5-Next pinned processor metadata must retain its "
-                "Glm5NextVideoProcessor declaration even though Session D "
-                "rejects video requests."
-            )
-        tokenizer = get_tokenizer(
+        processor = Glm5NextProcessor.from_pretrained(
             tokenizer_name,
             *args,
-            tokenizer_mode=tokenizer_mode,
             trust_remote_code=trust_remote_code,
-            tokenizer_revision=revision,
             revision=revision,
+            use_fast=True,
             **kwargs,
         )
-        # The pinned wheel does not contain Glm5NextVideoProcessor.  The parent
-        # processor's type contract nevertheless requires a video component,
-        # so use its compatible GLM46V base purely as a structural placeholder.
-        # It is never callable through the GLM5 facade or SGLang request path.
-        processor = Glm5NextProcessor(
-            image_processor=image_processor,
-            tokenizer=tokenizer,
-            video_processor=Glm46VVideoProcessor(),
-            chat_template=processor_dict.get("chat_template"),
-        )
+        if not isinstance(processor.image_processor, Glm5NextImageProcessor):
+            raise TypeError(
+                "GLM-5-Next checkpoint did not load Glm5NextImageProcessor: "
+                f"got {type(processor.image_processor).__name__}."
+            )
+        if not isinstance(processor.video_processor, Glm5NextVideoProcessor):
+            raise TypeError(
+                "GLM-5-Next checkpoint did not load Glm5NextVideoProcessor: "
+                f"got {type(processor.video_processor).__name__}."
+            )
+        if (
+            processor.image_processor.patch_expand_factor != 1
+            or processor.video_processor.patch_expand_factor != 1
+            or processor.video_processor.fps != 2
+        ):
+            raise ValueError(
+                "GLM-5-Next processor metadata changed: expected factor=1 for "
+                "image/video and video fps=2."
+            )
         return processor
 
     # fix: for Qwen2-VL and Sarashina2Vision models, inject default 'size' if not provided.

--- a/python/sglang/srt/utils/hf_transformers_utils.py
+++ b/python/sglang/srt/utils/hf_transformers_utils.py
@@ -54,6 +54,8 @@ from sglang.srt.configs import (
     DotsVLMConfig,
     ExaoneConfig,
     FalconH1Config,
+    Glm5NextConfig,
+    Glm5NextTextConfig,
     GraniteMoeHybridConfig,
     JetNemotronConfig,
     JetVLMConfig,
@@ -94,6 +96,8 @@ _CONFIG_REGISTRY: List[Type[PretrainedConfig]] = [
     # effect registration. The dataclass is lightweight and doesn't pull
     # DSV4 module deps.
     DeepSeekV4Config,
+    Glm5NextConfig,
+    Glm5NextTextConfig,
     MultiModalityConfig,
     KimiVLConfig,
     InternVLChatConfig,
@@ -818,4 +822,3 @@ def get_rope_config(config):
     if rope_params is not None:
         return rope_params["rope_theta"], rope_params
     return getattr(config, "rope_theta", 10000), getattr(config, "rope_scaling", None)
-

--- a/python/sglang/srt/utils/hf_transformers_utils.py
+++ b/python/sglang/srt/utils/hf_transformers_utils.py
@@ -737,6 +737,90 @@ def get_processor(
         config.update({"architectures": ["DeepseekOCRForCausalLM"]})
         _override_v_head_dim_if_zero(config)
 
+    if config.model_type == "glm5_next":
+        if use_fast is False:
+            raise ValueError(
+                "GLM-5-Next Session D requires the built-in torchvision image "
+                "processor; the slow image processor is not supported."
+            )
+
+        # transformers-kt 5.6.0.post1 has Glm46VProcessor, but no AutoProcessor
+        # or AutoImageProcessor registration for the checkpoint's Glmga class.
+        # Read the standard inline processor config and assemble the supported
+        # components directly, without importing a patched Transformers tree.
+        from transformers.models.glm46v.processing_glm46v import Glm46VProcessor
+        from transformers.models.glm46v.video_processing_glm46v import (
+            Glm46VVideoProcessor,
+        )
+
+        from sglang.srt.multimodal.processors.glm5_next import (
+            Glm5NextImageProcessor,
+            Glm5NextProcessor,
+        )
+
+        processor_lookup_kwargs = {
+            key: value
+            for key, value in kwargs.items()
+            if key
+            in {
+                "cache_dir",
+                "force_download",
+                "local_files_only",
+                "proxies",
+                "token",
+                "subfolder",
+            }
+        }
+        processor_dict, _ = Glm46VProcessor.get_processor_dict(
+            tokenizer_name,
+            revision=revision,
+            **processor_lookup_kwargs,
+        )
+        processor_class = processor_dict.get("processor_class")
+        if processor_class != "Glm46VProcessor":
+            raise ValueError(
+                "GLM-5-Next expected processor_class='Glm46VProcessor'; "
+                f"got {processor_class!r}."
+            )
+        image_config = processor_dict.get("image_processor")
+        if not isinstance(image_config, dict):
+            raise ValueError(
+                "GLM-5-Next processor_config.json must contain an inline "
+                "image_processor object."
+            )
+        image_processor = Glm5NextImageProcessor.from_checkpoint_config(
+            image_config
+        )
+        video_config = processor_dict.get("video_processor")
+        if not isinstance(video_config, dict) or video_config.get(
+            "video_processor_type"
+        ) != "Glm5NextVideoProcessor":
+            raise ValueError(
+                "GLM-5-Next pinned processor metadata must retain its "
+                "Glm5NextVideoProcessor declaration even though Session D "
+                "rejects video requests."
+            )
+        tokenizer = get_tokenizer(
+            tokenizer_name,
+            *args,
+            tokenizer_mode=tokenizer_mode,
+            trust_remote_code=trust_remote_code,
+            tokenizer_revision=revision,
+            revision=revision,
+            **kwargs,
+        )
+        # The pinned wheel does not contain Glm5NextVideoProcessor.  The parent
+        # processor's type contract nevertheless requires a video component,
+        # so use its compatible GLM46V base purely as a structural placeholder.
+        # It is never callable through the GLM5 facade or SGLang request path.
+        processor = Glm5NextProcessor(
+            image_processor=image_processor,
+            tokenizer=tokenizer,
+            video_processor=Glm46VVideoProcessor(),
+            chat_template=processor_dict.get("chat_template"),
+        )
+        return processor
+
     # fix: for Qwen2-VL and Sarashina2Vision models, inject default 'size' if not provided.
     if config.model_type in {"qwen2_vl", "sarashina2_vision"}:
         if "size" not in kwargs:

--- a/scripts/glm5_next_consumer_gpu_compile.py
+++ b/scripts/glm5_next_consumer_gpu_compile.py
@@ -1,0 +1,636 @@
+#!/usr/bin/env python3
+"""Offline-compile GLM-5-Next's SM86/SM89 Triton kernel matrix.
+
+This does not require a GPU.  It validates that the installed Triton toolchain
+can lower every model-local consumer-GPU kernel to the requested CUDA target.
+It is intentionally separate from numerical and end-to-end acceptance, which
+must run on real hardware.  Pass ``--resource-report`` to force recompilation
+and expose ptxas register, stack, and spill counts for static-config review.
+
+After this passes, run the consumer-GPU unit file on the target host, then use
+``glm5_next_session_c_benchmark.py collect --decode-input 32768
+--decode-output 256`` against a CUDA-Graph-enabled server.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import triton
+from triton.backends.compiler import GPUTarget
+from triton.compiler import ASTSource
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load(name: str, relative_path: str) -> ModuleType:
+    path = ROOT / relative_path
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _compile(
+    *,
+    label: str,
+    capability: int,
+    kernel: Any,
+    signature: dict[str, str],
+    constants: dict[str, Any],
+    num_warps: int,
+    num_stages: int,
+) -> None:
+    target = GPUTarget("cuda", capability, 32)
+    backend = triton.compiler.make_backend(target)
+    options = backend.parse_options({"num_warps": num_warps, "num_stages": num_stages})
+    triton.compile(
+        ASTSource(kernel, signature, constants),
+        target=target,
+        options=options.__dict__,
+    )
+    print(f"PASS {label}")
+
+
+def _compile_indexer(indexer: ModuleType, capability: int) -> None:
+    is_sm86 = capability == 86
+    value_type = "*bf16" if is_sm86 else "*fp8e4nv"
+    block_k, num_warps, num_stages = indexer.glm5_next_indexer_launch_config(
+        (capability // 10, capability % 10)
+    )
+    flat_signature = {
+        "q_ptr": value_type,
+        "k_ptr": value_type,
+        "k_scale_ptr": "*fp32",
+        "weights_ptr": "*fp32",
+        "ks_ptr": "*i32",
+        "ke_ptr": "*i32",
+        "logits_ptr": "*fp32",
+        "num_keys": "i32",
+    }
+    flat_constants = {
+        "stride_q_row": 4096,
+        "stride_q_head": 128,
+        "stride_q_dim": 1,
+        "stride_k_row": 128,
+        "stride_k_dim": 1,
+        "stride_weights_row": 32,
+        "stride_weights_head": 1,
+        "stride_logits_row": 32768,
+        "NUM_HEADS": 32,
+        "HEAD_DIM": 128,
+        "USE_K_SCALE": not is_sm86,
+        "BLOCK_K": block_k,
+    }
+    _compile(
+        label=f"indexer-flat-sm{capability}",
+        capability=capability,
+        kernel=indexer._glm5_next_flat_mqa_logits_kernel,
+        signature=flat_signature,
+        constants=flat_constants,
+        num_warps=num_warps,
+        num_stages=num_stages,
+    )
+
+    paged_signature = {
+        "q_ptr": value_type,
+        "cache_ptr": value_type,
+        "cache_scale_ptr": "*bf16" if is_sm86 else "*fp32",
+        "weights_ptr": "*fp32",
+        "seq_lens_ptr": "*i32",
+        "page_table_ptr": "*i32",
+        "logits_ptr": "*fp32",
+        "max_seq_len": "i32",
+        "num_cache_pages": "i32",
+    }
+    paged_constants = {
+        "stride_q_row": 4096,
+        "stride_q_head": 128,
+        "stride_q_dim": 1,
+        "stride_cache_page": 8192 if is_sm86 else 8448,
+        "stride_weights_row": 32,
+        "stride_weights_head": 1,
+        "stride_page_table_row": 4096,
+        "stride_page_table_col": 1,
+        "stride_logits_row": 262144,
+        "SCALE_OFFSET": 0 if is_sm86 else 2048,
+        "SCALE_PAGE_STRIDE": 0 if is_sm86 else 2112,
+        "NUM_HEADS": 32,
+        "HEAD_DIM": 128,
+        "PAGE_SIZE": 64,
+        "USE_K_SCALE": not is_sm86,
+        "BLOCK_K": block_k,
+    }
+    _compile(
+        label=f"indexer-paged-sm{capability}",
+        capability=capability,
+        kernel=indexer._glm5_next_paged_mqa_logits_kernel,
+        signature=paged_signature,
+        constants=paged_constants,
+        num_warps=num_warps,
+        num_stages=num_stages,
+    )
+
+
+def _compile_sparse_mla(sparse: ModuleType, capability: int) -> None:
+    is_sm86 = capability == 86
+    block_t, num_warps, num_stages = sparse.glm5_next_sparse_mla_launch_config(
+        (capability // 10, capability % 10)
+    )
+    signature = {
+        "query_ptr": "*bf16",
+        "kv_ptr": "*bf16" if is_sm86 else "*fp8e4nv",
+        "kv_scale_ptr": "*bf16" if is_sm86 else "*fp32",
+        "indices_ptr": "*i32",
+        "output_ptr": "*bf16",
+        "sm_scale": "fp32",
+        "num_kv_tokens": "i64",
+        "topk": "i32",
+    }
+    constants = {
+        "stride_query_row": 16384,
+        "stride_query_head": 512,
+        "stride_query_dim": 1,
+        "stride_kv_row": 512,
+        "stride_kv_dim": 1,
+        "stride_kv_scale_row": 512 if is_sm86 else 4,
+        "stride_kv_scale_group": 1,
+        "stride_indices_row": 2051,
+        "stride_indices_col": 1,
+        "stride_output_row": 16384,
+        "stride_output_head": 512,
+        "stride_output_dim": 1,
+        "HEAD_DIM": 512,
+        "SCALE_GROUP_SIZE": 128,
+        "USE_KV_SCALE": not is_sm86,
+        "BLOCK_T": block_t,
+    }
+    _compile(
+        label=f"sparse-mla-sm{capability}",
+        capability=capability,
+        kernel=sparse._glm5_next_sparse_mla_decode_kernel,
+        signature=signature,
+        constants=constants,
+        num_warps=num_warps,
+        num_stages=num_stages,
+    )
+
+
+def _compile_kda(kda: ModuleType, capability: int) -> None:
+    capability_tuple = (capability // 10, capability % 10)
+    gate_config, decode_config = kda.glm5_next_kda_launch_config(capability_tuple)
+    gate_block_t, gate_warps, gate_stages = gate_config
+    decode_warps, decode_stages = decode_config
+    _compile(
+        label=f"kda-gate-sm{capability}",
+        capability=capability,
+        kernel=kda._glm5_next_safe_gate_kernel,
+        signature={
+            "raw_gate": "*bf16",
+            "A_log": "*fp32",
+            "output": "*fp32",
+            "dt_bias": "*bf16",
+            "lower_bound": "fp32",
+            "T": "i32",
+            "H": "i32",
+        },
+        constants={
+            "D": 128,
+            "BT": gate_block_t,
+            "BD": 128,
+            "HAS_BIAS": True,
+        },
+        num_warps=gate_warps,
+        num_stages=gate_stages,
+    )
+    _compile(
+        label=f"kda-decode-sm{capability}",
+        capability=capability,
+        kernel=kda._glm5_next_safe_decode_kernel,
+        signature={
+            "A_log": "*fp32",
+            "raw_gate": "*bf16",
+            "dt_bias": "*bf16",
+            "lower_bound": "fp32",
+            "q": "*bf16",
+            "k": "*bf16",
+            "v": "*bf16",
+            "raw_beta": "*bf16",
+            "output": "*bf16",
+            "state_source": "*fp32",
+            "state_indices": "*i32",
+            "query_start_loc": "*i32",
+            "scale": "fp32",
+            "T": "i32",
+        },
+        constants={
+            "B": 1,
+            "H": 16,
+            "HV": 64,
+            "K": 128,
+            "V": 128,
+            "BK": 128,
+            "BV": 32,
+            "USE_INITIAL_STATE": True,
+            "USE_QK_L2NORM_IN_KERNEL": True,
+            "IS_VARLEN": True,
+            "SPLIT_N_HV_GRID": False,
+        },
+        num_warps=decode_warps,
+        num_stages=decode_stages,
+    )
+
+
+def _runtime_stride_signature(prefixes: tuple[str, ...]) -> dict[str, str]:
+    return {name: "i32" for name in prefixes}
+
+
+def _compile_kpool_sm86(kpool: ModuleType) -> None:
+    capability = 86
+    _compile(
+        label="kpool-gather-sm86",
+        capability=capability,
+        kernel=kpool._gather_index_k_bf16_prefix_into_kernel,
+        signature={
+            "buf_ptr": "*bf16",
+            "page_indices_ptr": "*i32",
+            "k_out_ptr": "*bf16",
+        },
+        constants={
+            "PAGE_SIZE": 64,
+            "BUF_NUMEL_PER_PAGE": 8192,
+            "HEAD_DIM": 128,
+            "BLOCK_D": 128,
+        },
+        num_warps=4,
+        num_stages=2,
+    )
+    writer_signature = {
+        "buf_ptr": "*bf16",
+        "slot_k_ptr": "*bf16",
+        "slot_score_ptr": "*bf16",
+        "ape_ptr": "*fp32",
+        "loc_ptr": "*i64",
+        "write_mask_ptr": "*i1",
+        "compressed_k_ptr": "*bf16",
+        "compressed_scale_ptr": "*bf16",
+        **_runtime_stride_signature(
+            (
+                "slot_k_stride_0",
+                "slot_k_stride_1",
+                "slot_score_stride_0",
+                "slot_score_stride_1",
+                "ape_stride_0",
+            )
+        ),
+    }
+    _compile(
+        label="kpool-writer-sm86",
+        capability=capability,
+        kernel=kpool._kpool_softmax_rotate_write_cache_bf16_kernel,
+        signature=writer_signature,
+        constants={
+            "PAGE_SIZE": 64,
+            "BUF_NUMEL_PER_PAGE": 8192,
+            "POOL_SIZE": 4,
+            "HEAD_DIM": 128,
+            "HAS_WRITE_MASK": False,
+            "RETURN_COMPRESSED": False,
+            "WRITE_CACHE": True,
+            "BLOCK_D": 128,
+        },
+        num_warps=4,
+        num_stages=2,
+    )
+    _compile(
+        label="kpool-writer-return-sm86",
+        capability=capability,
+        kernel=kpool._kpool_softmax_rotate_write_cache_bf16_kernel,
+        signature={**writer_signature, "compressed_scale_ptr": "*fp32"},
+        constants={
+            "PAGE_SIZE": 64,
+            "BUF_NUMEL_PER_PAGE": 8192,
+            "POOL_SIZE": 4,
+            "HEAD_DIM": 128,
+            "HAS_WRITE_MASK": False,
+            "RETURN_COMPRESSED": True,
+            "WRITE_CACHE": False,
+            "BLOCK_D": 128,
+        },
+        num_warps=4,
+        num_stages=2,
+    )
+    _compile(
+        label="kpool-writer-write-return-sm86",
+        capability=capability,
+        kernel=kpool._kpool_softmax_rotate_write_cache_bf16_kernel,
+        signature={**writer_signature, "compressed_scale_ptr": "*fp32"},
+        constants={
+            "PAGE_SIZE": 64,
+            "BUF_NUMEL_PER_PAGE": 8192,
+            "POOL_SIZE": 4,
+            "HEAD_DIM": 128,
+            "HAS_WRITE_MASK": False,
+            "RETURN_COMPRESSED": True,
+            "WRITE_CACHE": True,
+            "BLOCK_D": 128,
+        },
+        num_warps=4,
+        num_stages=2,
+    )
+    common_decode_signature = {
+        "buf_ptr": "*bf16",
+        "tail_k_ptr": "*bf16",
+        "tail_score_ptr": "*bf16",
+        "key_ptr": "*bf16",
+        "slot_score_ptr": "*bf16",
+        "ape_ptr": "*fp32",
+        "block_tables_ptr": "*i32",
+        "req_pool_indices_ptr": "*i32",
+        "positions_ptr": "*i64",
+        "seq_lens_ptr": "*i32",
+        "out_cache_loc_ptr": "*i64",
+        **_runtime_stride_signature(
+            (
+                "tail_k_stride_0",
+                "tail_k_stride_1",
+                "tail_score_stride_0",
+                "tail_score_stride_1",
+                "key_stride_0",
+                "slot_score_stride_0",
+                "ape_stride_0",
+                "block_tables_stride_0",
+                "block_tables_stride_1",
+            )
+        ),
+    }
+    _compile(
+        label="kpool-decode-sm86",
+        capability=capability,
+        kernel=kpool._kpool_decode_update_and_maybe_write_cache_bf16_kernel,
+        signature=common_decode_signature,
+        constants={
+            "REQ_POOL_SIZE": 2048,
+            "BUF_NUMEL_PER_PAGE": 8192,
+            "POOL_SIZE": 4,
+            "TAIL_SIZE": 4,
+            "HEAD_DIM": 128,
+            "BLOCK_TABLE_COLS": 16384,
+            "BLOCK_D": 128,
+            "SLOTS_PER_PAGE": 64,
+        },
+        num_warps=4,
+        num_stages=2,
+    )
+    _compile(
+        label="kpool-assemble-sm86",
+        capability=capability,
+        kernel=kpool._kpool_assemble_softmax_rotate_write_cache_bf16_kernel,
+        signature={
+            "buf_ptr": "*bf16",
+            "chunk_k_ptr": "*bf16",
+            "chunk_score_ptr": "*bf16",
+            "tail_k_ptr": "*bf16",
+            "tail_score_ptr": "*bf16",
+            "req_pool_idx_ptr": "*i32",
+            "n_from_tail_ptr": "*i32",
+            "chunk_src_start_ptr": "*i64",
+            "tail_logical_base_ptr": "*i64",
+            "ape_ptr": "*fp32",
+            "loc_ptr": "*i64",
+            "write_mask_ptr": "*i1",
+            **_runtime_stride_signature(
+                (
+                    "chunk_stride_0",
+                    "tail_stride_0",
+                    "tail_stride_1",
+                    "ape_stride_0",
+                )
+            ),
+        },
+        constants={
+            "BUF_NUMEL_PER_PAGE": 8192,
+            "POOL_SIZE": 4,
+            "TAIL_SIZE": 4,
+            "HEAD_DIM": 128,
+            "HAS_WRITE_MASK": True,
+            "BLOCK_D": 128,
+            "SLOTS_PER_PAGE": 64,
+        },
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+def _compile_kpool_sm89(kpool: ModuleType) -> None:
+    capability = 89
+    _compile(
+        label="kpool-gather-sm89",
+        capability=capability,
+        kernel=kpool._gather_index_k_scale_prefix_into_kernel,
+        signature={
+            "buf_u8_ptr": "*u8",
+            "buf_fp32_ptr": "*fp32",
+            "page_indices_ptr": "*i32",
+            "k_out_ptr": "*u8",
+            "scale_out_ptr": "*fp32",
+        },
+        constants={
+            "PAGE_SIZE": 64,
+            "BUF_NUMEL_PER_PAGE": 8448,
+            "HEAD_DIM": 128,
+            "S_OFFSET_NBYTES_IN_PAGE": 8192,
+            "BLOCK_D": 128,
+        },
+        num_warps=4,
+        num_stages=3,
+    )
+    writer_signature = {
+        "buf_fp8_ptr": "*fp8e4nv",
+        "buf_fp32_ptr": "*fp32",
+        "slot_k_ptr": "*bf16",
+        "slot_score_ptr": "*bf16",
+        "ape_ptr": "*fp32",
+        "loc_ptr": "*i64",
+        "write_mask_ptr": "*i1",
+        "compressed_k_ptr": "*fp8e4nv",
+        "compressed_scale_ptr": "*fp32",
+        **_runtime_stride_signature(
+            (
+                "slot_k_stride_0",
+                "slot_k_stride_1",
+                "slot_score_stride_0",
+                "slot_score_stride_1",
+                "ape_stride_0",
+            )
+        ),
+    }
+    _compile(
+        label="kpool-writer-sm89",
+        capability=capability,
+        kernel=kpool._kpool_softmax_rotate_write_cache_kernel,
+        signature=writer_signature,
+        constants={
+            "PAGE_SIZE": 64,
+            "BUF_NUMEL_PER_PAGE": 8448,
+            "POOL_SIZE": 4,
+            "HEAD_DIM": 128,
+            "S_OFFSET_NBYTES_IN_PAGE": 8192,
+            "ROUND_SCALE": False,
+            "HAS_WRITE_MASK": False,
+            "RETURN_COMPRESSED": False,
+            "WRITE_CACHE": True,
+            "BLOCK_D": 128,
+        },
+        num_warps=4,
+        num_stages=3,
+    )
+    decode_signature = {
+        "buf_fp8_ptr": "*fp8e4nv",
+        "buf_fp32_ptr": "*fp32",
+        "tail_k_ptr": "*bf16",
+        "tail_score_ptr": "*bf16",
+        "key_ptr": "*bf16",
+        "slot_score_ptr": "*bf16",
+        "ape_ptr": "*fp32",
+        "block_tables_ptr": "*i32",
+        "req_pool_indices_ptr": "*i32",
+        "positions_ptr": "*i64",
+        "seq_lens_ptr": "*i32",
+        "out_cache_loc_ptr": "*i64",
+        **_runtime_stride_signature(
+            (
+                "tail_k_stride_0",
+                "tail_k_stride_1",
+                "tail_score_stride_0",
+                "tail_score_stride_1",
+                "key_stride_0",
+                "slot_score_stride_0",
+                "ape_stride_0",
+                "block_tables_stride_0",
+                "block_tables_stride_1",
+            )
+        ),
+    }
+    _compile(
+        label="kpool-decode-sm89",
+        capability=capability,
+        kernel=kpool._kpool_decode_update_and_maybe_write_cache_kernel,
+        signature=decode_signature,
+        constants={
+            "REQ_POOL_SIZE": 2048,
+            "PAGE_SIZE": 64,
+            "BUF_NUMEL_PER_PAGE": 8448,
+            "POOL_SIZE": 4,
+            "TAIL_SIZE": 4,
+            "HEAD_DIM": 128,
+            "BLOCK_TABLE_COLS": 16384,
+            "S_OFFSET_NBYTES_IN_PAGE": 8192,
+            "ROUND_SCALE": False,
+            "BLOCK_D": 128,
+            "SLOTS_PER_PAGE": 64,
+        },
+        num_warps=4,
+        num_stages=3,
+    )
+    _compile(
+        label="kpool-assemble-sm89",
+        capability=capability,
+        kernel=kpool._kpool_assemble_softmax_rotate_write_cache_kernel,
+        signature={
+            "buf_fp8_ptr": "*fp8e4nv",
+            "buf_fp32_ptr": "*fp32",
+            "chunk_k_ptr": "*bf16",
+            "chunk_score_ptr": "*bf16",
+            "tail_k_ptr": "*bf16",
+            "tail_score_ptr": "*bf16",
+            "req_pool_idx_ptr": "*i32",
+            "n_from_tail_ptr": "*i32",
+            "chunk_src_start_ptr": "*i64",
+            "tail_logical_base_ptr": "*i64",
+            "ape_ptr": "*fp32",
+            "loc_ptr": "*i64",
+            "write_mask_ptr": "*i1",
+            **_runtime_stride_signature(
+                (
+                    "chunk_stride_0",
+                    "tail_stride_0",
+                    "tail_stride_1",
+                    "ape_stride_0",
+                )
+            ),
+        },
+        constants={
+            "BUF_NUMEL_PER_PAGE": 8448,
+            "POOL_SIZE": 4,
+            "TAIL_SIZE": 4,
+            "HEAD_DIM": 128,
+            "S_OFFSET_NBYTES_IN_PAGE": 8192,
+            "ROUND_SCALE": False,
+            "HAS_WRITE_MASK": True,
+            "BLOCK_D": 128,
+            "SLOTS_PER_PAGE": 64,
+        },
+        num_warps=4,
+        num_stages=3,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--targets",
+        nargs="+",
+        choices=("86", "89"),
+        default=("86", "89"),
+    )
+    parser.add_argument(
+        "--resource-report",
+        action="store_true",
+        help="force recompilation and print ptxas register/spill usage",
+    )
+    args = parser.parse_args()
+
+    if args.resource_report:
+        from triton import knobs
+
+        knobs.compilation.always_compile = True
+        knobs.nvidia.dump_ptxas_log = True
+
+    indexer = _load(
+        "_glm5_next_indexer_compile",
+        "python/sglang/srt/layers/attention/nsa/glm5_next_indexer_triton.py",
+    )
+    sparse = _load(
+        "_glm5_next_sparse_compile",
+        "python/sglang/srt/layers/attention/nsa/glm5_next_sparse_attention.py",
+    )
+    kda = _load(
+        "_glm5_next_kda_compile",
+        "python/sglang/srt/layers/attention/linear/kernels/glm5_next_kda_ops.py",
+    )
+    kpool = _load(
+        "_glm5_next_kpool_compile",
+        "python/sglang/srt/layers/attention/nsa/kpool_fp8_index.py",
+    )
+
+    for target in args.targets:
+        capability = int(target)
+        _compile_indexer(indexer, capability)
+        _compile_sparse_mla(sparse, capability)
+        _compile_kda(kda, capability)
+        if capability == 86:
+            _compile_kpool_sm86(kpool)
+        else:
+            _compile_kpool_sm89(kpool)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/glm5_next_session_c_benchmark.py
+++ b/scripts/glm5_next_session_c_benchmark.py
@@ -1,0 +1,835 @@
+#!/usr/bin/env python3
+"""Session-C single-concurrency HTTP benchmark and acceptance collector.
+
+This script intentionally does not import SGLang.  It drives the native
+``/generate`` endpoint with deterministic token-id inputs and writes a
+machine-readable record suitable for comparing eager and CUDA Graph servers.
+
+The current SGLang response always reports ``meta_info.e2e_latency``.  With
+``--enable-metrics`` it additionally reports ``meta_info.decode_throughput``
+using this server-side definition::
+
+    completion_tokens / (finished_time - first_token_time)
+
+There are no direct TTFT or ITL response fields.  When both server fields are
+present, this collector recovers the server decode interval from that exact
+definition, then derives server TTFT and mean ITL.  Missing or inconsistent
+fields remain ``null`` and fail the performance gate.  Client streaming clocks
+are retained only as diagnostics and never substitute for server metrics.
+
+Examples::
+
+    python scripts/glm5_next_session_c_benchmark.py collect \
+      --label eager --base-url http://127.0.0.1:30100 \
+      --output /mnt/.../session_c/perf/eager.json
+
+    python scripts/glm5_next_session_c_benchmark.py collect \
+      --label graph --base-url http://127.0.0.1:30101 \
+      --output /mnt/.../session_c/perf/graph.json
+
+    python scripts/glm5_next_session_c_benchmark.py compare \
+      --eager /mnt/.../session_c/perf/eager.json \
+      --graph /mnt/.../session_c/perf/graph.json \
+      --output /mnt/.../session_c/perf/graph-vs-eager.json
+
+    python scripts/glm5_next_session_c_benchmark.py long \
+      --label layerwise-500k-1024 --base-url http://127.0.0.1:30101 \
+      --output /mnt/.../session_c/perf/layerwise-500k-1024.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import platform
+import statistics
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Callable, Iterable
+
+SCHEMA_VERSION = 1
+FIXTURE_SEED = 20260812
+DEFAULT_VOCAB_SIZE = 154880
+DEFAULT_WARMUPS = 2
+DEFAULT_MEASURED = 5
+DEFAULT_SHORT_INPUT = 128
+DEFAULT_SHORT_OUTPUT = 128
+DEFAULT_DECODE_INPUT = 4096
+DEFAULT_DECODE_OUTPUT = 256
+DEFAULT_LONG_INPUT = 500_000
+DEFAULT_LONG_OUTPUT = 1024
+
+SERVER_METRIC_DERIVATION = {
+    "server_e2e_s": "meta_info.e2e_latency",
+    "server_output_throughput_tps": "meta_info.decode_throughput",
+    "server_decode_duration_s": (
+        "meta_info.completion_tokens / meta_info.decode_throughput"
+    ),
+    "server_ttft_s": ("meta_info.e2e_latency - server_decode_duration_s"),
+    "server_mean_itl_s": (
+        "server_decode_duration_s / (meta_info.completion_tokens - 1)"
+    ),
+}
+
+REQUIRED_MEASURED_METRICS = (
+    "wall_e2e_s",
+    "server_e2e_s",
+    "server_ttft_s",
+    "server_mean_itl_s",
+    "server_output_throughput_tps",
+)
+
+
+def _finite_number(value: Any) -> bool:
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(float(value))
+    )
+
+
+def _sha256_token_ids(token_ids: Iterable[int]) -> str:
+    digest = hashlib.sha256()
+    for token_id in token_ids:
+        digest.update(int(token_id).to_bytes(4, "little", signed=False))
+    return digest.hexdigest()
+
+
+def build_fixture(
+    length: int,
+    vocab_size: int,
+    *,
+    salt: int,
+    seed: int = FIXTURE_SEED,
+) -> dict[str, Any]:
+    """Build a deterministic tokenizer-independent token-id fixture."""
+    if length <= 0:
+        raise ValueError(f"input length must be positive, got {length}")
+    if vocab_size < 4096:
+        raise ValueError(f"unexpectedly small vocabulary: {vocab_size}")
+    span = vocab_size - 2048
+    token_ids = [
+        1024 + ((index * 7_919 + salt * 104_729 + seed) % span)
+        for index in range(length)
+    ]
+    return {
+        "input_tokens": length,
+        "vocab_size": vocab_size,
+        "fixture_seed": seed,
+        "salt": salt,
+        "input_sha256": _sha256_token_ids(token_ids),
+        "input_ids": token_ids,
+    }
+
+
+def percentile(values: list[float], percent: float) -> float:
+    """Return a linearly interpolated percentile (NumPy's default method)."""
+    if not values:
+        raise ValueError("percentile requires at least one value")
+    if not 0.0 <= percent <= 100.0:
+        raise ValueError(f"percent must be in [0, 100], got {percent}")
+    ordered = sorted(float(value) for value in values)
+    position = (len(ordered) - 1) * percent / 100.0
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return ordered[lower]
+    fraction = position - lower
+    return ordered[lower] * (1.0 - fraction) + ordered[upper] * fraction
+
+
+def _metric_summary(records: list[dict[str, Any]], key: str) -> dict[str, Any]:
+    values = [record.get(key) for record in records]
+    finite = [float(value) for value in values if _finite_number(value)]
+    complete = len(finite) == len(records) and bool(records)
+    return {
+        "count": len(finite),
+        "expected_count": len(records),
+        "complete": complete,
+        "median": statistics.median(finite) if complete else None,
+        "p95": percentile(finite, 95.0) if complete else None,
+        "values": finite,
+    }
+
+
+def extract_server_metrics(
+    meta_info: dict[str, Any], completion_tokens: int
+) -> dict[str, Any]:
+    """Extract only genuine server timing and exact algebraic derivatives."""
+    result: dict[str, Any] = {
+        "server_e2e_s": None,
+        "server_decode_duration_s": None,
+        "server_ttft_s": None,
+        "server_mean_itl_s": None,
+        "server_output_throughput_tps": None,
+        "server_metric_errors": [],
+        "server_metric_derivation": SERVER_METRIC_DERIVATION,
+    }
+    e2e = meta_info.get("e2e_latency")
+    throughput = meta_info.get("decode_throughput")
+
+    if not _finite_number(e2e) or float(e2e) <= 0.0:
+        result["server_metric_errors"].append(
+            "missing or invalid meta_info.e2e_latency"
+        )
+    else:
+        result["server_e2e_s"] = float(e2e)
+
+    if not _finite_number(throughput) or float(throughput) <= 0.0:
+        result["server_metric_errors"].append(
+            "missing or invalid meta_info.decode_throughput; "
+            "launch SGLang with --enable-metrics"
+        )
+        return result
+    result["server_output_throughput_tps"] = float(throughput)
+
+    if completion_tokens <= 1:
+        result["server_metric_errors"].append(
+            "at least two completion tokens are required for ITL"
+        )
+        return result
+    if result["server_e2e_s"] is None:
+        return result
+
+    decode_duration = completion_tokens / float(throughput)
+    ttft = float(e2e) - decode_duration
+    tolerance = max(float(e2e) * 1e-9, 1e-9)
+    if not math.isfinite(decode_duration) or decode_duration <= 0.0:
+        result["server_metric_errors"].append(
+            "derived server decode duration is invalid"
+        )
+        return result
+    if ttft < -tolerance or ttft > float(e2e) + tolerance:
+        result["server_metric_errors"].append(
+            "server timing fields are inconsistent: recovered TTFT is outside "
+            "the E2E interval"
+        )
+        return result
+
+    result["server_decode_duration_s"] = decode_duration
+    result["server_ttft_s"] = max(ttft, 0.0)
+    result["server_mean_itl_s"] = decode_duration / (completion_tokens - 1)
+    return result
+
+
+def _post_json_request(
+    url: str,
+    body: dict[str, Any],
+    *,
+    timeout: float,
+    opener: Callable[..., Any],
+) -> Any:
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(body, separators=(",", ":")).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    return opener(request, timeout=timeout)
+
+
+def flush_cache(
+    base_url: str,
+    *,
+    timeout: float,
+    opener: Callable[..., Any] = urllib.request.urlopen,
+) -> None:
+    """Flush before every request so repeated prompts cannot hit prefix cache."""
+    with _post_json_request(
+        f"{base_url.rstrip('/')}/flush_cache",
+        {},
+        timeout=timeout,
+        opener=opener,
+    ) as response:
+        status = getattr(response, "status", response.getcode())
+        payload = response.read()
+    if status < 200 or status >= 300:
+        raise RuntimeError(f"flush_cache returned HTTP {status}: {payload[:512]!r}")
+
+
+def _update_output_ids(
+    output_ids: list[int], raw_ids: Any, previous_count: int, current_count: int
+) -> list[int]:
+    chunk_ids = [int(token_id) for token_id in (raw_ids or [])]
+    if len(chunk_ids) == current_count:
+        return chunk_ids
+    delta = current_count - previous_count
+    if delta > 0 and len(chunk_ids) >= delta:
+        output_ids.extend(chunk_ids[-delta:])
+    return output_ids
+
+
+def run_streaming_request(
+    base_url: str,
+    input_ids: list[int],
+    output_tokens: int,
+    *,
+    timeout: float,
+    opener: Callable[..., Any] = urllib.request.urlopen,
+    clock: Callable[[], float] = time.perf_counter,
+) -> dict[str, Any]:
+    """Run one request and return raw, client, and server timing evidence."""
+    request_body = {
+        "input_ids": input_ids,
+        "sampling_params": {
+            "temperature": 0,
+            "max_new_tokens": output_tokens,
+            "ignore_eos": True,
+            "skip_special_tokens": False,
+        },
+        "stream": True,
+    }
+    started = clock()
+    first_token_at: float | None = None
+    token_arrival_times: list[float] = []
+    output_ids: list[int] = []
+    completion_tokens = 0
+    final_meta: dict[str, Any] = {}
+    finish_reason: Any = None
+    stream_had_multi_token_chunk = False
+
+    try:
+        response_context = _post_json_request(
+            f"{base_url.rstrip('/')}/generate",
+            request_body,
+            timeout=timeout,
+            opener=opener,
+        )
+        with response_context as response:
+            status = getattr(response, "status", response.getcode())
+            if status < 200 or status >= 300:
+                error_body = response.read()
+                raise RuntimeError(
+                    f"generate returned HTTP {status}: {error_body[:1024]!r}"
+                )
+            for raw_line in response:
+                line = raw_line.strip()
+                if not line.startswith(b"data:"):
+                    continue
+                raw_data = line[5:].strip()
+                if raw_data == b"[DONE]":
+                    break
+                message = json.loads(raw_data)
+                meta = message.get("meta_info") or {}
+                current_count = int(meta.get("completion_tokens") or 0)
+                if current_count > completion_tokens:
+                    arrived = clock()
+                    delta = current_count - completion_tokens
+                    if delta != 1:
+                        stream_had_multi_token_chunk = True
+                    if first_token_at is None:
+                        first_token_at = arrived
+                    token_arrival_times.extend([arrived] * delta)
+                    output_ids = _update_output_ids(
+                        output_ids,
+                        message.get("output_ids"),
+                        completion_tokens,
+                        current_count,
+                    )
+                    completion_tokens = current_count
+                final_meta = meta
+                if meta.get("finish_reason") is not None:
+                    finish_reason = meta["finish_reason"]
+    except urllib.error.HTTPError as error:
+        detail = error.read()[:1024]
+        raise RuntimeError(
+            f"generate returned HTTP {error.code}: {detail!r}"
+        ) from error
+
+    finished = clock()
+    if first_token_at is None:
+        raise RuntimeError("stream ended without an output token")
+    prompt_tokens = int(final_meta.get("prompt_tokens") or 0)
+    if prompt_tokens != len(input_ids):
+        raise RuntimeError(
+            f"server reported {prompt_tokens} prompt tokens, expected {len(input_ids)}"
+        )
+    if completion_tokens != output_tokens or len(output_ids) != output_tokens:
+        raise RuntimeError(
+            "incomplete output: "
+            f"completion_tokens={completion_tokens}, output_ids={len(output_ids)}, "
+            f"expected={output_tokens}"
+        )
+    if finish_reason is None:
+        raise RuntimeError("final response did not contain a finish_reason")
+
+    wall_e2e = finished - started
+    client_ttft = first_token_at - started
+    client_itls: list[float] = []
+    if not stream_had_multi_token_chunk and len(token_arrival_times) > 1:
+        client_itls = [
+            later - earlier
+            for earlier, later in zip(token_arrival_times, token_arrival_times[1:])
+        ]
+    record: dict[str, Any] = {
+        "success": True,
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "output_ids": output_ids,
+        "output_sha256": _sha256_token_ids(output_ids),
+        "finish_reason": finish_reason,
+        "wall_e2e_s": wall_e2e,
+        "client_ttft_s": client_ttft,
+        "client_mean_itl_s": (statistics.mean(client_itls) if client_itls else None),
+        "client_output_throughput_tps": completion_tokens / wall_e2e,
+        "client_stream_itl_complete": bool(client_itls),
+        "raw_server_meta": {
+            key: final_meta.get(key)
+            for key in (
+                "e2e_latency",
+                "decode_throughput",
+                "request_received_ts",
+                "request_finished_ts",
+                "forward_entry_time",
+                "prefill_finished_time",
+                "queue_time",
+                "prefill_waiting_latency",
+                "prefill_launch_latency",
+                "prompt_tokens",
+                "completion_tokens",
+            )
+            if key in final_meta
+        },
+    }
+    record.update(extract_server_metrics(final_meta, completion_tokens))
+    return record
+
+
+def summarize_records(
+    records: list[dict[str, Any]], *, expected_count: int
+) -> dict[str, Any]:
+    successful = [record for record in records if record.get("success")]
+    request_complete = (
+        len(records) == expected_count and len(successful) == expected_count
+    )
+    metric_summaries = {
+        key: _metric_summary(successful, key) for key in REQUIRED_MEASURED_METRICS
+    }
+    output_digest_values = [record.get("output_sha256") for record in successful]
+    output_evidence_complete = all(
+        isinstance(value, str) and bool(value) for value in output_digest_values
+    )
+    output_digests = set(output_digest_values) if output_evidence_complete else set()
+    failures = [
+        str(record.get("error", "request failed"))
+        for record in records
+        if not record.get("success")
+    ]
+    for key, summary in metric_summaries.items():
+        if not summary["complete"]:
+            failures.append(f"measured metric {key} is incomplete")
+    if not output_evidence_complete:
+        failures.append("measured output digest evidence is incomplete")
+    deterministic = (
+        request_complete and output_evidence_complete and len(output_digests) == 1
+    )
+    if not deterministic:
+        failures.append("measured output token ids are not deterministic")
+    return {
+        "expected_measured_requests": expected_count,
+        "successful_measured_requests": len(successful),
+        "requests_complete": request_complete,
+        "deterministic_output_ids": deterministic,
+        "output_digest_evidence_complete": output_evidence_complete,
+        "metrics": metric_summaries,
+        "failures": failures,
+        "pass": not failures,
+    }
+
+
+def _failed_record(error: Exception) -> dict[str, Any]:
+    return {
+        "success": False,
+        "error": f"{type(error).__name__}: {error}",
+        **{key: None for key in REQUIRED_MEASURED_METRICS},
+    }
+
+
+def collect_shape(
+    *,
+    name: str,
+    role: str,
+    base_url: str,
+    input_tokens: int,
+    output_tokens: int,
+    vocab_size: int,
+    fixture_seed: int,
+    salt: int,
+    warmups: int,
+    measured: int,
+    timeout: float,
+    should_flush_cache: bool,
+    opener: Callable[..., Any] = urllib.request.urlopen,
+) -> dict[str, Any]:
+    fixture = build_fixture(input_tokens, vocab_size, salt=salt, seed=fixture_seed)
+    input_ids = fixture.pop("input_ids")
+
+    def invoke(phase: str, index: int) -> dict[str, Any]:
+        try:
+            if should_flush_cache:
+                flush_cache(base_url, timeout=timeout, opener=opener)
+            record = run_streaming_request(
+                base_url,
+                input_ids,
+                output_tokens,
+                timeout=timeout,
+                opener=opener,
+            )
+        except Exception as error:  # Preserve partial acceptance evidence.
+            record = _failed_record(error)
+        record.update({"phase": phase, "index": index})
+        return record
+
+    warmup_records = [invoke("warmup", index) for index in range(warmups)]
+    measured_records = [invoke("measured", index) for index in range(measured)]
+    summary = summarize_records(measured_records, expected_count=measured)
+    warmups_complete = len(warmup_records) == warmups and all(
+        record.get("success") for record in warmup_records
+    )
+    failures = list(summary["failures"])
+    if not warmups_complete:
+        failures.append("one or more warmup requests failed")
+    return {
+        "name": name,
+        "role": role,
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "fixture": fixture,
+        "warmups": warmup_records,
+        "measured": measured_records,
+        "summary": summary,
+        "failures": failures,
+        "pass": warmups_complete and summary["pass"],
+    }
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    with temporary.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+    temporary.replace(path)
+
+
+def run_collect(args: argparse.Namespace) -> int:
+    shapes = [
+        collect_shape(
+            name=f"short_{args.short_input}_{args.short_output}",
+            role="short",
+            base_url=args.base_url,
+            input_tokens=args.short_input,
+            output_tokens=args.short_output,
+            vocab_size=args.vocab_size,
+            fixture_seed=args.fixture_seed,
+            salt=17,
+            warmups=args.warmups,
+            measured=args.measured,
+            timeout=args.request_timeout,
+            should_flush_cache=not args.no_flush_cache,
+        ),
+        collect_shape(
+            name=f"decode_{args.decode_input}_{args.decode_output}",
+            role="decode",
+            base_url=args.base_url,
+            input_tokens=args.decode_input,
+            output_tokens=args.decode_output,
+            vocab_size=args.vocab_size,
+            fixture_seed=args.fixture_seed,
+            salt=41,
+            warmups=args.warmups,
+            measured=args.measured,
+            timeout=args.request_timeout,
+            should_flush_cache=not args.no_flush_cache,
+        ),
+    ]
+    contract_compliant = (
+        args.warmups == DEFAULT_WARMUPS
+        and args.measured == DEFAULT_MEASURED
+        and args.short_input == DEFAULT_SHORT_INPUT
+        and args.short_output == DEFAULT_SHORT_OUTPUT
+        and args.decode_input == DEFAULT_DECODE_INPUT
+        and args.decode_output == DEFAULT_DECODE_OUTPUT
+    )
+    failures = []
+    if not contract_compliant:
+        failures.append(
+            "collection parameters differ from the frozen Session-C contract"
+        )
+    failures.extend(
+        f"{shape['name']}: {failure}"
+        for shape in shapes
+        for failure in shape["failures"]
+    )
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "kind": "glm5_next_session_c_benchmark",
+        "created_unix": time.time(),
+        "label": args.label,
+        "base_url": args.base_url.rstrip("/"),
+        "environment": {"python": sys.version, "platform": platform.platform()},
+        "contract": {
+            "request_concurrency": 1,
+            "warmups": args.warmups,
+            "measured": args.measured,
+            "flush_cache_before_each_request": not args.no_flush_cache,
+            "server_metrics_required": True,
+            "requires_server_enable_metrics": True,
+            "metric_derivation": SERVER_METRIC_DERIVATION,
+            "compliant": contract_compliant,
+        },
+        "shapes": shapes,
+        "failures": failures,
+        "pass": not failures,
+    }
+    _atomic_write_json(Path(args.output), payload)
+    print(
+        json.dumps(
+            {
+                "output": str(Path(args.output)),
+                "pass": payload["pass"],
+                "shape_pass": {shape["name"]: shape["pass"] for shape in shapes},
+            },
+            indent=2,
+        )
+    )
+    return 0 if payload["pass"] else 1
+
+
+def _shape_by_role(payload: dict[str, Any], role: str) -> dict[str, Any] | None:
+    matches = [
+        shape for shape in payload.get("shapes", []) if shape.get("role") == role
+    ]
+    return matches[0] if len(matches) == 1 else None
+
+
+def _summary_value(
+    shape: dict[str, Any] | None, metric: str, statistic: str
+) -> float | None:
+    if shape is None:
+        return None
+    value = shape.get("summary", {}).get("metrics", {}).get(metric, {}).get(statistic)
+    return float(value) if _finite_number(value) else None
+
+
+def compare_payloads(eager: dict[str, Any], graph: dict[str, Any]) -> dict[str, Any]:
+    eager_decode = _shape_by_role(eager, "decode")
+    graph_decode = _shape_by_role(graph, "decode")
+    failures: list[str] = []
+    if eager.get("schema_version") != SCHEMA_VERSION:
+        failures.append("unsupported eager schema")
+    if graph.get("schema_version") != SCHEMA_VERSION:
+        failures.append("unsupported graph schema")
+    for role, payload in (("eager", eager), ("graph", graph)):
+        if payload.get("kind") != "glm5_next_session_c_benchmark":
+            failures.append(f"{role} payload kind is invalid")
+        if payload.get("pass") is not True:
+            failures.append(f"{role} collection did not pass")
+        if payload.get("contract", {}).get("compliant") is not True:
+            failures.append(f"{role} contract is not compliant")
+    if eager.get("contract") != graph.get("contract"):
+        failures.append("eager and graph contracts differ")
+    if eager_decode is None or graph_decode is None:
+        failures.append("each input must contain exactly one decode shape")
+    elif (
+        eager_decode.get("input_tokens"),
+        eager_decode.get("output_tokens"),
+        eager_decode.get("fixture", {}).get("input_sha256"),
+    ) != (
+        graph_decode.get("input_tokens"),
+        graph_decode.get("output_tokens"),
+        graph_decode.get("fixture", {}).get("input_sha256"),
+    ):
+        failures.append("eager and graph decode fixtures do not match")
+
+    eager_itl_median = _summary_value(eager_decode, "server_mean_itl_s", "median")
+    graph_itl_median = _summary_value(graph_decode, "server_mean_itl_s", "median")
+    eager_itl_p95 = _summary_value(eager_decode, "server_mean_itl_s", "p95")
+    graph_itl_p95 = _summary_value(graph_decode, "server_mean_itl_s", "p95")
+    eager_throughput = _summary_value(
+        eager_decode, "server_output_throughput_tps", "median"
+    )
+    graph_throughput = _summary_value(
+        graph_decode, "server_output_throughput_tps", "median"
+    )
+
+    def upper_gate(
+        name: str, actual: float | None, limit: float | None
+    ) -> dict[str, Any]:
+        available = actual is not None and limit is not None
+        return {
+            "name": name,
+            "actual": actual,
+            "limit": limit,
+            "operator": "<=",
+            "pass": bool(available and actual <= limit),
+            "reason": None if available else "required server metric is null",
+        }
+
+    median_gate = upper_gate(
+        "graph_median_itl_at_most_0.90_eager",
+        graph_itl_median,
+        eager_itl_median * 0.90 if eager_itl_median is not None else None,
+    )
+    p95_gate = upper_gate(
+        "graph_p95_itl_at_most_1.05_eager",
+        graph_itl_p95,
+        eager_itl_p95 * 1.05 if eager_itl_p95 is not None else None,
+    )
+    best_throughput = (
+        max(eager_throughput, graph_throughput)
+        if eager_throughput is not None and graph_throughput is not None
+        else None
+    )
+    throughput_available = graph_throughput is not None and best_throughput is not None
+    throughput_gate = {
+        "name": "graph_throughput_at_least_0.95_best_correct",
+        "actual": graph_throughput,
+        "limit": best_throughput * 0.95 if best_throughput is not None else None,
+        "operator": ">=",
+        "pass": bool(
+            throughput_available and graph_throughput >= best_throughput * 0.95
+        ),
+        "reason": None if throughput_available else "required server metric is null",
+    }
+    gates = [median_gate, p95_gate, throughput_gate]
+    failures.extend(gate["name"] for gate in gates if not gate["pass"])
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "kind": "glm5_next_session_c_graph_comparison",
+        "created_unix": time.time(),
+        "eager_label": eager.get("label"),
+        "graph_label": graph.get("label"),
+        "gates": gates,
+        "failures": failures,
+        "pass": not failures,
+    }
+
+
+def run_compare(args: argparse.Namespace) -> int:
+    eager_path = Path(args.eager)
+    graph_path = Path(args.graph)
+    eager = json.loads(eager_path.read_text(encoding="utf-8"))
+    graph = json.loads(graph_path.read_text(encoding="utf-8"))
+    payload = compare_payloads(eager, graph)
+    payload["inputs"] = {
+        "eager": str(eager_path.resolve()),
+        "graph": str(graph_path.resolve()),
+    }
+    _atomic_write_json(Path(args.output), payload)
+    print(
+        json.dumps(
+            {"output": args.output, "pass": payload["pass"], "gates": payload["gates"]},
+            indent=2,
+        )
+    )
+    return 0 if payload["pass"] else 1
+
+
+def run_long(args: argparse.Namespace) -> int:
+    fixture = build_fixture(
+        args.input_length,
+        args.vocab_size,
+        salt=73,
+        seed=args.fixture_seed,
+    )
+    input_ids = fixture.pop("input_ids")
+    try:
+        if not args.no_flush_cache:
+            flush_cache(args.base_url, timeout=args.request_timeout)
+        record = run_streaming_request(
+            args.base_url,
+            input_ids,
+            args.output_length,
+            timeout=args.request_timeout,
+        )
+    except Exception as error:
+        record = _failed_record(error)
+    contract_compliant = (
+        args.input_length == DEFAULT_LONG_INPUT
+        and args.output_length == DEFAULT_LONG_OUTPUT
+    )
+    failures = []
+    if not record.get("success"):
+        failures.append(str(record.get("error", "long request failed")))
+    if not contract_compliant:
+        failures.append(
+            "long request must be exactly 500000 input + 1024 output tokens"
+        )
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "kind": "glm5_next_session_c_long_context",
+        "created_unix": time.time(),
+        "label": args.label,
+        "base_url": args.base_url.rstrip("/"),
+        "contract": {
+            "request_concurrency": 1,
+            "input_tokens": DEFAULT_LONG_INPUT,
+            "output_tokens": DEFAULT_LONG_OUTPUT,
+            "throughput_gate": None,
+            "compliant": contract_compliant,
+        },
+        "fixture": fixture,
+        "input_tokens": args.input_length,
+        "output_tokens": args.output_length,
+        "record": record,
+        "failures": failures,
+        "pass": not failures,
+    }
+    _atomic_write_json(Path(args.output), payload)
+    print(json.dumps({"output": args.output, "pass": payload["pass"]}, indent=2))
+    return 0 if payload["pass"] else 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="mode", required=True)
+
+    collect = subparsers.add_parser("collect", help="collect short and decode runs")
+    collect.add_argument("--label", required=True)
+    collect.add_argument("--base-url", default="http://127.0.0.1:30100")
+    collect.add_argument("--output", required=True)
+    collect.add_argument("--vocab-size", type=int, default=DEFAULT_VOCAB_SIZE)
+    collect.add_argument("--fixture-seed", type=int, default=FIXTURE_SEED)
+    collect.add_argument("--short-input", type=int, default=DEFAULT_SHORT_INPUT)
+    collect.add_argument("--short-output", type=int, default=DEFAULT_SHORT_OUTPUT)
+    collect.add_argument("--decode-input", type=int, default=DEFAULT_DECODE_INPUT)
+    collect.add_argument("--decode-output", type=int, default=DEFAULT_DECODE_OUTPUT)
+    collect.add_argument("--warmups", type=int, default=DEFAULT_WARMUPS)
+    collect.add_argument("--measured", type=int, default=DEFAULT_MEASURED)
+    collect.add_argument("--request-timeout", type=float, default=3600.0)
+    collect.add_argument("--no-flush-cache", action="store_true")
+    collect.set_defaults(func=run_collect)
+
+    compare = subparsers.add_parser("compare", help="apply eager/graph gates")
+    compare.add_argument("--eager", required=True)
+    compare.add_argument("--graph", required=True)
+    compare.add_argument("--output", required=True)
+    compare.set_defaults(func=run_compare)
+
+    long_context = subparsers.add_parser("long", help="run one 500K+1024 request")
+    long_context.add_argument("--label", required=True)
+    long_context.add_argument("--base-url", default="http://127.0.0.1:30100")
+    long_context.add_argument("--output", required=True)
+    long_context.add_argument("--vocab-size", type=int, default=DEFAULT_VOCAB_SIZE)
+    long_context.add_argument("--fixture-seed", type=int, default=FIXTURE_SEED)
+    long_context.add_argument("--input-length", type=int, default=DEFAULT_LONG_INPUT)
+    long_context.add_argument("--output-length", type=int, default=DEFAULT_LONG_OUTPUT)
+    long_context.add_argument("--request-timeout", type=float, default=7200.0)
+    long_context.add_argument("--no-flush-cache", action="store_true")
+    long_context.set_defaults(func=run_long)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/glm5_next_session_c_final_acceptance.py
+++ b/scripts/glm5_next_session_c_final_acceptance.py
@@ -224,29 +224,37 @@ def validate_graph_counter_progress(
     failures: list[str] = []
     expected_ranks = {str(rank) for rank in range(tp_size)}
     per_rank: dict[str, Any] = {}
-    for mode in ("decode_cuda_graph", "decode_none"):
-        if (
-            set(before.get(mode, {})) != expected_ranks
-            or set(after.get(mode, {})) != expected_ranks
-        ):
-            failures.append(
-                f"{mode} counters do not cover exact TP ranks 0..{tp_size - 1}"
-            )
+    if (
+        set(before.get("decode_cuda_graph", {})) != expected_ranks
+        or set(after.get("decode_cuda_graph", {})) != expected_ranks
+    ):
+        failures.append(
+            "decode_cuda_graph counters do not cover exact TP ranks "
+            f"0..{tp_size - 1}"
+        )
+    unexpected_none_ranks = (
+        set(before.get("decode_none", {}))
+        | set(after.get("decode_none", {}))
+    ) - expected_ranks
+    if unexpected_none_ranks:
+        failures.append(
+            "decode_none contains unexpected TP ranks: "
+            f"{sorted(unexpected_none_ranks, key=int)}"
+        )
     for rank in sorted(expected_ranks, key=int):
         graph_before = before.get("decode_cuda_graph", {}).get(rank)
         graph_after = after.get("decode_cuda_graph", {}).get(rank)
-        none_before = before.get("decode_none", {}).get(rank)
-        none_after = after.get("decode_none", {}).get(rank)
+        # prometheus_client does not publish a labeled Counter series before
+        # its first increment.  A rank which has never executed decode_none
+        # therefore has no series, and its exact counter value is zero.
+        none_before = before.get("decode_none", {}).get(rank, 0.0)
+        none_after = after.get("decode_none", {}).get(rank, 0.0)
         graph_delta = (
             graph_after - graph_before
             if graph_before is not None and graph_after is not None
             else None
         )
-        none_delta = (
-            none_after - none_before
-            if none_before is not None and none_after is not None
-            else None
-        )
+        none_delta = none_after - none_before
         rank_failures: list[str] = []
         if graph_delta is not None and graph_delta < minimum_graph_delta_per_rank:
             rank_failures.append(
@@ -265,7 +273,7 @@ def validate_graph_counter_progress(
             "failures": rank_failures,
             "pass": not rank_failures
             and graph_delta is not None
-            and none_delta is not None,
+            and none_delta == 0,
         }
     return {
         "expected_tp_ranks": sorted(expected_ranks, key=int),
@@ -278,13 +286,19 @@ def validate_graph_counter_progress(
 
 
 def parse_layerwise_summaries(text: str) -> list[dict[str, Any]]:
+    """Return one completion summary per full 42-layer prefill round."""
     summaries: list[dict[str, Any]] = []
     for match in LAYERWISE_PATTERN.finditer(text):
         item: dict[str, Any] = {
             key: int(value) if key != "load_kind" else value
             for key, value in match.groupdict().items()
         }
-        summaries.append(item)
+        # Production logs every MoE layer so operators can diagnose a stalled
+        # prefetch.  Only layer 44 completes a round and advances
+        # completed_rounds; accepting all 42 events as summaries makes every
+        # healthy request fail the exact-round gate.
+        if item["layer"] == 44:
+            summaries.append(item)
     return summaries
 
 
@@ -447,7 +461,7 @@ def validate_prefill_parity_server_log(text: str, *, threshold: int) -> dict[str
     else:
         if LAYERWISE_STARTUP_PATTERN.search(text) is not None:
             failures.append("threshold-0 server allocated the layerwise manager")
-        if parse_layerwise_summaries(text):
+        if LAYERWISE_PATTERN.search(text) is not None:
             failures.append("threshold-0 server executed the layerwise manager")
 
     return {

--- a/scripts/glm5_next_session_c_final_acceptance.py
+++ b/scripts/glm5_next_session_c_final_acceptance.py
@@ -6,14 +6,15 @@ which the ordinary correctness oracle and performance benchmark deliberately
 do not prove:
 
 * exact layerwise-prefill chunk boundaries (128/4096/4097/8193);
-* threshold-0 ordinary prefill versus threshold-1 layerwise parity;
+* threshold-0 ordinary prefill versus threshold-1024 layerwise parity;
 * the final 500000-input + 1024-output integrated request;
 * real decode CUDA Graph counter movement; and
 * exact batch-size 1/2/4 graph replay for the Qwen regression.
 
 The layerwise and long modes require access to the server log.  They snapshot
-the log immediately before each request and accept only complete 42-layer
-rounds with the expected cumulative counters and ``fallback_count=0``.
+the log immediately before each request and accept only complete generic
+``SharedFullContext`` 42-layer compute rounds.  The GLM-specific storage
+contract is one lazily allocated full-layer GPU slot and two host expert slots.
 """
 
 from __future__ import annotations
@@ -44,11 +45,12 @@ DEFAULT_VOCAB_SIZE = 154880
 LAYERWISE_LENGTHS = (128, 4096, 4097, 8193)
 LAYERWISE_CHUNK_SIZE = 4096
 LAYERWISE_MOE_LAYERS = 42
-LAYERWISE_PREFETCH_HITS_PER_ROUND = LAYERWISE_MOE_LAYERS - 1
-LAYERWISE_FINAL_SLOT = (LAYERWISE_MOE_LAYERS - 1) % 2
+LAYERWISE_FIRST_LAYER = 3
+LAYERWISE_LAST_LAYER = 44
+LAYERWISE_TOKEN_THRESHOLD = 1024
 DEFAULT_BOUNDARY_OUTPUT = 16
 LAYERWISE_FIXTURE_SEED = 20260811
-REQUIRED_TP_SIZE = 8
+REQUIRED_TP_SIZE = 4
 PREFILL_PARITY_COLLECTION_TOP_K = 256
 PREFILL_PARITY_COMPARISON_TOP_K = 64
 PREFILL_PARITY_LOGPROB_ATOL = 5e-2
@@ -60,22 +62,23 @@ BUCKET_OUTPUT_TOKENS = 8
 BUCKET_TOP_K = 64
 
 LAYERWISE_PATTERN = re.compile(
-    r"KT GLM-5-Next FP8 layerwise prefill: "
-    r"layer=(?P<layer>\d+) epoch=(?P<epoch>\d+) "
-    r"slot=(?P<slot>\d+) (?P<load_kind>prefetch-hit|prime) "
-    r"apply_count=(?P<apply_count>\d+) "
-    r"prime_count=(?P<prime_count>\d+) "
-    r"prefetch_hit_count=(?P<prefetch_hit_count>\d+) "
-    r"completed_rounds=(?P<completed_rounds>\d+) "
-    r"fallback_count=(?P<fallback_count>\d+)"
+    r"KT layerwise prefill: layer (?P<layer>\d+) "
+    r"compute = (?P<compute_ms>[-+0-9.eE]+) ms"
+    r"(?:, expert update = (?P<expert_update_ms>[-+0-9.eE]+) ms)?"
 )
 
 LAYERWISE_STARTUP_PATTERN = re.compile(
-    r"KT GLM-5-Next FP8 layerwise prefill eagerly allocated two raw "
-    r"E4M3\+FP32 full-layer slots on (?P<device>\S+) before KV profiling "
-    r"\(total=(?P<total_gib>[0-9]+(?:\.[0-9]+)?) GiB, "
-    r"contract=(?P<contract>[0-9a-f]{64}), "
-    r"fallback_count=(?P<fallback_count>\d+)\)"
+    r"KT GLM-5-Next FP8 layerwise prefill lazily allocated generic "
+    r"SharedFullContext: gpu_full_layer_slots=(?P<gpu_slots>\d+) "
+    r"host_expert_slots=(?P<host_slots>\d+) "
+    r"gpu_slot_bytes=(?P<gpu_slot_bytes>\d+) "
+    r"host_buffer_bytes=(?P<host_buffer_bytes>\d+) "
+    r"device=(?P<device>\S+)"
+)
+
+LEGACY_LAYERWISE_PATTERNS = (
+    re.compile(r"eagerly allocated two raw E4M3\+FP32 full-layer slots"),
+    re.compile(r"KT GLM-5-Next FP8 layerwise prefill: .*prefetch-hit"),
 )
 
 SERVER_ARGS_PATTERN = re.compile(r"server_args=ServerArgs\((?P<body>[^\n]+)\)")
@@ -286,33 +289,53 @@ def validate_graph_counter_progress(
 
 
 def parse_layerwise_summaries(text: str) -> list[dict[str, Any]]:
-    """Return one completion summary per full 42-layer prefill round."""
-    summaries: list[dict[str, Any]] = []
-    for match in LAYERWISE_PATTERN.finditer(text):
-        item: dict[str, Any] = {
-            key: int(value) if key != "load_kind" else value
-            for key, value in match.groupdict().items()
+    """Group generic layerwise compute events into ordered 42-layer rounds.
+
+    Partial and malformed groups are deliberately retained so the validator
+    can fail closed instead of silently discarding evidence from a stalled or
+    out-of-order loader.
+    """
+    events = [
+        {
+            "layer": int(match.group("layer")),
+            "compute_ms": float(match.group("compute_ms")),
+            "expert_update_ms": (
+                float(match.group("expert_update_ms"))
+                if match.group("expert_update_ms") is not None
+                else None
+            ),
         }
-        # Production logs every MoE layer so operators can diagnose a stalled
-        # prefetch.  Only layer 44 completes a round and advances
-        # completed_rounds; accepting all 42 events as summaries makes every
-        # healthy request fail the exact-round gate.
-        if item["layer"] == 44:
-            summaries.append(item)
+        for match in LAYERWISE_PATTERN.finditer(text)
+    ]
+    summaries: list[dict[str, Any]] = []
+    for start in range(0, len(events), LAYERWISE_MOE_LAYERS):
+        group = events[start : start + LAYERWISE_MOE_LAYERS]
+        summaries.append(
+            {
+                "round_index": len(summaries),
+                "layers": [event["layer"] for event in group],
+                "compute_ms": [event["compute_ms"] for event in group],
+                "expert_update_ms": [
+                    event["expert_update_ms"] for event in group
+                ],
+                "complete": len(group) == LAYERWISE_MOE_LAYERS,
+            }
+        )
     return summaries
 
 
-def _zero_layerwise_summary() -> dict[str, int]:
-    return {
-        "layer": 44,
-        "epoch": -1,
-        "slot": -1,
-        "apply_count": 0,
-        "prime_count": 0,
-        "prefetch_hit_count": 0,
-        "completed_rounds": 0,
-        "fallback_count": 0,
-    }
+def expected_layerwise_rounds(
+    input_tokens: int,
+    chunk_size: int,
+    *,
+    threshold: int = LAYERWISE_TOKEN_THRESHOLD,
+) -> int:
+    """Count chunks large enough to enter the generic full-layer route."""
+    if threshold <= 0:
+        return 0
+    full_chunks, tail = divmod(input_tokens, chunk_size)
+    qualifying_full_chunks = full_chunks if chunk_size >= threshold else 0
+    return qualifying_full_chunks + int(tail >= threshold)
 
 
 def validate_layerwise_progress(
@@ -322,93 +345,102 @@ def validate_layerwise_progress(
     expected_rounds: int,
 ) -> list[str]:
     failures: list[str] = []
-    prior = dict(previous or _zero_layerwise_summary())
     if len(current) != expected_rounds:
         failures.append(
             f"expected {expected_rounds} completed layerwise rounds, "
             f"observed {len(current)}"
         )
+    expected_layers = list(range(LAYERWISE_FIRST_LAYER, LAYERWISE_LAST_LAYER + 1))
     for index, summary in enumerate(current):
-        expected = {
-            "layer": 44,
-            "epoch": int(prior["epoch"]) + 1,
-            "slot": LAYERWISE_FINAL_SLOT,
-            "load_kind": "prefetch-hit",
-            "apply_count": int(prior["apply_count"]) + LAYERWISE_MOE_LAYERS,
-            "prime_count": int(prior["prime_count"]) + 1,
-            "prefetch_hit_count": int(prior["prefetch_hit_count"])
-            + LAYERWISE_PREFETCH_HITS_PER_ROUND,
-            "completed_rounds": int(prior["completed_rounds"]) + 1,
-            "fallback_count": 0,
-        }
-        for key, expected_value in expected.items():
-            if summary.get(key) != expected_value:
-                failures.append(
-                    f"round {index} {key}: expected {expected_value}, "
-                    f"observed {summary.get(key)}"
-                )
-        if summary.get("apply_count") != summary.get("prime_count", 0) + summary.get(
-            "prefetch_hit_count", 0
-        ):
+        if summary.get("round_index") != index:
             failures.append(
-                f"round {index}: apply_count does not equal prime+prefetch_hit"
+                f"round {index}: round_index is {summary.get('round_index')!r}"
             )
-        prior = summary
+        if summary.get("complete") is not True:
+            failures.append(f"round {index}: generic compute sequence is incomplete")
+        if summary.get("layers") != expected_layers:
+            failures.append(
+                f"round {index}: expected ordered layers "
+                f"{LAYERWISE_FIRST_LAYER}..{LAYERWISE_LAST_LAYER}, "
+                f"observed {summary.get('layers')!r}"
+            )
+        timings = summary.get("compute_ms")
+        if (
+            not isinstance(timings, list)
+            or len(timings) != LAYERWISE_MOE_LAYERS
+            or any(not math.isfinite(value) or value < 0 for value in timings)
+        ):
+            failures.append(f"round {index}: compute timings are invalid")
     return failures
 
 
-def validate_layerwise_startup(text: str) -> dict[str, Any]:
-    """Prove that the required two GPU slots were allocated before KV pools."""
+def validate_layerwise_startup(
+    text: str, *, require_allocation: bool = True
+) -> dict[str, Any]:
+    """Validate the lazy generic SharedFullContext allocation contract."""
     failures: list[str] = []
     matches = list(LAYERWISE_STARTUP_PATTERN.finditer(text))
-    if len(matches) != 1:
+    if len(matches) > 1 or (require_allocation and len(matches) != 1):
         failures.append(
-            "expected exactly one GLM-5-Next FP8 two-slot allocation marker, "
+            "expected exactly one GLM-5-Next lazy SharedFullContext allocation "
+            "marker, "
             f"observed {len(matches)}"
         )
     allocation: dict[str, Any] | None = None
     if matches:
         match = matches[0]
-        total_gib = float(match.group("total_gib"))
-        fallback_count = int(match.group("fallback_count"))
+        gpu_slots = int(match.group("gpu_slots"))
+        host_slots = int(match.group("host_slots"))
+        gpu_slot_bytes = int(match.group("gpu_slot_bytes"))
+        host_buffer_bytes = int(match.group("host_buffer_bytes"))
         allocation = {
             "offset": match.start(),
             "device": match.group("device"),
-            "total_gib": total_gib,
-            "contract_sha256": match.group("contract"),
-            "fallback_count": fallback_count,
+            "gpu_full_layer_slots": gpu_slots,
+            "host_expert_slots": host_slots,
+            "gpu_slot_bytes": gpu_slot_bytes,
+            "host_buffer_bytes": host_buffer_bytes,
         }
-        if total_gib <= 0:
-            failures.append("layerwise two-slot allocation size is not positive")
-        if fallback_count != 0:
+        if gpu_slots != 1:
             failures.append(
-                f"startup layerwise fallback_count is {fallback_count}, expected 0"
+                f"gpu_full_layer_slots is {gpu_slots}, expected exactly 1"
             )
+        if host_slots != 2:
+            failures.append(f"host_expert_slots is {host_slots}, expected exactly 2")
+        if gpu_slot_bytes <= 0 or host_buffer_bytes <= 0:
+            failures.append("lazy layerwise allocation byte counts must be positive")
 
         memory_pool_offsets = [
             match.start() for match in re.finditer(r"Memory pool end\.", text)
         ]
         if not memory_pool_offsets:
             failures.append("server log has no completed KV memory-pool marker")
-        elif match.start() >= min(memory_pool_offsets):
+        elif match.start() <= max(memory_pool_offsets):
             failures.append(
-                "layerwise two-slot allocation marker does not precede KV memory pool"
+                "layerwise allocation is not lazy: marker must follow KV memory pool"
             )
 
         ready_offset = text.find("The server is fired up and ready to roll!")
         if ready_offset < 0:
             failures.append("server-ready marker is missing")
-        elif match.start() >= ready_offset:
+        elif match.start() <= ready_offset:
             failures.append(
-                "layerwise two-slot allocation marker does not precede server ready"
+                "layerwise allocation is not lazy: marker must follow server ready"
             )
         first_round = LAYERWISE_PATTERN.search(text)
         if first_round is not None and match.start() >= first_round.start():
-            failures.append("layerwise execution appears before startup allocation")
+            failures.append("generic layerwise execution appears before lazy allocation")
+
+    if text.count("The server is fired up and ready to roll!") != 1:
+        failures.append("server log must contain exactly one server-ready marker")
+    for legacy_pattern in LEGACY_LAYERWISE_PATTERNS:
+        if legacy_pattern.search(text) is not None:
+            failures.append("server log contains a legacy eager/two-slot protocol marker")
 
     return {
         "allocation": allocation,
         "allocation_marker_count": len(matches),
+        "allocation_required": require_allocation,
         "failures": failures,
         "pass": not failures,
     }
@@ -420,7 +452,7 @@ def _server_arg_value(body: str, name: str) -> str | None:
 
 
 def validate_prefill_parity_server_log(text: str, *, threshold: int) -> dict[str, Any]:
-    """Bind a parity collection to the exact TP8 threshold-0/1 server."""
+    """Bind a parity collection to the exact TP4 threshold-0/1024 server."""
     failures: list[str] = []
     server_args_matches = list(SERVER_ARGS_PATTERN.finditer(text))
     fields: dict[str, str | None] = {}
@@ -455,14 +487,18 @@ def validate_prefill_parity_server_log(text: str, *, threshold: int) -> dict[str
     if text.count("The server is fired up and ready to roll!") != 1:
         failures.append("server log must contain exactly one server-ready marker")
 
-    startup = validate_layerwise_startup(text) if threshold == 1 else None
+    startup = (
+        validate_layerwise_startup(text, require_allocation=False)
+        if threshold == LAYERWISE_TOKEN_THRESHOLD
+        else None
+    )
     if startup is not None:
         failures.extend(startup["failures"])
     else:
         if LAYERWISE_STARTUP_PATTERN.search(text) is not None:
-            failures.append("threshold-0 server allocated the layerwise manager")
+            failures.append("threshold-0 server allocated SharedFullContext")
         if LAYERWISE_PATTERN.search(text) is not None:
-            failures.append("threshold-0 server executed the layerwise manager")
+            failures.append("threshold-0 server executed generic layerwise prefill")
 
     return {
         "threshold": threshold,
@@ -492,8 +528,9 @@ def _log_before(path: Path) -> tuple[int, dict[str, Any] | None]:
     if not path.is_file():
         raise FileNotFoundError(path)
     size = path.stat().st_size
-    summaries = parse_layerwise_summaries(_read_tail(path))
-    return size, summaries[-1] if summaries else None
+    # Generic SharedFullContext logs have no global epoch/counter.  Every
+    # request is validated from its exact append-only log window instead.
+    return size, None
 
 
 def _log_after(path: Path, offset: int) -> tuple[int, str]:
@@ -571,7 +608,7 @@ def _capture_request_evidence(
     counters_after = cuda_graph_counters_by_rank(metrics_after_text)
 
     summaries = parse_layerwise_summaries(log_segment)
-    expected_rounds = math.ceil(len(input_ids) / chunk_size)
+    expected_rounds = expected_layerwise_rounds(len(input_ids), chunk_size)
     failures.extend(
         validate_layerwise_progress(
             previous_summary,
@@ -646,13 +683,15 @@ def run_layerwise(args: argparse.Namespace) -> int:
         failures.append(
             "layerwise matrix must use lengths 128/4096/4097/8193, "
             "chunk size 4096, exactly 16 output tokens, seed 20260811, "
-            "TP=8, and vocab size 154880"
+            "TP=4, and vocab size 154880"
         )
 
     server_log = Path(args.server_log)
     try:
         startup_text = server_log.read_text(encoding="utf-8", errors="replace")
-        startup_evidence = validate_layerwise_startup(startup_text)
+        startup_evidence = validate_prefill_parity_server_log(
+            startup_text, threshold=LAYERWISE_TOKEN_THRESHOLD
+        )
     except Exception as error:
         startup_evidence = {
             "failures": [f"{type(error).__name__}: {error}"],
@@ -696,6 +735,20 @@ def run_layerwise(args: argparse.Namespace) -> int:
         if not evidence["pass"] and args.stop_on_failure:
             break
 
+    try:
+        final_log = server_log.read_text(encoding="utf-8", errors="replace")
+        allocation_evidence = validate_layerwise_startup(
+            final_log, require_allocation=True
+        )
+    except Exception as error:
+        allocation_evidence = {
+            "failures": [f"{type(error).__name__}: {error}"],
+            "pass": False,
+        }
+    failures.extend(
+        f"allocation: {failure}" for failure in allocation_evidence["failures"]
+    )
+
     payload = {
         "schema_version": SCHEMA_VERSION,
         "kind": "glm5_next_session_c_layerwise_boundaries",
@@ -707,17 +760,22 @@ def run_layerwise(args: argparse.Namespace) -> int:
             "chunk_size": args.chunk_size,
             "output_tokens": args.output_length,
             "expected_rounds": {
-                str(length): math.ceil(length / args.chunk_size) for length in lengths
+                str(length): expected_layerwise_rounds(length, args.chunk_size)
+                for length in lengths
             },
             "require_decode_cuda_graph": True,
-            "require_layerwise_fallback_zero": True,
-            "require_startup_two_slot_allocation_before_kv_pool": True,
+            "layerwise_token_threshold": LAYERWISE_TOKEN_THRESHOLD,
+            "require_generic_complete_layer_rounds": True,
+            "require_lazy_shared_full_context": True,
+            "gpu_full_layer_slots": 1,
+            "host_expert_slots": 2,
             "fixture_seed": args.fixture_seed,
             "vocab_size": args.vocab_size,
             "tp_size": args.tp_size,
             "compliant": contract_compliant,
         },
         "startup_evidence": startup_evidence,
+        "allocation_evidence": allocation_evidence,
         "cases": cases,
         "failures": failures,
         "pass": not failures,
@@ -747,7 +805,7 @@ def run_long(args: argparse.Namespace) -> int:
     if not contract_compliant:
         failures.append(
             "final long request requires exactly 500000 input, 1024 output, "
-            "layerwise chunk size 4096, seed 20260812, TP=8, and vocab 154880"
+            "layerwise chunk size 4096, seed 20260812, TP=4, and vocab 154880"
         )
     try:
         if not contract_compliant:
@@ -771,6 +829,19 @@ def run_long(args: argparse.Namespace) -> int:
             "pass": False,
         }
     failures.extend(evidence["failures"])
+    try:
+        allocation_evidence = validate_layerwise_startup(
+            Path(args.server_log).read_text(encoding="utf-8", errors="replace"),
+            require_allocation=True,
+        )
+    except Exception as error:
+        allocation_evidence = {
+            "failures": [f"{type(error).__name__}: {error}"],
+            "pass": False,
+        }
+    failures.extend(
+        f"allocation: {failure}" for failure in allocation_evidence["failures"]
+    )
     payload = {
         "schema_version": SCHEMA_VERSION,
         "kind": "glm5_next_session_c_final_long_context",
@@ -782,9 +853,15 @@ def run_long(args: argparse.Namespace) -> int:
             "input_tokens": MIN_LONG_INPUT,
             "output_tokens": MIN_LONG_OUTPUT,
             "chunk_size": args.chunk_size,
-            "expected_layerwise_rounds": math.ceil(args.input_length / args.chunk_size),
+            "expected_layerwise_rounds": expected_layerwise_rounds(
+                args.input_length, args.chunk_size
+            ),
             "require_decode_cuda_graph": True,
-            "require_layerwise_fallback_zero": True,
+            "layerwise_token_threshold": LAYERWISE_TOKEN_THRESHOLD,
+            "require_generic_complete_layer_rounds": True,
+            "require_lazy_shared_full_context": True,
+            "gpu_full_layer_slots": 1,
+            "host_expert_slots": 2,
             "throughput_gate": None,
             "fixture_seed": args.fixture_seed,
             "vocab_size": args.vocab_size,
@@ -793,6 +870,7 @@ def run_long(args: argparse.Namespace) -> int:
         },
         "fixture": fixture,
         "evidence": evidence,
+        "allocation_evidence": allocation_evidence,
         "failures": failures,
         "pass": not failures,
     }
@@ -983,8 +1061,8 @@ def _collect_prefill_parity_case(
     after_offset, log_segment = _log_after(server_log, before_offset)
     summaries = parse_layerwise_summaries(log_segment)
     failures: list[str] = []
-    expected_rounds = math.ceil(length / args.chunk_size)
-    if args.threshold == 1:
+    expected_rounds = expected_layerwise_rounds(length, args.chunk_size)
+    if args.threshold == LAYERWISE_TOKEN_THRESHOLD:
         failures.extend(
             validate_layerwise_progress(
                 previous_summary,
@@ -1012,7 +1090,11 @@ def _collect_prefill_parity_case(
         "prompt_tokens": meta.get("prompt_tokens"),
         "completion_tokens": meta.get("completion_tokens"),
         "top_logprobs": top_logprobs,
-        "expected_layerwise_rounds": expected_rounds if args.threshold == 1 else 0,
+        "expected_layerwise_rounds": (
+            expected_rounds
+            if args.threshold == LAYERWISE_TOKEN_THRESHOLD
+            else 0
+        ),
         "previous_layerwise_summary": previous_summary,
         "layerwise_summaries": summaries,
         "server_log_window": {
@@ -1030,7 +1112,7 @@ def _collect_prefill_parity_case(
 def run_prefill_parity(args: argparse.Namespace) -> int:
     lengths = tuple(args.lengths)
     contract_compliant = (
-        args.threshold in (0, 1)
+        args.threshold in (0, LAYERWISE_TOKEN_THRESHOLD)
         and lengths == LAYERWISE_LENGTHS
         and args.output_length == DEFAULT_BOUNDARY_OUTPUT
         and args.chunk_size == LAYERWISE_CHUNK_SIZE
@@ -1042,9 +1124,9 @@ def run_prefill_parity(args: argparse.Namespace) -> int:
     failures: list[str] = []
     if not contract_compliant:
         failures.append(
-            "prefill parity requires threshold 0/1, lengths "
+            "prefill parity requires threshold 0/1024, lengths "
             "128/4096/4097/8193, output 16, chunk 4096, seed 20260811, "
-            "TP=8, vocab 154880, and collected top-k 256"
+            "TP=4, vocab 154880, and collected top-k 256"
         )
 
     server_log = Path(args.server_log)
@@ -1081,6 +1163,39 @@ def run_prefill_parity(args: argparse.Namespace) -> int:
         failures.extend(f"length {length}: {failure}" for failure in case["failures"])
         if not case["pass"] and args.stop_on_failure:
             break
+
+    try:
+        final_log = server_log.read_text(encoding="utf-8", errors="replace")
+        final_server_evidence = validate_prefill_parity_server_log(
+            final_log, threshold=args.threshold
+        )
+        if args.threshold == LAYERWISE_TOKEN_THRESHOLD:
+            allocation_evidence = validate_layerwise_startup(
+                final_log, require_allocation=True
+            )
+            final_server_evidence["layerwise_startup"] = allocation_evidence
+            final_server_evidence["failures"] = list(
+                dict.fromkeys(
+                    final_server_evidence["failures"]
+                    + allocation_evidence["failures"]
+                )
+            )
+            final_server_evidence["pass"] = not final_server_evidence["failures"]
+        server_evidence = final_server_evidence | {
+            "path": str(server_log.resolve()),
+            "initial_size": server_evidence.get("initial_size"),
+            "initial_sha256": server_evidence.get("initial_sha256"),
+        }
+    except Exception as error:
+        server_evidence = {
+            **server_evidence,
+            "failures": server_evidence.get("failures", [])
+            + [f"{type(error).__name__}: {error}"],
+            "pass": False,
+        }
+    failures.extend(
+        f"final server: {failure}" for failure in server_evidence["failures"]
+    )
 
     payload = {
         "schema_version": SCHEMA_VERSION,
@@ -1142,10 +1257,24 @@ def _validate_prefill_collection(
         ):
             failures.append(f"{role}: server_args evidence is invalid")
         startup = server_evidence.get("layerwise_startup")
-        if expected_threshold == 1 and (
+        if expected_threshold == LAYERWISE_TOKEN_THRESHOLD and (
             not isinstance(startup, dict) or startup.get("pass") is not True
         ):
             failures.append(f"{role}: layerwise startup evidence is invalid")
+        elif expected_threshold == LAYERWISE_TOKEN_THRESHOLD:
+            allocation = startup.get("allocation")
+            if (
+                not isinstance(allocation, dict)
+                or allocation.get("gpu_full_layer_slots") != 1
+                or allocation.get("host_expert_slots") != 2
+                or not isinstance(allocation.get("gpu_slot_bytes"), int)
+                or allocation["gpu_slot_bytes"] <= 0
+                or not isinstance(allocation.get("host_buffer_bytes"), int)
+                or allocation["host_buffer_bytes"] <= 0
+            ):
+                failures.append(
+                    f"{role}: lazy SharedFullContext slot evidence is invalid"
+                )
         if expected_threshold == 0 and startup is not None:
             failures.append(f"{role}: threshold-0 startup evidence is not null")
         if not isinstance(server_evidence.get("path"), str):
@@ -1242,8 +1371,10 @@ def _validate_prefill_collection(
             failures.append(f"{role} length {length}: completion token count differs")
 
         summaries = case.get("layerwise_summaries")
-        expected_rounds = math.ceil(length / LAYERWISE_CHUNK_SIZE)
-        if expected_threshold == 1:
+        expected_rounds = expected_layerwise_rounds(
+            length, LAYERWISE_CHUNK_SIZE
+        )
+        if expected_threshold == LAYERWISE_TOKEN_THRESHOLD:
             if not isinstance(summaries, list):
                 failures.append(
                     f"{role} length {length}: layerwise summaries are missing"
@@ -1361,7 +1492,9 @@ def compare_prefill_parity_payloads(
         baseline, role="threshold-0", expected_threshold=0
     )
     candidate_failures, candidate_cases = _validate_prefill_collection(
-        candidate, role="threshold-1", expected_threshold=1
+        candidate,
+        role="threshold-1024",
+        expected_threshold=LAYERWISE_TOKEN_THRESHOLD,
     )
     failures.extend(candidate_failures)
     diagnostics: list[dict[str, Any]] = []
@@ -1434,7 +1567,7 @@ def compare_prefill_parity_payloads(
             if missing:
                 failures.append(
                     f"length {length} step {step_index}: {len(missing)} "
-                    "threshold-0 top-64 IDs are absent from threshold-1 top-256"
+                    "threshold-0 top-64 IDs are absent from threshold-1024 top-256"
                 )
             if numerical_failures:
                 failures.append(
@@ -1447,7 +1580,7 @@ def compare_prefill_parity_payloads(
         "created_unix": time.time(),
         "contract": {
             "baseline_threshold": 0,
-            "candidate_threshold": 1,
+            "candidate_threshold": LAYERWISE_TOKEN_THRESHOLD,
             "lengths": list(LAYERWISE_LENGTHS),
             "output_tokens": DEFAULT_BOUNDARY_OUTPUT,
             "fixture_seed": LAYERWISE_FIXTURE_SEED,
@@ -1467,13 +1600,13 @@ def compare_prefill_parity_payloads(
 
 def run_compare_prefill_parity(args: argparse.Namespace) -> int:
     baseline_path = Path(args.threshold_0)
-    candidate_path = Path(args.threshold_1)
+    candidate_path = Path(args.threshold_1024)
     baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
     candidate = json.loads(candidate_path.read_text(encoding="utf-8"))
     payload = compare_prefill_parity_payloads(baseline, candidate)
     payload["inputs"] = {
         "threshold_0": str(baseline_path.resolve()),
-        "threshold_1": str(candidate_path.resolve()),
+        "threshold_1024": str(candidate_path.resolve()),
     }
     _atomic_write_json(Path(args.output), payload)
     print(json.dumps({"output": args.output, "pass": payload["pass"]}, indent=2))
@@ -1709,7 +1842,7 @@ def _add_common_request_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--fixture-seed", type=int, default=FIXTURE_SEED)
     parser.add_argument("--request-timeout", type=float, default=86_400.0)
     parser.add_argument("--no-flush-cache", action="store_true")
-    parser.add_argument("--tp-size", type=int, default=8)
+    parser.add_argument("--tp-size", type=int, default=REQUIRED_TP_SIZE)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -1738,7 +1871,12 @@ def build_parser() -> argparse.ArgumentParser:
     )
     _add_common_request_args(prefill_parity)
     prefill_parity.add_argument("--server-log", required=True)
-    prefill_parity.add_argument("--threshold", type=int, choices=(0, 1), required=True)
+    prefill_parity.add_argument(
+        "--threshold",
+        type=int,
+        choices=(0, LAYERWISE_TOKEN_THRESHOLD),
+        required=True,
+    )
     prefill_parity.add_argument(
         "--lengths", type=int, nargs="+", default=list(LAYERWISE_LENGTHS)
     )
@@ -1757,10 +1895,10 @@ def build_parser() -> argparse.ArgumentParser:
 
     compare_prefill = subparsers.add_parser(
         "compare-prefill-parity",
-        help="compare frozen threshold-0 and threshold-1 prefill collections",
+        help="compare frozen threshold-0 and threshold-1024 prefill collections",
     )
     compare_prefill.add_argument("--threshold-0", required=True)
-    compare_prefill.add_argument("--threshold-1", required=True)
+    compare_prefill.add_argument("--threshold-1024", required=True)
     compare_prefill.add_argument("--output", required=True)
     compare_prefill.set_defaults(func=run_compare_prefill_parity)
 

--- a/scripts/glm5_next_session_c_final_acceptance.py
+++ b/scripts/glm5_next_session_c_final_acceptance.py
@@ -1,0 +1,1789 @@
+#!/usr/bin/env python3
+"""Fail-closed Session-C final acceptance driver.
+
+This is an HTTP/log artifact harness, not serving code.  It covers the pieces
+which the ordinary correctness oracle and performance benchmark deliberately
+do not prove:
+
+* exact layerwise-prefill chunk boundaries (128/4096/4097/8193);
+* threshold-0 ordinary prefill versus threshold-1 layerwise parity;
+* the final 500000-input + 1024-output integrated request;
+* real decode CUDA Graph counter movement; and
+* exact batch-size 1/2/4 graph replay for the Qwen regression.
+
+The layerwise and long modes require access to the server log.  They snapshot
+the log immediately before each request and accept only complete 42-layer
+rounds with the expected cumulative counters and ``fallback_count=0``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from glm5_next_session_c_benchmark import (  # noqa: E402
+    FIXTURE_SEED,
+    build_fixture,
+    flush_cache,
+    run_streaming_request,
+)
+
+
+SCHEMA_VERSION = 1
+DEFAULT_VOCAB_SIZE = 154880
+LAYERWISE_LENGTHS = (128, 4096, 4097, 8193)
+LAYERWISE_CHUNK_SIZE = 4096
+LAYERWISE_MOE_LAYERS = 42
+LAYERWISE_PREFETCH_HITS_PER_ROUND = LAYERWISE_MOE_LAYERS - 1
+LAYERWISE_FINAL_SLOT = (LAYERWISE_MOE_LAYERS - 1) % 2
+DEFAULT_BOUNDARY_OUTPUT = 16
+LAYERWISE_FIXTURE_SEED = 20260811
+REQUIRED_TP_SIZE = 8
+PREFILL_PARITY_COLLECTION_TOP_K = 256
+PREFILL_PARITY_COMPARISON_TOP_K = 64
+PREFILL_PARITY_LOGPROB_ATOL = 5e-2
+PREFILL_PARITY_LOGPROB_RTOL = 5e-2
+MIN_LONG_INPUT = 500_000
+MIN_LONG_OUTPUT = 1024
+BUCKET_INPUT_TOKENS = 128
+BUCKET_OUTPUT_TOKENS = 8
+BUCKET_TOP_K = 64
+
+LAYERWISE_PATTERN = re.compile(
+    r"KT GLM-5-Next FP8 layerwise prefill: "
+    r"layer=(?P<layer>\d+) epoch=(?P<epoch>\d+) "
+    r"slot=(?P<slot>\d+) (?P<load_kind>prefetch-hit|prime) "
+    r"apply_count=(?P<apply_count>\d+) "
+    r"prime_count=(?P<prime_count>\d+) "
+    r"prefetch_hit_count=(?P<prefetch_hit_count>\d+) "
+    r"completed_rounds=(?P<completed_rounds>\d+) "
+    r"fallback_count=(?P<fallback_count>\d+)"
+)
+
+LAYERWISE_STARTUP_PATTERN = re.compile(
+    r"KT GLM-5-Next FP8 layerwise prefill eagerly allocated two raw "
+    r"E4M3\+FP32 full-layer slots on (?P<device>\S+) before KV profiling "
+    r"\(total=(?P<total_gib>[0-9]+(?:\.[0-9]+)?) GiB, "
+    r"contract=(?P<contract>[0-9a-f]{64}), "
+    r"fallback_count=(?P<fallback_count>\d+)\)"
+)
+
+SERVER_ARGS_PATTERN = re.compile(r"server_args=ServerArgs\((?P<body>[^\n]+)\)")
+
+PROMETHEUS_VALUE_PATTERN = re.compile(
+    r"^(?P<name>[^\s{]+)(?:\{(?P<labels>[^}]*)\})?\s+"
+    r"(?P<value>[-+0-9.eE]+)(?:\s+\d+)?$"
+)
+
+FATAL_LOG_PATTERNS = (
+    re.compile(r"Traceback \(most recent call last\)"),
+    re.compile(r"CUDA out of memory", re.IGNORECASE),
+    re.compile(r"CUDA error", re.IGNORECASE),
+    re.compile(r"illegal memory access", re.IGNORECASE),
+    re.compile(r"device-side assert", re.IGNORECASE),
+    re.compile(r"\b(?:nan|inf)\b", re.IGNORECASE),
+    re.compile(r"deadlock", re.IGNORECASE),
+    re.compile(r"manager is poisoned", re.IGNORECASE),
+)
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    with temporary.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+    temporary.replace(path)
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _sha256_token_rows(rows: list[list[int]]) -> str:
+    digest = hashlib.sha256()
+    for row in rows:
+        digest.update(len(row).to_bytes(8, "little", signed=False))
+        for token_id in row:
+            digest.update(int(token_id).to_bytes(4, "little", signed=False))
+    return digest.hexdigest()
+
+
+def _finite_tree(value: Any) -> bool:
+    if isinstance(value, bool) or value is None or isinstance(value, str):
+        return True
+    if isinstance(value, (int, float)):
+        return math.isfinite(float(value))
+    if isinstance(value, dict):
+        return all(_finite_tree(item) for item in value.values())
+    if isinstance(value, list):
+        return all(_finite_tree(item) for item in value)
+    return True
+
+
+def _get_text(url: str, *, timeout: float) -> str:
+    request = urllib.request.Request(url, method="GET")
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            status = getattr(response, "status", response.getcode())
+            body = response.read()
+    except urllib.error.HTTPError as error:
+        detail = error.read()[:1024]
+        raise RuntimeError(
+            f"GET {url} returned HTTP {error.code}: {detail!r}"
+        ) from error
+    if status < 200 or status >= 300:
+        raise RuntimeError(f"GET {url} returned HTTP {status}: {body[:1024]!r}")
+    return body.decode("utf-8", errors="replace")
+
+
+def fetch_metrics(base_url: str, *, timeout: float) -> str:
+    return _get_text(f"{base_url.rstrip('/')}/metrics", timeout=timeout)
+
+
+def prometheus_counter_value(
+    text: str,
+    metric_name: str,
+    *,
+    required_labels: dict[str, str] | None = None,
+) -> float | None:
+    """Sum all matching Prometheus samples, or return None if none exist."""
+    required_labels = required_labels or {}
+    total = 0.0
+    matches = 0
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        match = PROMETHEUS_VALUE_PATTERN.match(line)
+        if match is None or match.group("name") != metric_name:
+            continue
+        labels = dict(
+            re.findall(r'(\w+)="((?:[^"\\]|\\.)*)"', match.group("labels") or "")
+        )
+        if any(labels.get(key) != value for key, value in required_labels.items()):
+            continue
+        value = float(match.group("value"))
+        if not math.isfinite(value):
+            continue
+        total += value
+        matches += 1
+    return total if matches else None
+
+
+def decode_graph_counter(text: str) -> float | None:
+    return prometheus_counter_value(
+        text,
+        "sglang:cuda_graph_passes_total",
+        required_labels={"mode": "decode_cuda_graph"},
+    )
+
+
+def cuda_graph_counters_by_rank(text: str) -> dict[str, dict[str, float]]:
+    counters = {"decode_cuda_graph": {}, "decode_none": {}}
+    for raw_line in text.splitlines():
+        match = PROMETHEUS_VALUE_PATTERN.match(raw_line.strip())
+        if match is None or match.group("name") != "sglang:cuda_graph_passes_total":
+            continue
+        labels = dict(
+            re.findall(r'(\w+)="((?:[^"\\]|\\.)*)"', match.group("labels") or "")
+        )
+        mode = labels.get("mode")
+        # ``tp_rank`` is the production metric contract.  Accepting the older,
+        # ambiguous ``rank`` label can accidentally aggregate unrelated ranks
+        # and must fail closed in final acceptance.
+        rank = labels.get("tp_rank")
+        if mode not in counters or rank is None:
+            continue
+        value = float(match.group("value"))
+        if not math.isfinite(value):
+            continue
+        if rank in counters[mode]:
+            raise ValueError(f"duplicate {mode} counter for TP rank {rank}")
+        counters[mode][rank] = value
+    return counters
+
+
+def validate_graph_counter_progress(
+    before: dict[str, dict[str, float]],
+    after: dict[str, dict[str, float]],
+    *,
+    tp_size: int,
+    minimum_graph_delta_per_rank: int,
+) -> dict[str, Any]:
+    failures: list[str] = []
+    expected_ranks = {str(rank) for rank in range(tp_size)}
+    per_rank: dict[str, Any] = {}
+    for mode in ("decode_cuda_graph", "decode_none"):
+        if (
+            set(before.get(mode, {})) != expected_ranks
+            or set(after.get(mode, {})) != expected_ranks
+        ):
+            failures.append(
+                f"{mode} counters do not cover exact TP ranks 0..{tp_size - 1}"
+            )
+    for rank in sorted(expected_ranks, key=int):
+        graph_before = before.get("decode_cuda_graph", {}).get(rank)
+        graph_after = after.get("decode_cuda_graph", {}).get(rank)
+        none_before = before.get("decode_none", {}).get(rank)
+        none_after = after.get("decode_none", {}).get(rank)
+        graph_delta = (
+            graph_after - graph_before
+            if graph_before is not None and graph_after is not None
+            else None
+        )
+        none_delta = (
+            none_after - none_before
+            if none_before is not None and none_after is not None
+            else None
+        )
+        rank_failures: list[str] = []
+        if graph_delta is not None and graph_delta < minimum_graph_delta_per_rank:
+            rank_failures.append(
+                f"graph delta {graph_delta} is below {minimum_graph_delta_per_rank}"
+            )
+        if none_delta is not None and none_delta != 0:
+            rank_failures.append(f"decode_none delta is {none_delta}, expected 0")
+        failures.extend(f"TP rank {rank}: {item}" for item in rank_failures)
+        per_rank[rank] = {
+            "graph_before": graph_before,
+            "graph_after": graph_after,
+            "graph_delta": graph_delta,
+            "decode_none_before": none_before,
+            "decode_none_after": none_after,
+            "decode_none_delta": none_delta,
+            "failures": rank_failures,
+            "pass": not rank_failures
+            and graph_delta is not None
+            and none_delta is not None,
+        }
+    return {
+        "expected_tp_ranks": sorted(expected_ranks, key=int),
+        "minimum_graph_delta_per_rank": minimum_graph_delta_per_rank,
+        "expected_decode_none_delta_per_rank": 0,
+        "per_rank": per_rank,
+        "failures": failures,
+        "pass": not failures,
+    }
+
+
+def parse_layerwise_summaries(text: str) -> list[dict[str, Any]]:
+    summaries: list[dict[str, Any]] = []
+    for match in LAYERWISE_PATTERN.finditer(text):
+        item: dict[str, Any] = {
+            key: int(value) if key != "load_kind" else value
+            for key, value in match.groupdict().items()
+        }
+        summaries.append(item)
+    return summaries
+
+
+def _zero_layerwise_summary() -> dict[str, int]:
+    return {
+        "layer": 44,
+        "epoch": -1,
+        "slot": -1,
+        "apply_count": 0,
+        "prime_count": 0,
+        "prefetch_hit_count": 0,
+        "completed_rounds": 0,
+        "fallback_count": 0,
+    }
+
+
+def validate_layerwise_progress(
+    previous: dict[str, Any] | None,
+    current: list[dict[str, Any]],
+    *,
+    expected_rounds: int,
+) -> list[str]:
+    failures: list[str] = []
+    prior = dict(previous or _zero_layerwise_summary())
+    if len(current) != expected_rounds:
+        failures.append(
+            f"expected {expected_rounds} completed layerwise rounds, "
+            f"observed {len(current)}"
+        )
+    for index, summary in enumerate(current):
+        expected = {
+            "layer": 44,
+            "epoch": int(prior["epoch"]) + 1,
+            "slot": LAYERWISE_FINAL_SLOT,
+            "load_kind": "prefetch-hit",
+            "apply_count": int(prior["apply_count"]) + LAYERWISE_MOE_LAYERS,
+            "prime_count": int(prior["prime_count"]) + 1,
+            "prefetch_hit_count": int(prior["prefetch_hit_count"])
+            + LAYERWISE_PREFETCH_HITS_PER_ROUND,
+            "completed_rounds": int(prior["completed_rounds"]) + 1,
+            "fallback_count": 0,
+        }
+        for key, expected_value in expected.items():
+            if summary.get(key) != expected_value:
+                failures.append(
+                    f"round {index} {key}: expected {expected_value}, "
+                    f"observed {summary.get(key)}"
+                )
+        if summary.get("apply_count") != summary.get("prime_count", 0) + summary.get(
+            "prefetch_hit_count", 0
+        ):
+            failures.append(
+                f"round {index}: apply_count does not equal prime+prefetch_hit"
+            )
+        prior = summary
+    return failures
+
+
+def validate_layerwise_startup(text: str) -> dict[str, Any]:
+    """Prove that the required two GPU slots were allocated before KV pools."""
+    failures: list[str] = []
+    matches = list(LAYERWISE_STARTUP_PATTERN.finditer(text))
+    if len(matches) != 1:
+        failures.append(
+            "expected exactly one GLM-5-Next FP8 two-slot allocation marker, "
+            f"observed {len(matches)}"
+        )
+    allocation: dict[str, Any] | None = None
+    if matches:
+        match = matches[0]
+        total_gib = float(match.group("total_gib"))
+        fallback_count = int(match.group("fallback_count"))
+        allocation = {
+            "offset": match.start(),
+            "device": match.group("device"),
+            "total_gib": total_gib,
+            "contract_sha256": match.group("contract"),
+            "fallback_count": fallback_count,
+        }
+        if total_gib <= 0:
+            failures.append("layerwise two-slot allocation size is not positive")
+        if fallback_count != 0:
+            failures.append(
+                f"startup layerwise fallback_count is {fallback_count}, expected 0"
+            )
+
+        memory_pool_offsets = [
+            match.start() for match in re.finditer(r"Memory pool end\.", text)
+        ]
+        if not memory_pool_offsets:
+            failures.append("server log has no completed KV memory-pool marker")
+        elif match.start() >= min(memory_pool_offsets):
+            failures.append(
+                "layerwise two-slot allocation marker does not precede KV memory pool"
+            )
+
+        ready_offset = text.find("The server is fired up and ready to roll!")
+        if ready_offset < 0:
+            failures.append("server-ready marker is missing")
+        elif match.start() >= ready_offset:
+            failures.append(
+                "layerwise two-slot allocation marker does not precede server ready"
+            )
+        first_round = LAYERWISE_PATTERN.search(text)
+        if first_round is not None and match.start() >= first_round.start():
+            failures.append("layerwise execution appears before startup allocation")
+
+    return {
+        "allocation": allocation,
+        "allocation_marker_count": len(matches),
+        "failures": failures,
+        "pass": not failures,
+    }
+
+
+def _server_arg_value(body: str, name: str) -> str | None:
+    match = re.search(rf"(?:^|, ){re.escape(name)}=(?P<value>.*?)(?=, \w+=|$)", body)
+    return match.group("value") if match is not None else None
+
+
+def validate_prefill_parity_server_log(text: str, *, threshold: int) -> dict[str, Any]:
+    """Bind a parity collection to the exact TP8 threshold-0/1 server."""
+    failures: list[str] = []
+    server_args_matches = list(SERVER_ARGS_PATTERN.finditer(text))
+    fields: dict[str, str | None] = {}
+    if len(server_args_matches) != 1:
+        failures.append(
+            f"expected exactly one server_args record, observed {len(server_args_matches)}"
+        )
+    if server_args_matches:
+        body = server_args_matches[0].group("body")
+        fields = {
+            name: _server_arg_value(body, name)
+            for name in (
+                "tp_size",
+                "chunked_prefill_size",
+                "kt_method",
+                "kt_gpu_prefill_token_threshold",
+            )
+        }
+        expected = {
+            "tp_size": str(REQUIRED_TP_SIZE),
+            "chunked_prefill_size": str(LAYERWISE_CHUNK_SIZE),
+            "kt_method": "'FP8'",
+            "kt_gpu_prefill_token_threshold": str(threshold),
+        }
+        for name, expected_value in expected.items():
+            if fields.get(name) != expected_value:
+                failures.append(
+                    f"server_args {name}: expected {expected_value}, "
+                    f"observed {fields.get(name)}"
+                )
+
+    if text.count("The server is fired up and ready to roll!") != 1:
+        failures.append("server log must contain exactly one server-ready marker")
+
+    startup = validate_layerwise_startup(text) if threshold == 1 else None
+    if startup is not None:
+        failures.extend(startup["failures"])
+    else:
+        if LAYERWISE_STARTUP_PATTERN.search(text) is not None:
+            failures.append("threshold-0 server allocated the layerwise manager")
+        if parse_layerwise_summaries(text):
+            failures.append("threshold-0 server executed the layerwise manager")
+
+    return {
+        "threshold": threshold,
+        "server_args": fields,
+        "layerwise_startup": startup,
+        "failures": failures,
+        "pass": not failures,
+    }
+
+
+def fatal_log_lines(text: str) -> list[str]:
+    failures: list[str] = []
+    for line in text.splitlines():
+        if any(pattern.search(line) for pattern in FATAL_LOG_PATTERNS):
+            failures.append(line[:2048])
+    return failures
+
+
+def _read_tail(path: Path, *, maximum_bytes: int = 4 * 1024 * 1024) -> str:
+    size = path.stat().st_size
+    with path.open("rb") as handle:
+        handle.seek(max(0, size - maximum_bytes))
+        return handle.read().decode("utf-8", errors="replace")
+
+
+def _log_before(path: Path) -> tuple[int, dict[str, Any] | None]:
+    if not path.is_file():
+        raise FileNotFoundError(path)
+    size = path.stat().st_size
+    summaries = parse_layerwise_summaries(_read_tail(path))
+    return size, summaries[-1] if summaries else None
+
+
+def _log_after(path: Path, offset: int) -> tuple[int, str]:
+    size = path.stat().st_size
+    if size < offset:
+        raise RuntimeError(
+            f"server log was truncated during request: before={offset}, after={size}"
+        )
+    with path.open("rb") as handle:
+        handle.seek(offset)
+        data = handle.read()
+    return size, data.decode("utf-8", errors="replace")
+
+
+def validate_completed_request(
+    record: dict[str, Any], *, output_tokens: int, vocab_size: int
+) -> list[str]:
+    failures: list[str] = []
+    if not record.get("success"):
+        return [str(record.get("error", "request failed"))]
+    if not _finite_tree(record):
+        failures.append("request record contains NaN or Inf")
+    finish_reason = record.get("finish_reason")
+    finish_type = (
+        finish_reason.get("type") if isinstance(finish_reason, dict) else finish_reason
+    )
+    if finish_type != "length":
+        failures.append(f"request finish_reason is {finish_reason!r}, expected length")
+    output_ids = record.get("output_ids")
+    if not isinstance(output_ids, list) or len(output_ids) != output_tokens:
+        failures.append("request output token shape is invalid")
+    elif any(
+        isinstance(token_id, bool)
+        or not isinstance(token_id, int)
+        or not 0 <= token_id < vocab_size
+        for token_id in output_ids
+    ):
+        failures.append("request contains an out-of-range output token ID")
+    return failures
+
+
+def _capture_request_evidence(
+    *,
+    base_url: str,
+    server_log: Path,
+    input_ids: list[int],
+    output_tokens: int,
+    chunk_size: int,
+    timeout: float,
+    should_flush_cache: bool,
+    tp_size: int,
+    vocab_size: int,
+) -> dict[str, Any]:
+    failures: list[str] = []
+    before_offset, previous_summary = _log_before(server_log)
+    metrics_before_text = fetch_metrics(base_url, timeout=timeout)
+    graph_before = decode_graph_counter(metrics_before_text)
+    counters_before = cuda_graph_counters_by_rank(metrics_before_text)
+    record: dict[str, Any]
+    try:
+        if should_flush_cache:
+            flush_cache(base_url, timeout=timeout)
+        record = run_streaming_request(
+            base_url,
+            input_ids,
+            output_tokens,
+            timeout=timeout,
+        )
+    except Exception as error:
+        record = {"success": False, "error": f"{type(error).__name__}: {error}"}
+        failures.append(str(record["error"]))
+    after_offset, log_segment = _log_after(server_log, before_offset)
+    metrics_after_text = fetch_metrics(base_url, timeout=timeout)
+    graph_after = decode_graph_counter(metrics_after_text)
+    counters_after = cuda_graph_counters_by_rank(metrics_after_text)
+
+    summaries = parse_layerwise_summaries(log_segment)
+    expected_rounds = math.ceil(len(input_ids) / chunk_size)
+    failures.extend(
+        validate_layerwise_progress(
+            previous_summary,
+            summaries,
+            expected_rounds=expected_rounds,
+        )
+    )
+    fatal_lines = fatal_log_lines(log_segment)
+    if fatal_lines:
+        failures.append(f"server log contains {len(fatal_lines)} fatal line(s)")
+    graph_delta = (
+        graph_after - graph_before
+        if graph_before is not None and graph_after is not None
+        else None
+    )
+    graph_gate = validate_graph_counter_progress(
+        counters_before,
+        counters_after,
+        tp_size=tp_size,
+        minimum_graph_delta_per_rank=max(output_tokens - 1, 1),
+    )
+    failures.extend(graph_gate["failures"])
+
+    request_failures = validate_completed_request(
+        record, output_tokens=output_tokens, vocab_size=vocab_size
+    )
+    for failure in request_failures:
+        if failure not in failures:
+            failures.append(failure)
+    return {
+        "input_tokens": len(input_ids),
+        "output_tokens": output_tokens,
+        "expected_layerwise_rounds": expected_rounds,
+        "previous_layerwise_summary": previous_summary,
+        "layerwise_summaries": summaries,
+        "decode_cuda_graph_counter": {
+            "before": graph_before,
+            "after": graph_after,
+            "delta": graph_delta,
+            "minimum_delta": max(output_tokens - 1, 1),
+            "per_rank_gate": graph_gate,
+        },
+        "server_log_window": {
+            "path": str(server_log.resolve()),
+            "start_offset": before_offset,
+            "end_offset": after_offset,
+            "sha256": _sha256_bytes(log_segment.encode("utf-8")),
+            "fatal_lines": fatal_lines,
+        },
+        "metrics_evidence": {
+            "before_sha256": _sha256_bytes(metrics_before_text.encode("utf-8")),
+            "after_sha256": _sha256_bytes(metrics_after_text.encode("utf-8")),
+        },
+        "record": record,
+        "failures": failures,
+        "pass": not failures,
+    }
+
+
+def run_layerwise(args: argparse.Namespace) -> int:
+    lengths = tuple(args.lengths)
+    failures: list[str] = []
+    contract_compliant = (
+        lengths == LAYERWISE_LENGTHS
+        and args.chunk_size == LAYERWISE_CHUNK_SIZE
+        and args.output_length == DEFAULT_BOUNDARY_OUTPUT
+        and args.fixture_seed == LAYERWISE_FIXTURE_SEED
+        and args.vocab_size == DEFAULT_VOCAB_SIZE
+        and args.tp_size == REQUIRED_TP_SIZE
+    )
+    if not contract_compliant:
+        failures.append(
+            "layerwise matrix must use lengths 128/4096/4097/8193, "
+            "chunk size 4096, exactly 16 output tokens, seed 20260811, "
+            "TP=8, and vocab size 154880"
+        )
+
+    server_log = Path(args.server_log)
+    try:
+        startup_text = server_log.read_text(encoding="utf-8", errors="replace")
+        startup_evidence = validate_layerwise_startup(startup_text)
+    except Exception as error:
+        startup_evidence = {
+            "failures": [f"{type(error).__name__}: {error}"],
+            "pass": False,
+        }
+    failures.extend(f"startup: {failure}" for failure in startup_evidence["failures"])
+
+    cases: list[dict[str, Any]] = []
+    for length in lengths if contract_compliant and startup_evidence["pass"] else ():
+        fixture = build_fixture(
+            length,
+            args.vocab_size,
+            salt=89,
+            seed=args.fixture_seed,
+        )
+        input_ids = fixture.pop("input_ids")
+        try:
+            evidence = _capture_request_evidence(
+                base_url=args.base_url,
+                server_log=Path(args.server_log),
+                input_ids=input_ids,
+                output_tokens=args.output_length,
+                chunk_size=args.chunk_size,
+                timeout=args.request_timeout,
+                should_flush_cache=not args.no_flush_cache,
+                tp_size=args.tp_size,
+                vocab_size=args.vocab_size,
+            )
+        except Exception as error:
+            evidence = {
+                "input_tokens": length,
+                "output_tokens": args.output_length,
+                "failures": [f"{type(error).__name__}: {error}"],
+                "pass": False,
+            }
+        evidence["fixture"] = fixture
+        cases.append(evidence)
+        failures.extend(
+            f"length {length}: {failure}" for failure in evidence["failures"]
+        )
+        if not evidence["pass"] and args.stop_on_failure:
+            break
+
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "kind": "glm5_next_session_c_layerwise_boundaries",
+        "created_unix": time.time(),
+        "label": args.label,
+        "base_url": args.base_url.rstrip("/"),
+        "contract": {
+            "lengths": list(lengths),
+            "chunk_size": args.chunk_size,
+            "output_tokens": args.output_length,
+            "expected_rounds": {
+                str(length): math.ceil(length / args.chunk_size) for length in lengths
+            },
+            "require_decode_cuda_graph": True,
+            "require_layerwise_fallback_zero": True,
+            "require_startup_two_slot_allocation_before_kv_pool": True,
+            "fixture_seed": args.fixture_seed,
+            "vocab_size": args.vocab_size,
+            "tp_size": args.tp_size,
+            "compliant": contract_compliant,
+        },
+        "startup_evidence": startup_evidence,
+        "cases": cases,
+        "failures": failures,
+        "pass": not failures,
+    }
+    _atomic_write_json(Path(args.output), payload)
+    print(json.dumps({"output": args.output, "pass": payload["pass"]}, indent=2))
+    return 0 if payload["pass"] else 1
+
+
+def run_long(args: argparse.Namespace) -> int:
+    fixture = build_fixture(
+        args.input_length,
+        args.vocab_size,
+        salt=73,
+        seed=args.fixture_seed,
+    )
+    input_ids = fixture.pop("input_ids")
+    failures: list[str] = []
+    contract_compliant = (
+        args.input_length == MIN_LONG_INPUT
+        and args.output_length == MIN_LONG_OUTPUT
+        and args.chunk_size == LAYERWISE_CHUNK_SIZE
+        and args.fixture_seed == FIXTURE_SEED
+        and args.vocab_size == DEFAULT_VOCAB_SIZE
+        and args.tp_size == REQUIRED_TP_SIZE
+    )
+    if not contract_compliant:
+        failures.append(
+            "final long request requires exactly 500000 input, 1024 output, "
+            "layerwise chunk size 4096, seed 20260812, TP=8, and vocab 154880"
+        )
+    try:
+        if not contract_compliant:
+            raise ValueError("refusing to issue a non-contract final long request")
+        evidence = _capture_request_evidence(
+            base_url=args.base_url,
+            server_log=Path(args.server_log),
+            input_ids=input_ids,
+            output_tokens=args.output_length,
+            chunk_size=args.chunk_size,
+            timeout=args.request_timeout,
+            should_flush_cache=not args.no_flush_cache,
+            tp_size=args.tp_size,
+            vocab_size=args.vocab_size,
+        )
+    except Exception as error:
+        evidence = {
+            "input_tokens": args.input_length,
+            "output_tokens": args.output_length,
+            "failures": [f"{type(error).__name__}: {error}"],
+            "pass": False,
+        }
+    failures.extend(evidence["failures"])
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "kind": "glm5_next_session_c_final_long_context",
+        "created_unix": time.time(),
+        "label": args.label,
+        "base_url": args.base_url.rstrip("/"),
+        "contract": {
+            "request_concurrency": 1,
+            "input_tokens": MIN_LONG_INPUT,
+            "output_tokens": MIN_LONG_OUTPUT,
+            "chunk_size": args.chunk_size,
+            "expected_layerwise_rounds": math.ceil(args.input_length / args.chunk_size),
+            "require_decode_cuda_graph": True,
+            "require_layerwise_fallback_zero": True,
+            "throughput_gate": None,
+            "fixture_seed": args.fixture_seed,
+            "vocab_size": args.vocab_size,
+            "tp_size": args.tp_size,
+            "compliant": contract_compliant,
+        },
+        "fixture": fixture,
+        "evidence": evidence,
+        "failures": failures,
+        "pass": not failures,
+    }
+    _atomic_write_json(Path(args.output), payload)
+    print(json.dumps({"output": args.output, "pass": payload["pass"]}, indent=2))
+    return 0 if payload["pass"] else 1
+
+
+def _post_batch(
+    base_url: str,
+    rows: list[list[int]],
+    *,
+    output_tokens: int,
+    top_k: int,
+    timeout: float,
+    vocab_size: int,
+) -> list[dict[str, Any]]:
+    body = {
+        "input_ids": rows,
+        "sampling_params": {
+            "temperature": 0,
+            "max_new_tokens": output_tokens,
+            "ignore_eos": True,
+            "skip_special_tokens": False,
+        },
+        "return_logprob": True,
+        "top_logprobs_num": top_k,
+        "return_text_in_logprobs": False,
+    }
+    request = urllib.request.Request(
+        f"{base_url.rstrip('/')}/generate",
+        data=json.dumps(body, separators=(",", ":")).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            status = getattr(response, "status", response.getcode())
+            raw = response.read()
+    except urllib.error.HTTPError as error:
+        detail = error.read()[:1024]
+        raise RuntimeError(
+            f"generate returned HTTP {error.code}: {detail!r}"
+        ) from error
+    if status < 200 or status >= 300:
+        raise RuntimeError(f"generate returned HTTP {status}: {raw[:1024]!r}")
+    payload = json.loads(raw)
+    rows_out = payload if isinstance(payload, list) else [payload]
+    if len(rows_out) != len(rows):
+        raise RuntimeError(
+            f"batch response has {len(rows_out)} rows, expected {len(rows)}"
+        )
+    if not _finite_tree(rows_out):
+        raise RuntimeError("batch response contains NaN or Inf")
+    for index, row in enumerate(rows_out):
+        if not isinstance(row, dict):
+            raise RuntimeError(f"row {index} is not an object")
+        output_ids = row.get("output_ids") or []
+        if len(output_ids) != output_tokens:
+            raise RuntimeError(
+                f"row {index} has {len(output_ids)} output ids, "
+                f"expected {output_tokens}"
+            )
+        for token_id in output_ids:
+            if (
+                isinstance(token_id, bool)
+                or not isinstance(token_id, int)
+                or not 0 <= token_id < vocab_size
+            ):
+                raise RuntimeError(
+                    f"row {index} has invalid output token id {token_id!r}"
+                )
+        meta = row.get("meta_info") or {}
+        if meta.get("prompt_tokens") != len(rows[index]):
+            raise RuntimeError(f"row {index} has invalid prompt_tokens")
+        if meta.get("completion_tokens") != output_tokens:
+            raise RuntimeError(f"row {index} has invalid completion_tokens")
+        finish_reason = meta.get("finish_reason")
+        finish_type = (
+            finish_reason.get("type")
+            if isinstance(finish_reason, dict)
+            else finish_reason
+        )
+        if finish_type != "length":
+            raise RuntimeError(
+                f"row {index} has invalid finish_reason {finish_reason!r}"
+            )
+        raw_steps = meta.get("output_top_logprobs") or []
+        if len(raw_steps) != output_tokens:
+            raise RuntimeError(
+                f"row {index} has {len(raw_steps)} top-logprob steps, "
+                f"expected {output_tokens}"
+            )
+        for step_index, raw_top in enumerate(raw_steps):
+            if len(raw_top or []) < top_k:
+                raise RuntimeError(
+                    f"row {index} step {step_index} has {len(raw_top or [])} "
+                    f"top logprobs, expected at least {top_k}"
+                )
+            seen: set[int] = set()
+            for entry in raw_top:
+                if isinstance(entry, dict):
+                    token_id, logprob = entry.get("token_id"), entry.get("logprob")
+                elif isinstance(entry, (list, tuple)) and len(entry) >= 2:
+                    logprob, token_id = entry[0], entry[1]
+                else:
+                    raise RuntimeError(
+                        f"row {index} step {step_index} has invalid top logprob"
+                    )
+                if (
+                    isinstance(token_id, bool)
+                    or not isinstance(token_id, int)
+                    or not 0 <= token_id < vocab_size
+                    or token_id in seen
+                ):
+                    raise RuntimeError(
+                        f"row {index} step {step_index} has invalid top token id {token_id!r}"
+                    )
+                seen.add(token_id)
+                if (
+                    isinstance(logprob, bool)
+                    or not isinstance(logprob, (int, float))
+                    or not math.isfinite(float(logprob))
+                ):
+                    raise RuntimeError(
+                        f"row {index} step {step_index} has invalid logprob {logprob!r}"
+                    )
+            generated_id = output_ids[step_index]
+            generated_entries = []
+            for entry in raw_top:
+                if isinstance(entry, dict):
+                    token_id, logprob = entry.get("token_id"), entry.get("logprob")
+                else:
+                    logprob, token_id = entry[0], entry[1]
+                if token_id == generated_id:
+                    generated_entries.append(float(logprob))
+            maximum_logprob = max(
+                float(entry.get("logprob"))
+                if isinstance(entry, dict)
+                else float(entry[0])
+                for entry in raw_top
+            )
+            if not generated_entries or generated_entries[0] != maximum_logprob:
+                raise RuntimeError(
+                    f"row {index} step {step_index} generated token "
+                    f"{generated_id} is not the greedy top-logprob token"
+                )
+    return rows_out
+
+
+def _normalize_top_logprobs(raw_steps: Any, top_k: int) -> list[list[dict[str, Any]]]:
+    normalized: list[list[dict[str, Any]]] = []
+    for raw_top in raw_steps or []:
+        step: list[dict[str, Any]] = []
+        for entry in (raw_top or [])[:top_k]:
+            if isinstance(entry, dict):
+                token_id = entry.get("token_id")
+                logprob = entry.get("logprob")
+            else:
+                logprob, token_id = entry[0], entry[1]
+            step.append({"token_id": int(token_id), "logprob": float(logprob)})
+        normalized.append(step)
+    return normalized
+
+
+def _collect_prefill_parity_case(
+    args: argparse.Namespace, *, length: int
+) -> dict[str, Any]:
+    fixture = build_fixture(
+        length,
+        args.vocab_size,
+        salt=89,
+        seed=args.fixture_seed,
+    )
+    input_ids = fixture.pop("input_ids")
+    server_log = Path(args.server_log)
+    before_offset, previous_summary = _log_before(server_log)
+    if not args.no_flush_cache:
+        flush_cache(args.base_url, timeout=args.request_timeout)
+    response = _post_batch(
+        args.base_url,
+        [input_ids],
+        output_tokens=args.output_length,
+        top_k=args.top_k,
+        timeout=args.request_timeout,
+        vocab_size=args.vocab_size,
+    )[0]
+    after_offset, log_segment = _log_after(server_log, before_offset)
+    summaries = parse_layerwise_summaries(log_segment)
+    failures: list[str] = []
+    expected_rounds = math.ceil(length / args.chunk_size)
+    if args.threshold == 1:
+        failures.extend(
+            validate_layerwise_progress(
+                previous_summary,
+                summaries,
+                expected_rounds=expected_rounds,
+            )
+        )
+    elif summaries:
+        failures.append(
+            f"threshold-0 request emitted {len(summaries)} layerwise round(s)"
+        )
+    fatal_lines = fatal_log_lines(log_segment)
+    if fatal_lines:
+        failures.append(f"server log contains {len(fatal_lines)} fatal line(s)")
+
+    output_ids = [int(token_id) for token_id in response.get("output_ids", [])]
+    meta = response.get("meta_info") or {}
+    top_logprobs = _normalize_top_logprobs(meta.get("output_top_logprobs"), args.top_k)
+    return {
+        "input_tokens": length,
+        "fixture": fixture,
+        "output_ids": output_ids,
+        "output_sha256": _sha256_token_rows([output_ids]),
+        "finish_reason": meta.get("finish_reason"),
+        "prompt_tokens": meta.get("prompt_tokens"),
+        "completion_tokens": meta.get("completion_tokens"),
+        "top_logprobs": top_logprobs,
+        "expected_layerwise_rounds": expected_rounds if args.threshold == 1 else 0,
+        "previous_layerwise_summary": previous_summary,
+        "layerwise_summaries": summaries,
+        "server_log_window": {
+            "path": str(server_log.resolve()),
+            "start_offset": before_offset,
+            "end_offset": after_offset,
+            "sha256": _sha256_bytes(log_segment.encode("utf-8")),
+            "fatal_lines": fatal_lines,
+        },
+        "failures": failures,
+        "pass": not failures,
+    }
+
+
+def run_prefill_parity(args: argparse.Namespace) -> int:
+    lengths = tuple(args.lengths)
+    contract_compliant = (
+        args.threshold in (0, 1)
+        and lengths == LAYERWISE_LENGTHS
+        and args.output_length == DEFAULT_BOUNDARY_OUTPUT
+        and args.chunk_size == LAYERWISE_CHUNK_SIZE
+        and args.fixture_seed == LAYERWISE_FIXTURE_SEED
+        and args.tp_size == REQUIRED_TP_SIZE
+        and args.vocab_size == DEFAULT_VOCAB_SIZE
+        and args.top_k == PREFILL_PARITY_COLLECTION_TOP_K
+    )
+    failures: list[str] = []
+    if not contract_compliant:
+        failures.append(
+            "prefill parity requires threshold 0/1, lengths "
+            "128/4096/4097/8193, output 16, chunk 4096, seed 20260811, "
+            "TP=8, vocab 154880, and collected top-k 256"
+        )
+
+    server_log = Path(args.server_log)
+    try:
+        initial_log = server_log.read_text(encoding="utf-8", errors="replace")
+        server_evidence = validate_prefill_parity_server_log(
+            initial_log, threshold=args.threshold
+        )
+        server_evidence.update(
+            {
+                "path": str(server_log.resolve()),
+                "initial_size": len(initial_log.encode("utf-8")),
+                "initial_sha256": _sha256_bytes(initial_log.encode("utf-8")),
+            }
+        )
+    except Exception as error:
+        server_evidence = {
+            "failures": [f"{type(error).__name__}: {error}"],
+            "pass": False,
+        }
+    failures.extend(f"server: {failure}" for failure in server_evidence["failures"])
+
+    cases: list[dict[str, Any]] = []
+    for length in lengths if contract_compliant and server_evidence["pass"] else ():
+        try:
+            case = _collect_prefill_parity_case(args, length=length)
+        except Exception as error:
+            case = {
+                "input_tokens": length,
+                "failures": [f"{type(error).__name__}: {error}"],
+                "pass": False,
+            }
+        cases.append(case)
+        failures.extend(f"length {length}: {failure}" for failure in case["failures"])
+        if not case["pass"] and args.stop_on_failure:
+            break
+
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "kind": "glm5_next_session_c_prefill_threshold_collection",
+        "created_unix": time.time(),
+        "label": args.label,
+        "base_url": args.base_url.rstrip("/"),
+        "contract": {
+            "threshold": args.threshold,
+            "lengths": list(lengths),
+            "output_tokens": args.output_length,
+            "chunk_size": args.chunk_size,
+            "fixture_seed": args.fixture_seed,
+            "tp_size": args.tp_size,
+            "vocab_size": args.vocab_size,
+            "collection_top_k": args.top_k,
+            "comparison_top_k": PREFILL_PARITY_COMPARISON_TOP_K,
+            "temperature": 0,
+            "ignore_eos": True,
+            "require_finish_reason_length": True,
+            "require_exact_greedy_tokens": True,
+            "compliant": contract_compliant,
+        },
+        "server_evidence": server_evidence,
+        "cases": cases,
+        "failures": failures,
+        "pass": not failures,
+    }
+    _atomic_write_json(Path(args.output), payload)
+    print(json.dumps({"output": args.output, "pass": payload["pass"]}, indent=2))
+    return 0 if payload["pass"] else 1
+
+
+def _validate_prefill_collection(
+    payload: dict[str, Any], *, role: str, expected_threshold: int
+) -> tuple[list[str], dict[int, dict[str, Any]]]:
+    failures: list[str] = []
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        failures.append(f"{role}: unsupported schema")
+    if payload.get("kind") != "glm5_next_session_c_prefill_threshold_collection":
+        failures.append(f"{role}: payload kind is invalid")
+    if payload.get("pass") is not True:
+        failures.append(f"{role}: collection did not pass")
+    server_evidence = payload.get("server_evidence")
+    if not isinstance(server_evidence, dict) or server_evidence.get("pass") is not True:
+        failures.append(f"{role}: server evidence did not pass")
+    else:
+        if server_evidence.get("threshold") != expected_threshold:
+            failures.append(f"{role}: server-evidence threshold is invalid")
+        server_args = server_evidence.get("server_args")
+        expected_server_args = {
+            "tp_size": str(REQUIRED_TP_SIZE),
+            "chunked_prefill_size": str(LAYERWISE_CHUNK_SIZE),
+            "kt_method": "'FP8'",
+            "kt_gpu_prefill_token_threshold": str(expected_threshold),
+        }
+        if not isinstance(server_args, dict) or any(
+            server_args.get(key) != value for key, value in expected_server_args.items()
+        ):
+            failures.append(f"{role}: server_args evidence is invalid")
+        startup = server_evidence.get("layerwise_startup")
+        if expected_threshold == 1 and (
+            not isinstance(startup, dict) or startup.get("pass") is not True
+        ):
+            failures.append(f"{role}: layerwise startup evidence is invalid")
+        if expected_threshold == 0 and startup is not None:
+            failures.append(f"{role}: threshold-0 startup evidence is not null")
+        if not isinstance(server_evidence.get("path"), str):
+            failures.append(f"{role}: server-log path evidence is missing")
+        initial_size = server_evidence.get("initial_size")
+        if (
+            isinstance(initial_size, bool)
+            or not isinstance(initial_size, int)
+            or initial_size <= 0
+        ):
+            failures.append(f"{role}: server-log size evidence is invalid")
+        initial_sha256 = server_evidence.get("initial_sha256")
+        if (
+            not isinstance(initial_sha256, str)
+            or re.fullmatch(r"[0-9a-f]{64}", initial_sha256) is None
+        ):
+            failures.append(f"{role}: server-log digest evidence is invalid")
+    contract = payload.get("contract")
+    expected_contract = {
+        "threshold": expected_threshold,
+        "lengths": list(LAYERWISE_LENGTHS),
+        "output_tokens": DEFAULT_BOUNDARY_OUTPUT,
+        "chunk_size": LAYERWISE_CHUNK_SIZE,
+        "fixture_seed": LAYERWISE_FIXTURE_SEED,
+        "tp_size": REQUIRED_TP_SIZE,
+        "vocab_size": DEFAULT_VOCAB_SIZE,
+        "collection_top_k": PREFILL_PARITY_COLLECTION_TOP_K,
+        "comparison_top_k": PREFILL_PARITY_COMPARISON_TOP_K,
+        "temperature": 0,
+        "ignore_eos": True,
+        "require_finish_reason_length": True,
+        "require_exact_greedy_tokens": True,
+        "compliant": True,
+    }
+    if not isinstance(contract, dict):
+        failures.append(f"{role}: contract is missing")
+    else:
+        if set(contract) != set(expected_contract):
+            failures.append(f"{role}: contract fields are not exact")
+        for key, expected in expected_contract.items():
+            if contract.get(key) != expected:
+                failures.append(
+                    f"{role}: contract {key} is {contract.get(key)!r}, "
+                    f"expected {expected!r}"
+                )
+
+    raw_cases = payload.get("cases")
+    if not isinstance(raw_cases, list):
+        failures.append(f"{role}: cases are missing")
+        return failures, {}
+    cases: dict[int, dict[str, Any]] = {}
+    for index, case in enumerate(raw_cases):
+        if not isinstance(case, dict):
+            failures.append(f"{role}: case {index} is not an object")
+            continue
+        length = case.get("input_tokens")
+        if isinstance(length, bool) or not isinstance(length, int):
+            failures.append(f"{role}: case {index} has invalid input length")
+            continue
+        if length in cases:
+            failures.append(f"{role}: duplicate length {length}")
+            continue
+        cases[length] = case
+    if set(cases) != set(LAYERWISE_LENGTHS):
+        failures.append(f"{role}: case set is not exact 128/4096/4097/8193")
+
+    for length, case in cases.items():
+        if case.get("pass") is not True or case.get("failures") != []:
+            failures.append(f"{role} length {length}: case did not pass cleanly")
+        fixture = case.get("fixture")
+        if not isinstance(fixture, dict):
+            failures.append(f"{role} length {length}: fixture is missing")
+        else:
+            expected_fixture = build_fixture(
+                length,
+                DEFAULT_VOCAB_SIZE,
+                salt=89,
+                seed=LAYERWISE_FIXTURE_SEED,
+            )
+            expected_fixture.pop("input_ids")
+            if fixture != expected_fixture:
+                failures.append(f"{role} length {length}: fixture contract differs")
+        finish_reason = case.get("finish_reason")
+        finish_type = (
+            finish_reason.get("type")
+            if isinstance(finish_reason, dict)
+            else finish_reason
+        )
+        if finish_type != "length":
+            failures.append(f"{role} length {length}: finish_reason is not length")
+        if case.get("prompt_tokens") != length:
+            failures.append(f"{role} length {length}: prompt token count differs")
+        if case.get("completion_tokens") != DEFAULT_BOUNDARY_OUTPUT:
+            failures.append(f"{role} length {length}: completion token count differs")
+
+        summaries = case.get("layerwise_summaries")
+        expected_rounds = math.ceil(length / LAYERWISE_CHUNK_SIZE)
+        if expected_threshold == 1:
+            if not isinstance(summaries, list):
+                failures.append(
+                    f"{role} length {length}: layerwise summaries are missing"
+                )
+            else:
+                progress_failures = validate_layerwise_progress(
+                    case.get("previous_layerwise_summary"),
+                    summaries,
+                    expected_rounds=expected_rounds,
+                )
+                failures.extend(
+                    f"{role} length {length}: {failure}"
+                    for failure in progress_failures
+                )
+            if case.get("expected_layerwise_rounds") != expected_rounds:
+                failures.append(
+                    f"{role} length {length}: expected-round evidence differs"
+                )
+        elif summaries != [] or case.get("expected_layerwise_rounds") != 0:
+            failures.append(
+                f"{role} length {length}: threshold-0 layerwise evidence is invalid"
+            )
+        log_window = case.get("server_log_window")
+        if not isinstance(log_window, dict):
+            failures.append(f"{role} length {length}: log-window evidence is missing")
+        else:
+            start_offset = log_window.get("start_offset")
+            end_offset = log_window.get("end_offset")
+            window_sha256 = log_window.get("sha256")
+            if (
+                isinstance(start_offset, bool)
+                or not isinstance(start_offset, int)
+                or isinstance(end_offset, bool)
+                or not isinstance(end_offset, int)
+                or start_offset < 0
+                or end_offset < start_offset
+            ):
+                failures.append(
+                    f"{role} length {length}: log-window offsets are invalid"
+                )
+            if (
+                not isinstance(window_sha256, str)
+                or re.fullmatch(r"[0-9a-f]{64}", window_sha256) is None
+            ):
+                failures.append(f"{role} length {length}: log-window digest is invalid")
+            if log_window.get("fatal_lines") != []:
+                failures.append(
+                    f"{role} length {length}: log-window fatal evidence is not empty"
+                )
+
+        output_ids = case.get("output_ids")
+        valid_output = (
+            isinstance(output_ids, list)
+            and len(output_ids) == DEFAULT_BOUNDARY_OUTPUT
+            and all(
+                not isinstance(token_id, bool)
+                and isinstance(token_id, int)
+                and 0 <= token_id < DEFAULT_VOCAB_SIZE
+                for token_id in output_ids
+            )
+        )
+        if not valid_output:
+            failures.append(f"{role} length {length}: output token IDs are invalid")
+        elif case.get("output_sha256") != _sha256_token_rows([output_ids]):
+            failures.append(f"{role} length {length}: output digest is invalid")
+
+        top = case.get("top_logprobs")
+        valid_top = isinstance(top, list) and len(top) == DEFAULT_BOUNDARY_OUTPUT
+        if valid_top:
+            for step_index, step in enumerate(top):
+                if (
+                    not isinstance(step, list)
+                    or len(step) != PREFILL_PARITY_COLLECTION_TOP_K
+                ):
+                    valid_top = False
+                    break
+                seen: set[int] = set()
+                for item in step:
+                    if not isinstance(item, dict):
+                        valid_top = False
+                        break
+                    token_id = item.get("token_id")
+                    logprob = item.get("logprob")
+                    if (
+                        isinstance(token_id, bool)
+                        or not isinstance(token_id, int)
+                        or not 0 <= token_id < DEFAULT_VOCAB_SIZE
+                        or token_id in seen
+                        or isinstance(logprob, bool)
+                        or not isinstance(logprob, (int, float))
+                        or not math.isfinite(float(logprob))
+                    ):
+                        valid_top = False
+                        break
+                    seen.add(token_id)
+                if not valid_top:
+                    break
+                if valid_output:
+                    generated_id = output_ids[step_index]
+                    by_id = {item["token_id"]: float(item["logprob"]) for item in step}
+                    if generated_id not in by_id or by_id[generated_id] != max(
+                        by_id.values()
+                    ):
+                        valid_top = False
+                        break
+        if not valid_top:
+            failures.append(f"{role} length {length}: top-logprob evidence is invalid")
+    return failures, cases
+
+
+def compare_prefill_parity_payloads(
+    baseline: dict[str, Any], candidate: dict[str, Any]
+) -> dict[str, Any]:
+    failures, baseline_cases = _validate_prefill_collection(
+        baseline, role="threshold-0", expected_threshold=0
+    )
+    candidate_failures, candidate_cases = _validate_prefill_collection(
+        candidate, role="threshold-1", expected_threshold=1
+    )
+    failures.extend(candidate_failures)
+    diagnostics: list[dict[str, Any]] = []
+
+    comparable_lengths = (
+        sorted(set(baseline_cases) & set(candidate_cases)) if not failures else []
+    )
+    for length in comparable_lengths:
+        expected = baseline_cases[length]
+        actual = candidate_cases[length]
+        if expected.get("fixture") != actual.get("fixture"):
+            failures.append(f"length {length}: input fixture differs")
+        expected_ids = expected.get("output_ids")
+        actual_ids = actual.get("output_ids")
+        if expected_ids != actual_ids:
+            failures.append(f"length {length}: greedy output token IDs differ")
+        expected_top = expected.get("top_logprobs")
+        actual_top = actual.get("top_logprobs")
+        if not isinstance(expected_top, list) or not isinstance(actual_top, list):
+            failures.append(f"length {length}: top-logprob evidence is missing")
+            continue
+        for step_index, (expected_step, actual_step) in enumerate(
+            zip(expected_top, actual_top)
+        ):
+            if not isinstance(expected_step, list) or not isinstance(actual_step, list):
+                failures.append(f"length {length} step {step_index}: invalid top list")
+                continue
+            actual_by_id = {
+                int(item["token_id"]): float(item["logprob"])
+                for item in actual_step
+                if isinstance(item, dict)
+                and isinstance(item.get("token_id"), int)
+                and not isinstance(item.get("token_id"), bool)
+                and isinstance(item.get("logprob"), (int, float))
+                and not isinstance(item.get("logprob"), bool)
+            }
+            reference = expected_step[:PREFILL_PARITY_COMPARISON_TOP_K]
+            missing = [
+                int(item["token_id"])
+                for item in reference
+                if isinstance(item, dict) and int(item["token_id"]) not in actual_by_id
+            ]
+            numerical_failures = 0
+            max_abs = 0.0
+            max_relative = 0.0
+            for item in reference:
+                token_id = int(item["token_id"])
+                if token_id not in actual_by_id:
+                    continue
+                expected_value = float(item["logprob"])
+                actual_value = actual_by_id[token_id]
+                delta = abs(expected_value - actual_value)
+                relative = delta / max(abs(expected_value), 1e-6)
+                max_abs = max(max_abs, delta)
+                max_relative = max(max_relative, relative)
+                if delta > PREFILL_PARITY_LOGPROB_ATOL + (
+                    PREFILL_PARITY_LOGPROB_RTOL * abs(expected_value)
+                ):
+                    numerical_failures += 1
+            diagnostics.append(
+                {
+                    "input_tokens": length,
+                    "step": step_index,
+                    "missing_threshold_0_top_ids": missing,
+                    "numerical_failures": numerical_failures,
+                    "max_abs": max_abs,
+                    "max_relative": max_relative,
+                }
+            )
+            if missing:
+                failures.append(
+                    f"length {length} step {step_index}: {len(missing)} "
+                    "threshold-0 top-64 IDs are absent from threshold-1 top-256"
+                )
+            if numerical_failures:
+                failures.append(
+                    f"length {length} step {step_index}: {numerical_failures} "
+                    "top logprobs exceed atol=0.05, rtol=0.05"
+                )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "kind": "glm5_next_session_c_prefill_threshold_comparison",
+        "created_unix": time.time(),
+        "contract": {
+            "baseline_threshold": 0,
+            "candidate_threshold": 1,
+            "lengths": list(LAYERWISE_LENGTHS),
+            "output_tokens": DEFAULT_BOUNDARY_OUTPUT,
+            "fixture_seed": LAYERWISE_FIXTURE_SEED,
+            "tp_size": REQUIRED_TP_SIZE,
+            "vocab_size": DEFAULT_VOCAB_SIZE,
+            "collection_top_k": PREFILL_PARITY_COLLECTION_TOP_K,
+            "comparison_top_k": PREFILL_PARITY_COMPARISON_TOP_K,
+            "logprob_atol": PREFILL_PARITY_LOGPROB_ATOL,
+            "logprob_rtol": PREFILL_PARITY_LOGPROB_RTOL,
+            "require_exact_greedy_tokens": True,
+        },
+        "diagnostics": diagnostics,
+        "failures": failures,
+        "pass": not failures,
+    }
+
+
+def run_compare_prefill_parity(args: argparse.Namespace) -> int:
+    baseline_path = Path(args.threshold_0)
+    candidate_path = Path(args.threshold_1)
+    baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
+    candidate = json.loads(candidate_path.read_text(encoding="utf-8"))
+    payload = compare_prefill_parity_payloads(baseline, candidate)
+    payload["inputs"] = {
+        "threshold_0": str(baseline_path.resolve()),
+        "threshold_1": str(candidate_path.resolve()),
+    }
+    _atomic_write_json(Path(args.output), payload)
+    print(json.dumps({"output": args.output, "pass": payload["pass"]}, indent=2))
+    return 0 if payload["pass"] else 1
+
+
+def run_buckets(args: argparse.Namespace) -> int:
+    cases: list[dict[str, Any]] = []
+    failures: list[str] = []
+    contract_compliant = (
+        args.vocab_size == DEFAULT_VOCAB_SIZE
+        and args.fixture_seed == FIXTURE_SEED
+        and args.input_length == BUCKET_INPUT_TOKENS
+        and args.output_length == BUCKET_OUTPUT_TOKENS
+        and args.top_k == BUCKET_TOP_K
+    )
+    if not contract_compliant:
+        failures.append(
+            "exact-bucket parameters differ from the frozen Session-C contract"
+        )
+    for batch_size in (1, 2, 4):
+        fixtures = [
+            build_fixture(
+                args.input_length,
+                args.vocab_size,
+                salt=401 + batch_size * 17 + row,
+                seed=args.fixture_seed,
+            )
+            for row in range(batch_size)
+        ]
+        rows = [fixture.pop("input_ids") for fixture in fixtures]
+        try:
+            if not args.no_flush_cache:
+                flush_cache(args.base_url, timeout=args.request_timeout)
+            metrics_before = fetch_metrics(args.base_url, timeout=args.request_timeout)
+            graph_before = decode_graph_counter(metrics_before)
+            response = _post_batch(
+                args.base_url,
+                rows,
+                output_tokens=args.output_length,
+                top_k=args.top_k,
+                timeout=args.request_timeout,
+                vocab_size=args.vocab_size,
+            )
+            metrics_after = fetch_metrics(args.base_url, timeout=args.request_timeout)
+            graph_after = decode_graph_counter(metrics_after)
+            counters_before = cuda_graph_counters_by_rank(metrics_before)
+            counters_after = cuda_graph_counters_by_rank(metrics_after)
+            if graph_before is None or graph_after is None:
+                raise RuntimeError("decode CUDA Graph Prometheus counter is missing")
+            graph_delta = graph_after - graph_before
+            minimum_delta = max(args.output_length - 1, 1)
+            graph_gate = validate_graph_counter_progress(
+                counters_before,
+                counters_after,
+                tp_size=args.tp_size,
+                minimum_graph_delta_per_rank=minimum_delta,
+            )
+            if not graph_gate["pass"]:
+                raise RuntimeError("; ".join(graph_gate["failures"]))
+            output_rows = [
+                [int(token_id) for token_id in row.get("output_ids", [])]
+                for row in response
+            ]
+            top_logprobs = [
+                _normalize_top_logprobs(
+                    (row.get("meta_info") or {}).get("output_top_logprobs"),
+                    args.top_k,
+                )
+                for row in response
+            ]
+            case = {
+                "batch_size": batch_size,
+                "fixtures": fixtures,
+                "input_rows_sha256": _sha256_token_rows(rows),
+                "output_rows": output_rows,
+                "output_rows_sha256": _sha256_token_rows(output_rows),
+                "top_k": args.top_k,
+                "top_logprobs": top_logprobs,
+                "decode_cuda_graph_counter": {
+                    "before": graph_before,
+                    "after": graph_after,
+                    "delta": graph_delta,
+                    "minimum_delta": minimum_delta,
+                    "per_rank_gate": graph_gate,
+                },
+                "failures": [],
+                "pass": True,
+            }
+        except Exception as error:
+            case = {
+                "batch_size": batch_size,
+                "fixtures": fixtures,
+                "input_rows_sha256": _sha256_token_rows(rows),
+                "failures": [f"{type(error).__name__}: {error}"],
+                "pass": False,
+            }
+        cases.append(case)
+        failures.extend(
+            f"batch {batch_size}: {failure}" for failure in case["failures"]
+        )
+        if not case["pass"] and args.stop_on_failure:
+            break
+
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "kind": "session_c_exact_cuda_graph_buckets",
+        "created_unix": time.time(),
+        "label": args.label,
+        "base_url": args.base_url.rstrip("/"),
+        "contract": {
+            "batch_sizes": [1, 2, 4],
+            "input_tokens": args.input_length,
+            "output_tokens": args.output_length,
+            "top_k": args.top_k,
+            "vocab_size": args.vocab_size,
+            "fixture_seed": args.fixture_seed,
+            "require_decode_cuda_graph": True,
+            "compliant": contract_compliant,
+        },
+        "cases": cases,
+        "failures": failures,
+        "pass": not failures,
+    }
+    _atomic_write_json(Path(args.output), payload)
+    print(json.dumps({"output": args.output, "pass": payload["pass"]}, indent=2))
+    return 0 if payload["pass"] else 1
+
+
+def compare_bucket_payloads(
+    baseline: dict[str, Any], candidate: dict[str, Any]
+) -> dict[str, Any]:
+    failures: list[str] = []
+    if baseline.get("schema_version") != SCHEMA_VERSION:
+        failures.append("unsupported baseline schema")
+    if candidate.get("schema_version") != SCHEMA_VERSION:
+        failures.append("unsupported candidate schema")
+    for role, payload in (("baseline", baseline), ("candidate", candidate)):
+        if payload.get("kind") != "session_c_exact_cuda_graph_buckets":
+            failures.append(f"{role} payload kind is invalid")
+        contract = payload.get("contract", {})
+        if contract.get("compliant") is not True:
+            failures.append(f"{role} bucket contract is not compliant")
+        if contract.get("batch_sizes") != [1, 2, 4]:
+            failures.append(f"{role} bucket set contract is invalid")
+        if contract.get("input_tokens") != BUCKET_INPUT_TOKENS:
+            failures.append(f"{role} input-token contract is invalid")
+        if contract.get("output_tokens") != BUCKET_OUTPUT_TOKENS:
+            failures.append(f"{role} output-token contract is invalid")
+        if contract.get("top_k") != BUCKET_TOP_K:
+            failures.append(f"{role} top-k contract is invalid")
+    if baseline.get("contract") != candidate.get("contract"):
+        failures.append("baseline and candidate bucket contracts differ")
+    if not baseline.get("pass"):
+        failures.append("baseline bucket collection did not pass")
+    if not candidate.get("pass"):
+        failures.append("candidate bucket collection did not pass")
+    baseline_cases = {
+        int(case["batch_size"]): case for case in baseline.get("cases", [])
+    }
+    candidate_cases = {
+        int(case["batch_size"]): case for case in candidate.get("cases", [])
+    }
+    if set(baseline_cases) != {1, 2, 4} or set(candidate_cases) != {1, 2, 4}:
+        failures.append("both collections must contain exact buckets 1, 2, and 4")
+    for batch_size in sorted(set(baseline_cases) & set(candidate_cases)):
+        expected = baseline_cases[batch_size]
+        actual = candidate_cases[batch_size]
+        if expected.get("pass") is not True or actual.get("pass") is not True:
+            failures.append(f"batch {batch_size}: case did not pass")
+        if expected.get("input_rows_sha256") != actual.get("input_rows_sha256"):
+            failures.append(f"batch {batch_size}: input fixture digest mismatch")
+        if expected.get("output_rows") != actual.get("output_rows"):
+            failures.append(f"batch {batch_size}: generated output IDs differ")
+        if expected.get("top_k") != actual.get("top_k"):
+            failures.append(f"batch {batch_size}: top-k contract differs")
+        for role, case in (("baseline", expected), ("candidate", actual)):
+            rows = case.get("output_rows")
+            top = case.get("top_logprobs")
+            if (
+                not isinstance(rows, list)
+                or len(rows) != batch_size
+                or any(len(row) != BUCKET_OUTPUT_TOKENS for row in rows)
+            ):
+                failures.append(f"batch {batch_size}: {role} output shape is invalid")
+            if (
+                not isinstance(top, list)
+                or len(top) != batch_size
+                or any(
+                    len(steps) != BUCKET_OUTPUT_TOKENS
+                    or any(len(items) != BUCKET_TOP_K for items in steps)
+                    for steps in top
+                )
+            ):
+                failures.append(
+                    f"batch {batch_size}: {role} top-logprob shape is invalid"
+                )
+        expected_top = expected.get("top_logprobs")
+        actual_top = actual.get("top_logprobs")
+        if expected_top is None or actual_top is None:
+            failures.append(f"batch {batch_size}: top-logprob evidence is missing")
+        elif expected_top != actual_top:
+            failures.append(f"batch {batch_size}: top logprobs differ")
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "kind": "session_c_exact_cuda_graph_bucket_comparison",
+        "created_unix": time.time(),
+        "failures": failures,
+        "pass": not failures,
+    }
+
+
+def run_compare_buckets(args: argparse.Namespace) -> int:
+    baseline_path = Path(args.baseline)
+    candidate_path = Path(args.candidate)
+    baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
+    candidate = json.loads(candidate_path.read_text(encoding="utf-8"))
+    payload = compare_bucket_payloads(baseline, candidate)
+    payload["inputs"] = {
+        "baseline": str(baseline_path.resolve()),
+        "candidate": str(candidate_path.resolve()),
+    }
+    _atomic_write_json(Path(args.output), payload)
+    print(json.dumps({"output": args.output, "pass": payload["pass"]}, indent=2))
+    return 0 if payload["pass"] else 1
+
+
+def _add_common_request_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--label", required=True)
+    parser.add_argument("--base-url", default="http://127.0.0.1:30100")
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--vocab-size", type=int, default=DEFAULT_VOCAB_SIZE)
+    parser.add_argument("--fixture-seed", type=int, default=FIXTURE_SEED)
+    parser.add_argument("--request-timeout", type=float, default=86_400.0)
+    parser.add_argument("--no-flush-cache", action="store_true")
+    parser.add_argument("--tp-size", type=int, default=8)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="mode", required=True)
+
+    layerwise = subparsers.add_parser(
+        "layerwise", help="run the exact 128/4096/4097/8193 boundary matrix"
+    )
+    _add_common_request_args(layerwise)
+    layerwise.add_argument("--server-log", required=True)
+    layerwise.add_argument(
+        "--lengths", type=int, nargs="+", default=list(LAYERWISE_LENGTHS)
+    )
+    layerwise.add_argument("--chunk-size", type=int, default=LAYERWISE_CHUNK_SIZE)
+    layerwise.add_argument("--output-length", type=int, default=DEFAULT_BOUNDARY_OUTPUT)
+    layerwise.add_argument("--stop-on-failure", action="store_true")
+    layerwise.set_defaults(
+        func=run_layerwise,
+        fixture_seed=LAYERWISE_FIXTURE_SEED,
+    )
+
+    prefill_parity = subparsers.add_parser(
+        "prefill-parity",
+        help="collect one exact ordinary/layerwise prefill threshold side",
+    )
+    _add_common_request_args(prefill_parity)
+    prefill_parity.add_argument("--server-log", required=True)
+    prefill_parity.add_argument("--threshold", type=int, choices=(0, 1), required=True)
+    prefill_parity.add_argument(
+        "--lengths", type=int, nargs="+", default=list(LAYERWISE_LENGTHS)
+    )
+    prefill_parity.add_argument("--chunk-size", type=int, default=LAYERWISE_CHUNK_SIZE)
+    prefill_parity.add_argument(
+        "--output-length", type=int, default=DEFAULT_BOUNDARY_OUTPUT
+    )
+    prefill_parity.add_argument(
+        "--top-k", type=int, default=PREFILL_PARITY_COLLECTION_TOP_K
+    )
+    prefill_parity.add_argument("--stop-on-failure", action="store_true")
+    prefill_parity.set_defaults(
+        func=run_prefill_parity,
+        fixture_seed=LAYERWISE_FIXTURE_SEED,
+    )
+
+    compare_prefill = subparsers.add_parser(
+        "compare-prefill-parity",
+        help="compare frozen threshold-0 and threshold-1 prefill collections",
+    )
+    compare_prefill.add_argument("--threshold-0", required=True)
+    compare_prefill.add_argument("--threshold-1", required=True)
+    compare_prefill.add_argument("--output", required=True)
+    compare_prefill.set_defaults(func=run_compare_prefill_parity)
+
+    long_context = subparsers.add_parser(
+        "long", help="run the final integrated 500000-input + 1024-output gate"
+    )
+    _add_common_request_args(long_context)
+    long_context.add_argument("--server-log", required=True)
+    long_context.add_argument("--input-length", type=int, default=MIN_LONG_INPUT)
+    long_context.add_argument("--output-length", type=int, default=MIN_LONG_OUTPUT)
+    long_context.add_argument("--chunk-size", type=int, default=LAYERWISE_CHUNK_SIZE)
+    long_context.set_defaults(func=run_long)
+
+    buckets = subparsers.add_parser(
+        "buckets", help="exercise exact decode CUDA Graph buckets 1/2/4"
+    )
+    _add_common_request_args(buckets)
+    buckets.add_argument("--input-length", type=int, default=BUCKET_INPUT_TOKENS)
+    buckets.add_argument("--output-length", type=int, default=BUCKET_OUTPUT_TOKENS)
+    buckets.add_argument("--top-k", type=int, default=BUCKET_TOP_K)
+    buckets.add_argument("--stop-on-failure", action="store_true")
+    buckets.set_defaults(func=run_buckets)
+
+    compare = subparsers.add_parser(
+        "compare-buckets", help="compare baseline/candidate bucket output IDs"
+    )
+    compare.add_argument("--baseline", required=True)
+    compare.add_argument("--candidate", required=True)
+    compare.add_argument("--output", required=True)
+    compare.set_defaults(func=run_compare_buckets)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/glm5_next_session_c_graph_acceptance.py
+++ b/scripts/glm5_next_session_c_graph_acceptance.py
@@ -1132,7 +1132,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--eager-json")
     parser.add_argument("--vocab-size", type=int, default=DEFAULT_VOCAB_SIZE)
     parser.add_argument("--top-k", type=int, default=DEFAULT_TOP_K)
-    parser.add_argument("--tp-size", type=int, default=8)
+    parser.add_argument("--tp-size", type=int, default=4)
     parser.add_argument("--request-timeout", type=float, default=7200)
     parser.add_argument("--no-flush-cache", action="store_true")
     return parser

--- a/scripts/glm5_next_session_c_graph_acceptance.py
+++ b/scripts/glm5_next_session_c_graph_acceptance.py
@@ -1,0 +1,1157 @@
+#!/usr/bin/env python3
+"""HTTP acceptance harness for GLM-5-Next decode CUDA Graphs.
+
+The harness intentionally has no dependency on SGLang internals.  It sends
+three deterministic batched requests (A, poison, A) for each frozen graph
+bucket, validates eight greedy decode steps and their top log-probabilities,
+and stores the complete HTTP and Prometheus evidence in one JSON file.
+
+An eager baseline can be collected with ``--mode eager`` and supplied to the
+graph run with ``--eager-json``.  Graph use is accepted only from a real
+``/metrics`` counter carrying the ``decode_cuda_graph`` mode.  Server log text
+is deliberately not an input to this program and remains separate evidence.
+
+Examples::
+
+    python scripts/glm5_next_session_c_graph_acceptance.py \
+      --mode eager --base-url http://127.0.0.1:30100 \
+      --output /mnt/.../graph_acceptance/eager.json
+
+    python scripts/glm5_next_session_c_graph_acceptance.py \
+      --mode graph --base-url http://127.0.0.1:30101 \
+      --eager-json /mnt/.../graph_acceptance/eager.json \
+      --output /mnt/.../graph_acceptance/graph.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import platform
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Callable
+
+
+SCHEMA_VERSION = 1
+FIXTURE_SEED = 20260812
+BATCH_SIZES = (1, 2, 4)
+PHASES = ("a_before", "poison", "a_after")
+PROMPT_TOKENS = 1
+OUTPUT_TOKENS = 8
+DEFAULT_VOCAB_SIZE = 154880
+DEFAULT_TOP_K = 64
+TOP_LOGPROB_ATOL = 5e-2
+TOP_LOGPROB_RTOL = 5e-2
+
+_METRIC_LINE = re.compile(
+    r"^([a-zA-Z_:][a-zA-Z0-9_:]*)(?:\{(.*)\})?\s+([^\s]+)"
+    r"(?:\s+[^\s]+)?$"
+)
+_METRIC_LABEL = re.compile(r'([a-zA-Z_][a-zA-Z0-9_]*)="((?:\\.|[^"\\])*)"')
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    with temporary.open("w", encoding="utf-8") as handle:
+        json.dump(
+            payload,
+            handle,
+            allow_nan=False,
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+        handle.write("\n")
+    temporary.replace(path)
+
+
+def _json_safe(value: Any) -> Any:
+    """Keep malformed non-finite server values representable in strict JSON."""
+
+    if isinstance(value, float) and not math.isfinite(value):
+        if math.isnan(value):
+            return "NaN"
+        return "Infinity" if value > 0 else "-Infinity"
+    if isinstance(value, dict):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(item) for item in value]
+    return value
+
+
+def _sha256_json(value: Any) -> str:
+    encoded = json.dumps(value, separators=(",", ":"), sort_keys=True).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def build_fixtures(vocab_size: int) -> list[dict[str, Any]]:
+    """Build stable one-token A/poison/A batches for graph buckets 1/2/4."""
+
+    if vocab_size < 4096:
+        raise ValueError(f"unexpectedly small vocabulary: {vocab_size}")
+    span = vocab_size - 2048
+    fixtures: list[dict[str, Any]] = []
+    for batch_size in BATCH_SIZES:
+        a_tokens = [
+            1024 + ((FIXTURE_SEED + batch_size * 104729 + row * 7919) % span)
+            for row in range(batch_size)
+        ]
+        poison_tokens = [
+            1024 + ((FIXTURE_SEED + 97 + batch_size * 130363 + row * 1543) % span)
+            for row in range(batch_size)
+        ]
+        if any(a == poison for a, poison in zip(a_tokens, poison_tokens)):
+            raise RuntimeError(f"A and poison fixtures overlap for bs={batch_size}")
+        fixtures.append(
+            {
+                "batch_size": batch_size,
+                "prompt_length": PROMPT_TOKENS,
+                "a_tokens": a_tokens,
+                "poison_tokens": poison_tokens,
+                "a_sha256": _sha256_json(a_tokens),
+                "poison_sha256": _sha256_json(poison_tokens),
+            }
+        )
+    return fixtures
+
+
+def _request_bytes(
+    request: urllib.request.Request,
+    *,
+    timeout: float,
+    opener: Callable[..., Any],
+) -> bytes:
+    try:
+        with opener(request, timeout=timeout) as response:
+            status = getattr(response, "status", response.getcode())
+            payload = response.read()
+    except urllib.error.HTTPError as error:
+        detail = error.read()[:4096]
+        raise RuntimeError(
+            f"HTTP {error.code} from {request.full_url}: {detail!r}"
+        ) from error
+    if status < 200 or status >= 300:
+        raise RuntimeError(f"HTTP {status} from {request.full_url}: {payload[:4096]!r}")
+    return payload
+
+
+def _post_json(
+    url: str,
+    body: dict[str, Any],
+    *,
+    timeout: float,
+    opener: Callable[..., Any],
+) -> Any:
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(body, separators=(",", ":")).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    payload = _request_bytes(request, timeout=timeout, opener=opener)
+    return json.loads(payload)
+
+
+def _get_text(
+    url: str,
+    *,
+    timeout: float,
+    opener: Callable[..., Any],
+) -> str:
+    request = urllib.request.Request(url, method="GET")
+    payload = _request_bytes(request, timeout=timeout, opener=opener)
+    return payload.decode("utf-8")
+
+
+def _parse_metric_labels(raw: str | None) -> dict[str, str]:
+    if not raw:
+        return {}
+    labels: dict[str, str] = {}
+    consumed = []
+    for match in _METRIC_LABEL.finditer(raw):
+        key, encoded_value = match.groups()
+        try:
+            value = json.loads(f'"{encoded_value}"')
+        except json.JSONDecodeError:
+            value = encoded_value
+        labels[key] = value
+        consumed.append(match.span())
+
+    # Reject partially parsed label blocks instead of accidentally matching a
+    # malformed line.  Only commas and whitespace may remain between matches.
+    cursor = 0
+    for start, end in consumed:
+        if raw[cursor:start].strip(" ,\t"):
+            return {}
+        cursor = end
+    if raw[cursor:].strip(" ,\t"):
+        return {}
+    return labels
+
+
+def parse_prometheus_metrics(text: str) -> list[dict[str, Any]]:
+    """Parse numeric Prometheus samples while retaining their source lines."""
+
+    samples: list[dict[str, Any]] = []
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        match = _METRIC_LINE.fullmatch(line)
+        if match is None:
+            continue
+        name, raw_labels, raw_value = match.groups()
+        try:
+            value = float(raw_value)
+        except ValueError:
+            continue
+        samples.append(
+            {
+                "name": name,
+                "labels": _parse_metric_labels(raw_labels),
+                "value": value,
+                "finite": math.isfinite(value),
+                "line": line,
+            }
+        )
+    return samples
+
+
+def _is_decode_cuda_graph_counter(sample: dict[str, Any]) -> bool:
+    name = str(sample.get("name", "")).lower().replace(":", "_")
+    labels = {
+        str(key).lower(): str(value).lower()
+        for key, value in sample.get("labels", {}).items()
+    }
+    counter_like = name.endswith("_total") or name.endswith("_count")
+    labeled_mode = any(
+        value == "decode_cuda_graph"
+        for key, value in labels.items()
+        if key in {"mode", "forward_mode", "graph_mode", "cuda_graph_mode"}
+    )
+    labeled_counter = labeled_mode and "cuda_graph" in name and counter_like
+    dedicated_counter = "decode_cuda_graph" in name and counter_like
+    return bool(sample.get("finite") and (labeled_counter or dedicated_counter))
+
+
+def decode_cuda_graph_counter(text: str) -> dict[str, Any]:
+    matched = [
+        sample
+        for sample in parse_prometheus_metrics(text)
+        if _is_decode_cuda_graph_counter(sample)
+    ]
+    return {
+        "available": bool(matched),
+        "total": sum(float(sample["value"]) for sample in matched) if matched else None,
+        "samples": matched,
+    }
+
+
+def cuda_graph_counters_by_rank(text: str) -> dict[str, dict[str, float]]:
+    """Return the production CUDA-graph counter split by mode and TP rank."""
+
+    counters = {"decode_cuda_graph": {}, "decode_none": {}}
+    for sample in parse_prometheus_metrics(text):
+        if sample.get("name") != "sglang:cuda_graph_passes_total":
+            continue
+        labels = sample.get("labels", {})
+        mode = labels.get("mode")
+        rank = labels.get("tp_rank", labels.get("rank"))
+        if mode not in counters or rank is None or not sample.get("finite"):
+            continue
+        if rank in counters[mode]:
+            raise ValueError(f"duplicate {mode} counter for TP rank {rank}")
+        counters[mode][str(rank)] = float(sample["value"])
+    return counters
+
+
+def compare_metric_snapshots(
+    before: dict[str, Any],
+    after: dict[str, Any],
+    *,
+    tp_size: int = 1,
+    minimum_graph_delta_per_rank: float = 1.0,
+) -> dict[str, Any]:
+    before_counter = before.get("decode_cuda_graph_counter", {})
+    after_counter = after.get("decode_cuda_graph_counter", {})
+    before_total = before_counter.get("total")
+    after_total = after_counter.get("total")
+    failures: list[str] = []
+    delta = None
+    expected_ranks = {str(rank) for rank in range(tp_size)}
+    before_by_rank = before.get("cuda_graph_counters_by_rank", {})
+    after_by_rank = after.get("cuda_graph_counters_by_rank", {})
+    per_rank: dict[str, Any] = {}
+
+    if not before.get("success"):
+        failures.append("the pre-run /metrics snapshot failed")
+    if not after.get("success"):
+        failures.append("the post-run /metrics snapshot failed")
+    if not before_counter.get("available"):
+        failures.append("no decode_cuda_graph counter was exposed before the run")
+    if not after_counter.get("available"):
+        failures.append("no decode_cuda_graph counter was exposed after the run")
+    if before_total is not None and after_total is not None:
+        delta = float(after_total) - float(before_total)
+    for mode in ("decode_cuda_graph", "decode_none"):
+        before_ranks = set(before_by_rank.get(mode, {}))
+        after_ranks = set(after_by_rank.get(mode, {}))
+        if before_ranks != expected_ranks or after_ranks != expected_ranks:
+            failures.append(
+                f"{mode} TP rank set mismatch: expected={sorted(expected_ranks)}, "
+                f"before={sorted(before_ranks)}, after={sorted(after_ranks)}"
+            )
+    for rank in sorted(expected_ranks, key=int):
+        graph_before = before_by_rank.get("decode_cuda_graph", {}).get(rank)
+        graph_after = after_by_rank.get("decode_cuda_graph", {}).get(rank)
+        none_before = before_by_rank.get("decode_none", {}).get(rank)
+        none_after = after_by_rank.get("decode_none", {}).get(rank)
+        rank_failures: list[str] = []
+        graph_delta = (
+            graph_after - graph_before
+            if graph_before is not None and graph_after is not None
+            else None
+        )
+        none_delta = (
+            none_after - none_before
+            if none_before is not None and none_after is not None
+            else None
+        )
+        if graph_delta is not None and graph_delta < minimum_graph_delta_per_rank:
+            rank_failures.append(
+                f"graph delta {graph_delta} is below {minimum_graph_delta_per_rank}"
+            )
+        if none_delta is not None and none_delta != 0:
+            rank_failures.append(f"decode_none delta is {none_delta}, expected 0")
+        failures.extend(f"TP rank {rank}: {failure}" for failure in rank_failures)
+        per_rank[rank] = {
+            "graph_before": graph_before,
+            "graph_after": graph_after,
+            "graph_delta": graph_delta,
+            "decode_none_before": none_before,
+            "decode_none_after": none_after,
+            "decode_none_delta": none_delta,
+            "failures": rank_failures,
+            "pass": not rank_failures
+            and graph_delta is not None
+            and none_delta is not None,
+        }
+
+    return {
+        "source": "HTTP /metrics only",
+        "log_evidence_used": False,
+        "before_total": before_total,
+        "after_total": after_total,
+        "delta": delta,
+        "expected_tp_ranks": sorted(expected_ranks, key=int),
+        "minimum_graph_delta_per_rank": minimum_graph_delta_per_rank,
+        "expected_decode_none_delta_per_rank": 0,
+        "per_rank": per_rank,
+        "failures": failures,
+        "pass": not failures,
+    }
+
+
+def _metrics_snapshot(
+    base_url: str,
+    *,
+    timeout: float,
+    opener: Callable[..., Any],
+) -> dict[str, Any]:
+    url = f"{base_url.rstrip('/')}/metrics"
+    try:
+        text = _get_text(url, timeout=timeout, opener=opener)
+        return {
+            "success": True,
+            "url": url,
+            "retrieved_unix": time.time(),
+            "raw_text": text,
+            "raw_sha256": hashlib.sha256(text.encode()).hexdigest(),
+            "decode_cuda_graph_counter": decode_cuda_graph_counter(text),
+            "cuda_graph_counters_by_rank": cuda_graph_counters_by_rank(text),
+        }
+    except Exception as error:
+        return {
+            "success": False,
+            "url": url,
+            "retrieved_unix": time.time(),
+            "error": f"{type(error).__name__}: {error}",
+            "raw_text": None,
+            "raw_sha256": None,
+            "decode_cuda_graph_counter": {
+                "available": False,
+                "total": None,
+                "samples": [],
+            },
+            "cuda_graph_counters_by_rank": {
+                "decode_cuda_graph": {},
+                "decode_none": {},
+            },
+        }
+
+
+def _parse_top_logprobs(raw: Any) -> list[dict[str, float | int]]:
+    parsed: list[dict[str, float | int]] = []
+    seen: set[int] = set()
+    if not isinstance(raw, list):
+        raise TypeError(f"top logprobs must be a list, got {type(raw).__name__}")
+    for entry in raw:
+        if isinstance(entry, dict):
+            token_id = entry.get("token_id")
+            logprob = entry.get("logprob")
+        elif isinstance(entry, (list, tuple)) and len(entry) >= 2:
+            logprob, token_id = entry[0], entry[1]
+        else:
+            raise TypeError(f"invalid top-logprob entry: {entry!r}")
+        if isinstance(token_id, bool) or not isinstance(token_id, (int, float)):
+            raise TypeError(f"invalid top-logprob token id: {token_id!r}")
+        if not math.isfinite(float(token_id)) or int(token_id) != token_id:
+            raise ValueError(f"invalid top-logprob token id: {token_id!r}")
+        token_id = int(token_id)
+        if token_id in seen:
+            raise ValueError(f"duplicate top-logprob token id: {token_id}")
+        seen.add(token_id)
+        try:
+            logprob = float(logprob)
+        except (TypeError, ValueError) as error:
+            raise TypeError(
+                f"invalid logprob for token {token_id}: {logprob!r}"
+            ) from error
+        if not math.isfinite(logprob):
+            raise ValueError(f"non-finite logprob for token {token_id}: {logprob}")
+        parsed.append({"token_id": token_id, "logprob": logprob})
+    return parsed
+
+
+def _normalize_generate_response(
+    raw_response: Any,
+    *,
+    prompt_tokens: list[int],
+    output_tokens: int,
+    top_k: int,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    batch_size = len(prompt_tokens)
+    failures: list[str] = []
+    if isinstance(raw_response, dict) and batch_size == 1:
+        responses = [raw_response]
+    elif isinstance(raw_response, list):
+        responses = raw_response
+    else:
+        return [], [
+            f"expected a list of {batch_size} responses, got "
+            f"{type(raw_response).__name__}"
+        ]
+    if len(responses) != batch_size:
+        failures.append(
+            f"response batch size mismatch: expected {batch_size}, got {len(responses)}"
+        )
+
+    sequences: list[dict[str, Any]] = []
+    for sequence_index, (prompt_token, response) in enumerate(
+        zip(prompt_tokens, responses)
+    ):
+        sequence_failures: list[str] = []
+        if not isinstance(response, dict):
+            failures.append(
+                f"sequence {sequence_index}: response is {type(response).__name__}"
+            )
+            continue
+        raw_ids = response.get("output_ids")
+        if not isinstance(raw_ids, list):
+            generated_ids: list[int] = []
+            sequence_failures.append("output_ids is not a list")
+        else:
+            generated_ids = []
+            for token_id in raw_ids:
+                if isinstance(token_id, bool) or not isinstance(token_id, (int, float)):
+                    sequence_failures.append(f"invalid output token id: {token_id!r}")
+                    continue
+                if not math.isfinite(float(token_id)) or int(token_id) != token_id:
+                    sequence_failures.append(f"invalid output token id: {token_id!r}")
+                    continue
+                generated_ids.append(int(token_id))
+        if len(generated_ids) != output_tokens:
+            sequence_failures.append(
+                f"expected {output_tokens} output ids, got {len(generated_ids)}"
+            )
+
+        meta = response.get("meta_info")
+        if not isinstance(meta, dict):
+            meta = {}
+            sequence_failures.append("meta_info is not an object")
+        completion_tokens = meta.get("completion_tokens")
+        if completion_tokens is not None and completion_tokens != output_tokens:
+            sequence_failures.append(
+                f"meta_info.completion_tokens={completion_tokens}, expected {output_tokens}"
+            )
+        raw_steps = meta.get("output_top_logprobs")
+        if not isinstance(raw_steps, list):
+            raw_steps = []
+            sequence_failures.append("meta_info.output_top_logprobs is not a list")
+        if len(raw_steps) != output_tokens:
+            sequence_failures.append(
+                f"expected {output_tokens} top-logprob steps, got {len(raw_steps)}"
+            )
+
+        steps: list[dict[str, Any]] = []
+        for step_index, raw_top in enumerate(raw_steps[:output_tokens]):
+            try:
+                top_logprobs = _parse_top_logprobs(raw_top)
+                if len(top_logprobs) < top_k:
+                    raise ValueError(
+                        f"expected at least {top_k} top logprobs, got {len(top_logprobs)}"
+                    )
+                top_logprobs = top_logprobs[:top_k]
+            except Exception as error:
+                sequence_failures.append(
+                    f"step {step_index}: {type(error).__name__}: {error}"
+                )
+                top_logprobs = []
+            steps.append(
+                {
+                    "step": step_index,
+                    "token_id": (
+                        generated_ids[step_index]
+                        if step_index < len(generated_ids)
+                        else None
+                    ),
+                    "top_logprobs": top_logprobs,
+                }
+            )
+
+        if sequence_failures:
+            failures.extend(
+                f"sequence {sequence_index}: {failure}" for failure in sequence_failures
+            )
+        sequences.append(
+            {
+                "sequence_index": sequence_index,
+                "input_ids": [prompt_token],
+                "generated_ids": generated_ids,
+                "steps": steps,
+                "failures": sequence_failures,
+                "pass": not sequence_failures,
+            }
+        )
+    return sequences, failures
+
+
+def _run_phase(
+    base_url: str,
+    *,
+    batch_size: int,
+    phase: str,
+    prompt_tokens: list[int],
+    top_k: int,
+    timeout: float,
+    opener: Callable[..., Any],
+) -> dict[str, Any]:
+    request_body = {
+        "input_ids": [[token_id] for token_id in prompt_tokens],
+        "sampling_params": {
+            "temperature": 0,
+            "max_new_tokens": OUTPUT_TOKENS,
+            "ignore_eos": True,
+            "skip_special_tokens": False,
+        },
+        "return_logprob": True,
+        "top_logprobs_num": top_k,
+        "return_text_in_logprobs": False,
+    }
+    started = time.perf_counter()
+    raw_response: Any = None
+    try:
+        raw_response = _post_json(
+            f"{base_url.rstrip('/')}/generate",
+            request_body,
+            timeout=timeout,
+            opener=opener,
+        )
+    except Exception as error:
+        return {
+            "phase": phase,
+            "batch_size": batch_size,
+            "request": request_body,
+            "raw_response": None,
+            "sequences": [],
+            "elapsed_seconds": time.perf_counter() - started,
+            "failures": [f"HTTP request failed: {type(error).__name__}: {error}"],
+            "pass": False,
+        }
+
+    try:
+        sequences, failures = _normalize_generate_response(
+            raw_response,
+            prompt_tokens=prompt_tokens,
+            output_tokens=OUTPUT_TOKENS,
+            top_k=top_k,
+        )
+        return {
+            "phase": phase,
+            "batch_size": batch_size,
+            "request": request_body,
+            "raw_response": _json_safe(raw_response),
+            "sequences": sequences,
+            "elapsed_seconds": time.perf_counter() - started,
+            "failures": failures,
+            "pass": not failures,
+        }
+    except Exception as error:
+        return {
+            "phase": phase,
+            "batch_size": batch_size,
+            "request": request_body,
+            "raw_response": _json_safe(raw_response),
+            "sequences": [],
+            "elapsed_seconds": time.perf_counter() - started,
+            "failures": [
+                f"response validation failed: {type(error).__name__}: {error}"
+            ],
+            "pass": False,
+        }
+
+
+def _compare_phase_records(
+    expected: dict[str, Any],
+    actual: dict[str, Any],
+    *,
+    context: str,
+    atol: float,
+    rtol: float,
+) -> dict[str, Any]:
+    failures: list[str] = []
+    diagnostics: list[dict[str, Any]] = []
+    expected_sequences = expected.get("sequences", [])
+    actual_sequences = actual.get("sequences", [])
+    if len(expected_sequences) != len(actual_sequences):
+        failures.append(
+            f"{context}: sequence count mismatch: "
+            f"{len(expected_sequences)} != {len(actual_sequences)}"
+        )
+
+    for sequence_index, (expected_sequence, actual_sequence) in enumerate(
+        zip(expected_sequences, actual_sequences)
+    ):
+        prefix = f"{context} sequence {sequence_index}"
+        if expected_sequence.get("input_ids") != actual_sequence.get("input_ids"):
+            failures.append(f"{prefix}: input ids mismatch")
+        expected_ids = expected_sequence.get("generated_ids", [])
+        actual_ids = actual_sequence.get("generated_ids", [])
+        if expected_ids != actual_ids:
+            failures.append(
+                f"{prefix}: generated token mismatch: {expected_ids} != {actual_ids}"
+            )
+        first_divergent_step = next(
+            (
+                index
+                for index, (expected_id, actual_id) in enumerate(
+                    zip(expected_ids, actual_ids)
+                )
+                if expected_id != actual_id
+            ),
+            None,
+        )
+        if first_divergent_step is None and len(expected_ids) != len(actual_ids):
+            first_divergent_step = min(len(expected_ids), len(actual_ids))
+
+        expected_steps = expected_sequence.get("steps", [])
+        actual_steps = actual_sequence.get("steps", [])
+        if len(expected_steps) != len(actual_steps):
+            failures.append(
+                f"{prefix}: step count mismatch: "
+                f"{len(expected_steps)} != {len(actual_steps)}"
+            )
+        for step_index, (expected_step, actual_step) in enumerate(
+            zip(expected_steps, actual_steps)
+        ):
+            if first_divergent_step is not None and step_index > first_divergent_step:
+                diagnostics.append(
+                    {
+                        "context": context,
+                        "sequence": sequence_index,
+                        "step": step_index,
+                        "status": "skipped_due_to_prefix_divergence",
+                    }
+                )
+                continue
+            expected_top = expected_step.get("top_logprobs", [])
+            actual_by_id = {
+                int(item["token_id"]): float(item["logprob"])
+                for item in actual_step.get("top_logprobs", [])
+            }
+            missing_ids: list[int] = []
+            outside_tolerance: list[dict[str, Any]] = []
+            max_abs = 0.0
+            max_relative = 0.0
+            for item in expected_top:
+                token_id = int(item["token_id"])
+                if token_id not in actual_by_id:
+                    missing_ids.append(token_id)
+                    continue
+                expected_value = float(item["logprob"])
+                actual_value = actual_by_id[token_id]
+                delta = abs(expected_value - actual_value)
+                relative = delta / max(abs(expected_value), 1e-6)
+                max_abs = max(max_abs, delta)
+                max_relative = max(max_relative, relative)
+                if delta > atol + rtol * abs(expected_value):
+                    outside_tolerance.append(
+                        {
+                            "token_id": token_id,
+                            "expected": expected_value,
+                            "actual": actual_value,
+                            "absolute_delta": delta,
+                            "relative_delta": relative,
+                        }
+                    )
+            diagnostics.append(
+                {
+                    "context": context,
+                    "sequence": sequence_index,
+                    "step": step_index,
+                    "status": "compared",
+                    "max_abs": max_abs,
+                    "max_relative": max_relative,
+                    "missing_reference_top_ids": missing_ids,
+                    "outside_tolerance": outside_tolerance,
+                }
+            )
+            if missing_ids:
+                failures.append(
+                    f"{prefix} step {step_index}: {len(missing_ids)} reference "
+                    "top-logprob token ids are missing"
+                )
+            if outside_tolerance:
+                failures.append(
+                    f"{prefix} step {step_index}: {len(outside_tolerance)} "
+                    f"logprobs outside atol={atol}, rtol={rtol}"
+                )
+
+    return {
+        "context": context,
+        "atol": atol,
+        "rtol": rtol,
+        "failures": failures,
+        "diagnostics": diagnostics,
+        "pass": not failures,
+    }
+
+
+def _poison_was_observed(
+    a_phase: dict[str, Any], poison_phase: dict[str, Any]
+) -> dict[str, Any]:
+    for sequence_index, (a_sequence, poison_sequence) in enumerate(
+        zip(a_phase.get("sequences", []), poison_phase.get("sequences", []))
+    ):
+        if a_sequence.get("generated_ids") != poison_sequence.get("generated_ids"):
+            return {
+                "observed": True,
+                "sequence": sequence_index,
+                "reason": "generated_ids_changed",
+            }
+        for step_index, (a_step, poison_step) in enumerate(
+            zip(a_sequence.get("steps", []), poison_sequence.get("steps", []))
+        ):
+            a_values = {
+                int(item["token_id"]): float(item["logprob"])
+                for item in a_step.get("top_logprobs", [])
+            }
+            poison_values = {
+                int(item["token_id"]): float(item["logprob"])
+                for item in poison_step.get("top_logprobs", [])
+            }
+            if set(a_values) != set(poison_values):
+                return {
+                    "observed": True,
+                    "sequence": sequence_index,
+                    "step": step_index,
+                    "reason": "top_logprob_token_ids_changed",
+                }
+            if any(
+                not math.isclose(
+                    a_values[token_id],
+                    poison_values[token_id],
+                    rel_tol=1e-7,
+                    abs_tol=1e-7,
+                )
+                for token_id in a_values
+            ):
+                return {
+                    "observed": True,
+                    "sequence": sequence_index,
+                    "step": step_index,
+                    "reason": "top_logprob_values_changed",
+                }
+    return {
+        "observed": False,
+        "reason": "poison request reproduced all A outputs and top logprobs",
+    }
+
+
+def _evaluate_a_poison_a(case: dict[str, Any]) -> dict[str, Any]:
+    by_phase = {phase["phase"]: phase for phase in case.get("phases", [])}
+    failures: list[str] = []
+    if set(by_phase) != set(PHASES):
+        failures.append(
+            f"phase set mismatch: expected {list(PHASES)}, got {sorted(by_phase)}"
+        )
+        return {"pass": False, "failures": failures}
+    for phase_name, phase in by_phase.items():
+        if not phase.get("pass"):
+            failures.extend(
+                f"{phase_name}: {failure}" for failure in phase.get("failures", [])
+            )
+
+    repeat = _compare_phase_records(
+        by_phase["a_before"],
+        by_phase["a_after"],
+        context=f"bs={case['batch_size']} A repeat",
+        atol=TOP_LOGPROB_ATOL,
+        rtol=TOP_LOGPROB_RTOL,
+    )
+    if not repeat["pass"]:
+        failures.extend(repeat["failures"])
+    poison = _poison_was_observed(by_phase["a_before"], by_phase["poison"])
+    if not poison["observed"]:
+        failures.append(str(poison["reason"]))
+    return {
+        "a_repeat": repeat,
+        "poison": poison,
+        "failures": failures,
+        "pass": not failures,
+    }
+
+
+def _case_map(payload: dict[str, Any]) -> dict[int, dict[str, Any]]:
+    result: dict[int, dict[str, Any]] = {}
+    for case in payload.get("cases", []):
+        batch_size = int(case["batch_size"])
+        if batch_size in result:
+            raise ValueError(f"duplicate batch size in payload: {batch_size}")
+        result[batch_size] = case
+    return result
+
+
+def compare_acceptance_payloads(
+    eager: dict[str, Any],
+    graph: dict[str, Any],
+    *,
+    atol: float = TOP_LOGPROB_ATOL,
+    rtol: float = TOP_LOGPROB_RTOL,
+) -> dict[str, Any]:
+    failures: list[str] = []
+    comparisons: list[dict[str, Any]] = []
+    if eager.get("schema_version") != SCHEMA_VERSION:
+        failures.append("unsupported eager schema")
+    if graph.get("schema_version") != SCHEMA_VERSION:
+        failures.append("unsupported graph schema")
+    if eager.get("mode") != "eager":
+        failures.append("reference payload is not an eager run")
+    if graph.get("mode") != "graph":
+        failures.append("candidate payload is not a graph run")
+    if eager.get("contract") != graph.get("contract"):
+        failures.append("eager and graph contracts differ")
+    if not eager.get("collection_pass", eager.get("pass", False)):
+        failures.append("eager collection did not pass")
+    if not graph.get("collection_pass", False):
+        failures.append("graph collection did not pass")
+
+    try:
+        eager_cases = _case_map(eager)
+        graph_cases = _case_map(graph)
+    except Exception as error:
+        failures.append(f"invalid case map: {type(error).__name__}: {error}")
+        eager_cases, graph_cases = {}, {}
+    if set(eager_cases) != set(BATCH_SIZES) or set(graph_cases) != set(BATCH_SIZES):
+        failures.append(
+            f"case set mismatch: eager={sorted(eager_cases)}, "
+            f"graph={sorted(graph_cases)}"
+        )
+
+    for batch_size in sorted(set(eager_cases) & set(graph_cases)):
+        eager_case = eager_cases[batch_size]
+        graph_case = graph_cases[batch_size]
+        if eager_case.get("fixture") != graph_case.get("fixture"):
+            failures.append(f"bs={batch_size}: fixture mismatch")
+            continue
+        eager_phases = {phase["phase"]: phase for phase in eager_case.get("phases", [])}
+        graph_phases = {phase["phase"]: phase for phase in graph_case.get("phases", [])}
+        if set(eager_phases) != set(graph_phases):
+            failures.append(f"bs={batch_size}: phase set mismatch")
+        for phase in PHASES:
+            if phase not in eager_phases or phase not in graph_phases:
+                continue
+            result = _compare_phase_records(
+                eager_phases[phase],
+                graph_phases[phase],
+                context=f"bs={batch_size} phase={phase} eager-vs-graph",
+                atol=atol,
+                rtol=rtol,
+            )
+            comparisons.append(result)
+            failures.extend(result["failures"])
+
+    return {
+        "kind": "glm5_next_session_c_eager_graph_comparison",
+        "atol": atol,
+        "rtol": rtol,
+        "tokens_exact_required": True,
+        "comparisons": comparisons,
+        "failures": failures,
+        "pass": not failures,
+    }
+
+
+def _flush_cache(
+    base_url: str,
+    *,
+    timeout: float,
+    opener: Callable[..., Any],
+) -> dict[str, Any]:
+    url = f"{base_url.rstrip('/')}/flush_cache"
+    try:
+        request = urllib.request.Request(
+            url,
+            data=b"{}",
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        response = _request_bytes(request, timeout=timeout, opener=opener)
+        return {
+            "success": True,
+            "url": url,
+            "response_text": response.decode("utf-8", errors="replace"),
+        }
+    except Exception as error:
+        return {
+            "success": False,
+            "url": url,
+            "error": f"{type(error).__name__}: {error}",
+        }
+
+
+def collect_acceptance(
+    args: argparse.Namespace,
+    *,
+    opener: Callable[..., Any] = urllib.request.urlopen,
+) -> dict[str, Any]:
+    if args.mode == "graph" and not args.eager_json:
+        raise ValueError("--eager-json is required in graph mode")
+    started = time.time()
+    base_url = args.base_url.rstrip("/")
+    fixtures = build_fixtures(args.vocab_size)
+    failures: list[str] = []
+
+    metrics_before = _metrics_snapshot(
+        base_url, timeout=args.request_timeout, opener=opener
+    )
+    flush = (
+        {"success": True, "skipped": True}
+        if args.no_flush_cache
+        else _flush_cache(base_url, timeout=args.request_timeout, opener=opener)
+    )
+    if not flush.get("success"):
+        failures.append(f"flush_cache failed: {flush.get('error')}")
+
+    cases: list[dict[str, Any]] = []
+    for fixture in fixtures:
+        batch_size = int(fixture["batch_size"])
+        phase_inputs = {
+            "a_before": fixture["a_tokens"],
+            "poison": fixture["poison_tokens"],
+            "a_after": fixture["a_tokens"],
+        }
+        phases = [
+            _run_phase(
+                base_url,
+                batch_size=batch_size,
+                phase=phase,
+                prompt_tokens=phase_inputs[phase],
+                top_k=args.top_k,
+                timeout=args.request_timeout,
+                opener=opener,
+            )
+            for phase in PHASES
+        ]
+        case = {"batch_size": batch_size, "fixture": fixture, "phases": phases}
+        case["a_poison_a"] = _evaluate_a_poison_a(case)
+        case["pass"] = bool(case["a_poison_a"]["pass"])
+        if not case["pass"]:
+            failures.extend(
+                f"bs={batch_size}: {failure}"
+                for failure in case["a_poison_a"]["failures"]
+            )
+        cases.append(case)
+
+    metrics_after = _metrics_snapshot(
+        base_url, timeout=args.request_timeout, opener=opener
+    )
+    graph_metric_gate = compare_metric_snapshots(
+        metrics_before,
+        metrics_after,
+        tp_size=args.tp_size,
+        minimum_graph_delta_per_rank=len(BATCH_SIZES)
+        * len(PHASES)
+        * (OUTPUT_TOKENS - 1),
+    )
+    graph_metric_gate["required"] = args.mode == "graph"
+    if args.mode == "graph" and not graph_metric_gate["pass"]:
+        failures.extend(graph_metric_gate["failures"])
+
+    contract = {
+        "batch_sizes": list(BATCH_SIZES),
+        "request_concurrency": "one native HTTP batch at a time",
+        "prompt_tokens_per_request": PROMPT_TOKENS,
+        "output_tokens_per_request": OUTPUT_TOKENS,
+        "phases": list(PHASES),
+        "temperature": 0,
+        "ignore_eos": True,
+        "top_k": args.top_k,
+        "top_logprob_atol": TOP_LOGPROB_ATOL,
+        "top_logprob_rtol": TOP_LOGPROB_RTOL,
+        "requires_http_metrics_for_graph": True,
+        "metrics_evidence_version": 2,
+        "tp_size": args.tp_size,
+        "server_log_evidence_is_separate": True,
+    }
+    collection_pass = all(case.get("pass") for case in cases) and flush.get("success")
+    payload: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "kind": "glm5_next_session_c_graph_acceptance",
+        "created_unix": time.time(),
+        "elapsed_seconds": time.time() - started,
+        "label": args.label,
+        "mode": args.mode,
+        "base_url": base_url,
+        "environment": {"python": sys.version, "platform": platform.platform()},
+        "fixture_seed": FIXTURE_SEED,
+        "vocab_size": args.vocab_size,
+        "contract": contract,
+        "flush_cache": flush,
+        "cases": cases,
+        "metrics": {
+            "before": metrics_before,
+            "after": metrics_after,
+            "decode_cuda_graph_gate": graph_metric_gate,
+        },
+        "collection_pass": collection_pass,
+        "comparison": None,
+        "failures": failures,
+    }
+
+    if args.eager_json is not None:
+        eager_path = Path(args.eager_json)
+        try:
+            eager = json.loads(eager_path.read_text(encoding="utf-8"))
+            comparison = compare_acceptance_payloads(eager, payload)
+            comparison["eager_json"] = str(eager_path.resolve())
+            comparison["eager_sha256"] = _sha256_file(eager_path)
+            payload["comparison"] = comparison
+            if not comparison["pass"]:
+                failures.extend(comparison["failures"])
+        except Exception as error:
+            message = f"eager comparison failed: {type(error).__name__}: {error}"
+            payload["comparison"] = {"pass": False, "failures": [message]}
+            failures.append(message)
+
+    payload["pass"] = bool(
+        collection_pass
+        and (args.mode != "graph" or graph_metric_gate["pass"])
+        and (payload["comparison"] is None or payload["comparison"]["pass"])
+        and not failures
+    )
+    return payload
+
+
+def run(
+    args: argparse.Namespace,
+    *,
+    opener: Callable[..., Any] = urllib.request.urlopen,
+) -> int:
+    try:
+        payload = collect_acceptance(args, opener=opener)
+    except Exception as error:
+        payload = {
+            "schema_version": SCHEMA_VERSION,
+            "kind": "glm5_next_session_c_graph_acceptance",
+            "created_unix": time.time(),
+            "label": getattr(args, "label", None),
+            "mode": getattr(args, "mode", None),
+            "base_url": getattr(args, "base_url", None),
+            "collection_pass": False,
+            "comparison": None,
+            "failures": [f"{type(error).__name__}: {error}"],
+            "pass": False,
+        }
+    output = Path(args.output)
+    _atomic_write_json(output, payload)
+    print(
+        json.dumps(
+            {
+                "output": str(output),
+                "pass": payload["pass"],
+                "collection_pass": payload.get("collection_pass"),
+                "graph_metrics_pass": payload.get("metrics", {})
+                .get("decode_cuda_graph_gate", {})
+                .get("pass"),
+                "comparison_pass": (
+                    payload.get("comparison", {}).get("pass")
+                    if payload.get("comparison") is not None
+                    else None
+                ),
+                "failures": payload.get("failures", []),
+            },
+            indent=2,
+        )
+    )
+    return 0 if payload["pass"] else 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", default="http://127.0.0.1:30000")
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--label", default="graph")
+    parser.add_argument("--mode", choices=("eager", "graph"), default="graph")
+    parser.add_argument("--eager-json")
+    parser.add_argument("--vocab-size", type=int, default=DEFAULT_VOCAB_SIZE)
+    parser.add_argument("--top-k", type=int, default=DEFAULT_TOP_K)
+    parser.add_argument("--tp-size", type=int, default=8)
+    parser.add_argument("--request-timeout", type=float, default=7200)
+    parser.add_argument("--no-flush-cache", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    if args.top_k <= 0:
+        raise ValueError("--top-k must be positive")
+    if args.request_timeout <= 0:
+        raise ValueError("--request-timeout must be positive")
+    if args.mode == "eager" and args.eager_json is not None:
+        raise ValueError("--eager-json is only valid in graph mode")
+    if args.mode == "graph" and args.eager_json is None:
+        raise ValueError("--eager-json is required in graph mode")
+    if args.tp_size <= 0:
+        raise ValueError("--tp-size must be positive")
+    return run(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/glm5_next_session_c_oracle.py
+++ b/scripts/glm5_next_session_c_oracle.py
@@ -1,0 +1,1157 @@
+#!/usr/bin/env python3
+"""Session-C text correctness oracle for GLM-5-Next-0808.
+
+The harness deliberately has no dependency on SGLang internals.  It runs two
+short, token-id based requests against the patched Transformers model and an
+SGLang HTTP server, then compares generated token ids and top-log-probability
+values.  The Transformers side also retains the complete vocabulary logits so
+that regressions can be investigated without reloading the 300+ GiB model.
+
+Typical usage on qj5090::
+
+    PYTHONPATH=/path/to/patched-transformers/src \
+      /path/to/reference-venv/bin/python scripts/glm5_next_session_c_oracle.py hf \
+      --model-path /mnt/.../GLM-5-Next-0808/hf_fp8 \
+      --output-dir /mnt/.../session_c/oracle
+
+    python scripts/glm5_next_session_c_oracle.py server \
+      --base-url http://127.0.0.1:30000 \
+      --output-dir /mnt/.../session_c/eager
+
+    python scripts/glm5_next_session_c_oracle.py compare \
+      --hf-result /mnt/.../session_c/oracle/hf_oracle.json \
+      --server-result /mnt/.../session_c/eager/sglang_result.json \
+      --output-dir /mnt/.../session_c/eager
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import random
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = 2
+FIXTURE_SEED = 20260811
+PROMPT_LENGTHS = (16, 128)
+DEFAULT_NEW_TOKENS = 4
+DEFAULT_TOP_K = 256
+COMPARISON_TOP_K = 64
+HF_CACHE_CONTRACT = {
+    "version": 1,
+    "implementation": "transformers.cache_utils.DynamicCache(config=text_config)",
+    "use_cache": True,
+    "explicit_cache_position": True,
+    "explicit_position_ids": True,
+    "strict_exact_growth": True,
+}
+EXPECTED_HF_LAYER_COUNT = 45
+EXPECTED_HF_KDA_LAYER_IDS = tuple(
+    layer_id for layer_id in range(EXPECTED_HF_LAYER_COUNT) if layer_id % 4 != 3
+)
+EXPECTED_HF_KDA_CONV_WEIGHT_SHAPE = (3 * 64 * 128, 1, 4)
+HF_KDA_CONV_FP32_CONTRACT = {
+    "version": 1,
+    "expected_layer_count": len(EXPECTED_HF_KDA_LAYER_IDS),
+    "expected_layer_ids": list(EXPECTED_HF_KDA_LAYER_IDS),
+    "expected_weight_shape": list(EXPECTED_HF_KDA_CONV_WEIGHT_SHAPE),
+    "runtime_dtype": "torch.float32",
+    "activation": "silu",
+    "activation_mode": "fused_causal_conv1d",
+    "authoritative_runtime": (
+        "official SGLang Glm5NextLinearAttention.qkv_conv1d params_dtype=torch.float32"
+    ),
+    "correction_reason": (
+        "the pinned Transformers prequantized renamed-key loader bypasses "
+        "_keep_in_fp32_modules_strict and leaves self_attn.conv1d.weight BF16"
+    ),
+}
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _sha256_file(path: Path) -> str | None:
+    if not path.is_file():
+        return None
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def build_fixtures(vocab_size: int) -> list[dict[str, Any]]:
+    """Return deterministic, tokenizer-independent text fixtures."""
+    if vocab_size < 4096:
+        raise ValueError(f"unexpectedly small vocabulary: {vocab_size}")
+    fixtures: list[dict[str, Any]] = []
+    for prompt_length in PROMPT_LENGTHS:
+        rng = random.Random(FIXTURE_SEED + prompt_length)
+        # Keep clear of low control ids and the high special-token band.
+        token_ids = [
+            rng.randrange(1024, vocab_size - 1024) for _ in range(prompt_length)
+        ]
+        encoded = b"".join(
+            int(token_id).to_bytes(4, "little") for token_id in token_ids
+        )
+        fixtures.append(
+            {
+                "name": f"tokens_{prompt_length}",
+                "prompt_length": prompt_length,
+                "input_ids": token_ids,
+                "input_sha256": _sha256_bytes(encoded),
+            }
+        )
+    return fixtures
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    with temporary.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, ensure_ascii=False, indent=2, sort_keys=True)
+        handle.write("\n")
+    temporary.replace(path)
+
+
+def _git_head(source_root: str | None) -> str | None:
+    if not source_root:
+        return None
+    try:
+        return subprocess.check_output(
+            ["git", "-C", source_root, "rev-parse", "HEAD"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+
+def _model_manifest(model_path: Path) -> dict[str, Any]:
+    interesting = ("config.json", "model.safetensors.index.json", "tokenizer.json")
+    return {
+        "path": str(model_path.resolve()),
+        "files": {
+            name: _sha256_file(model_path / name)
+            for name in interesting
+            if (model_path / name).exists()
+        },
+    }
+
+
+def _finite(values: list[float]) -> bool:
+    return all(math.isfinite(value) for value in values)
+
+
+def _top_logprobs(logits: Any, top_k: int) -> list[dict[str, float | int]]:
+    import torch
+
+    logprobs = torch.log_softmax(logits.float(), dim=-1)
+    values, indices = torch.topk(logprobs, k=min(top_k, logprobs.shape[-1]))
+    return [
+        {"token_id": int(token_id), "logprob": float(logprob)}
+        for token_id, logprob in zip(indices.tolist(), values.tolist())
+    ]
+
+
+def _repair_hf_kda_conv_weights(model: Any) -> dict[str, Any]:
+    """Repair and attest the pinned HF loader's GLM KDA-conv dtype bug.
+
+    The checkpoint contains separate q/k/v BF16 causal-convolution weights.  The
+    Transformers conversion mapping merges them into ``self_attn.conv1d``, but
+    its prequantized renamed-key branch skips the model's strict-FP32 module
+    rule.  Official SGLang constructs the corresponding merged runtime weight
+    in FP32 and applies SiLU inside the causal-convolution operation.  Validate
+    the complete fixed-model structure before mutating any parameter, then cast
+    every affected weight and revalidate it before CPU-offload hooks are added.
+    """
+    import torch
+
+    try:
+        text_config = model.config.text_config
+        layers = model.model.language_model.layers
+    except AttributeError as error:
+        raise RuntimeError(
+            "invalid patched-Transformers oracle: missing GLM text model structure"
+        ) from error
+
+    if len(layers) != EXPECTED_HF_LAYER_COUNT:
+        raise RuntimeError(
+            "invalid patched-Transformers oracle: expected "
+            f"{EXPECTED_HF_LAYER_COUNT} text layers, found {len(layers)}"
+        )
+    layer_types = getattr(text_config, "layer_types", None)
+    if not isinstance(layer_types, (list, tuple)) or len(layer_types) != len(layers):
+        raise RuntimeError(
+            "invalid patched-Transformers oracle: layer_types does not describe "
+            "all runtime text layers"
+        )
+    kda_layer_ids = tuple(
+        layer_id
+        for layer_id, layer_type in enumerate(layer_types)
+        if layer_type == "linear_attention"
+    )
+    if kda_layer_ids != EXPECTED_HF_KDA_LAYER_IDS:
+        raise RuntimeError(
+            "invalid patched-Transformers oracle: KDA layer IDs differ from the "
+            f"frozen GLM-5-Next-0808 contract: {list(kda_layer_ids)}"
+        )
+
+    expected_config = {
+        "linear_num_heads": 64,
+        "linear_head_dim": 128,
+        "linear_conv_kernel_dim": 4,
+    }
+    for name, expected in expected_config.items():
+        actual = getattr(text_config, name, None)
+        if actual != expected:
+            raise RuntimeError(
+                "invalid patched-Transformers oracle: "
+                f"text_config.{name}={actual!r}, expected {expected}"
+            )
+
+    validated: list[tuple[int, Any]] = []
+    source_dtype_by_layer: dict[str, str] = {}
+    allowed_source_dtypes = {torch.bfloat16, torch.float32}
+    expected_channels = EXPECTED_HF_KDA_CONV_WEIGHT_SHAPE[0]
+    for layer_id in kda_layer_ids:
+        self_attn = getattr(layers[layer_id], "self_attn", None)
+        conv1d = getattr(self_attn, "conv1d", None)
+        module_name = f"model.language_model.layers.{layer_id}.self_attn.conv1d"
+        if not isinstance(conv1d, torch.nn.Conv1d):
+            raise RuntimeError(
+                f"invalid patched-Transformers oracle: {module_name} is not Conv1d"
+            )
+        structural_contract = {
+            "in_channels": expected_channels,
+            "out_channels": expected_channels,
+            "groups": expected_channels,
+            "kernel_size": (4,),
+            "stride": (1,),
+            "padding": (3,),
+            "dilation": (1,),
+        }
+        for name, expected in structural_contract.items():
+            actual = getattr(conv1d, name, None)
+            if actual != expected:
+                raise RuntimeError(
+                    f"invalid patched-Transformers oracle: {module_name}.{name}="
+                    f"{actual!r}, expected {expected!r}"
+                )
+        if conv1d.bias is not None:
+            raise RuntimeError(
+                f"invalid patched-Transformers oracle: {module_name} has a bias"
+            )
+        if tuple(conv1d.weight.shape) != EXPECTED_HF_KDA_CONV_WEIGHT_SHAPE:
+            raise RuntimeError(
+                f"invalid patched-Transformers oracle: {module_name}.weight shape "
+                f"{tuple(conv1d.weight.shape)} != "
+                f"{EXPECTED_HF_KDA_CONV_WEIGHT_SHAPE}"
+            )
+        if conv1d.weight.dtype not in allowed_source_dtypes:
+            raise RuntimeError(
+                f"invalid patched-Transformers oracle: {module_name}.weight dtype "
+                f"{conv1d.weight.dtype} is neither BF16 nor FP32"
+            )
+        if getattr(self_attn, "layer_idx", None) != layer_id:
+            raise RuntimeError(
+                f"invalid patched-Transformers oracle: layer {layer_id} reports "
+                f"self_attn.layer_idx={getattr(self_attn, 'layer_idx', None)!r}"
+            )
+        if getattr(self_attn, "activation", None) != "silu":
+            raise RuntimeError(
+                f"invalid patched-Transformers oracle: {module_name} does not use "
+                "fused SiLU"
+            )
+        source_dtype_by_layer[str(layer_id)] = str(conv1d.weight.dtype)
+        validated.append((layer_id, conv1d))
+
+    converted_layer_ids = [
+        layer_id
+        for layer_id, conv1d in validated
+        if conv1d.weight.dtype == torch.bfloat16
+    ]
+    already_fp32_layer_ids = [
+        layer_id
+        for layer_id, conv1d in validated
+        if conv1d.weight.dtype == torch.float32
+    ]
+    with torch.no_grad():
+        for _, conv1d in validated:
+            conv1d.weight.data = conv1d.weight.data.to(dtype=torch.float32)
+
+    runtime_dtype_by_layer: dict[str, str] = {}
+    for layer_id, conv1d in validated:
+        if (
+            tuple(conv1d.weight.shape) != EXPECTED_HF_KDA_CONV_WEIGHT_SHAPE
+            or conv1d.weight.dtype != torch.float32
+        ):
+            raise RuntimeError(
+                "invalid patched-Transformers oracle: KDA-conv FP32 repair did "
+                f"not hold for layer {layer_id}"
+            )
+        runtime_dtype_by_layer[str(layer_id)] = str(conv1d.weight.dtype)
+
+    return {
+        "contract": HF_KDA_CONV_FP32_CONTRACT,
+        "source_dtype_by_layer": source_dtype_by_layer,
+        "converted_layer_ids": converted_layer_ids,
+        "already_fp32_layer_ids": already_fp32_layer_ids,
+        "runtime_dtype_by_layer": runtime_dtype_by_layer,
+        "verified_layer_ids": list(kda_layer_ids),
+    }
+
+
+def _load_hf_model(args: argparse.Namespace) -> tuple[Any, dict[str, Any]]:
+    # DeepGEMM is intentionally disabled for this one-device CPU-offload oracle.
+    # The patched FP8 implementation falls back to its Triton path.
+    os.environ.setdefault("TRANSFORMERS_DISABLE_DEEPGEMM_LINEAR", "1")
+    import torch
+    from accelerate import cpu_offload
+    from transformers import AutoConfig, Glm5NextForConditionalGeneration
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("the FP8 Transformers oracle requires a CUDA device")
+    execution_device = torch.device(args.device)
+    torch.cuda.set_device(execution_device)
+    config = AutoConfig.from_pretrained(args.model_path, local_files_only=True)
+    quantization_config = config.quantization_config
+    skip_modules = quantization_config.get("modules_to_not_convert", [])
+    # The official checkpoint uses the pre-modularized names
+    # ``self_attn.f_{a,b}_proj`` while the patched model nests both projections
+    # under ``self_attn.forget_gate``.  The generic conversion map correctly
+    # renames checkpoint keys, but the FP8 skip-list normalizer in the supplied
+    # patch currently misses this nesting.  Repair the two skip names before
+    # module replacement; otherwise Transformers turns BF16 forget-gate linears
+    # into FP8Linear and silently initializes nonexistent scale tensors.
+    repaired_skip_modules = []
+    repaired_count = 0
+    for name in skip_modules:
+        if ".self_attn.f_a_proj" in name:
+            name = name.replace(
+                ".self_attn.f_a_proj", ".self_attn.forget_gate.f_a_proj"
+            )
+            repaired_count += 1
+        elif ".self_attn.f_b_proj" in name:
+            name = name.replace(
+                ".self_attn.f_b_proj", ".self_attn.forget_gate.f_b_proj"
+            )
+            repaired_count += 1
+        repaired_skip_modules.append(name)
+    if repaired_count != 68:
+        raise RuntimeError(
+            "expected to repair 68 GLM linear-attention forget-gate skip-list "
+            f"entries, repaired {repaired_count}"
+        )
+    quantization_config["modules_to_not_convert"] = repaired_skip_modules
+
+    model = Glm5NextForConditionalGeneration.from_pretrained(
+        args.model_path,
+        config=config,
+        attn_implementation="eager",
+        device_map={"": "cpu"},
+        dtype=torch.bfloat16,
+        local_files_only=True,
+        low_cpu_mem_usage=True,
+    )
+    model.eval()
+    kda_conv_correction = _repair_hf_kda_conv_weights(model)
+    cpu_offload(model, execution_device=execution_device, offload_buffers=True)
+    for module_name in (
+        "model.language_model.layers.0.self_attn.forget_gate.f_a_proj",
+        "model.language_model.layers.0.self_attn.forget_gate.f_b_proj",
+    ):
+        module = model.get_submodule(module_name)
+        if module.__class__.__name__ != "Linear" or hasattr(module, "weight_scale_inv"):
+            raise RuntimeError(
+                f"invalid patched-Transformers oracle: {module_name} was "
+                f"quantized as {module.__class__.__name__}"
+            )
+    return model, {"glm5_next_kda_conv_fp32": kda_conv_correction}
+
+
+def _cache_counter(value: Any, *, label: str) -> int:
+    """Convert a scalar cache counter to a fail-closed non-negative integer."""
+    if hasattr(value, "numel"):
+        if int(value.numel()) != 1:
+            raise RuntimeError(f"{label} is not scalar: shape={tuple(value.shape)}")
+        value = value.item()
+    if isinstance(value, bool):
+        raise RuntimeError(f"{label} is boolean, not a token counter")
+    try:
+        converted = int(value)
+    except (TypeError, ValueError, OverflowError) as error:
+        raise RuntimeError(f"{label} is not an integer: {value!r}") from error
+    if converted < 0 or converted != value:
+        raise RuntimeError(f"{label} is not a non-negative integer: {value!r}")
+    return converted
+
+
+def _cache_progress(cache: Any, *, label: str) -> dict[str, int]:
+    """Read every public/legacy token counter exposed by a Transformers cache."""
+    if cache is None:
+        raise RuntimeError(f"{label}: use_cache=True returned past_key_values=None")
+    get_seq_length = getattr(cache, "get_seq_length", None)
+    if not callable(get_seq_length):
+        raise RuntimeError(f"{label}: cache has no callable get_seq_length()")
+
+    progress = {
+        "sequence_length": _cache_counter(
+            get_seq_length(), label=f"{label}.get_seq_length()"
+        )
+    }
+    # Transformers versions differ on whether this counter is public, private,
+    # or entirely represented by get_seq_length().  If either form exists, it
+    # is part of the contract and must agree with the authoritative length.
+    for attribute in ("seen_tokens", "_seen_tokens"):
+        try:
+            value = getattr(cache, attribute)
+        except AttributeError:
+            continue
+        if callable(value):
+            value = value()
+        progress[attribute] = _cache_counter(value, label=f"{label}.{attribute}")
+    return progress
+
+
+def _assert_cache_progress(
+    progress: dict[str, int], *, expected: int, label: str
+) -> None:
+    for counter_name, value in progress.items():
+        if value != expected:
+            raise RuntimeError(
+                f"{label}: cache {counter_name}={value}, expected exactly {expected}"
+            )
+
+
+def _new_hf_dynamic_cache(model: Any) -> Any:
+    """Construct the cache class used by the official patched GLM5 model."""
+    from transformers.cache_utils import DynamicCache
+
+    config = model.config
+    get_text_config = getattr(config, "get_text_config", None)
+    text_config = (
+        get_text_config()
+        if callable(get_text_config)
+        else getattr(config, "text_config", config)
+    )
+    cache = DynamicCache(config=text_config)
+    initial = _cache_progress(cache, label="new HF DynamicCache")
+    _assert_cache_progress(initial, expected=0, label="new HF DynamicCache")
+    return cache
+
+
+def _run_hf_case(
+    model: Any,
+    fixture: dict[str, Any],
+    *,
+    device: str,
+    max_new_tokens: int,
+    top_k: int,
+) -> tuple[dict[str, Any], Any]:
+    import torch
+
+    input_ids = torch.tensor([fixture["input_ids"]], dtype=torch.long, device=device)
+    past_key_values = _new_hf_dynamic_cache(model)
+    initial_progress = _cache_progress(
+        past_key_values, label=f"{fixture['name']} initial cache"
+    )
+    _assert_cache_progress(
+        initial_progress, expected=0, label=f"{fixture['name']} initial cache"
+    )
+    generated_ids: list[int] = []
+    full_logits: list[Any] = []
+    steps: list[dict[str, Any]] = []
+    cache_steps: list[dict[str, Any]] = []
+
+    with torch.inference_mode():
+        for step_index in range(max_new_tokens):
+            expected_before = (
+                0 if step_index == 0 else fixture["prompt_length"] + step_index - 1
+            )
+            expected_after = expected_before + int(input_ids.shape[1])
+            before_progress = _cache_progress(
+                past_key_values,
+                label=f"{fixture['name']} step {step_index} cache before",
+            )
+            _assert_cache_progress(
+                before_progress,
+                expected=expected_before,
+                label=f"{fixture['name']} step {step_index} cache before",
+            )
+
+            # These are the same absolute positions used by GenerationMixin,
+            # made explicit so the hand-written rollout cannot silently restart
+            # at position zero on a decode step.
+            cache_position = torch.arange(
+                expected_before,
+                expected_after,
+                dtype=torch.long,
+                device=device,
+            )
+            position_ids = cache_position.unsqueeze(0)
+            attention_mask = torch.ones(
+                (1, expected_after), dtype=torch.long, device=device
+            )
+            outputs = model(
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                past_key_values=past_key_values,
+                cache_position=cache_position,
+                use_cache=True,
+                logits_to_keep=1,
+                return_dict=True,
+            )
+            returned_cache = getattr(outputs, "past_key_values", None)
+            after_progress = _cache_progress(
+                returned_cache,
+                label=f"{fixture['name']} step {step_index} cache after",
+            )
+            _assert_cache_progress(
+                after_progress,
+                expected=expected_after,
+                label=f"{fixture['name']} step {step_index} cache after",
+            )
+            if after_progress["sequence_length"] <= before_progress["sequence_length"]:
+                raise RuntimeError(
+                    f"{fixture['name']} step {step_index}: cache did not strictly grow: "
+                    f"{before_progress['sequence_length']} -> "
+                    f"{after_progress['sequence_length']}"
+                )
+
+            step_logits = outputs.logits[0, -1].float().cpu()
+            if not bool(torch.isfinite(step_logits).all()):
+                raise RuntimeError(
+                    f"non-finite HF logits in {fixture['name']} step {step_index}"
+                )
+            next_token = int(torch.argmax(step_logits))
+            generated_ids.append(next_token)
+            full_logits.append(step_logits)
+            steps.append(
+                {
+                    "step": step_index,
+                    "token_id": next_token,
+                    "top_logprobs": _top_logprobs(step_logits, top_k),
+                }
+            )
+            cache_steps.append(
+                {
+                    "step": step_index,
+                    "input_length": int(input_ids.shape[1]),
+                    "attention_mask_length": int(attention_mask.shape[1]),
+                    "cache_position": cache_position.tolist(),
+                    "position_ids": position_ids[0].tolist(),
+                    "before": before_progress,
+                    "after": after_progress,
+                }
+            )
+            past_key_values = returned_cache
+            input_ids = torch.tensor([[next_token]], dtype=torch.long, device=device)
+
+    return (
+        {
+            "name": fixture["name"],
+            "prompt_length": fixture["prompt_length"],
+            "input_sha256": fixture["input_sha256"],
+            "generated_ids": generated_ids,
+            "steps": steps,
+            "cache_audit": {
+                "cache_class": (
+                    f"{past_key_values.__class__.__module__}."
+                    f"{past_key_values.__class__.__qualname__}"
+                ),
+                "use_cache": True,
+                "initial": initial_progress,
+                "steps": cache_steps,
+            },
+        },
+        torch.stack(full_logits),
+    )
+
+
+def run_hf(args: argparse.Namespace) -> int:
+    import torch
+
+    started = time.time()
+    model_path = Path(args.model_path)
+    if not model_path.is_dir():
+        raise FileNotFoundError(model_path)
+    model, oracle_corrections = _load_hf_model(args)
+    text_config = model.config.text_config
+    fixtures = build_fixtures(int(text_config.vocab_size))
+    repetitions: list[dict[str, Any]] = []
+    tensors_by_repeat: list[dict[str, Any]] = []
+
+    for repeat_index in range(args.repeats):
+        repeat_cases: list[dict[str, Any]] = []
+        repeat_tensors: dict[str, Any] = {}
+        for fixture in fixtures:
+            case, logits = _run_hf_case(
+                model,
+                fixture,
+                device=args.device,
+                max_new_tokens=args.max_new_tokens,
+                top_k=args.top_k,
+            )
+            repeat_cases.append(case)
+            repeat_tensors[fixture["name"]] = logits
+            torch.cuda.empty_cache()
+        repetitions.append({"repeat": repeat_index, "cases": repeat_cases})
+        tensors_by_repeat.append(repeat_tensors)
+
+    envelope: dict[str, Any] = {
+        "max_abs": 0.0,
+        "max_relative": 0.0,
+        "tokens_exact": True,
+    }
+    if args.repeats > 1:
+        reference = tensors_by_repeat[0]
+        reference_cases = {case["name"]: case for case in repetitions[0]["cases"]}
+        for repeat_index in range(1, args.repeats):
+            candidate_cases = {
+                case["name"]: case for case in repetitions[repeat_index]["cases"]
+            }
+            for name, expected in reference.items():
+                candidate = tensors_by_repeat[repeat_index][name]
+                delta = (expected - candidate).abs()
+                relative = delta / expected.abs().clamp_min(1e-6)
+                envelope["max_abs"] = max(envelope["max_abs"], float(delta.max()))
+                envelope["max_relative"] = max(
+                    envelope["max_relative"], float(relative.max())
+                )
+                envelope["tokens_exact"] = bool(envelope["tokens_exact"]) and (
+                    reference_cases[name]["generated_ids"]
+                    == candidate_cases[name]["generated_ids"]
+                )
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    logits_path = output_dir / "hf_full_logits.pt"
+    # Persist all repetitions.  A full run is still only a few MiB.
+    torch.save(tensors_by_repeat, logits_path)
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "kind": "patched_transformers_oracle",
+        "created_unix": time.time(),
+        "elapsed_seconds": time.time() - started,
+        "model": _model_manifest(model_path),
+        "source_head": _git_head(args.source_root),
+        "environment": {
+            "python": sys.version,
+            "torch": torch.__version__,
+            "transformers": __import__("transformers").__version__,
+            "device": args.device,
+        },
+        "fixture_seed": FIXTURE_SEED,
+        "cache_contract": HF_CACHE_CONTRACT,
+        "oracle_corrections": oracle_corrections,
+        "max_new_tokens": args.max_new_tokens,
+        "top_k": args.top_k,
+        "repeat_envelope": envelope,
+        "cases": repetitions[0]["cases"],
+        "repetitions": args.repeats,
+        "full_logits_file": logits_path.name,
+        "pass": bool(envelope["tokens_exact"]),
+    }
+    _write_json(output_dir / "hf_oracle.json", payload)
+    print(json.dumps({"pass": payload["pass"], "repeat_envelope": envelope}, indent=2))
+    return 0 if payload["pass"] else 1
+
+
+def _parse_sglang_top_logprobs(raw: Any) -> list[dict[str, float | int]]:
+    parsed: list[dict[str, float | int]] = []
+    for entry in raw or []:
+        if isinstance(entry, dict):
+            token_id = entry.get("token_id")
+            logprob = entry.get("logprob")
+        else:
+            logprob, token_id = entry[0], entry[1]
+        parsed.append({"token_id": int(token_id), "logprob": float(logprob)})
+    return parsed
+
+
+def run_server(args: argparse.Namespace) -> int:
+    import requests
+
+    started = time.time()
+    base_url = args.base_url.rstrip("/")
+    if not args.no_flush_cache:
+        response = requests.post(
+            f"{base_url}/flush_cache", timeout=args.request_timeout
+        )
+        response.raise_for_status()
+
+    # Match the model-config vocabulary exactly.  Fixture ids deliberately stay
+    # below the tokenizer's high special-token band, but the RNG upper bound must
+    # still equal the Transformers oracle or the two sides receive different ids.
+    fixtures = build_fixtures(args.vocab_size)
+    cases: list[dict[str, Any]] = []
+    for fixture in fixtures:
+        request_body = {
+            "input_ids": fixture["input_ids"],
+            "sampling_params": {
+                "temperature": 0,
+                "max_new_tokens": args.max_new_tokens,
+                "ignore_eos": True,
+                "skip_special_tokens": False,
+            },
+            "return_logprob": True,
+            "top_logprobs_num": args.top_k,
+            "return_text_in_logprobs": False,
+        }
+        response = requests.post(
+            f"{base_url}/generate", json=request_body, timeout=args.request_timeout
+        )
+        response.raise_for_status()
+        body = response.json()
+        if isinstance(body, list):
+            if len(body) != 1:
+                raise RuntimeError(f"unexpected batched SGLang response: {len(body)}")
+            body = body[0]
+        meta = body.get("meta_info", {})
+        generated_ids = [int(token_id) for token_id in body.get("output_ids", [])]
+        raw_steps = meta.get("output_top_logprobs", [])
+        if (
+            len(generated_ids) != args.max_new_tokens
+            or len(raw_steps) != args.max_new_tokens
+        ):
+            raise RuntimeError(
+                f"incomplete SGLang result for {fixture['name']}: "
+                f"ids={len(generated_ids)} top_logprobs={len(raw_steps)}"
+            )
+        steps: list[dict[str, Any]] = []
+        for index, (token_id, raw_top) in enumerate(zip(generated_ids, raw_steps)):
+            top_logprobs = _parse_sglang_top_logprobs(raw_top)
+            if len(top_logprobs) < min(args.top_k, args.vocab_size):
+                raise RuntimeError(
+                    f"short top-logprob list in {fixture['name']} step {index}: "
+                    f"{len(top_logprobs)}"
+                )
+            if not _finite([float(item["logprob"]) for item in top_logprobs]):
+                raise RuntimeError(
+                    f"non-finite SGLang logprobs in {fixture['name']} step {index}"
+                )
+            steps.append(
+                {"step": index, "token_id": token_id, "top_logprobs": top_logprobs}
+            )
+        cases.append(
+            {
+                "name": fixture["name"],
+                "prompt_length": fixture["prompt_length"],
+                "input_sha256": fixture["input_sha256"],
+                "generated_ids": generated_ids,
+                "steps": steps,
+            }
+        )
+
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "kind": "sglang_http_result",
+        "created_unix": time.time(),
+        "elapsed_seconds": time.time() - started,
+        "base_url": base_url,
+        "source_head": _git_head(args.source_root),
+        "fixture_seed": FIXTURE_SEED,
+        "max_new_tokens": args.max_new_tokens,
+        "top_k": args.top_k,
+        "cases": cases,
+        "pass": True,
+    }
+    output_dir = Path(args.output_dir)
+    _write_json(output_dir / "sglang_result.json", payload)
+    print(
+        json.dumps({"pass": True, "cases": [case["name"] for case in cases]}, indent=2)
+    )
+    return 0
+
+
+def _validate_serialized_cache_audit(
+    case: dict[str, Any], *, max_new_tokens: int
+) -> list[str]:
+    """Validate the persisted evidence before accepting an HF oracle file."""
+    failures: list[str] = []
+    audit = case.get("cache_audit")
+    if not isinstance(audit, dict):
+        return ["missing cache_audit"]
+    if audit.get("use_cache") is not True:
+        failures.append("cache_audit does not attest use_cache=True")
+    if not isinstance(audit.get("cache_class"), str) or not audit["cache_class"]:
+        failures.append("cache_audit has no cache class")
+
+    initial = audit.get("initial")
+    if not isinstance(initial, dict) or initial.get("sequence_length") != 0:
+        failures.append("cache did not start at sequence length zero")
+    elif any(value != 0 for value in initial.values()):
+        failures.append("an initial cache token counter was nonzero")
+
+    cache_steps = audit.get("steps")
+    if not isinstance(cache_steps, list) or len(cache_steps) != max_new_tokens:
+        failures.append(
+            "cache audit step count differs from max_new_tokens: "
+            f"{len(cache_steps) if isinstance(cache_steps, list) else 'invalid'} "
+            f"!= {max_new_tokens}"
+        )
+        return failures
+
+    prompt_length = case.get("prompt_length")
+    if not isinstance(prompt_length, int) or prompt_length <= 0:
+        failures.append("invalid prompt_length in cache audit")
+        return failures
+
+    for step_index, step in enumerate(cache_steps):
+        if not isinstance(step, dict):
+            failures.append(f"cache step {step_index} is not an object")
+            continue
+        expected_before = 0 if step_index == 0 else prompt_length + step_index - 1
+        expected_input_length = prompt_length if step_index == 0 else 1
+        expected_after = expected_before + expected_input_length
+        expected_positions = list(range(expected_before, expected_after))
+        expected_scalars = {
+            "step": step_index,
+            "input_length": expected_input_length,
+            "attention_mask_length": expected_after,
+        }
+        for key, expected in expected_scalars.items():
+            if step.get(key) != expected:
+                failures.append(
+                    f"cache step {step_index} {key}={step.get(key)!r}, "
+                    f"expected {expected}"
+                )
+        for key in ("cache_position", "position_ids"):
+            if step.get(key) != expected_positions:
+                failures.append(
+                    f"cache step {step_index} {key}={step.get(key)!r}, "
+                    f"expected {expected_positions}"
+                )
+        for phase, expected in (("before", expected_before), ("after", expected_after)):
+            progress = step.get(phase)
+            if not isinstance(progress, dict) or "sequence_length" not in progress:
+                failures.append(f"cache step {step_index} has invalid {phase} counters")
+                continue
+            for counter_name, value in progress.items():
+                if value != expected:
+                    failures.append(
+                        f"cache step {step_index} {phase}.{counter_name}={value!r}, "
+                        f"expected {expected}"
+                    )
+            if phase == "after" and progress["sequence_length"] <= expected_before:
+                failures.append(f"cache step {step_index} did not strictly grow")
+    return failures
+
+
+def _validate_serialized_hf_kda_conv_correction(
+    oracle: dict[str, Any],
+) -> list[str]:
+    """Reject oracle evidence that lacks the fixed FP32 fused-conv contract."""
+    failures: list[str] = []
+    corrections = oracle.get("oracle_corrections")
+    if not isinstance(corrections, dict):
+        return ["missing oracle_corrections"]
+    correction = corrections.get("glm5_next_kda_conv_fp32")
+    if not isinstance(correction, dict):
+        return ["missing glm5_next_kda_conv_fp32 correction"]
+    if correction.get("contract") != HF_KDA_CONV_FP32_CONTRACT:
+        failures.append("KDA-conv correction contract differs from the frozen contract")
+
+    expected_keys = {str(layer_id) for layer_id in EXPECTED_HF_KDA_LAYER_IDS}
+    source_dtypes = correction.get("source_dtype_by_layer")
+    if not isinstance(source_dtypes, dict) or set(source_dtypes) != expected_keys:
+        failures.append("KDA-conv correction source dtype layer set is invalid")
+        source_dtypes = {}
+    elif not all(
+        dtype in {"torch.bfloat16", "torch.float32"} for dtype in source_dtypes.values()
+    ):
+        failures.append("KDA-conv correction contains an unexpected source dtype")
+
+    converted = correction.get("converted_layer_ids")
+    already_fp32 = correction.get("already_fp32_layer_ids")
+    if not isinstance(converted, list) or not all(
+        isinstance(layer_id, int) for layer_id in converted
+    ):
+        failures.append("KDA-conv converted layer IDs are invalid")
+        converted = []
+    if not isinstance(already_fp32, list) or not all(
+        isinstance(layer_id, int) for layer_id in already_fp32
+    ):
+        failures.append("KDA-conv already-FP32 layer IDs are invalid")
+        already_fp32 = []
+    expected_converted = [
+        layer_id
+        for layer_id in EXPECTED_HF_KDA_LAYER_IDS
+        if source_dtypes.get(str(layer_id)) == "torch.bfloat16"
+    ]
+    expected_already_fp32 = [
+        layer_id
+        for layer_id in EXPECTED_HF_KDA_LAYER_IDS
+        if source_dtypes.get(str(layer_id)) == "torch.float32"
+    ]
+    if converted != expected_converted:
+        failures.append("KDA-conv converted layers disagree with source dtypes")
+    if already_fp32 != expected_already_fp32:
+        failures.append("KDA-conv already-FP32 layers disagree with source dtypes")
+
+    runtime_dtypes = correction.get("runtime_dtype_by_layer")
+    if (
+        not isinstance(runtime_dtypes, dict)
+        or set(runtime_dtypes) != expected_keys
+        or set(runtime_dtypes.values()) != {"torch.float32"}
+    ):
+        failures.append("KDA-conv runtime dtype attestation is not all FP32")
+    if correction.get("verified_layer_ids") != list(EXPECTED_HF_KDA_LAYER_IDS):
+        failures.append("KDA-conv verified layer IDs are incomplete")
+    return failures
+
+
+def compare_payloads(
+    oracle: dict[str, Any],
+    candidate: dict[str, Any],
+    *,
+    atol: float,
+    rtol: float,
+    comparison_top_k: int = COMPARISON_TOP_K,
+) -> dict[str, Any]:
+    """Compare independent greedy rollouts while their prefixes are identical.
+
+    Logits at the first token-mismatch step are still comparable because both
+    implementations consumed the same prefix.  Once that token differs, later
+    logits are conditioned on different prefixes and must not be used as a
+    numerical correctness signal.  The token mismatch itself remains a hard
+    failure.
+    """
+    failures: list[str] = []
+    diagnostics: list[dict[str, Any]] = []
+    if oracle.get("schema_version") != SCHEMA_VERSION:
+        failures.append("unsupported oracle schema")
+    if candidate.get("schema_version") != SCHEMA_VERSION:
+        failures.append("unsupported candidate schema")
+    if oracle.get("kind") != "patched_transformers_oracle":
+        failures.append("oracle payload kind is not patched_transformers_oracle")
+    if candidate.get("kind") != "sglang_http_result":
+        failures.append("candidate payload kind is not sglang_http_result")
+    if oracle.get("pass") is not True:
+        failures.append("oracle payload did not pass")
+    if candidate.get("pass") is not True:
+        failures.append("candidate payload did not pass")
+    if oracle.get("fixture_seed") != FIXTURE_SEED:
+        failures.append("oracle fixture seed differs from the frozen contract")
+    if candidate.get("fixture_seed") != FIXTURE_SEED:
+        failures.append("candidate fixture seed differs from the frozen contract")
+    if oracle.get("max_new_tokens") != candidate.get("max_new_tokens"):
+        failures.append("oracle and candidate max_new_tokens differ")
+    oracle_max_new_tokens = oracle.get("max_new_tokens")
+    if not isinstance(oracle_max_new_tokens, int) or oracle_max_new_tokens <= 0:
+        failures.append("invalid max_new_tokens contract")
+        oracle_max_new_tokens = 0
+    for role, payload in (("oracle", oracle), ("candidate", candidate)):
+        top_k = payload.get("top_k")
+        if not isinstance(top_k, int) or top_k < comparison_top_k:
+            failures.append(
+                f"{role} top_k is smaller than comparison_top_k={comparison_top_k}"
+            )
+    if oracle.get("repetitions", 0) < 2:
+        failures.append("oracle payload lacks two deterministic repetitions")
+    if oracle.get("repeat_envelope", {}).get("tokens_exact") is not True:
+        failures.append("oracle repeated generated tokens were not exact")
+    if oracle.get("cache_contract") != HF_CACHE_CONTRACT:
+        failures.append("oracle payload lacks the strict HF cache contract")
+    failures.extend(_validate_serialized_hf_kda_conv_correction(oracle))
+    oracle_cases = {case["name"]: case for case in oracle.get("cases", [])}
+    candidate_cases = {case["name"]: case for case in candidate.get("cases", [])}
+    if set(oracle_cases) != set(candidate_cases):
+        failures.append(
+            f"case set mismatch: oracle={sorted(oracle_cases)} "
+            f"candidate={sorted(candidate_cases)}"
+        )
+
+    for name in sorted(set(oracle_cases) & set(candidate_cases)):
+        expected_case = oracle_cases[name]
+        actual_case = candidate_cases[name]
+        failures.extend(
+            f"{name}: invalid HF cache audit: {failure}"
+            for failure in _validate_serialized_cache_audit(
+                expected_case,
+                max_new_tokens=oracle_max_new_tokens,
+            )
+        )
+        if expected_case.get("input_sha256") != actual_case.get("input_sha256"):
+            failures.append(f"{name}: input token digest mismatch")
+            continue
+        expected_generated = expected_case.get("generated_ids", [])
+        actual_generated = actual_case.get("generated_ids", [])
+        if expected_generated != actual_generated:
+            failures.append(
+                f"{name}: generated token mismatch: "
+                f"{expected_generated} != {actual_generated}"
+            )
+        first_divergent_step = next(
+            (
+                step_index
+                for step_index, (expected_token, actual_token) in enumerate(
+                    zip(expected_generated, actual_generated)
+                )
+                if expected_token != actual_token
+            ),
+            None,
+        )
+        if first_divergent_step is None and len(expected_generated) != len(
+            actual_generated
+        ):
+            first_divergent_step = min(len(expected_generated), len(actual_generated))
+        expected_steps = expected_case.get("steps", [])
+        actual_steps = actual_case.get("steps", [])
+        if len(expected_steps) != len(actual_steps):
+            failures.append(
+                f"{name}: step count mismatch: {len(expected_steps)} != {len(actual_steps)}"
+            )
+        for step_index, (expected_step, actual_step) in enumerate(
+            zip(expected_steps, actual_steps)
+        ):
+            if first_divergent_step is not None and step_index > first_divergent_step:
+                diagnostics.append(
+                    {
+                        "case": name,
+                        "step": step_index,
+                        "status": "skipped_due_to_prefix_divergence",
+                        "first_divergent_step": first_divergent_step,
+                    }
+                )
+                continue
+            expected_top = expected_step["top_logprobs"][:comparison_top_k]
+            actual_by_id = {
+                int(item["token_id"]): float(item["logprob"])
+                for item in actual_step["top_logprobs"]
+            }
+            missing = [
+                int(item["token_id"])
+                for item in expected_top
+                if int(item["token_id"]) not in actual_by_id
+            ]
+            max_abs = 0.0
+            max_relative = 0.0
+            numerical_failures = 0
+            for item in expected_top:
+                token_id = int(item["token_id"])
+                if token_id not in actual_by_id:
+                    continue
+                expected_value = float(item["logprob"])
+                actual_value = actual_by_id[token_id]
+                delta = abs(expected_value - actual_value)
+                relative = delta / max(abs(expected_value), 1e-6)
+                max_abs = max(max_abs, delta)
+                max_relative = max(max_relative, relative)
+                if delta > atol + rtol * abs(expected_value):
+                    numerical_failures += 1
+            diagnostics.append(
+                {
+                    "case": name,
+                    "step": step_index,
+                    "status": "compared",
+                    "max_abs": max_abs,
+                    "max_relative": max_relative,
+                    "missing_reference_top_ids": missing,
+                    "numerical_failures": numerical_failures,
+                }
+            )
+            if missing:
+                failures.append(
+                    f"{name} step {step_index}: {len(missing)} oracle top-"
+                    f"{comparison_top_k} ids absent from candidate top list"
+                )
+            if numerical_failures:
+                failures.append(
+                    f"{name} step {step_index}: {numerical_failures} logprobs outside "
+                    f"atol={atol}, rtol={rtol}"
+                )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "kind": "glm5_next_correctness_comparison",
+        "pass": not failures,
+        "atol": atol,
+        "rtol": rtol,
+        "comparison_top_k": comparison_top_k,
+        "failures": failures,
+        "diagnostics": diagnostics,
+    }
+
+
+def run_compare(args: argparse.Namespace) -> int:
+    with Path(args.hf_result).open(encoding="utf-8") as handle:
+        oracle = json.load(handle)
+    with Path(args.server_result).open(encoding="utf-8") as handle:
+        candidate = json.load(handle)
+    result = compare_payloads(
+        oracle,
+        candidate,
+        atol=args.atol,
+        rtol=args.rtol,
+        comparison_top_k=args.comparison_top_k,
+    )
+    result["oracle"] = str(Path(args.hf_result).resolve())
+    result["candidate"] = str(Path(args.server_result).resolve())
+    result["created_unix"] = time.time()
+    _write_json(Path(args.output_dir) / "comparison.json", result)
+    print(json.dumps(result, indent=2))
+    return 0 if result["pass"] else 1
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    hf_parser = subparsers.add_parser("hf", help="run the patched Transformers oracle")
+    hf_parser.add_argument("--model-path", required=True)
+    hf_parser.add_argument("--output-dir", required=True)
+    hf_parser.add_argument("--source-root")
+    hf_parser.add_argument("--device", default="cuda:0")
+    hf_parser.add_argument("--repeats", type=int, default=2)
+    hf_parser.add_argument("--max-new-tokens", type=int, default=DEFAULT_NEW_TOKENS)
+    hf_parser.add_argument("--top-k", type=int, default=DEFAULT_TOP_K)
+    hf_parser.set_defaults(func=run_hf)
+
+    server_parser = subparsers.add_parser("server", help="query an SGLang server")
+    server_parser.add_argument("--base-url", default="http://127.0.0.1:30000")
+    server_parser.add_argument("--output-dir", required=True)
+    server_parser.add_argument("--source-root")
+    server_parser.add_argument("--vocab-size", type=int, default=154880)
+    server_parser.add_argument("--max-new-tokens", type=int, default=DEFAULT_NEW_TOKENS)
+    server_parser.add_argument("--top-k", type=int, default=DEFAULT_TOP_K)
+    server_parser.add_argument("--request-timeout", type=float, default=7200)
+    server_parser.add_argument("--no-flush-cache", action="store_true")
+    server_parser.set_defaults(func=run_server)
+
+    compare_parser = subparsers.add_parser(
+        "compare", help="compare oracle and server JSON"
+    )
+    compare_parser.add_argument("--hf-result", required=True)
+    compare_parser.add_argument("--server-result", required=True)
+    compare_parser.add_argument("--output-dir", required=True)
+    compare_parser.add_argument("--atol", type=float, default=5e-2)
+    compare_parser.add_argument("--rtol", type=float, default=5e-2)
+    compare_parser.add_argument(
+        "--comparison-top-k", type=int, default=COMPARISON_TOP_K
+    )
+    compare_parser.set_defaults(func=run_compare)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    if hasattr(args, "repeats") and args.repeats < 2:
+        raise ValueError("the oracle requires at least two repetitions")
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/glm5_next_session_c_qa_gsm_graph_acceptance.py
+++ b/scripts/glm5_next_session_c_qa_gsm_graph_acceptance.py
@@ -1,0 +1,1345 @@
+#!/usr/bin/env python3
+"""Fail-closed Session-C graph acceptance for natural QA and GSM8K-200.
+
+This driver deliberately talks only to public HTTP endpoints and the checked-in
+GSM8K benchmark.  Both modes preserve the exact Prometheus text before and
+after inference and require, for every configured TP rank, movement of the
+official decode CUDA Graph counter with no positive movement of ``decode_none``.
+Decode speed is taken from each native response's
+``meta_info.decode_throughput``; inter-token-latency metrics are diagnostic only.
+
+Examples::
+
+    python scripts/glm5_next_session_c_qa_gsm_graph_acceptance.py qa \
+      --base-url http://127.0.0.1:30100 --model /mnt/models/GLM-5-Next-0808 \
+      --output /mnt/artifacts/qa.json --tp-size 8
+
+    python scripts/glm5_next_session_c_qa_gsm_graph_acceptance.py gsm8k \
+      --base-url http://127.0.0.1:30100 --data-path /mnt/data/test.jsonl \
+      --result-file /mnt/artifacts/gsm/result.jsonl \
+      --raw-result-file /mnt/artifacts/gsm/raw.jsonl \
+      --work-dir /mnt/artifacts/gsm/work \
+      --output /mnt/artifacts/gsm/acceptance.json --tp-size 8
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import math
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any, Callable
+
+
+SCHEMA_VERSION = 1
+QA_KIND = "glm5_next_session_c_natural_qa_graph_acceptance"
+GSM_KIND = "glm5_next_session_c_gsm8k_200_graph_acceptance"
+GRAPH_METRIC = "sglang:cuda_graph_passes_total"
+ITL_SUM_METRIC = "sglang:inter_token_latency_seconds_sum"
+ITL_COUNT_METRIC = "sglang:inter_token_latency_seconds_count"
+GSM_QUESTIONS = 200
+GSM_SHOTS = 5
+GSM_PARALLEL = 1
+GSM_MAX_NEW_TOKENS = 512
+QA_SPEED_PROBE_MAX_NEW_TOKENS = 8
+DEFAULT_GSM_DATA_SHA256 = (
+    "3730d312f6e3440559ace48831e51066acaca737f6eabec99bccb9e4b3c39d14"
+)
+
+_METRIC_LINE = re.compile(
+    r"^(?P<name>[a-zA-Z_:][a-zA-Z0-9_:]*)(?:\{(?P<labels>.*)\})?\s+"
+    r"(?P<value>[^\s]+)(?:\s+[^\s]+)?$"
+)
+_METRIC_LABEL = re.compile(
+    r'(?P<name>[a-zA-Z_][a-zA-Z0-9_]*)="(?P<value>(?:\\.|[^"\\])*)"'
+)
+
+
+GSM_BENCHMARK_WORKER = r"""
+import json
+import runpy
+import sys
+from pathlib import Path
+
+benchmark_path = sys.argv[1]
+speed_path = Path(sys.argv[2])
+sys.argv = [benchmark_path, *sys.argv[3:]]
+
+from sglang.test import test_utils
+
+original_dump_bench_raw_result = test_utils.dump_bench_raw_result
+
+
+def dump_bench_raw_result_with_speed(path, states, preds, labels):
+    original_dump_bench_raw_result(path, states, preds, labels)
+    rows = [
+        {
+            "prompt_id": prompt_id,
+            "meta_info": state.get_meta_info("answer"),
+        }
+        for prompt_id, state in enumerate(states)
+    ]
+    encoded = "".join(
+        json.dumps(row, allow_nan=False, separators=(",", ":")) + "\n"
+        for row in rows
+    )
+    speed_path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = speed_path.with_suffix(speed_path.suffix + ".tmp")
+    temporary.write_text(encoded, encoding="utf-8")
+    temporary.replace(speed_path)
+
+
+test_utils.dump_bench_raw_result = dump_bench_raw_result_with_speed
+runpy.run_path(benchmark_path, run_name="__main__")
+""".strip()
+
+
+def _utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat()
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _atomic_write_bytes(path: Path, data: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_bytes(data)
+    temporary.replace(path)
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    encoded = (
+        json.dumps(
+            payload,
+            allow_nan=False,
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode("utf-8")
+    _atomic_write_bytes(path, encoded)
+
+
+def _strict_json_loads(text: str) -> Any:
+    def reject_constant(value: str) -> None:
+        raise ValueError(f"non-finite JSON constant {value!r}")
+
+    return json.loads(text, parse_constant=reject_constant)
+
+
+def _finite_number(value: Any) -> bool:
+    return (
+        not isinstance(value, bool)
+        and isinstance(value, (int, float))
+        and math.isfinite(float(value))
+    )
+
+
+def _decode_prometheus_label(value: str) -> str:
+    # Prometheus uses the same escapes needed here (\\, \", and \n) as a JSON
+    # string.  json.loads also makes malformed escapes fail closed.
+    return json.loads(f'"{value}"')
+
+
+def parse_prometheus_metrics(text: str) -> list[dict[str, Any]]:
+    samples: list[dict[str, Any]] = []
+    for line_number, raw_line in enumerate(text.splitlines(), start=1):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        match = _METRIC_LINE.match(line)
+        if match is None:
+            continue
+        labels_text = match.group("labels") or ""
+        labels: dict[str, str] = {}
+        for label_match in _METRIC_LABEL.finditer(labels_text):
+            name = label_match.group("name")
+            if name in labels:
+                raise ValueError(
+                    f"duplicate label {name!r} on metrics line {line_number}"
+                )
+            labels[name] = _decode_prometheus_label(label_match.group("value"))
+        try:
+            value = float(match.group("value"))
+        except ValueError:
+            value = math.nan
+        samples.append(
+            {
+                "name": match.group("name"),
+                "labels": labels,
+                "value": value,
+                "finite": math.isfinite(value),
+                "line_number": line_number,
+                "line": raw_line,
+            }
+        )
+    return samples
+
+
+def analyze_metrics(text: str) -> dict[str, Any]:
+    """Extract graph counters and optional diagnostic ITL metrics."""
+
+    failures: list[str] = []
+    try:
+        samples = parse_prometheus_metrics(text)
+    except (ValueError, json.JSONDecodeError) as error:
+        return {
+            "graph_counters": {"decode_cuda_graph": {}, "decode_none": {}},
+            "inter_token_latency": {
+                "sum": None,
+                "count": None,
+                "available": False,
+                "diagnostics": [],
+            },
+            "failures": [f"Prometheus parse failed: {error}"],
+        }
+
+    graph_counters: dict[str, dict[str, float]] = {
+        "decode_cuda_graph": {},
+        "decode_none": {},
+    }
+    for sample in samples:
+        if sample["name"] != GRAPH_METRIC:
+            continue
+        labels = sample["labels"]
+        mode = labels.get("mode")
+        if mode not in graph_counters:
+            continue
+        rank = labels.get("tp_rank")
+        if rank is None:
+            failures.append(f"{GRAPH_METRIC} {mode} sample has no tp_rank label")
+            continue
+        if not sample["finite"]:
+            failures.append(f"{GRAPH_METRIC} {mode} TP rank {rank} is non-finite")
+            continue
+        if sample["value"] < 0:
+            failures.append(f"{GRAPH_METRIC} {mode} TP rank {rank} is negative")
+            continue
+        if rank in graph_counters[mode]:
+            failures.append(f"duplicate {GRAPH_METRIC} {mode} TP rank {rank}")
+            continue
+        graph_counters[mode][rank] = float(sample["value"])
+
+    itl: dict[str, Any] = {
+        "sum": None,
+        "count": None,
+        "available": False,
+        "diagnostics": [],
+    }
+    for field, metric_name in (
+        ("sum", ITL_SUM_METRIC),
+        ("count", ITL_COUNT_METRIC),
+    ):
+        matched = [sample for sample in samples if sample["name"] == metric_name]
+        if not matched:
+            itl["diagnostics"].append(f"missing optional metric {metric_name}")
+            continue
+        if any(not sample["finite"] for sample in matched):
+            itl["diagnostics"].append(
+                f"optional metric {metric_name} contains non-finite data"
+            )
+            continue
+        itl[field] = sum(float(sample["value"]) for sample in matched)
+        if not _finite_number(itl[field]):
+            itl["diagnostics"].append(
+                f"optional metric {metric_name} aggregate is non-finite"
+            )
+            itl[field] = None
+            continue
+        if itl[field] < 0:
+            itl["diagnostics"].append(f"optional metric {metric_name} is negative")
+        if field == "count" and not float(itl[field]).is_integer():
+            itl["diagnostics"].append(
+                f"optional metric {metric_name} is not an integer count"
+            )
+    itl["available"] = (
+        _finite_number(itl["sum"])
+        and _finite_number(itl["count"])
+        and itl["sum"] >= 0
+        and itl["count"] >= 0
+        and float(itl["count"]).is_integer()
+    )
+
+    return {
+        "graph_counters": graph_counters,
+        "inter_token_latency": itl,
+        "failures": failures,
+    }
+
+
+def compare_metrics(
+    before: dict[str, Any],
+    after: dict[str, Any],
+    *,
+    tp_size: int,
+    minimum_graph_delta_per_rank: float,
+) -> dict[str, Any]:
+    """Prove graph decode on every TP rank; ITL remains diagnostic only."""
+
+    failures = [
+        *(f"before: {failure}" for failure in before.get("failures", [])),
+        *(f"after: {failure}" for failure in after.get("failures", [])),
+    ]
+    if (
+        not _finite_number(minimum_graph_delta_per_rank)
+        or minimum_graph_delta_per_rank <= 0
+    ):
+        failures.append("minimum graph delta per rank must be positive and finite")
+    expected_ranks = {str(rank) for rank in range(tp_size)}
+    before_graph = before.get("graph_counters", {})
+    after_graph = after.get("graph_counters", {})
+    per_rank: dict[str, dict[str, Any]] = {}
+
+    graph_before_ranks = set(before_graph.get("decode_cuda_graph", {}))
+    graph_after_ranks = set(after_graph.get("decode_cuda_graph", {}))
+    if graph_before_ranks != expected_ranks or graph_after_ranks != expected_ranks:
+        failures.append(
+            "decode_cuda_graph TP rank set mismatch: "
+            f"expected={sorted(expected_ranks)}, "
+            f"before={sorted(graph_before_ranks)}, "
+            f"after={sorted(graph_after_ranks)}"
+        )
+
+    none_before_ranks = set(before_graph.get("decode_none", {}))
+    none_after_ranks = set(after_graph.get("decode_none", {}))
+    unexpected_none_ranks = (none_before_ranks | none_after_ranks) - expected_ranks
+    if unexpected_none_ranks:
+        failures.append(
+            f"decode_none contains unexpected TP ranks: {sorted(unexpected_none_ranks)}"
+        )
+
+    for rank in sorted(expected_ranks, key=int):
+        graph_before = before_graph.get("decode_cuda_graph", {}).get(rank)
+        graph_after = after_graph.get("decode_cuda_graph", {}).get(rank)
+        # Prometheus does not emit a counter series before its first increment.
+        # Therefore an absent decode_none series is semantically zero in either
+        # snapshot, including a partially materialized per-rank vector.
+        none_before = before_graph.get("decode_none", {}).get(rank, 0.0)
+        none_after = after_graph.get("decode_none", {}).get(rank, 0.0)
+        graph_delta = (
+            graph_after - graph_before
+            if graph_before is not None and graph_after is not None
+            else None
+        )
+        none_delta = none_after - none_before
+        rank_failures: list[str] = []
+        if graph_delta is None:
+            rank_failures.append("decode_cuda_graph delta is unavailable")
+        elif graph_delta < minimum_graph_delta_per_rank:
+            rank_failures.append(
+                f"decode_cuda_graph delta {graph_delta} is below "
+                f"{minimum_graph_delta_per_rank}"
+            )
+        if none_delta > 0:
+            rank_failures.append(
+                f"decode_none delta must not be positive, got {none_delta}"
+            )
+        failures.extend(f"TP rank {rank}: {failure}" for failure in rank_failures)
+        per_rank[rank] = {
+            "decode_cuda_graph_before": graph_before,
+            "decode_cuda_graph_after": graph_after,
+            "decode_cuda_graph_delta": graph_delta,
+            "decode_none_before": none_before,
+            "decode_none_after": none_after,
+            "decode_none_delta": none_delta,
+            "pass": not rank_failures,
+        }
+
+    before_itl = before.get("inter_token_latency", {})
+    after_itl = after.get("inter_token_latency", {})
+    sum_before = before_itl.get("sum")
+    sum_after = after_itl.get("sum")
+    count_before = before_itl.get("count")
+    count_after = after_itl.get("count")
+    sum_delta = (
+        float(sum_after) - float(sum_before)
+        if _finite_number(sum_before) and _finite_number(sum_after)
+        else None
+    )
+    count_delta = (
+        float(count_after) - float(count_before)
+        if _finite_number(count_before) and _finite_number(count_after)
+        else None
+    )
+    decode_tokens_per_second = None
+    itl_diagnostics = [
+        *(f"before: {item}" for item in before_itl.get("diagnostics", [])),
+        *(f"after: {item}" for item in after_itl.get("diagnostics", [])),
+    ]
+    if sum_delta is None or count_delta is None:
+        itl_diagnostics.append("inter-token latency delta is unavailable")
+    elif count_delta <= 0:
+        itl_diagnostics.append(
+            f"inter-token latency count delta is not positive: {count_delta}"
+        )
+    elif sum_delta <= 0:
+        itl_diagnostics.append(
+            f"inter-token latency sum delta is not positive: {sum_delta}"
+        )
+    else:
+        decode_tokens_per_second = count_delta / sum_delta
+        if not math.isfinite(decode_tokens_per_second):
+            itl_diagnostics.append("derived ITL decode token/s is non-finite")
+            decode_tokens_per_second = None
+
+    return {
+        "pass": not failures,
+        "failures": failures,
+        "tp_size": tp_size,
+        "minimum_graph_delta_per_rank": minimum_graph_delta_per_rank,
+        "per_rank": per_rank,
+        "inter_token_latency": {
+            "sum_before_seconds": sum_before,
+            "sum_after_seconds": sum_after,
+            "sum_delta_seconds": sum_delta,
+            "count_before_tokens": count_before,
+            "count_after_tokens": count_after,
+            "count_delta_tokens": count_delta,
+            "decode_tokens_per_second": decode_tokens_per_second,
+            "formula": "count_delta_tokens / sum_delta_seconds",
+            "blocking": False,
+            "available": decode_tokens_per_second is not None,
+            "diagnostics": itl_diagnostics,
+        },
+    }
+
+
+def _request_bytes(
+    request: urllib.request.Request,
+    *,
+    timeout: float,
+    opener: Callable[..., Any] = urllib.request.urlopen,
+) -> tuple[int, bytes, dict[str, str]]:
+    try:
+        with opener(request, timeout=timeout) as response:
+            status = int(getattr(response, "status", response.getcode()))
+            body = response.read()
+            headers = dict(response.headers.items())
+    except urllib.error.HTTPError as error:
+        detail = error.read()[:4096]
+        raise RuntimeError(
+            f"HTTP {error.code} from {request.full_url}: {detail!r}"
+        ) from error
+    if not 200 <= status < 300:
+        raise RuntimeError(f"HTTP {status} from {request.full_url}: {body[:4096]!r}")
+    return status, body, headers
+
+
+def fetch_metrics(
+    base_url: str,
+    *,
+    timeout: float,
+    raw_path: Path,
+    opener: Callable[..., Any] = urllib.request.urlopen,
+) -> dict[str, Any]:
+    request = urllib.request.Request(f"{base_url.rstrip('/')}/metrics", method="GET")
+    status, body, _headers = _request_bytes(request, timeout=timeout, opener=opener)
+    text = body.decode("utf-8", errors="strict")
+    _atomic_write_bytes(raw_path, body)
+    return {
+        "http_status": status,
+        "raw_path": str(raw_path.resolve()),
+        "raw_sha256": _sha256_bytes(body),
+        "raw_size_bytes": len(body),
+        "raw_text": text,
+        **analyze_metrics(text),
+    }
+
+
+def validate_qa_response(
+    payload: Any,
+    *,
+    expected_content: str,
+    expected_finish_reason: str,
+) -> dict[str, Any]:
+    failures: list[str] = []
+    content = None
+    finish_reason = None
+    usage: Any = None
+    if not isinstance(payload, dict):
+        failures.append("response JSON must be an object")
+    else:
+        choices = payload.get("choices")
+        if not isinstance(choices, list) or len(choices) != 1:
+            failures.append("response choices must contain exactly one item")
+        else:
+            choice = choices[0]
+            if not isinstance(choice, dict):
+                failures.append("response choice must be an object")
+            else:
+                if choice.get("index") != 0:
+                    failures.append("response choice index must be 0")
+                finish_reason = choice.get("finish_reason")
+                if finish_reason != expected_finish_reason:
+                    failures.append(
+                        f"finish_reason must be {expected_finish_reason!r}, "
+                        f"got {finish_reason!r}"
+                    )
+                message = choice.get("message")
+                if not isinstance(message, dict):
+                    failures.append("response choice.message must be an object")
+                else:
+                    if message.get("role") != "assistant":
+                        failures.append("response message role must be 'assistant'")
+                    content = message.get("content")
+                    if not isinstance(content, str) or not content.strip():
+                        failures.append("response content must be a non-empty string")
+                    elif expected_content not in content:
+                        failures.append(
+                            f"response content does not contain {expected_content!r}"
+                        )
+
+        usage = payload.get("usage")
+        if not isinstance(usage, dict):
+            failures.append("response usage must be an object")
+        else:
+            prompt_tokens = usage.get("prompt_tokens")
+            completion_tokens = usage.get("completion_tokens")
+            total_tokens = usage.get("total_tokens")
+            if (
+                not isinstance(prompt_tokens, int)
+                or isinstance(prompt_tokens, bool)
+                or prompt_tokens <= 0
+            ):
+                failures.append("usage.prompt_tokens must be a positive integer")
+            if (
+                not isinstance(completion_tokens, int)
+                or isinstance(completion_tokens, bool)
+                or completion_tokens <= 0
+            ):
+                failures.append("usage.completion_tokens must be a positive integer")
+            if not isinstance(total_tokens, int) or isinstance(total_tokens, bool):
+                failures.append("usage.total_tokens must be an integer")
+            elif (
+                isinstance(prompt_tokens, int)
+                and not isinstance(prompt_tokens, bool)
+                and isinstance(completion_tokens, int)
+                and not isinstance(completion_tokens, bool)
+                and total_tokens != prompt_tokens + completion_tokens
+            ):
+                failures.append(
+                    "usage.total_tokens must equal prompt_tokens + completion_tokens"
+                )
+
+    return {
+        "pass": not failures,
+        "failures": failures,
+        "content": content,
+        "finish_reason": finish_reason,
+        "usage": usage,
+    }
+
+
+def validate_decode_speed_responses(
+    payload: Any,
+    *,
+    expected_count: int,
+    require_prompt_ids: bool,
+) -> dict[str, Any]:
+    """Require a finite positive native decode throughput for every response."""
+
+    failures: list[str] = []
+    if isinstance(payload, dict) and expected_count == 1 and not require_prompt_ids:
+        rows = [payload]
+    elif isinstance(payload, list):
+        rows = payload
+    else:
+        rows = []
+        failures.append("decode-speed payload must be a response object or row list")
+
+    if len(rows) != expected_count:
+        failures.append(
+            f"decode-speed response count must be {expected_count}, got {len(rows)}"
+        )
+
+    prompt_ids: list[Any] = []
+    throughputs: list[float] = []
+    for index, row in enumerate(rows):
+        if not isinstance(row, dict):
+            failures.append(f"decode-speed response {index} must be an object")
+            continue
+        if require_prompt_ids:
+            prompt_ids.append(row.get("prompt_id"))
+        meta_info = row.get("meta_info")
+        if not isinstance(meta_info, dict):
+            failures.append(
+                f"decode-speed response {index} meta_info must be an object"
+            )
+            continue
+        decode_throughput = meta_info.get("decode_throughput")
+        if not _finite_number(decode_throughput) or float(decode_throughput) <= 0:
+            failures.append(
+                "decode-speed response "
+                f"{index} meta_info.decode_throughput must be finite and positive"
+            )
+            continue
+        throughputs.append(float(decode_throughput))
+
+    if require_prompt_ids and prompt_ids != list(range(expected_count)):
+        failures.append(
+            f"decode-speed prompt_id sequence must be exactly 0..{expected_count - 1}"
+        )
+
+    minimum = min(throughputs) if throughputs else None
+    maximum = max(throughputs) if throughputs else None
+    mean = None
+    median = None
+    if throughputs:
+        try:
+            mean = math.fsum(throughputs) / len(throughputs)
+        except OverflowError:
+            mean = None
+        ordered = sorted(throughputs)
+        midpoint = len(ordered) // 2
+        if len(ordered) % 2:
+            median = ordered[midpoint]
+        else:
+            median = (ordered[midpoint - 1] + ordered[midpoint]) / 2
+        if not _finite_number(mean):
+            failures.append("decode-throughput mean is non-finite")
+            mean = None
+        if not _finite_number(median):
+            failures.append("decode-throughput median is non-finite")
+            median = None
+
+    return {
+        "pass": not failures,
+        "failures": failures,
+        "response_count": len(rows),
+        "expected_response_count": expected_count,
+        "decode_throughput": {
+            "source_field": "meta_info.decode_throughput",
+            "unit": "tokens/second",
+            "valid_response_count": len(throughputs),
+            "minimum": minimum,
+            "maximum": maximum,
+            "mean": mean,
+            "median": median,
+        },
+        "prompt_ids_sha256": (
+            _sha256_bytes(json.dumps(prompt_ids, separators=(",", ":")).encode("utf-8"))
+            if require_prompt_ids
+            else None
+        ),
+    }
+
+
+def validate_qa_speed_probe(payload: Any) -> dict[str, Any]:
+    failures: list[str] = []
+    speed = validate_decode_speed_responses(
+        payload,
+        expected_count=1,
+        require_prompt_ids=False,
+    )
+    failures.extend(speed["failures"])
+    output_text = None
+    completion_tokens = None
+    if isinstance(payload, dict):
+        output_text = payload.get("text")
+        if not isinstance(output_text, str) or not output_text:
+            failures.append("QA decode-speed probe text must be non-empty")
+        meta_info = payload.get("meta_info")
+        if isinstance(meta_info, dict):
+            completion_tokens = meta_info.get("completion_tokens")
+            if completion_tokens != QA_SPEED_PROBE_MAX_NEW_TOKENS:
+                failures.append(
+                    "QA decode-speed probe completion_tokens must be "
+                    f"{QA_SPEED_PROBE_MAX_NEW_TOKENS}, got {completion_tokens!r}"
+                )
+
+    return {
+        "pass": not failures,
+        "failures": failures,
+        "output_text": output_text,
+        "completion_tokens": completion_tokens,
+        "speed": speed,
+    }
+
+
+def _read_jsonl_strict(path: Path) -> tuple[list[Any], list[str]]:
+    failures: list[str] = []
+    rows: list[Any] = []
+    if not path.is_file():
+        return [], [f"missing JSONL file: {path}"]
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as error:
+        return [], [f"failed to read JSONL file {path}: {error}"]
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        if not line.strip():
+            failures.append(f"{path}: blank JSONL row {line_number}")
+            continue
+        try:
+            rows.append(_strict_json_loads(line))
+        except (ValueError, json.JSONDecodeError) as error:
+            failures.append(f"{path}: invalid JSON row {line_number}: {error}")
+    return rows, failures
+
+
+def validate_gsm_decode_speed_artifact(path: Path) -> dict[str, Any]:
+    rows, failures = _read_jsonl_strict(path)
+    validation = validate_decode_speed_responses(
+        rows,
+        expected_count=GSM_QUESTIONS,
+        require_prompt_ids=True,
+    )
+    failures.extend(validation["failures"])
+    artifact = {
+        "path": str(path.resolve()),
+        "sha256": _sha256_file(path) if path.is_file() else None,
+        "size_bytes": path.stat().st_size if path.is_file() else None,
+    }
+    return {
+        **validation,
+        "pass": not failures,
+        "failures": failures,
+        "artifact": artifact,
+    }
+
+
+def validate_gsm_artifacts(result_path: Path, raw_result_path: Path) -> dict[str, Any]:
+    """Validate exact benchmark cardinality/completion; accuracy has no floor."""
+
+    result_rows, failures = _read_jsonl_strict(result_path)
+    raw_rows, raw_failures = _read_jsonl_strict(raw_result_path)
+    failures.extend(raw_failures)
+    if len(result_rows) != 1:
+        failures.append(
+            f"result JSONL must contain exactly 1 row, got {len(result_rows)}"
+        )
+    if len(raw_rows) != GSM_QUESTIONS:
+        failures.append(
+            f"raw JSONL must contain exactly {GSM_QUESTIONS} rows, got {len(raw_rows)}"
+        )
+
+    summary = result_rows[0] if len(result_rows) == 1 else None
+    accuracy = None
+    if not isinstance(summary, dict):
+        if summary is not None:
+            failures.append("result row must be an object")
+    else:
+        expected_scalars = {
+            "task": "gsm8k",
+            "backend": "srt",
+            "num_requests": GSM_QUESTIONS,
+        }
+        for key, expected in expected_scalars.items():
+            if summary.get(key) != expected:
+                failures.append(
+                    f"result {key} must be {expected!r}, got {summary.get(key)!r}"
+                )
+        other = summary.get("other")
+        if not isinstance(other, dict):
+            failures.append("result other must be an object")
+        else:
+            if other.get("num_questions") != GSM_QUESTIONS:
+                failures.append(f"result other.num_questions must be {GSM_QUESTIONS}")
+            if other.get("parallel") != GSM_PARALLEL:
+                failures.append(f"result other.parallel must be {GSM_PARALLEL}")
+        accuracy = summary.get("accuracy")
+        if not _finite_number(accuracy) or not 0 <= float(accuracy) <= 1:
+            failures.append("result accuracy must be finite and in [0, 1]")
+        latency = summary.get("latency")
+        if not _finite_number(latency) or float(latency) <= 0:
+            failures.append("result latency must be a positive finite number")
+
+    prompt_ids: list[Any] = []
+    correct_count = 0
+    for index, row in enumerate(raw_rows):
+        if not isinstance(row, dict):
+            failures.append(f"raw row {index} must be an object")
+            continue
+        prompt_ids.append(row.get("prompt_id"))
+        if not isinstance(row.get("prompt"), str) or not row["prompt"].strip():
+            failures.append(f"raw row {index} prompt must be non-empty")
+        if not isinstance(row.get("output"), str) or not row["output"].strip():
+            failures.append(
+                f"raw row {index} output is not a completed non-empty string"
+            )
+        if not isinstance(row.get("correct"), bool):
+            failures.append(f"raw row {index} correct must be boolean")
+        elif row["correct"]:
+            correct_count += 1
+    if prompt_ids != list(range(GSM_QUESTIONS)):
+        failures.append("raw prompt_id sequence must be exactly 0..199")
+
+    raw_accuracy = (
+        correct_count / GSM_QUESTIONS if len(raw_rows) == GSM_QUESTIONS else None
+    )
+    if (
+        raw_accuracy is not None
+        and _finite_number(accuracy)
+        and round(raw_accuracy, 3) != float(accuracy)
+    ):
+        failures.append(
+            f"summary accuracy {accuracy} does not match rounded raw accuracy {raw_accuracy}"
+        )
+
+    artifacts: dict[str, Any] = {}
+    for name, path in (("result", result_path), ("raw_result", raw_result_path)):
+        if path.is_file():
+            artifacts[name] = {
+                "path": str(path.resolve()),
+                "sha256": _sha256_file(path),
+                "size_bytes": path.stat().st_size,
+            }
+        else:
+            artifacts[name] = {
+                "path": str(path.resolve()),
+                "sha256": None,
+                "size_bytes": None,
+            }
+
+    return {
+        "pass": not failures,
+        "failures": failures,
+        "summary": summary,
+        "raw_row_count": len(raw_rows),
+        "prompt_ids_sha256": _sha256_bytes(
+            json.dumps(prompt_ids, separators=(",", ":")).encode("utf-8")
+        ),
+        "accuracy": {
+            "value": accuracy,
+            "raw_value": raw_accuracy,
+            "blocking": False,
+            "minimum": None,
+        },
+        "artifacts": artifacts,
+    }
+
+
+def validate_evidence_envelope(
+    payload: Any,
+    *,
+    expected_kind: str,
+    expected_contract: dict[str, Any],
+) -> list[str]:
+    failures: list[str] = []
+    if not isinstance(payload, dict):
+        return ["evidence must be an object"]
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        failures.append(f"schema_version must be {SCHEMA_VERSION}")
+    if payload.get("kind") != expected_kind:
+        failures.append(f"kind must be {expected_kind!r}")
+    if payload.get("contract") != expected_contract:
+        failures.append(
+            "contract does not exactly match the invoked acceptance contract"
+        )
+    if not isinstance(payload.get("pass"), bool):
+        failures.append("pass must be boolean")
+    evidence_failures = payload.get("failures")
+    if not isinstance(evidence_failures, list) or any(
+        not isinstance(item, str) for item in evidence_failures
+    ):
+        failures.append("failures must be a list of strings")
+    elif payload.get("pass") != (not evidence_failures):
+        failures.append("pass must be true exactly when failures is empty")
+    return failures
+
+
+def _metrics_paths(output: Path) -> tuple[Path, Path]:
+    return (
+        output.with_suffix(output.suffix + ".metrics.before.prom"),
+        output.with_suffix(output.suffix + ".metrics.after.prom"),
+    )
+
+
+def _post_chat_completion(
+    base_url: str,
+    request_payload: dict[str, Any],
+    *,
+    timeout: float,
+    opener: Callable[..., Any] = urllib.request.urlopen,
+) -> dict[str, Any]:
+    body = json.dumps(request_payload, allow_nan=False, separators=(",", ":")).encode()
+    request = urllib.request.Request(
+        f"{base_url.rstrip('/')}/v1/chat/completions",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    status, response_body, headers = _request_bytes(
+        request, timeout=timeout, opener=opener
+    )
+    response_text = response_body.decode("utf-8", errors="strict")
+    response_json = _strict_json_loads(response_text)
+    return {
+        "http_status": status,
+        "headers": headers,
+        "body_sha256": _sha256_bytes(response_body),
+        "body_size_bytes": len(response_body),
+        "body_text": response_text,
+        "json": response_json,
+    }
+
+
+def _post_qa_speed_probe(
+    base_url: str,
+    prompt: str,
+    *,
+    timeout: float,
+    opener: Callable[..., Any] = urllib.request.urlopen,
+) -> dict[str, Any]:
+    request_payload = {
+        "text": prompt,
+        "sampling_params": {
+            "temperature": 0,
+            "max_new_tokens": QA_SPEED_PROBE_MAX_NEW_TOKENS,
+            "ignore_eos": True,
+        },
+        "stream": False,
+    }
+    body = json.dumps(request_payload, allow_nan=False, separators=(",", ":")).encode()
+    request = urllib.request.Request(
+        f"{base_url.rstrip('/')}/generate",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    status, response_body, headers = _request_bytes(
+        request, timeout=timeout, opener=opener
+    )
+    response_text = response_body.decode("utf-8", errors="strict")
+    response_json = _strict_json_loads(response_text)
+    return {
+        "request": request_payload,
+        "http_status": status,
+        "headers": headers,
+        "body_sha256": _sha256_bytes(response_body),
+        "body_size_bytes": len(response_body),
+        "body_text": response_text,
+        "json": response_json,
+    }
+
+
+def _finish_payload(
+    payload: dict[str, Any],
+    *,
+    kind: str,
+    contract: dict[str, Any],
+    failures: list[str],
+) -> dict[str, Any]:
+    payload.update(
+        {
+            "schema_version": SCHEMA_VERSION,
+            "kind": kind,
+            "contract": contract,
+            "failures": failures,
+            "pass": not failures,
+            "finished_at_utc": _utc_now(),
+        }
+    )
+    envelope_failures = validate_evidence_envelope(
+        payload, expected_kind=kind, expected_contract=contract
+    )
+    if envelope_failures:
+        payload["failures"].extend(
+            f"internal evidence envelope error: {failure}"
+            for failure in envelope_failures
+        )
+        payload["pass"] = False
+    return payload
+
+
+def qa_contract(args: argparse.Namespace) -> dict[str, Any]:
+    return {
+        "endpoint": "/v1/chat/completions",
+        "model": args.model,
+        "prompt": args.prompt,
+        "temperature": 0,
+        "stream": False,
+        "max_tokens": args.max_tokens,
+        "enable_thinking": False,
+        "expected_content_substring": args.expected_content,
+        "expected_finish_reason": args.expected_finish_reason,
+        "tp_size": args.tp_size,
+        "minimum_graph_delta_per_rank": args.minimum_graph_delta_per_rank,
+        "decode_none_positive_delta_allowed": False,
+        "missing_decode_none_series_value": 0,
+        "decode_speed": {
+            "source": "/generate response meta_info.decode_throughput",
+            "response_count": 1,
+            "finite_and_positive_for_every_response": True,
+            "probe_max_new_tokens": QA_SPEED_PROBE_MAX_NEW_TOKENS,
+            "probe_ignore_eos": True,
+        },
+        "inter_token_latency_required": False,
+    }
+
+
+def run_qa(args: argparse.Namespace) -> dict[str, Any]:
+    contract = qa_contract(args)
+    payload: dict[str, Any] = {"started_at_utc": _utc_now()}
+    failures: list[str] = []
+    before_path, after_path = _metrics_paths(args.output)
+    request_payload = {
+        "model": args.model,
+        "messages": [{"role": "user", "content": args.prompt}],
+        "temperature": 0,
+        "max_tokens": args.max_tokens,
+        "stream": False,
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+    payload["request"] = request_payload
+
+    before = fetch_metrics(
+        args.base_url, timeout=args.metrics_timeout, raw_path=before_path
+    )
+    response = _post_chat_completion(
+        args.base_url, request_payload, timeout=args.request_timeout
+    )
+    speed_probe = _post_qa_speed_probe(
+        args.base_url,
+        args.prompt,
+        timeout=args.request_timeout,
+    )
+    after = fetch_metrics(
+        args.base_url, timeout=args.metrics_timeout, raw_path=after_path
+    )
+    response_validation = validate_qa_response(
+        response["json"],
+        expected_content=args.expected_content,
+        expected_finish_reason=args.expected_finish_reason,
+    )
+    speed_validation = validate_qa_speed_probe(speed_probe["json"])
+    metrics_comparison = compare_metrics(
+        before,
+        after,
+        tp_size=args.tp_size,
+        minimum_graph_delta_per_rank=args.minimum_graph_delta_per_rank,
+    )
+    failures.extend(f"QA: {item}" for item in response_validation["failures"])
+    failures.extend(f"QA decode speed: {item}" for item in speed_validation["failures"])
+    failures.extend(f"metrics: {item}" for item in metrics_comparison["failures"])
+    payload.update(
+        {
+            "response": response,
+            "response_validation": response_validation,
+            "decode_speed_probe": speed_probe,
+            "decode_speed_validation": speed_validation,
+            "metrics": {
+                "before": before,
+                "after": after,
+                "comparison": metrics_comparison,
+            },
+        }
+    )
+    return _finish_payload(payload, kind=QA_KIND, contract=contract, failures=failures)
+
+
+def _parse_benchmark_endpoint(base_url: str) -> tuple[str, int]:
+    parsed = urllib.parse.urlsplit(base_url)
+    if parsed.scheme != "http" or parsed.hostname is None:
+        raise ValueError("GSM benchmark base URL must be an absolute HTTP URL")
+    if parsed.path not in {"", "/"} or parsed.query or parsed.fragment:
+        raise ValueError("base URL must not contain a path, query, or fragment")
+    port = parsed.port or 80
+    return parsed.hostname, port
+
+
+def _gsm_decode_speed_path(output: Path) -> Path:
+    return output.with_suffix(output.suffix + ".decode-speed.jsonl")
+
+
+def build_gsm_command(args: argparse.Namespace) -> list[str]:
+    host, port = _parse_benchmark_endpoint(args.base_url)
+    return [
+        args.python,
+        "-c",
+        GSM_BENCHMARK_WORKER,
+        str(args.benchmark_script),
+        str(_gsm_decode_speed_path(args.output)),
+        "--host",
+        host,
+        "--port",
+        str(port),
+        "--backend",
+        "srt",
+        "--data-path",
+        str(args.data_path),
+        "--num-questions",
+        str(GSM_QUESTIONS),
+        "--num-shots",
+        str(GSM_SHOTS),
+        "--parallel",
+        str(GSM_PARALLEL),
+        "--max-new-tokens",
+        str(GSM_MAX_NEW_TOKENS),
+        "--temperature",
+        "0",
+        "--top-p",
+        "1",
+        "--result-file",
+        str(args.result_file),
+        "--raw-result-file",
+        str(args.raw_result_file),
+    ]
+
+
+def gsm_contract(args: argparse.Namespace) -> dict[str, Any]:
+    return {
+        "benchmark": "benchmark/gsm8k/bench_sglang.py",
+        "backend": "srt",
+        "num_questions": GSM_QUESTIONS,
+        "num_shots": GSM_SHOTS,
+        "parallel": GSM_PARALLEL,
+        "max_new_tokens": GSM_MAX_NEW_TOKENS,
+        "temperature": 0,
+        "top_p": 1,
+        "result_rows": 1,
+        "raw_result_rows": GSM_QUESTIONS,
+        "raw_prompt_ids": "0..199",
+        "all_outputs_non_empty": True,
+        "accuracy_is_blocking": False,
+        "tp_size": args.tp_size,
+        "minimum_graph_delta_per_rank": args.minimum_graph_delta_per_rank,
+        "decode_none_positive_delta_allowed": False,
+        "missing_decode_none_series_value": 0,
+        "decode_speed": {
+            "source": "every GSM state meta_info.decode_throughput",
+            "response_count": GSM_QUESTIONS,
+            "prompt_ids": "0..199",
+            "finite_and_positive_for_every_response": True,
+        },
+        "inter_token_latency_required": False,
+        "data_sha256": args.expected_data_sha256,
+    }
+
+
+def run_gsm8k(args: argparse.Namespace) -> dict[str, Any]:
+    contract = gsm_contract(args)
+    payload: dict[str, Any] = {"started_at_utc": _utc_now()}
+    failures: list[str] = []
+    before_path, after_path = _metrics_paths(args.output)
+    speed_path = _gsm_decode_speed_path(args.output)
+
+    for path, name in (
+        (args.data_path, "data path"),
+        (args.benchmark_script, "benchmark script"),
+    ):
+        if not path.is_file():
+            raise FileNotFoundError(f"{name} is not a file: {path}")
+    for path in (args.result_file, args.raw_result_file, speed_path):
+        if path.exists():
+            raise FileExistsError(
+                f"refusing append-contaminated GSM artifact; path already exists: {path}"
+            )
+        path.parent.mkdir(parents=True, exist_ok=True)
+    args.work_dir.mkdir(parents=True, exist_ok=True)
+
+    command = build_gsm_command(args)
+    data_sha256 = _sha256_file(args.data_path)
+    payload["source"] = {
+        "data_path": str(args.data_path.resolve()),
+        "data_sha256": data_sha256,
+        "benchmark_script": str(args.benchmark_script.resolve()),
+        "benchmark_script_sha256": _sha256_file(args.benchmark_script),
+        "benchmark_worker_sha256": _sha256_bytes(GSM_BENCHMARK_WORKER.encode("utf-8")),
+    }
+    if data_sha256 != args.expected_data_sha256:
+        raise ValueError(
+            "GSM data SHA-256 mismatch: "
+            f"expected {args.expected_data_sha256}, got {data_sha256}"
+        )
+    payload["benchmark"] = {"command": command, "cwd": str(args.work_dir.resolve())}
+
+    before = fetch_metrics(
+        args.base_url, timeout=args.metrics_timeout, raw_path=before_path
+    )
+    completed = subprocess.run(
+        command,
+        cwd=args.work_dir,
+        env=os.environ.copy(),
+        capture_output=True,
+        text=False,
+        check=False,
+        timeout=args.benchmark_timeout,
+    )
+    stdout_path = args.output.with_suffix(args.output.suffix + ".benchmark.stdout.log")
+    stderr_path = args.output.with_suffix(args.output.suffix + ".benchmark.stderr.log")
+    _atomic_write_bytes(stdout_path, completed.stdout)
+    _atomic_write_bytes(stderr_path, completed.stderr)
+    payload["benchmark"].update(
+        {
+            "returncode": completed.returncode,
+            "stdout": {
+                "path": str(stdout_path.resolve()),
+                "sha256": _sha256_bytes(completed.stdout),
+                "size_bytes": len(completed.stdout),
+            },
+            "stderr": {
+                "path": str(stderr_path.resolve()),
+                "sha256": _sha256_bytes(completed.stderr),
+                "size_bytes": len(completed.stderr),
+            },
+        }
+    )
+    if completed.returncode != 0:
+        failures.append(f"GSM benchmark exited with status {completed.returncode}")
+
+    after = fetch_metrics(
+        args.base_url, timeout=args.metrics_timeout, raw_path=after_path
+    )
+    artifact_validation = validate_gsm_artifacts(args.result_file, args.raw_result_file)
+    speed_validation = validate_gsm_decode_speed_artifact(speed_path)
+    metrics_comparison = compare_metrics(
+        before,
+        after,
+        tp_size=args.tp_size,
+        minimum_graph_delta_per_rank=args.minimum_graph_delta_per_rank,
+    )
+    failures.extend(f"GSM artifact: {item}" for item in artifact_validation["failures"])
+    failures.extend(
+        f"GSM decode speed: {item}" for item in speed_validation["failures"]
+    )
+    failures.extend(f"metrics: {item}" for item in metrics_comparison["failures"])
+    payload.update(
+        {
+            "artifact_validation": artifact_validation,
+            "decode_speed_validation": speed_validation,
+            "metrics": {
+                "before": before,
+                "after": after,
+                "comparison": metrics_comparison,
+            },
+        }
+    )
+    return _finish_payload(payload, kind=GSM_KIND, contract=contract, failures=failures)
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be positive")
+    return parsed
+
+
+def _positive_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed) or parsed <= 0:
+        raise argparse.ArgumentTypeError("must be positive and finite")
+    return parsed
+
+
+def _sha256(value: str) -> str:
+    if not re.fullmatch(r"[0-9a-f]{64}", value):
+        raise argparse.ArgumentTypeError("must be a lowercase SHA-256 digest")
+    return value
+
+
+def _common_parser(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--base-url", required=True)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--tp-size", type=_positive_int, default=8)
+    parser.add_argument(
+        "--minimum-graph-delta-per-rank", type=_positive_float, default=1.0
+    )
+    parser.add_argument("--metrics-timeout", type=_positive_float, default=30.0)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="mode", required=True)
+
+    qa = subparsers.add_parser("qa", help="Run one natural OpenAI-compatible QA")
+    _common_parser(qa)
+    qa.add_argument("--model", required=True)
+    qa.add_argument(
+        "--prompt",
+        default=(
+            "Answer in one short sentence: What is the chemical formula for water? "
+            "Include the formula exactly as plain ASCII."
+        ),
+    )
+    qa.add_argument("--expected-content", default="H2O")
+    qa.add_argument("--expected-finish-reason", default="stop")
+    qa.add_argument("--max-tokens", type=_positive_int, default=64)
+    qa.add_argument("--request-timeout", type=_positive_float, default=300.0)
+
+    gsm = subparsers.add_parser("gsm8k", help="Run graph GSM8K with exactly 200 rows")
+    _common_parser(gsm)
+    gsm.add_argument("--data-path", required=True, type=Path)
+    gsm.add_argument(
+        "--expected-data-sha256",
+        type=_sha256,
+        default=DEFAULT_GSM_DATA_SHA256,
+        help="Frozen GSM8K JSONL digest; override only for a separately reviewed fixture",
+    )
+    gsm.add_argument("--result-file", required=True, type=Path)
+    gsm.add_argument("--raw-result-file", required=True, type=Path)
+    gsm.add_argument("--work-dir", required=True, type=Path)
+    gsm.add_argument("--python", default=sys.executable)
+    gsm.set_defaults(
+        benchmark_script=(
+            Path(__file__).resolve().parents[1] / "benchmark/gsm8k/bench_sglang.py"
+        )
+    )
+    gsm.add_argument("--benchmark-timeout", type=_positive_float, default=7200.0)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    args.output = args.output.resolve()
+    if args.mode == "gsm8k":
+        for name in (
+            "data_path",
+            "result_file",
+            "raw_result_file",
+            "work_dir",
+            "benchmark_script",
+        ):
+            setattr(args, name, getattr(args, name).resolve())
+        protected_paths = {
+            "output": args.output,
+            "data": args.data_path,
+            "benchmark": args.benchmark_script,
+            "result": args.result_file,
+            "raw_result": args.raw_result_file,
+            "decode_speed": _gsm_decode_speed_path(args.output),
+        }
+        if len(set(protected_paths.values())) != len(protected_paths):
+            collisions = ", ".join(
+                f"{name}={path}" for name, path in protected_paths.items()
+            )
+            raise SystemExit(f"GSM input/output paths must be distinct: {collisions}")
+    try:
+        payload = run_qa(args) if args.mode == "qa" else run_gsm8k(args)
+    except Exception as error:
+        kind = QA_KIND if args.mode == "qa" else GSM_KIND
+        contract = qa_contract(args) if args.mode == "qa" else gsm_contract(args)
+        payload = {
+            "schema_version": SCHEMA_VERSION,
+            "kind": kind,
+            "pass": False,
+            "contract": contract,
+            "failures": [f"{type(error).__name__}: {error}"],
+            "finished_at_utc": _utc_now(),
+        }
+    _atomic_write_json(args.output, payload)
+    print(json.dumps({"output": str(args.output), "pass": payload["pass"]}))
+    return 0 if payload["pass"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/glm5_next_session_c_qa_gsm_graph_acceptance.py
+++ b/scripts/glm5_next_session_c_qa_gsm_graph_acceptance.py
@@ -12,14 +12,14 @@ Examples::
 
     python scripts/glm5_next_session_c_qa_gsm_graph_acceptance.py qa \
       --base-url http://127.0.0.1:30100 --model /mnt/models/GLM-5-Next-0808 \
-      --output /mnt/artifacts/qa.json --tp-size 8
+      --output /mnt/artifacts/qa.json --tp-size 4
 
     python scripts/glm5_next_session_c_qa_gsm_graph_acceptance.py gsm8k \
       --base-url http://127.0.0.1:30100 --data-path /mnt/data/test.jsonl \
       --result-file /mnt/artifacts/gsm/result.jsonl \
       --raw-result-file /mnt/artifacts/gsm/raw.jsonl \
       --work-dir /mnt/artifacts/gsm/work \
-      --output /mnt/artifacts/gsm/acceptance.json --tp-size 8
+      --output /mnt/artifacts/gsm/acceptance.json --tp-size 4
 """
 
 from __future__ import annotations
@@ -1250,7 +1250,7 @@ def _sha256(value: str) -> str:
 def _common_parser(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--base-url", required=True)
     parser.add_argument("--output", required=True, type=Path)
-    parser.add_argument("--tp-size", type=_positive_int, default=8)
+    parser.add_argument("--tp-size", type=_positive_int, default=4)
     parser.add_argument(
         "--minimum-graph-delta-per-rank", type=_positive_float, default=1.0
     )

--- a/test/registered/function_call/test_glm5_next_tool_choice.py
+++ b/test/registered/function_call/test_glm5_next_tool_choice.py
@@ -1,0 +1,124 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from sglang.srt.entrypoints.openai.protocol import (
+    Function,
+    Tool,
+    ToolChoice,
+    ToolChoiceFuncName,
+)
+from sglang.srt.function_call.function_call_parser import FunctionCallParser
+from sglang.test.ci.ci_register import register_cpu_ci
+
+
+register_cpu_ci(0.2, "default")
+
+
+@pytest.fixture
+def tools():
+    return [
+        Tool(
+            type="function",
+            function=Function(
+                name="read_file",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "path": {"type": "string"},
+                        "line": {"type": "integer"},
+                    },
+                    "required": ["path"],
+                    "additionalProperties": False,
+                },
+            ),
+        ),
+        Tool(
+            type="function",
+            function=Function(
+                name="list_dir",
+                parameters={
+                    "type": "object",
+                    "properties": {"path": {"type": "string"}},
+                    "required": ["path"],
+                    "additionalProperties": False,
+                },
+            ),
+        ),
+    ]
+
+
+def test_required_uses_native_glm_ebnf(tools):
+    parser = FunctionCallParser(tools, "glm47", tool_choice="required")
+    constraint_type, grammar = parser.get_structure_constraint("required")
+
+    assert constraint_type == "ebnf"
+    assert '"<tool_call>read_file"' in grammar
+    assert '"<tool_call>list_dir"' in grammar
+    assert '"<arg_key>path</arg_key>"' in grammar
+    assert "root ::= tool_call+" in grammar
+    assert '"name"' not in grammar
+
+
+def test_named_choice_allows_exactly_the_selected_native_call(tools):
+    choice = ToolChoice(function=ToolChoiceFuncName(name="read_file"))
+    parser = FunctionCallParser(tools, "glm47", tool_choice=choice)
+    constraint_type, grammar = parser.get_structure_constraint(choice)
+
+    assert constraint_type == "ebnf"
+    assert "root ::= tool_0_call" in grammar
+    assert '"<tool_call>read_file"' in grammar
+    assert "list_dir" not in grammar
+    assert "tool_call+" not in grammar
+
+
+def test_forced_non_stream_parser_keeps_glm_xml_and_validates_schema(tools):
+    parser = FunctionCallParser(tools, "glm47", tool_choice="required")
+    text, calls = parser.parse_non_stream(
+        "<tool_call>read_file"
+        "<arg_key>path</arg_key><arg_value>/tmp/a.py</arg_value>"
+        "<arg_key>line</arg_key><arg_value>42</arg_value>"
+        "</tool_call>"
+    )
+
+    assert text == ""
+    assert len(calls) == 1
+    assert calls[0].name == "read_file"
+    assert json.loads(calls[0].parameters) == {"path": "/tmp/a.py", "line": 42}
+
+    with pytest.raises(ValueError, match="required property"):
+        parser.parse_non_stream(
+            "<tool_call>read_file"
+            "<arg_key>line</arg_key><arg_value>42</arg_value>"
+            "</tool_call>"
+        )
+
+
+def test_auto_streaming_still_uses_glm_detector(tools):
+    parser = FunctionCallParser(tools, "glm47", tool_choice="auto")
+    chunks = [
+        "<tool_",
+        "call>read_file<arg_key>path</arg_key>",
+        "<arg_value>/tmp/a.py</arg_value></tool_call>",
+    ]
+    calls = []
+    normal_text = ""
+    for chunk in chunks:
+        normal, parsed = parser.parse_stream_chunk(chunk)
+        normal_text += normal
+        calls.extend(parsed)
+
+    assert normal_text == ""
+    assert any(call.name == "read_file" for call in calls)
+    argument_deltas = "".join(call.parameters for call in calls if call.name is None)
+    assert "/tmp/a.py" in argument_deltas
+
+
+def test_serving_keeps_glm_forced_calls_on_model_parser():
+    serving_source = (
+        Path(__file__).resolve().parents[3]
+        / "python/sglang/srt/entrypoints/openai/serving_chat.py"
+    ).read_text(encoding="utf-8")
+    assert 'self.tool_call_parser != "glm47"' in serving_source
+    assert "if tool_call_constraint is None" in serving_source

--- a/test/registered/kernels/ops/layernorm/test_mhc_flat.py
+++ b/test/registered/kernels/ops/layernorm/test_mhc_flat.py
@@ -1,0 +1,167 @@
+"""Micro tests for the flat GLM-5-Next mHC functional contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import torch
+
+
+REPO_ROOT = Path(__file__).resolve().parents[5]
+MHC_PATH = REPO_ROOT / "python/sglang/kernels/ops/layernorm/mhc.py"
+
+
+def _load_mhc_module():
+    spec = importlib.util.spec_from_file_location("_glm5_next_mhc_flat", MHC_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+MHC = _load_mhc_module()
+
+
+class TestMHCFlatReference(unittest.TestCase):
+    TOKENS = 3
+    HC_MULT = 4
+    HIDDEN = 5
+
+    def _inputs(self, device="cpu"):
+        generator = torch.Generator(device=device).manual_seed(20260808)
+        total = self.HC_MULT * self.HIDDEN
+        mix_width = self.HC_MULT * (2 + self.HC_MULT)
+        x = torch.randn(self.TOKENS, total, generator=generator, device=device)
+        fn = torch.randn(mix_width, total, generator=generator, device=device)
+        scale = torch.randn(3, generator=generator, device=device)
+        base = torch.randn(mix_width, generator=generator, device=device)
+        return x, fn, scale, base
+
+    def _hc_pre(self, x, fn, scale, base):
+        with patch.dict(
+            os.environ,
+            {"SGLANG_OPT_USE_TILELANG_MHC_PRE": "0"},
+        ):
+            return MHC.hc_pre(
+                x=x,
+                hc_fn=fn,
+                hc_scale=scale,
+                hc_base=base,
+                hc_mult=self.HC_MULT,
+                rms_eps=1e-6,
+                hc_eps=1e-6,
+                sinkhorn_iters=8,
+            )
+
+    def test_expand_contract_round_trip(self):
+        x = torch.randn(self.TOKENS, self.HIDDEN)
+        expanded = MHC.hc_expand(x, self.HC_MULT)
+        self.assertEqual(expanded.shape, (self.TOKENS, 20))
+        torch.testing.assert_close(
+            MHC.hc_contract(expanded, self.HC_MULT), x, rtol=0, atol=0
+        )
+
+    def test_zero_projection_has_exact_pre_and_post_gate(self):
+        x, fn, scale, base = self._inputs()
+        fn.zero_()
+        scale.fill_(1)
+        base.zero_()
+        layer_input, h_res, h_post, norm_fused = self._hc_pre(x, fn, scale, base)
+
+        expected_pre = 0.5 + 1e-6
+        expected_input = (
+            x.reshape(self.TOKENS, self.HC_MULT, self.HIDDEN).sum(dim=1) * expected_pre
+        )
+        torch.testing.assert_close(layer_input, expected_input, rtol=1e-6, atol=1e-6)
+        torch.testing.assert_close(h_post, torch.ones_like(h_post), rtol=0, atol=0)
+        self.assertFalse(norm_fused)
+
+        comb = h_res.reshape(self.TOKENS, self.HC_MULT, self.HC_MULT)
+        torch.testing.assert_close(
+            comb.sum(dim=1),
+            torch.ones((self.TOKENS, self.HC_MULT)),
+            rtol=2e-5,
+            atol=2e-5,
+        )
+
+    def test_flat_frontend_matches_three_dimensional_reference(self):
+        x, fn, scale, base = self._inputs()
+        layer_input, h_res, h_post, norm_fused = self._hc_pre(x, fn, scale, base)
+        post, comb, expected_input = MHC._mhc_pre_torch(
+            residual=x.reshape(self.TOKENS, self.HC_MULT, self.HIDDEN),
+            fn=fn,
+            hc_scale=scale,
+            hc_base=base,
+            rms_eps=1e-6,
+            hc_pre_eps=1e-6,
+            hc_sinkhorn_eps=1e-6,
+            hc_post_mult_value=2.0,
+            sinkhorn_repeat=8,
+        )
+        torch.testing.assert_close(layer_input, expected_input)
+        torch.testing.assert_close(h_res, comb.flatten(1))
+        torch.testing.assert_close(h_post, post.flatten(1))
+        self.assertFalse(norm_fused)
+
+    def test_bfloat16_state_keeps_fp32_mix_metadata(self):
+        x, fn, scale, base = self._inputs()
+        x = x.to(torch.bfloat16)
+        layer_input, h_res, h_post, _ = self._hc_pre(x, fn, scale, base)
+        output = MHC.hc_post(
+            x=layer_input, residual=x, h_post=h_post, h_res=h_res, hc_mult=self.HC_MULT
+        )
+        self.assertEqual(layer_input.dtype, torch.bfloat16)
+        self.assertEqual(output.dtype, torch.bfloat16)
+        self.assertEqual(h_res.dtype, torch.float32)
+        self.assertEqual(h_post.dtype, torch.float32)
+        self.assertTrue(torch.isfinite(output).all())
+
+    def test_post_uses_input_to_output_combination_orientation(self):
+        x = torch.tensor([[10.0, 20.0]])
+        residual = torch.tensor([[1.0, 2.0, 3.0, 4.0]])
+        h_post = torch.tensor([[2.0, 3.0]])
+        # Output branch 0 takes residual branch 0; output branch 1 takes branch 1.
+        h_res = torch.tensor([[1.0, 0.0, 0.0, 1.0]])
+        with patch.dict(
+            os.environ,
+            {"SGLANG_OPT_USE_TILELANG_MHC_POST": "0"},
+        ):
+            actual = MHC.hc_post(x, residual, h_post, h_res, hc_mult=2)
+        expected = torch.tensor([[21.0, 42.0, 33.0, 64.0]])
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+    def test_empty_shapes_preserve_flat_contract(self):
+        total = self.HC_MULT * self.HIDDEN
+        mix_width = self.HC_MULT * (2 + self.HC_MULT)
+        x = torch.empty((0, total))
+        fn = torch.empty((mix_width, total), dtype=torch.float32)
+        scale = torch.empty((3,), dtype=torch.float32)
+        base = torch.empty((mix_width,), dtype=torch.float32)
+        layer_input, h_res, h_post, norm_fused = self._hc_pre(x, fn, scale, base)
+        self.assertEqual(layer_input.shape, (0, self.HIDDEN))
+        self.assertEqual(h_res.shape, (0, self.HC_MULT * self.HC_MULT))
+        self.assertEqual(h_post.shape, (0, self.HC_MULT))
+        self.assertFalse(norm_fused)
+        self.assertEqual(
+            MHC.hc_post(layer_input, x, h_post, h_res, self.HC_MULT).shape,
+            (0, total),
+        )
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is not available")
+    def test_cuda_reference_matches_cpu(self):
+        cpu_inputs = self._inputs("cpu")
+        cpu_outputs = self._hc_pre(*cpu_inputs)[:3]
+        cuda_inputs = tuple(t.cuda() for t in cpu_inputs)
+        cuda_outputs = self._hc_pre(*cuda_inputs)[:3]
+        for cpu, cuda in zip(cpu_outputs, cuda_outputs):
+            torch.testing.assert_close(cuda.cpu(), cpu, rtol=2e-5, atol=2e-5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/kernels/test_dsa_kpool_multi_pool.py
+++ b/test/registered/kernels/test_dsa_kpool_multi_pool.py
@@ -1,0 +1,248 @@
+"""CPU contracts for GLM-5-Next eager KPool writes spanning multiple pools.
+
+This intentionally does not cover CP, speculative decoding, or CUDA graphs.
+The source modules are loaded directly so the integer contracts remain runnable
+in a kernel-only environment without importing the full ``sglang`` package.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import torch
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+NSA_DIR = REPO_ROOT / "python/sglang/srt/layers/attention/nsa"
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_kpool_sources():
+    fp8_index = _load_module(
+        "_glm5_next_kpool_fp8_index_under_test",
+        NSA_DIR / "kpool_fp8_index.py",
+    )
+
+    stubs = {}
+    for name in (
+        "sglang",
+        "sglang.srt",
+        "sglang.srt.layers",
+        "sglang.srt.layers.attention",
+        "sglang.srt.layers.attention.nsa",
+        "sglang.srt.model_executor",
+    ):
+        package = types.ModuleType(name)
+        package.__path__ = []
+        stubs[name] = package
+
+    environ = types.ModuleType("sglang.srt.environ")
+    environ.envs = types.SimpleNamespace(
+        SGLANG_NSA_FUSE_TOPK=types.SimpleNamespace(get=lambda: False)
+    )
+    stubs[environ.__name__] = environ
+
+    forward_context = types.ModuleType("sglang.srt.model_executor.forward_context")
+    forward_context.get_req_to_token_pool = lambda: None
+    stubs[forward_context.__name__] = forward_context
+
+    utils = types.ModuleType("sglang.srt.utils")
+    utils.is_cuda = lambda: False
+    stubs[utils.__name__] = utils
+    stubs["sglang.srt.layers.attention.nsa.kpool_fp8_index"] = fp8_index
+
+    with patch.dict(sys.modules, stubs):
+        plan = _load_module(
+            "_glm5_next_kpool_plan_under_test",
+            NSA_DIR / "kpool_plan.py",
+        )
+    return fp8_index, plan
+
+
+KPOOL_FP8_INDEX, KPOOL_PLAN = _load_kpool_sources()
+
+
+class TestDsaKpoolMultiPool(unittest.TestCase):
+    POOL_SIZE = 4
+    SLOTS_PER_PAGE = 64
+
+    def test_layout_gate_is_glm5_next_specific(self):
+        self.assertTrue(KPOOL_PLAN._is_kpool_layout_enabled(4, 64))
+        self.assertFalse(KPOOL_PLAN._is_kpool_layout_enabled(2, 64))
+        self.assertFalse(KPOOL_PLAN._is_kpool_layout_enabled(4, 1))
+
+    def test_exact_integer_decomposition_across_boundaries(self):
+        cases = {
+            (0, 1): (0, 0, 0, 1),
+            (3, 1): (3, 0, 1, 0),
+            (3, 6): (3, 0, 2, 1),
+            (4, 4): (0, 1, 1, 0),
+            (255, 6): (3, 63, 2, 1),
+        }
+        for (start, length), expected in cases.items():
+            with self.subTest(start=start, length=length):
+                actual = KPOOL_PLAN._decompose_compress(start, length, self.POOL_SIZE)
+                self.assertEqual(tuple(actual), expected)
+
+    def test_integer_decomposition_exhaustive_near_page_boundaries(self):
+        for start in range(2 * self.SLOTS_PER_PAGE * self.POOL_SIZE):
+            for length in range(1, self.SLOTS_PER_PAGE + 1):
+                actual = KPOOL_PLAN._decompose_compress(start, length, self.POOL_SIZE)
+                expected_closed = (
+                    start + length
+                ) // self.POOL_SIZE - start // self.POOL_SIZE
+                consumed = max(
+                    0,
+                    actual.n_pool * self.POOL_SIZE - actual.first_slot,
+                )
+                self.assertEqual(actual.first_slot, start % self.POOL_SIZE)
+                self.assertEqual(actual.base_pool, start // self.POOL_SIZE)
+                self.assertEqual(actual.n_pool, expected_closed)
+                self.assertEqual(actual.tail_n_write, length - consumed)
+                self.assertLess(actual.tail_n_write, self.POOL_SIZE)
+
+    def test_eager_plan_records_every_closed_pool_and_tail(self):
+        plan = KPOOL_PLAN._KPoolCpuPlan()
+        KPOOL_PLAN._append_compress_rows(
+            plan,
+            pool_size=self.POOL_SIZE,
+            batch_size=2,
+            extend_seq_lens_cpu=[6, 6],
+            seq_lens_cpu=[9, 261],
+            req_pool_indices_cpu=[7, 11],
+        )
+
+        self.assertEqual(plan.pool_batch_idx, [0, 0, 1, 1])
+        self.assertEqual(plan.pool_req, [7, 7, 11, 11])
+        self.assertEqual(plan.pool_pool_id, [0, 1, 63, 64])
+        self.assertEqual(plan.pool_n_from_tail, [3, 0, 3, 0])
+        self.assertEqual(plan.pool_chunk_src, [0, 1, 6, 7])
+        self.assertEqual(plan.pool_tail_logical_base, [0, 4, 252, 256])
+        self.assertEqual(plan.tail_req, [7, 11])
+        self.assertEqual(plan.tail_dst_logical_start, [8, 260])
+        self.assertEqual(plan.tail_chunk_src, [5, 11])
+        self.assertEqual(plan.tail_n_write, [1, 1])
+
+    def test_ragged_page_plan_uses_exact_integer_counts(self):
+        plan = KPOOL_PLAN._KPoolCpuPlan()
+        KPOOL_PLAN._append_local_rows(
+            plan,
+            pool_size=self.POOL_SIZE,
+            slots_per_page=self.SLOTS_PER_PAGE,
+            local_extend_seq_lens_cpu=[6, 6],
+            local_seq_lens_cpu=[9, 261],
+        )
+
+        self.assertEqual(plan.ragged_q_len, [6, 6])
+        self.assertEqual(plan.ragged_pool_pages, [1, 2])
+        self.assertEqual(plan.cu_pages_excl, [0, 1])
+        self.assertEqual(plan.cu_q_len_excl, [0, 6])
+        self.assertEqual(plan.total_pool_pages, 3)
+
+    def test_pooled_page_table_and_physical_locations(self):
+        page_table = torch.arange(16, dtype=torch.int32).reshape(2, 8)
+        pooled = KPOOL_FP8_INDEX.build_pooled_page_table_64(page_table, self.POOL_SIZE)
+        torch.testing.assert_close(
+            pooled,
+            torch.tensor([[0, 4], [8, 12]], dtype=torch.int32),
+            rtol=0,
+            atol=0,
+        )
+        self.assertTrue(pooled.is_contiguous())
+        self.assertEqual(pooled.stride(-1), 1)
+
+        token_pages = torch.tensor([2, 3, 4, 5, 6, 7, 8, 9], dtype=torch.int32)
+        locs = KPOOL_FP8_INDEX.compute_pooled_write_locs(
+            token_pages,
+            torch.tensor([0, 63, 64], dtype=torch.int64),
+            self.POOL_SIZE,
+        )
+        torch.testing.assert_close(
+            locs,
+            torch.tensor([128, 191, 384], dtype=torch.int64),
+            rtol=0,
+            atol=0,
+        )
+
+    def test_pool_groups_expand_to_strict_token_width(self):
+        expanded = KPOOL_FP8_INDEX.expand_pooled_groups_to_topk(
+            group_ids=torch.tensor([[2, 0]], dtype=torch.int64),
+            group_valid=torch.tensor([[True, False]]),
+            topk=8,
+            pool_size=self.POOL_SIZE,
+        )
+        torch.testing.assert_close(
+            expanded,
+            torch.tensor([[8, 9, 10, 11, -1, -1, -1, -1]], dtype=torch.int32),
+            rtol=0,
+            atol=0,
+        )
+
+    def test_exact_overflow_fallback_keeps_late_unique_max_and_tail(self):
+        num_groups = KPOOL_FP8_INDEX.KPOOL_RADIX_EXACT_ROW_CAPACITY + 904
+        scores = torch.ones((1, num_groups), dtype=torch.float32)
+        scores[0, -1] = 1.05
+        result = KPOOL_FP8_INDEX._exact_topk_from_pooled_history_logits(
+            scores,
+            torch.tensor([num_groups], dtype=torch.int32),
+            pool_size=self.POOL_SIZE,
+            topk=2048,
+        )
+
+        unique_max_tokens = torch.arange(
+            (num_groups - 1) * self.POOL_SIZE,
+            num_groups * self.POOL_SIZE,
+            dtype=torch.int32,
+        )
+        for token in unique_max_tokens:
+            self.assertTrue(torch.any(result[0, :2048] == token))
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required")
+    def test_production_topk_routes_overflow_to_exact_fallback(self):
+        for num_groups in (
+            KPOOL_FP8_INDEX.KPOOL_RADIX_EXACT_ROW_CAPACITY + 904,
+            6000,
+            125000,
+        ):
+            with self.subTest(num_groups=num_groups):
+                scores = torch.ones((1, num_groups), dtype=torch.float32, device="cuda")
+                scores[0, -1] = 1.05
+                seq_len = num_groups * self.POOL_SIZE + 1
+
+                result = KPOOL_FP8_INDEX.topk_from_pooled_history_logits(
+                    scores,
+                    torch.tensor([num_groups], dtype=torch.int32, device="cuda"),
+                    pool_size=self.POOL_SIZE,
+                    topk=2048,
+                    seq_lens=torch.tensor([seq_len], dtype=torch.int32, device="cuda"),
+                )
+
+                last_group_start = (num_groups - 1) * self.POOL_SIZE
+                expected = torch.arange(
+                    last_group_start,
+                    last_group_start + self.POOL_SIZE,
+                    dtype=torch.int32,
+                    device="cuda",
+                )
+                for token in expected:
+                    self.assertTrue(torch.any(result[0] == token))
+                self.assertEqual(tuple(result.shape), (1, 2051))
+                self.assertEqual(int(result[0, 2048]), seq_len - 1)
+                self.assertTrue(torch.all(result[0, 2049:] == -1))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/kernels/test_dsa_kpool_multi_pool.py
+++ b/test/registered/kernels/test_dsa_kpool_multi_pool.py
@@ -1,16 +1,18 @@
-"""CPU contracts for GLM-5-Next eager KPool writes spanning multiple pools.
+"""Contracts for GLM-5-Next eager KPool writes spanning multiple pools.
 
-This intentionally does not cover CP, speculative decoding, or CUDA graphs.
-The source modules are loaded directly so the integer contracts remain runnable
-in a kernel-only environment without importing the full ``sglang`` package.
+This intentionally does not cover CP or speculative decoding.  Source modules
+are loaded directly so integer contracts remain runnable in a kernel-only
+environment, while SM120-only tests exercise real CUDA scoring and selection.
 """
 
 from __future__ import annotations
 
+import ast
 import importlib.util
 import sys
 import types
 import unittest
+from dataclasses import dataclass
 from pathlib import Path
 from unittest.mock import patch
 
@@ -35,6 +37,10 @@ def _load_kpool_sources():
         "_glm5_next_kpool_fp8_index_under_test",
         NSA_DIR / "kpool_fp8_index.py",
     )
+    indexer_logits = _load_module(
+        "_glm5_next_indexer_logits_under_test",
+        NSA_DIR / "glm5_next_indexer_logits.py",
+    )
 
     stubs = {}
     for name in (
@@ -55,10 +61,6 @@ def _load_kpool_sources():
     )
     stubs[environ.__name__] = environ
 
-    forward_context = types.ModuleType("sglang.srt.model_executor.forward_context")
-    forward_context.get_req_to_token_pool = lambda: None
-    stubs[forward_context.__name__] = forward_context
-
     utils = types.ModuleType("sglang.srt.utils")
     utils.is_cuda = lambda: False
     stubs[utils.__name__] = utils
@@ -69,10 +71,55 @@ def _load_kpool_sources():
             "_glm5_next_kpool_plan_under_test",
             NSA_DIR / "kpool_plan.py",
         )
-    return fp8_index, plan
+    return fp8_index, plan, indexer_logits
 
 
-KPOOL_FP8_INDEX, KPOOL_PLAN = _load_kpool_sources()
+KPOOL_FP8_INDEX, KPOOL_PLAN, INDEXER_LOGITS = _load_kpool_sources()
+
+
+def _compile_indexer_method(function_name: str, globals_: dict):
+    path = NSA_DIR / "nsa_indexer_kpool.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    indexer = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "IndexerKPool"
+    )
+    function = next(
+        node
+        for node in indexer.body
+        if isinstance(node, ast.FunctionDef) and node.name == function_name
+    )
+    function.decorator_list = []
+    function.body = [
+        node
+        for node in function.body
+        if not isinstance(node, (ast.Import, ast.ImportFrom))
+    ]
+    module = ast.Module(
+        body=[
+            ast.ImportFrom(
+                module="__future__",
+                names=[ast.alias(name="annotations")],
+                level=0,
+            ),
+            function,
+        ],
+        type_ignores=[],
+    )
+    ast.fix_missing_locations(module)
+    namespace = dict(globals_)
+    exec(compile(module, str(path), "exec"), namespace)
+    return namespace[function_name]
+
+
+@dataclass(frozen=True)
+class _PooledMetadata:
+    real_page_table: torch.Tensor
+    pooled_index_kpool: int = 1
+    pooled_cache_seqlens_int32: torch.Tensor | None = None
+    pooled_real_page_table: torch.Tensor | None = None
+    pooled_paged_mqa_schedule_metadata: torch.Tensor | None = None
 
 
 class TestDsaKpoolMultiPool(unittest.TestCase):
@@ -83,6 +130,41 @@ class TestDsaKpoolMultiPool(unittest.TestCase):
         self.assertTrue(KPOOL_PLAN._is_kpool_layout_enabled(4, 64))
         self.assertFalse(KPOOL_PLAN._is_kpool_layout_enabled(2, 64))
         self.assertFalse(KPOOL_PLAN._is_kpool_layout_enabled(4, 1))
+
+    def test_metadata_uses_explicit_forward_batch_request_pool(self):
+        table = object()
+        batch = types.SimpleNamespace(
+            req_to_token_pool=types.SimpleNamespace(req_to_token=table)
+        )
+        self.assertIs(KPOOL_PLAN._req_to_token_table_from_batch(batch), table)
+
+        for incomplete in (
+            types.SimpleNamespace(),
+            types.SimpleNamespace(req_to_token_pool=None),
+            types.SimpleNamespace(
+                req_to_token_pool=types.SimpleNamespace(req_to_token=None)
+            ),
+        ):
+            with self.subTest(incomplete=incomplete):
+                with self.assertRaisesRegex(RuntimeError, "KPool metadata requires"):
+                    KPOOL_PLAN._req_to_token_table_from_batch(incomplete)
+
+    def test_production_topk_source_has_no_host_sync(self):
+        tree = ast.parse((NSA_DIR / "kpool_fp8_index.py").read_text(encoding="utf-8"))
+        functions = {
+            node.name: ast.unparse(node)
+            for node in tree.body
+            if isinstance(node, ast.FunctionDef)
+            and node.name
+            in {
+                "_exact_topk_from_pooled_history_logits",
+                "topk_from_pooled_history_logits",
+            }
+        }
+        self.assertEqual(len(functions), 2)
+        for source in functions.values():
+            for host_sync in (".item()", ".cpu()", ".tolist()"):
+                self.assertNotIn(host_sync, source)
 
     def test_exact_integer_decomposition_across_boundaries(self):
         cases = {
@@ -191,8 +273,8 @@ class TestDsaKpoolMultiPool(unittest.TestCase):
             atol=0,
         )
 
-    def test_exact_overflow_fallback_keeps_late_unique_max_and_tail(self):
-        num_groups = KPOOL_FP8_INDEX.KPOOL_RADIX_EXACT_ROW_CAPACITY + 904
+    def test_hierarchical_exact_topk_keeps_late_unique_max(self):
+        num_groups = KPOOL_FP8_INDEX.KPOOL_HIERARCHICAL_TOPK_CHUNK_SIZE + 904
         scores = torch.ones((1, num_groups), dtype=torch.float32)
         scores[0, -1] = 1.05
         result = KPOOL_FP8_INDEX._exact_topk_from_pooled_history_logits(
@@ -210,11 +292,108 @@ class TestDsaKpoolMultiPool(unittest.TestCase):
         for token in unique_max_tokens:
             self.assertTrue(torch.any(result[0, :2048] == token))
 
+    def test_hierarchical_topk_short_rows_keep_only_finite_candidates(self):
+        scores = torch.full((1, 32), -9.0, dtype=torch.float32)
+        scores[0, 7] = 3.0
+        result = KPOOL_FP8_INDEX._exact_topk_from_pooled_history_logits(
+            scores,
+            torch.tensor([1], dtype=torch.int32),
+            pool_size=self.POOL_SIZE,
+            topk=8,
+            row_starts=torch.tensor([7], dtype=torch.int32),
+        )
+
+        torch.testing.assert_close(
+            result,
+            torch.tensor([[0, 1, 2, 3, -1, -1, -1, -1]], dtype=torch.int32),
+            rtol=0,
+            atol=0,
+        )
+
+    def test_hierarchical_topk_row_starts_and_page_row_mapping(self):
+        scores = torch.zeros((2, 12), dtype=torch.float32)
+        scores[0, 5] = 4.0
+        scores[1, 8] = 5.0
+        page_table = torch.stack(
+            [
+                torch.arange(100, 112, dtype=torch.int32),
+                torch.arange(200, 212, dtype=torch.int32),
+            ]
+        )
+        result = KPOOL_FP8_INDEX._exact_topk_from_pooled_history_logits(
+            scores,
+            torch.tensor([3, 3], dtype=torch.int32),
+            pool_size=self.POOL_SIZE,
+            topk=4,
+            row_starts=torch.tensor([4, 8], dtype=torch.int32),
+            page_table=page_table,
+            page_table_row_index=torch.tensor([1, 0], dtype=torch.int32),
+        )
+
+        torch.testing.assert_close(
+            result,
+            torch.tensor(
+                [[204, 205, 206, 207], [100, 101, 102, 103]],
+                dtype=torch.int32,
+            ),
+            rtol=0,
+            atol=0,
+        )
+
+    def test_graph_metadata_replay_updates_in_place(self):
+        forward_mode = types.SimpleNamespace(is_decode_or_idle=lambda: True)
+        seqlens = torch.tensor([7, 260], dtype=torch.int32)
+        metadata = _PooledMetadata(
+            real_page_table=torch.arange(16, dtype=torch.int32).reshape(2, 8)
+        )
+
+        with patch.object(KPOOL_PLAN, "is_cuda", return_value=True):
+            metadata = KPOOL_PLAN.init_pooled_paged_mqa_metadata(
+                metadata,
+                seqlens,
+                forward_mode,
+                pool_size=self.POOL_SIZE,
+                real_page_size=self.SLOTS_PER_PAGE,
+                slots_per_page=self.SLOTS_PER_PAGE,
+                build_schedule_metadata=False,
+            )
+
+            pooled_lens_ptr = metadata.pooled_cache_seqlens_int32.data_ptr()
+            pooled_table_ptr = metadata.pooled_real_page_table.data_ptr()
+            metadata.real_page_table.add_(100)
+            seqlens.copy_(torch.tensor([15, 256], dtype=torch.int32))
+            KPOOL_PLAN.update_pooled_paged_mqa_metadata(
+                metadata,
+                seqlens,
+                forward_mode,
+                pool_size=self.POOL_SIZE,
+                real_page_size=self.SLOTS_PER_PAGE,
+                slots_per_page=self.SLOTS_PER_PAGE,
+                build_schedule_metadata=False,
+            )
+
+        self.assertEqual(
+            metadata.pooled_cache_seqlens_int32.data_ptr(), pooled_lens_ptr
+        )
+        self.assertEqual(metadata.pooled_real_page_table.data_ptr(), pooled_table_ptr)
+        torch.testing.assert_close(
+            metadata.pooled_cache_seqlens_int32,
+            torch.tensor([3, 64], dtype=torch.int32),
+            rtol=0,
+            atol=0,
+        )
+        torch.testing.assert_close(
+            metadata.pooled_real_page_table,
+            torch.tensor([[100, 104], [108, 112]], dtype=torch.int32),
+            rtol=0,
+            atol=0,
+        )
+
     @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required")
-    def test_production_topk_routes_overflow_to_exact_fallback(self):
+    def test_production_topk_is_exact_across_hierarchical_chunks(self):
         for num_groups in (
-            KPOOL_FP8_INDEX.KPOOL_RADIX_EXACT_ROW_CAPACITY + 904,
-            6000,
+            KPOOL_FP8_INDEX.KPOOL_HIERARCHICAL_TOPK_CHUNK_SIZE + 904,
+            60000,
             125000,
         ):
             with self.subTest(num_groups=num_groups):
@@ -242,6 +421,229 @@ class TestDsaKpoolMultiPool(unittest.TestCase):
                 self.assertEqual(tuple(result.shape), (1, 2051))
                 self.assertEqual(int(result[0, 2048]), seq_len - 1)
                 self.assertTrue(torch.all(result[0, 2049:] == -1))
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required")
+    def test_hierarchical_topk_cuda_graph_replay_uses_device_lengths(self):
+        num_groups = KPOOL_FP8_INDEX.KPOOL_HIERARCHICAL_TOPK_CHUNK_SIZE + 4096
+        scores = torch.zeros((1, num_groups), dtype=torch.float32, device="cuda")
+        group_lengths = torch.tensor([35000], dtype=torch.int32, device="cuda")
+        seq_lens = torch.tensor([140001], dtype=torch.int32, device="cuda")
+        scores[0, 34000] = 7.0
+
+        def select():
+            return KPOOL_FP8_INDEX.topk_from_pooled_history_logits(
+                scores,
+                group_lengths,
+                pool_size=self.POOL_SIZE,
+                topk=2048,
+                seq_lens=seq_lens,
+            )
+
+        # Warm up both torch.topk shards before capture.
+        select()
+        torch.cuda.synchronize()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            result = select()
+
+        graph.replay()
+        torch.cuda.synchronize()
+        initial_tokens = torch.arange(34000 * 4, 34000 * 4 + 4, device="cuda")
+        for token in initial_tokens:
+            self.assertTrue(torch.any(result[0, :2048] == token))
+
+        scores.zero_()
+        scores[0, -1] = 9.0
+        group_lengths.fill_(num_groups)
+        seq_lens.fill_(num_groups * self.POOL_SIZE + 1)
+        graph.replay()
+        torch.cuda.synchronize()
+        replay_tokens = torch.arange(
+            (num_groups - 1) * 4,
+            num_groups * 4,
+            device="cuda",
+        )
+        for token in replay_tokens:
+            self.assertTrue(torch.any(result[0, :2048] == token))
+
+    @unittest.skipUnless(
+        torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 12,
+        "SM120 CUDA is required",
+    )
+    def test_sm120_streamed_prefill_matches_monolithic_ragged_and_paged(self):
+        torch.manual_seed(20260812)
+        device = torch.device("cuda")
+        rows, keys, heads, dim = 35, 320, 4, 128
+        q = (torch.randn(rows, heads, dim, device=device) * 0.25).to(
+            torch.float8_e4m3fn
+        )
+        k = (torch.randn(keys, dim, device=device) * 0.25).to(torch.float8_e4m3fn)
+        scales = torch.linspace(0.01, 0.05, keys, device=device)
+        weights = torch.randn(rows, heads, device=device)
+        starts = (torch.arange(rows, device=device, dtype=torch.int32) % 3) * 5
+        pool_lens = torch.full((rows,), keys, device=device, dtype=torch.int32) - starts
+        ends = starts + pool_lens
+        seq_lens = pool_lens * self.POOL_SIZE + (
+            torch.arange(rows, device=device, dtype=torch.int32) % self.POOL_SIZE
+        )
+
+        def select(logits, lengths, **kwargs):
+            return KPOOL_FP8_INDEX.topk_from_pooled_history_logits(
+                logits,
+                lengths,
+                pool_size=self.POOL_SIZE,
+                topk=512,
+                **kwargs,
+            )
+
+        streamed = _compile_indexer_method(
+            "_topk_from_glm5_next_eager_logits_rows",
+            {
+                "torch": torch,
+                "iter_glm5_next_eager_fp8_mqa_logits": (
+                    INDEXER_LOGITS.iter_glm5_next_eager_fp8_mqa_logits
+                ),
+            },
+        )
+        runner = types.SimpleNamespace(
+            index_topk=512,
+            index_kpool=self.POOL_SIZE,
+            _topk_from_kpool_logits=select,
+        )
+        logits = INDEXER_LOGITS.glm5_next_eager_fp8_mqa_logits(
+            q,
+            (k, scales),
+            weights,
+            starts,
+            ends,
+            query_chunk_size=rows,
+            key_chunk_size=97,
+        )
+
+        topk_offsets = torch.arange(rows, device=device, dtype=torch.int32) * 2048
+        expected_ragged = select(
+            logits,
+            pool_lens,
+            seq_lens=seq_lens,
+            topk_offsets=topk_offsets,
+            row_starts=starts,
+            out_rows=rows + 2,
+        )
+        actual_ragged = streamed(
+            runner,
+            q,
+            (k, scales),
+            weights,
+            pool_lens,
+            seq_lens,
+            starts,
+            ends,
+            total_q=rows + 2,
+            page_table=None,
+            topk_offsets=topk_offsets,
+            page_table_row_index=None,
+        )
+        torch.testing.assert_close(actual_ragged, expected_ragged, rtol=0, atol=0)
+
+        page_table = torch.arange(
+            41 * keys * self.POOL_SIZE,
+            device=device,
+            dtype=torch.int32,
+        ).reshape(41, keys * self.POOL_SIZE)
+        page_rows = (torch.arange(rows, device=device, dtype=torch.int64) * 7) % 41
+        expected_paged = select(
+            logits,
+            pool_lens,
+            seq_lens=seq_lens,
+            page_table=page_table,
+            row_starts=starts,
+            out_rows=rows + 2,
+            page_table_row_index=page_rows,
+        )
+        actual_paged = streamed(
+            runner,
+            q,
+            (k, scales),
+            weights,
+            pool_lens,
+            seq_lens,
+            starts,
+            ends,
+            total_q=rows + 2,
+            page_table=page_table,
+            topk_offsets=None,
+            page_table_row_index=page_rows,
+        )
+        torch.testing.assert_close(actual_paged, expected_paged, rtol=0, atol=0)
+
+    @unittest.skipUnless(
+        torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 12,
+        "SM120 CUDA is required",
+    )
+    def test_sm120_500k_pooled_width_prefill_temporary_peak_is_bounded(self):
+        torch.manual_seed(20260813)
+        device = torch.device("cuda")
+        rows, keys, heads, dim = 32, 125_056, 32, 128
+        q = (torch.randn(rows, heads, dim, device=device) * 0.125).to(
+            torch.float8_e4m3fn
+        )
+        k = (torch.randn(keys, dim, device=device) * 0.125).to(torch.float8_e4m3fn)
+        scales = torch.full((keys,), 0.01, device=device)
+        weights = torch.randn(rows, heads, device=device)
+        starts = torch.zeros(rows, device=device, dtype=torch.int32)
+        ends = torch.full((rows,), keys, device=device, dtype=torch.int32)
+        pool_lens = ends.clone()
+        seq_lens = pool_lens * self.POOL_SIZE
+
+        def select(logits, lengths, **kwargs):
+            return KPOOL_FP8_INDEX.topk_from_pooled_history_logits(
+                logits,
+                lengths,
+                pool_size=self.POOL_SIZE,
+                topk=2048,
+                **kwargs,
+            )
+
+        streamed = _compile_indexer_method(
+            "_topk_from_glm5_next_eager_logits_rows",
+            {
+                "torch": torch,
+                "iter_glm5_next_eager_fp8_mqa_logits": (
+                    INDEXER_LOGITS.iter_glm5_next_eager_fp8_mqa_logits
+                ),
+            },
+        )
+        runner = types.SimpleNamespace(
+            index_topk=2048,
+            index_kpool=self.POOL_SIZE,
+            _topk_from_kpool_logits=select,
+        )
+
+        torch.cuda.synchronize()
+        baseline = torch.cuda.memory_allocated()
+        torch.cuda.reset_peak_memory_stats()
+        result = streamed(
+            runner,
+            q,
+            (k, scales),
+            weights,
+            pool_lens,
+            seq_lens,
+            starts,
+            ends,
+            total_q=rows,
+            page_table=None,
+            topk_offsets=torch.zeros(rows, device=device, dtype=torch.int32),
+            page_table_row_index=None,
+        )
+        torch.cuda.synchronize()
+        peak_delta = torch.cuda.max_memory_allocated() - baseline
+
+        self.assertEqual(tuple(result.shape), (rows, 2051))
+        # Exact top-k retains one 128-group candidate pair per 32768-key shard;
+        # the bounded row chunk still stays far below the old multi-GiB QxK
+        # allocation.  Keep headroom for allocator/workspace changes.
+        self.assertLessEqual(peak_delta, 768 * 1024 * 1024)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/test_communicator_mhc_state.py
+++ b/test/registered/unit/test_communicator_mhc_state.py
@@ -260,6 +260,64 @@ class TestMHCState(unittest.TestCase):
         output, _ = state.attn_split(flat, out_norm=_ScaleNorm(2, 10.0))
         torch.testing.assert_close(output, torch.tensor([[1.0, 2.0]]))
 
+    def test_attention_all_reduce_cast_policy_is_opt_in_and_precedes_hc_post(self):
+        def run(output_dtype):
+            events = []
+
+            def pre(x, norm_weight, norm_eps):
+                del norm_weight, norm_eps
+                tokens = x.shape[0]
+                return (
+                    x,
+                    torch.zeros(tokens, 4),
+                    torch.zeros(tokens, 2),
+                    True,
+                )
+
+            def post(x, residual, h_res, h_post):
+                del h_res, h_post
+                events.append(("hc_post", x.dtype))
+                return residual
+
+            state = COMMUNICATOR_MHC.MHCState(
+                hc_mult=2,
+                hc_attn_pre=pre,
+                hc_ffn_pre=pre,
+                hc_post=post,
+                attn_all_reduce_output_dtype=output_dtype,
+                h_res=torch.zeros(1, 4),
+                h_post=torch.zeros(1, 2),
+            )
+
+            def all_reduce(x):
+                events.append(("all_reduce", x.dtype))
+                return x
+
+            with patch.object(
+                COMMUNICATOR_MHC,
+                "tensor_model_parallel_all_reduce",
+                side_effect=all_reduce,
+            ):
+                COMMUNICATOR_MHC.MHCCommunicateWithAllReduceAndLayerNormFn._gather_hidden_states_and_residual(
+                    hidden_states=torch.ones(1, 2, dtype=torch.float32),
+                    residual=torch.ones(1, 4, dtype=torch.bfloat16),
+                    forward_batch=object(),
+                    layernorm=None,
+                    context=types.SimpleNamespace(attn_dp_size=1, attn_cp_size=1),
+                    residual_input_mode=COMMUNICATOR_MHC.ScatterMode.TP_ATTN_FULL,
+                    mhc=state,
+                )
+            return events
+
+        self.assertEqual(
+            run(torch.bfloat16),
+            [("all_reduce", torch.float32), ("hc_post", torch.bfloat16)],
+        )
+        self.assertEqual(
+            run(None),
+            [("all_reduce", torch.float32), ("hc_post", torch.float32)],
+        )
+
 
 class TestMHCLayerCommunicatorTopology(unittest.TestCase):
     @staticmethod
@@ -281,6 +339,7 @@ class TestMHCLayerCommunicatorTopology(unittest.TestCase):
         pre=None,
         post=None,
         qkv_latent_func=None,
+        attn_all_reduce_output_dtype=None,
     ):
         norm = _ScaleNorm(hidden_size=2, scale=1.0)
 
@@ -305,6 +364,7 @@ class TestMHCLayerCommunicatorTopology(unittest.TestCase):
             hc_ffn_pre=pre,
             hc_post=post,
             qkv_latent_func=qkv_latent_func,
+            attn_all_reduce_output_dtype=attn_all_reduce_output_dtype,
         )
 
     def test_dsa_latent_is_installed_after_mhc_attention_preprocess(self):

--- a/test/registered/unit/test_communicator_mhc_state.py
+++ b/test/registered/unit/test_communicator_mhc_state.py
@@ -1,0 +1,400 @@
+"""CPU micro tests for the non-CP mHC communicator state machine."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import unittest
+from enum import Enum, auto
+from pathlib import Path
+from unittest.mock import patch
+
+import torch
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _load_source(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_communicator_module():
+    mhc = _load_source(
+        "_glm5_next_mhc_for_communicator_test",
+        REPO_ROOT / "python/sglang/kernels/ops/layernorm/mhc.py",
+    )
+
+    stubs = {}
+    for name in (
+        "sglang",
+        "sglang.kernels",
+        "sglang.kernels.ops",
+        "sglang.kernels.ops.layernorm",
+        "sglang.srt",
+        "sglang.srt.layers",
+        "sglang.srt.model_executor",
+    ):
+        package = types.ModuleType(name)
+        package.__path__ = []
+        stubs[name] = package
+    stubs["sglang.kernels.ops.layernorm.mhc"] = mhc
+
+    distributed = types.ModuleType("sglang.srt.distributed")
+    distributed.tensor_model_parallel_all_reduce = lambda x: x
+    stubs[distributed.__name__] = distributed
+
+    class ScatterMode(Enum):
+        SCATTERED = auto()
+        TP_ATTN_FULL = auto()
+        FULL = auto()
+
+    def _unused_simple(*args, **kwargs):
+        del args, kwargs
+        raise AssertionError("stub communication path must not run")
+
+    def _unused_gather(*args, **kwargs):
+        del args, kwargs
+        raise AssertionError("stub gather path must not run")
+
+    def _unused_trivial(*args, **kwargs):
+        del args, kwargs
+        raise AssertionError("stub layer-output path must not run")
+
+    class CommunicateContext:
+        attn_dp_size = 1
+        attn_cp_size = 1
+
+        @classmethod
+        def init_new(cls):
+            return types.SimpleNamespace(
+                attn_dp_size=cls.attn_dp_size,
+                attn_cp_size=cls.attn_cp_size,
+                attn_tp_size=1,
+            )
+
+    class CommunicateSimpleFn:
+        @staticmethod
+        def get_fn(*args, **kwargs):
+            del args, kwargs
+            return CommunicateSimpleFn._trivial
+
+        @staticmethod
+        def _trivial(hidden_states, **kwargs):
+            del kwargs
+            return hidden_states
+
+    class CommunicateWithAllReduceAndLayerNormFn:
+        _simple = staticmethod(_unused_simple)
+        _gather_hidden_states_and_residual = staticmethod(_unused_gather)
+
+        @staticmethod
+        def get_fn(*args, **kwargs):
+            del args, kwargs
+            return CommunicateWithAllReduceAndLayerNormFn._simple
+
+    class CommunicateSummableTensorPairFn:
+        _trivial = staticmethod(_unused_trivial)
+
+        @staticmethod
+        def get_fn(*args, **kwargs):
+            del args, kwargs
+            return CommunicateSummableTensorPairFn._trivial
+
+    class LayerCommunicator:
+        def __init__(
+            self,
+            layer_scatter_modes,
+            input_layernorm,
+            post_attention_layernorm,
+            allow_reduce_scatter=False,
+            is_last_layer=False,
+            qkv_latent_func=None,
+        ):
+            self.layer_scatter_modes = layer_scatter_modes
+            self.input_layernorm = input_layernorm
+            self.post_attention_layernorm = post_attention_layernorm
+            self.allow_reduce_scatter = allow_reduce_scatter
+            self.is_last_layer = is_last_layer
+            self.qkv_latent_func = qkv_latent_func
+            self._context = CommunicateContext.init_new()
+            self._post_init_communicate()
+
+    class AttentionInputs:
+        def __init__(self, hidden_states, forward_batch, qkv_latent_func):
+            self.hidden_states = hidden_states
+            self.forward_batch = forward_batch
+            self.qkv_latent_func = qkv_latent_func
+
+        def fetch_qkv_latent(self):
+            return self.qkv_latent_func(self.hidden_states, self.forward_batch)
+
+    class _AttnTpContext:
+        input_scattered = False
+        attn_inputs = None
+
+        def set_attn_inputs(self, attn_inputs):
+            self.attn_inputs = attn_inputs
+
+        def fetch_qkv_latent(self):
+            assert self.attn_inputs is not None
+            return self.attn_inputs.fetch_qkv_latent()
+
+    attn_tp_context = _AttnTpContext()
+
+    communicator = types.ModuleType("sglang.srt.layers.communicator")
+    communicator.AttentionInputs = AttentionInputs
+    communicator.CommunicateContext = CommunicateContext
+    communicator.CommunicateSimpleFn = CommunicateSimpleFn
+    communicator.CommunicateSummableTensorPairFn = CommunicateSummableTensorPairFn
+    communicator.CommunicateWithAllReduceAndLayerNormFn = (
+        CommunicateWithAllReduceAndLayerNormFn
+    )
+    communicator.LayerCommunicator = LayerCommunicator
+    communicator.LayerScatterModes = object
+    communicator.ScatterMode = ScatterMode
+    communicator.get_attn_tp_context = lambda: attn_tp_context
+    stubs[communicator.__name__] = communicator
+
+    forward_batch_info = types.ModuleType(
+        "sglang.srt.model_executor.forward_batch_info"
+    )
+    forward_batch_info.ForwardBatch = object
+    stubs[forward_batch_info.__name__] = forward_batch_info
+
+    with patch.dict(sys.modules, stubs):
+        return _load_source(
+            "_glm5_next_communicator_mhc_under_test",
+            REPO_ROOT / "python/sglang/srt/layers/communicator_mhc.py",
+        )
+
+
+COMMUNICATOR_MHC = _load_communicator_module()
+
+
+class _ScaleNorm(torch.nn.Module):
+    def __init__(self, hidden_size: int, scale: float):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.ones(hidden_size))
+        self.variance_epsilon = 1e-5
+        self.scale = scale
+
+    def forward(self, x):
+        return x * self.scale
+
+
+class TestMHCState(unittest.TestCase):
+    def test_attention_ffn_and_reset_lifecycle(self):
+        calls = []
+
+        def attn_pre(x, norm_weight, norm_eps):
+            calls.append(("attn_pre", norm_weight, norm_eps))
+            tokens = x.shape[0]
+            return (
+                x[:, :2],
+                torch.full((tokens, 4), 11.0),
+                torch.full((tokens, 2), 13.0),
+                False,
+            )
+
+        def ffn_pre(x, norm_weight, norm_eps):
+            calls.append(("ffn_pre", norm_weight, norm_eps))
+            tokens = x.shape[0]
+            return (
+                x[:, :2],
+                torch.full((tokens, 4), 17.0),
+                torch.full((tokens, 2), 19.0),
+                False,
+            )
+
+        def hc_post(x, residual, h_res, h_post):
+            calls.append(("post", h_res.clone(), h_post.clone()))
+            self.assertEqual(h_res.shape[-1], 4)
+            self.assertEqual(h_post.shape[-1], 2)
+            return residual + x.repeat(1, 2)
+
+        state = COMMUNICATOR_MHC.MHCState(
+            hc_mult=2,
+            hc_attn_pre=attn_pre,
+            hc_ffn_pre=ffn_pre,
+            hc_post=hc_post,
+        )
+        norm = _ScaleNorm(hidden_size=2, scale=3.0)
+        flat = torch.tensor([[1.0, 2.0, 3.0, 4.0]])
+
+        attn_input, attn_residual = state.attn_split(flat, out_norm=norm)
+        torch.testing.assert_close(attn_input, torch.tensor([[3.0, 6.0]]))
+        torch.testing.assert_close(attn_residual, flat)
+        self.assertEqual(calls[0][1].data_ptr(), norm.weight.data_ptr())
+        self.assertEqual(calls[0][2], norm.variance_epsilon)
+
+        ffn_input, ffn_residual = state.attn_to_mlp(
+            torch.tensor([[5.0, 7.0]]), attn_residual, out_norm=norm
+        )
+        torch.testing.assert_close(ffn_residual, torch.tensor([[6.0, 9.0, 8.0, 11.0]]))
+        torch.testing.assert_close(ffn_input, torch.tensor([[18.0, 27.0]]))
+
+        combined = state.mlp_combine(torch.tensor([[1.0, 1.0]]), ffn_residual)
+        torch.testing.assert_close(combined, torch.tensor([[7.0, 10.0, 9.0, 12.0]]))
+        self.assertEqual(calls[-1][1][0, 0].item(), 17.0)
+        self.assertEqual(calls[-1][2][0, 0].item(), 19.0)
+
+        state.reset_aux()
+        self.assertIsNone(state.h_res)
+        self.assertIsNone(state.h_post)
+
+    def test_fused_norm_flag_avoids_second_normalization(self):
+        def pre(x, norm_weight, norm_eps):
+            del norm_weight, norm_eps
+            tokens = x.shape[0]
+            return x[:, :2], torch.zeros(tokens, 4), torch.zeros(tokens, 2), True
+
+        state = COMMUNICATOR_MHC.MHCState(2, pre, pre, lambda *args: args[1])
+        flat = torch.tensor([[1.0, 2.0, 3.0, 4.0]])
+        output, _ = state.attn_split(flat, out_norm=_ScaleNorm(2, 10.0))
+        torch.testing.assert_close(output, torch.tensor([[1.0, 2.0]]))
+
+
+class TestMHCLayerCommunicatorTopology(unittest.TestCase):
+    @staticmethod
+    def _modes():
+        mode = COMMUNICATOR_MHC.ScatterMode.TP_ATTN_FULL
+        return types.SimpleNamespace(
+            layer_input_mode=mode,
+            attn_mode=mode,
+            mlp_mode=mode,
+            middle_residual_mode=mode,
+            layer_output_mode=mode,
+        )
+
+    def _construct(
+        self,
+        *,
+        is_first_layer=False,
+        is_last_layer=False,
+        pre=None,
+        post=None,
+        qkv_latent_func=None,
+    ):
+        norm = _ScaleNorm(hidden_size=2, scale=1.0)
+
+        if pre is None:
+
+            def pre(*args):
+                return args[0][:, :2], None, None, False
+
+        if post is None:
+
+            def post(*args):
+                return args[1]
+
+        return COMMUNICATOR_MHC.MHCLayerCommunicator(
+            layer_scatter_modes=self._modes(),
+            input_layernorm=norm,
+            post_attention_layernorm=norm,
+            is_first_layer=is_first_layer,
+            is_last_layer=is_last_layer,
+            hc_mult=2,
+            hc_attn_pre=pre,
+            hc_ffn_pre=pre,
+            hc_post=post,
+            qkv_latent_func=qkv_latent_func,
+        )
+
+    def test_dsa_latent_is_installed_after_mhc_attention_preprocess(self):
+        batch = object()
+        calls = []
+
+        def prepare_qkv_latent(hidden_states, forward_batch):
+            calls.append((hidden_states.clone(), forward_batch))
+            return hidden_states + 7
+
+        communicator = self._construct(qkv_latent_func=prepare_qkv_latent)
+        hidden_states, _ = communicator.prepare_attn(
+            torch.tensor([[1.0, 2.0, 3.0, 4.0]]),
+            None,
+            batch,
+        )
+        latent = COMMUNICATOR_MHC.get_attn_tp_context().fetch_qkv_latent()
+
+        torch.testing.assert_close(calls[0][0], hidden_states)
+        self.assertIs(calls[0][1], batch)
+        torch.testing.assert_close(latent, hidden_states + 7)
+
+    def test_attention_dp_and_cp_fail_during_construction(self):
+        context = COMMUNICATOR_MHC.CommunicateContext
+        for field in ("attn_dp_size", "attn_cp_size"):
+            setattr(context, field, 2)
+            try:
+                with self.assertRaisesRegex(NotImplementedError, "DP=1 and CP=1"):
+                    self._construct()
+            finally:
+                setattr(context, field, 1)
+
+    def test_runtime_scattered_input_fails_before_mhc_math(self):
+        communicator = self._construct()
+        attn_context = COMMUNICATOR_MHC.get_attn_tp_context()
+        attn_context.input_scattered = True
+        try:
+            with self.assertRaisesRegex(NotImplementedError, "scattered TP input"):
+                communicator.prepare_attn(
+                    torch.zeros(1, 4),
+                    None,
+                    object(),
+                )
+        finally:
+            attn_context.input_scattered = False
+
+    def test_first_and_last_layer_expand_then_contract(self):
+        pre_widths = []
+
+        def pre(x, norm_weight, norm_eps):
+            del norm_weight, norm_eps
+            pre_widths.append(x.shape[-1])
+            tokens = x.shape[0]
+            return (
+                x[:, :2],
+                torch.zeros(tokens, 4),
+                torch.zeros(tokens, 2),
+                False,
+            )
+
+        def post(x, residual, h_res, h_post):
+            del h_res, h_post
+            return residual + x.repeat(1, 2)
+
+        communicator = self._construct(
+            is_first_layer=True,
+            is_last_layer=True,
+            pre=pre,
+            post=post,
+        )
+        hidden_states, residual = communicator.prepare_attn(
+            torch.tensor([[1.0, 2.0]]),
+            None,
+            object(),
+        )
+        hidden_states, residual = communicator.prepare_mlp(
+            torch.zeros_like(hidden_states),
+            residual,
+            object(),
+        )
+        hidden_states, residual = communicator.postprocess_layer(
+            torch.zeros_like(hidden_states),
+            residual,
+            object(),
+        )
+
+        self.assertEqual(pre_widths, [4, 4])
+        torch.testing.assert_close(hidden_states, torch.tensor([[1.0, 2.0]]))
+        self.assertIsNone(residual)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/test_glm5_next_consumer_gpu_kernels.py
+++ b/test/registered/unit/test_glm5_next_consumer_gpu_kernels.py
@@ -1,0 +1,549 @@
+"""Static contracts for the GLM-5-Next SM86/SM89 kernel boundary."""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import math
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+INDEXER_PATH = (
+    REPO_ROOT / "python/sglang/srt/layers/attention/nsa/glm5_next_indexer_triton.py"
+)
+INDEXER_CALLER_PATH = (
+    REPO_ROOT / "python/sglang/srt/layers/attention/nsa/nsa_indexer_kpool.py"
+)
+KPOOL_PATH = REPO_ROOT / "python/sglang/srt/layers/attention/nsa/kpool_fp8_index.py"
+SPARSE_PATH = (
+    REPO_ROOT / "python/sglang/srt/layers/attention/nsa/glm5_next_sparse_attention.py"
+)
+BACKEND_PATH = REPO_ROOT / "python/sglang/srt/layers/attention/nsa_backend.py"
+CONFIG_PATH = REPO_ROOT / "python/sglang/srt/configs/glm5_next.py"
+
+
+def _load_indexer_module():
+    spec = importlib.util.spec_from_file_location(
+        "_glm5_next_consumer_indexer_test", INDEXER_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _function_source(path: Path, name: str) -> str:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    function = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == name
+    )
+    return ast.unparse(function)
+
+
+def _consumer_capability() -> tuple[int, int] | None:
+    if not torch.cuda.is_available():
+        return None
+    capability = torch.cuda.get_device_capability()
+    return capability if capability in ((8, 6), (8, 9)) else None
+
+
+def _expected_logits(query, keys, weights, starts, ends, scales=None):
+    scores = torch.bmm(
+        keys.to(torch.bfloat16).unsqueeze(0).expand(query.shape[0], -1, -1),
+        query.to(torch.bfloat16).transpose(1, 2),
+    )
+    logits = (torch.relu(scores).float() * weights.float().unsqueeze(1)).sum(2)
+    if scales is not None:
+        logits *= scales.float().unsqueeze(0)
+    positions = torch.arange(keys.shape[0], device=query.device).unsqueeze(0)
+    valid = (positions >= starts.unsqueeze(1)) & (positions < ends.unsqueeze(1))
+    return logits.masked_fill(~valid, float("-inf"))
+
+
+def _hadamard128_reference(values: torch.Tensor) -> torch.Tensor:
+    output = values.float()
+    stride = 1
+    while stride < 128:
+        view = output.reshape(*output.shape[:-1], -1, 2, stride)
+        left = view[..., 0, :].clone()
+        right = view[..., 1, :].clone()
+        output = torch.stack((left + right, left - right), dim=-2).reshape_as(output)
+        stride *= 2
+    return output * (1.0 / math.sqrt(128.0))
+
+
+def _compressed_bf16_reference(slot_k, slot_score, ape):
+    probabilities = torch.softmax(slot_score.float() + ape.unsqueeze(0), dim=1)
+    pooled = (probabilities * slot_k.float()).sum(1).to(torch.bfloat16).float()
+    return _hadamard128_reference(pooled).to(torch.bfloat16)
+
+
+class TestGlm5NextConsumerGPUKernels(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.indexer = _load_indexer_module()
+
+    def test_indexer_has_exact_static_configs(self):
+        self.assertEqual(
+            self.indexer.glm5_next_indexer_launch_config((8, 6)), (32, 4, 2)
+        )
+        self.assertEqual(
+            self.indexer.glm5_next_indexer_launch_config((8, 9)), (64, 4, 3)
+        )
+        for capability in ((8, 0), (9, 0), (12, 0)):
+            with self.subTest(capability=capability):
+                with self.assertRaisesRegex(ValueError, "unsupported"):
+                    self.indexer.glm5_next_indexer_launch_config(capability)
+
+    def test_indexer_cpu_route_is_disabled(self):
+        self.assertFalse(self.indexer.use_glm5_next_triton_indexer(torch.device("cpu")))
+
+    def test_indexer_kernels_keep_exact_score_contract(self):
+        flat = _function_source(INDEXER_PATH, "_glm5_next_flat_mqa_logits_kernel")
+        paged = _function_source(INDEXER_PATH, "_glm5_next_paged_mqa_logits_kernel")
+        for source in (flat, paged):
+            self.assertIn("tl.dot", source)
+            self.assertIn("tl.maximum(head_scores, 0.0)", source)
+            self.assertIn("tl.sum(head_scores * weights[None, :], axis=1)", source)
+            self.assertIn("if USE_K_SCALE", source)
+            for host_sync in (".item()", ".cpu()", ".tolist()"):
+                self.assertNotIn(host_sync, source)
+        self.assertIn("page_table_ptr", paged)
+        self.assertIn("key_offsets < seq_len", paged)
+
+    def test_dispatch_preserves_sm120_and_generic_nsa_paths(self):
+        paged = _function_source(INDEXER_CALLER_PATH, "_get_topk_paged")
+        ragged = _function_source(INDEXER_CALLER_PATH, "_get_topk_ragged_kpool_plan")
+        forward = _function_source(INDEXER_CALLER_PATH, "forward_cuda")
+
+        self.assertLess(
+            paged.index("if use_triton_logits"), paged.index("elif use_eager_logits")
+        )
+        self.assertIn("deep_gemm.fp8_paged_mqa_logits", paged)
+        self.assertIn("gather_index_k_bf16_prefix_into", ragged)
+        self.assertIn("deep_gemm.fp8_mqa_logits", ragged)
+        self.assertIn("if getattr(pool, 'index_cache_is_bf16', False)", forward)
+        self.assertIn("q_fp8, q_scale = act_quant", forward)
+
+    def test_sm86_kpool_has_isolated_bf16_transport_kernels(self):
+        source = KPOOL_PATH.read_text(encoding="utf-8")
+        for name in (
+            "_gather_index_k_bf16_prefix_into_kernel",
+            "_kpool_softmax_rotate_write_cache_bf16_kernel",
+            "_kpool_decode_update_and_maybe_write_cache_bf16_kernel",
+            "_kpool_assemble_softmax_rotate_write_cache_bf16_kernel",
+        ):
+            self.assertIn(f"def {name}(", source)
+        self.assertIn("if buf.dtype == torch.bfloat16", source)
+
+    def test_capability_matrix_and_flashinfer_boundary_fail_closed(self):
+        config = CONFIG_PATH.read_text(encoding="utf-8")
+        self.assertIn("if capability == (8, 6)", config)
+        self.assertIn("if capability == (8, 9)", config)
+        self.assertIn("if capability[0] >= 10", config)
+
+        forward = _function_source(BACKEND_PATH, "_forward_trtllm")
+        native_dispatch = forward.index("glm5_next_sparse_mla_reference")
+        flashinfer_import = forward.index("import flashinfer.decode")
+        self.assertLess(native_dispatch, flashinfer_import)
+
+    @unittest.skipUnless(
+        _consumer_capability() is not None,
+        "an SM86 or SM89 GPU is required",
+    )
+    def test_flat_indexer_matches_bf16_formula(self):
+        capability = _consumer_capability()
+        assert capability is not None
+        torch.manual_seed(20260817)
+        device = torch.device("cuda")
+        query_bf16 = (torch.randn(5, 32, 128, device=device) * 0.1).to(torch.bfloat16)
+        keys_bf16 = (torch.randn(137, 128, device=device) * 0.1).to(torch.bfloat16)
+        weights = torch.randn(5, 32, dtype=torch.float32, device=device)
+        starts = torch.tensor([0, 1, 17, 64, 137], dtype=torch.int32, device=device)
+        ends = torch.tensor([137, 80, 101, 137, 137], dtype=torch.int32, device=device)
+
+        if capability == (8, 6):
+            query, keys, scales = query_bf16, keys_bf16, None
+        else:
+            query = query_bf16.to(torch.float8_e4m3fn)
+            keys = keys_bf16.to(torch.float8_e4m3fn)
+            scales = torch.linspace(0.5, 1.5, keys.shape[0], device=device)
+
+        chunks = list(
+            self.indexer.iter_glm5_next_triton_mqa_logits(
+                query,
+                keys,
+                weights,
+                starts,
+                ends,
+                k_scale=scales,
+                query_chunk_size=2,
+            )
+        )
+        actual = torch.cat([chunk for _, _, chunk in chunks])
+        expected = _expected_logits(query, keys, weights, starts, ends, scales)
+        self.assertTrue(torch.equal(torch.isneginf(actual), torch.isneginf(expected)))
+        finite = torch.isfinite(expected)
+        torch.testing.assert_close(
+            actual[finite], expected[finite], rtol=2e-2, atol=2e-2
+        )
+
+    @unittest.skipUnless(
+        _consumer_capability() is not None,
+        "an SM86 or SM89 GPU is required",
+    )
+    def test_paged_indexer_matches_formula_and_replays_cuda_graph(self):
+        capability = _consumer_capability()
+        assert capability is not None
+        torch.manual_seed(20260818)
+        device = torch.device("cuda")
+        pages = 4
+        keys_bf16 = (torch.randn(pages, 64, 128, device=device) * 0.1).to(
+            torch.bfloat16
+        )
+        query_bf16 = (torch.randn(2, 32, 128, device=device) * 0.1).to(torch.bfloat16)
+        weights = torch.randn(2, 32, dtype=torch.float32, device=device)
+        page_table = torch.tensor([[2, 0], [3, 1]], dtype=torch.int32, device=device)
+        seq_lens = torch.tensor([70, 9], dtype=torch.int32, device=device)
+
+        if capability == (8, 6):
+            query = query_bf16
+            cache = keys_bf16.reshape(pages, -1).contiguous()
+            page_scales = None
+            use_scale = False
+        else:
+            query = query_bf16.to(torch.float8_e4m3fn)
+            keys = keys_bf16.to(torch.float8_e4m3fn)
+            page_scales = torch.linspace(
+                0.5, 1.5, pages * 64, dtype=torch.float32, device=device
+            ).reshape(pages, 64)
+            cache = torch.empty(
+                (pages, 64 * 128 + 64 * 4), dtype=torch.uint8, device=device
+            )
+            cache[:, : 64 * 128] = keys.reshape(pages, -1).view(torch.uint8)
+            cache[:, 64 * 128 :] = page_scales.view(torch.uint8).reshape(pages, -1)
+            use_scale = True
+
+        def expected_for_lengths(lengths):
+            rows = []
+            for row in range(2):
+                ordered_keys = keys_bf16.index_select(
+                    0, page_table[row].to(torch.int64)
+                ).reshape(-1, 128)
+                if capability == (8, 9):
+                    ordered_keys = ordered_keys.to(torch.float8_e4m3fn)
+                    ordered_scales = page_scales.index_select(
+                        0, page_table[row].to(torch.int64)
+                    ).reshape(-1)
+                else:
+                    ordered_scales = None
+                rows.append(
+                    _expected_logits(
+                        query[row : row + 1],
+                        ordered_keys,
+                        weights[row : row + 1],
+                        torch.zeros(1, dtype=torch.int32, device=device),
+                        lengths[row : row + 1],
+                        ordered_scales,
+                    )[0]
+                )
+            return torch.stack(rows)
+
+        self.indexer.glm5_next_triton_paged_mqa_logits(
+            query, cache, weights, seq_lens, page_table, 128, use_k_scale=use_scale
+        )
+        torch.cuda.synchronize()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            actual = self.indexer.glm5_next_triton_paged_mqa_logits(
+                query,
+                cache,
+                weights,
+                seq_lens,
+                page_table,
+                128,
+                use_k_scale=use_scale,
+            )
+        graph.replay()
+        torch.cuda.synchronize()
+        expected = expected_for_lengths(seq_lens)
+        self.assertTrue(torch.equal(torch.isneginf(actual), torch.isneginf(expected)))
+        finite = torch.isfinite(expected)
+        torch.testing.assert_close(
+            actual[finite], expected[finite], rtol=2e-2, atol=2e-2
+        )
+
+        seq_lens.copy_(torch.tensor([3, 127], dtype=torch.int32, device=device))
+        graph.replay()
+        torch.cuda.synchronize()
+        expected = expected_for_lengths(seq_lens)
+        self.assertTrue(torch.equal(torch.isneginf(actual), torch.isneginf(expected)))
+        finite = torch.isfinite(expected)
+        torch.testing.assert_close(
+            actual[finite], expected[finite], rtol=2e-2, atol=2e-2
+        )
+
+    @unittest.skipUnless(
+        _consumer_capability() is not None,
+        "an SM86 or SM89 GPU is required",
+    )
+    def test_consumer_sparse_mla_matches_oracle_and_replays_cuda_graph(self):
+        capability = _consumer_capability()
+        assert capability is not None
+        spec = importlib.util.spec_from_file_location(
+            "_glm5_next_sparse_consumer_test", SPARSE_PATH
+        )
+        assert spec is not None and spec.loader is not None
+        sparse = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(sparse)
+
+        torch.manual_seed(20260822)
+        query_cpu = (torch.randn(1, 2, 512) * 0.1).to(torch.bfloat16)
+        kv_bf16 = (torch.randn(16, 512) * 0.1).to(torch.bfloat16)
+        first_indices_cpu = torch.tensor(
+            [[0, 3, 5, 9, -1, -1, -1, -1]], dtype=torch.int32
+        )
+        second_indices_cpu = torch.tensor(
+            [[1, 2, 7, 12, 15, -1, -1, -1]], dtype=torch.int32
+        )
+        scale = 512**-0.5
+        if capability == (8, 6):
+            kv_cpu = kv_bf16
+            kv_scale_cpu = None
+        else:
+            blocks = kv_bf16.float().view(-1, 4, 128)
+            kv_scale_cpu = blocks.abs().amax(-1).clamp_min(1e-4) / 448.0
+            kv_cpu = (
+                (blocks / kv_scale_cpu.unsqueeze(-1))
+                .to(torch.float8_e4m3fn)
+                .view_as(kv_bf16)
+            )
+
+        expected = sparse.glm5_next_sparse_mla_reference(
+            query_cpu,
+            kv_cpu,
+            first_indices_cpu,
+            sm_scale=scale,
+            kv_scale=kv_scale_cpu,
+        )
+        query = query_cpu.cuda()
+        kv = kv_cpu.cuda()
+        indices = first_indices_cpu.cuda()
+        kv_scale = None if kv_scale_cpu is None else kv_scale_cpu.cuda()
+        actual = sparse.glm5_next_sparse_mla_reference(
+            query,
+            kv,
+            indices,
+            sm_scale=scale,
+            kv_scale=kv_scale,
+        )
+        torch.cuda.synchronize()
+        torch.testing.assert_close(actual.cpu(), expected, rtol=2e-2, atol=2e-2)
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            actual = sparse.glm5_next_sparse_mla_reference(
+                query,
+                kv,
+                indices,
+                sm_scale=scale,
+                kv_scale=kv_scale,
+            )
+        indices.copy_(second_indices_cpu)
+        graph.replay()
+        torch.cuda.synchronize()
+        expected = sparse.glm5_next_sparse_mla_reference(
+            query_cpu,
+            kv_cpu,
+            second_indices_cpu,
+            sm_scale=scale,
+            kv_scale=kv_scale_cpu,
+        )
+        torch.testing.assert_close(actual.cpu(), expected, rtol=2e-2, atol=2e-2)
+
+    @unittest.skipUnless(
+        _consumer_capability() == (8, 6),
+        "an SM86 GPU is required",
+    )
+    def test_sm86_bf16_kpool_writer_matches_reference(self):
+        spec = importlib.util.spec_from_file_location(
+            "_glm5_next_kpool_sm86_test", KPOOL_PATH
+        )
+        assert spec is not None and spec.loader is not None
+        kpool = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(kpool)
+
+        torch.manual_seed(20260819)
+        device = torch.device("cuda")
+        slot_k = torch.randn(2, 4, 128, dtype=torch.bfloat16, device=device)
+        slot_score = torch.randn(2, 4, 128, dtype=torch.bfloat16, device=device)
+        ape = torch.randn(4, 128, dtype=torch.float32, device=device)
+        loc = torch.tensor([0, 65], dtype=torch.int64, device=device)
+        cache = torch.zeros((2, 64 * 128), dtype=torch.bfloat16, device=device)
+        pool = SimpleNamespace(page_size=64, index_head_dim=128)
+
+        compressed, scales = kpool.kpool_softmax_rotate_write_cache(
+            pool,
+            cache,
+            slot_k,
+            slot_score,
+            ape,
+            loc,
+            return_compressed=True,
+        )
+        expected = _compressed_bf16_reference(slot_k, slot_score, ape)
+
+        torch.testing.assert_close(compressed, expected, rtol=2e-2, atol=2e-2)
+        torch.testing.assert_close(scales, torch.ones_like(scales), rtol=0, atol=0)
+        torch.testing.assert_close(cache[0, :128], expected[0], rtol=2e-2, atol=2e-2)
+        torch.testing.assert_close(cache[1, 128:256], expected[1], rtol=2e-2, atol=2e-2)
+
+    @unittest.skipUnless(
+        _consumer_capability() == (8, 6),
+        "an SM86 GPU is required",
+    )
+    def test_sm86_bf16_gather_and_extend_assemble_match_reference(self):
+        spec = importlib.util.spec_from_file_location(
+            "_glm5_next_kpool_sm86_extend_test", KPOOL_PATH
+        )
+        assert spec is not None and spec.loader is not None
+        kpool = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(kpool)
+
+        torch.manual_seed(20260820)
+        device = torch.device("cuda")
+        pool = SimpleNamespace(
+            page_size=64,
+            index_head_dim=128,
+            index_kpool=4,
+            tail_extra_slots=0,
+            slots_per_page=64,
+        )
+        cache = torch.randn(3, 64 * 128, dtype=torch.bfloat16, device=device)
+        page_indices = torch.tensor([2, 0], dtype=torch.int32, device=device)
+        gathered = torch.empty(70, 128, dtype=torch.bfloat16, device=device)
+        kpool.gather_index_k_bf16_prefix_into(pool, cache, page_indices, 70, gathered)
+        expected_gather = cache.index_select(0, page_indices.long()).view(-1, 128)[:70]
+        self.assertTrue(torch.equal(gathered, expected_gather))
+
+        cache.zero_()
+        chunk_k = torch.randn(4, 128, dtype=torch.bfloat16, device=device)
+        chunk_score = torch.randn(4, 128, dtype=torch.bfloat16, device=device)
+        tail_k = torch.randn(2, 4, 128, dtype=torch.bfloat16, device=device)
+        tail_score = torch.randn(2, 4, 128, dtype=torch.bfloat16, device=device)
+        ape = torch.randn(4, 128, dtype=torch.float32, device=device)
+        request = torch.tensor([1], dtype=torch.int32, device=device)
+        n_from_tail = torch.tensor([2], dtype=torch.int32, device=device)
+        chunk_start = torch.tensor([1], dtype=torch.int64, device=device)
+        tail_base = torch.tensor([3], dtype=torch.int64, device=device)
+        loc = torch.tensor([65], dtype=torch.int64, device=device)
+        kpool.kpool_assemble_softmax_rotate_write_cache(
+            pool,
+            cache,
+            chunk_k,
+            chunk_score,
+            tail_k,
+            tail_score,
+            request,
+            n_from_tail,
+            chunk_start,
+            tail_base,
+            ape,
+            loc,
+        )
+        selected_k = torch.stack(
+            (tail_k[1, 3], tail_k[1, 0], chunk_k[1], chunk_k[2])
+        ).unsqueeze(0)
+        selected_score = torch.stack(
+            (tail_score[1, 3], tail_score[1, 0], chunk_score[1], chunk_score[2])
+        ).unsqueeze(0)
+        expected = _compressed_bf16_reference(selected_k, selected_score, ape)[0]
+        torch.testing.assert_close(cache[1, 128:256], expected, rtol=2e-2, atol=2e-2)
+
+    @unittest.skipUnless(
+        _consumer_capability() == (8, 6),
+        "an SM86 GPU is required",
+    )
+    def test_sm86_bf16_decode_writer_replays_cuda_graph(self):
+        spec = importlib.util.spec_from_file_location(
+            "_glm5_next_kpool_sm86_decode_test", KPOOL_PATH
+        )
+        assert spec is not None and spec.loader is not None
+        kpool = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(kpool)
+
+        torch.manual_seed(20260821)
+        device = torch.device("cuda")
+        pool = SimpleNamespace(
+            page_size=64,
+            index_head_dim=128,
+            index_kpool=4,
+            tail_extra_slots=0,
+            slots_per_page=64,
+        )
+        cache = torch.zeros(2, 64 * 128, dtype=torch.bfloat16, device=device)
+        tail_seed = torch.randn(2, 4, 128, dtype=torch.bfloat16, device=device)
+        score_seed = torch.randn(2, 4, 128, dtype=torch.bfloat16, device=device)
+        tail_k = tail_seed.clone()
+        tail_score = score_seed.clone()
+        key = torch.randn(1, 128, dtype=torch.bfloat16, device=device)
+        score = torch.randn(1, 128, dtype=torch.bfloat16, device=device)
+        ape = torch.randn(4, 128, dtype=torch.float32, device=device)
+        block_tables = torch.zeros(1, 8, dtype=torch.int32, device=device)
+        block_tables[0, 0] = 1
+        request = torch.tensor([1], dtype=torch.int32, device=device)
+        positions = torch.tensor([3], dtype=torch.int64, device=device)
+        seq_lens = torch.tensor([4], dtype=torch.int32, device=device)
+        cache_locs = torch.tensor([1], dtype=torch.int64, device=device)
+
+        def write_decode():
+            kpool.kpool_decode_update_and_maybe_write_cache(
+                pool,
+                cache,
+                tail_k,
+                tail_score,
+                key,
+                score,
+                ape,
+                block_tables,
+                request,
+                positions,
+                seq_lens,
+                cache_locs,
+            )
+
+        write_decode()
+        torch.cuda.synchronize()
+        graph = torch.cuda.CUDAGraph()
+        tail_k.copy_(tail_seed)
+        tail_score.copy_(score_seed)
+        cache.zero_()
+        with torch.cuda.graph(graph):
+            write_decode()
+        tail_k.copy_(tail_seed)
+        tail_score.copy_(score_seed)
+        cache.zero_()
+        graph.replay()
+        torch.cuda.synchronize()
+
+        selected_k = torch.stack(
+            (tail_seed[1, 0], tail_seed[1, 1], tail_seed[1, 2], key[0])
+        ).unsqueeze(0)
+        selected_score = torch.stack(
+            (score_seed[1, 0], score_seed[1, 1], score_seed[1, 2], score[0])
+        ).unsqueeze(0)
+        expected = _compressed_bf16_reference(selected_k, selected_score, ape)[0]
+        torch.testing.assert_close(cache[1, :128], expected, rtol=2e-2, atol=2e-2)
+        self.assertTrue(torch.equal(tail_k[1, 3], key[0]))
+        self.assertTrue(torch.equal(tail_score[1, 3], score[0]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/test_glm5_next_dsa.py
+++ b/test/registered/unit/test_glm5_next_dsa.py
@@ -1,0 +1,264 @@
+"""CPU-only construction contracts for GLM-5-Next DSA attention."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+from torch import nn
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = REPO_ROOT / "python/sglang/srt/models/glm5_next_dsa.py"
+
+
+class _Glm5NextTextConfig:
+    model_type = "glm5_next_text"
+
+    def __init__(self, **overrides):
+        values = dict(
+            hidden_size=4096,
+            num_attention_heads=64,
+            qk_nope_head_dim=256,
+            qk_rope_head_dim=0,
+            v_head_dim=256,
+            q_lora_rank=1536,
+            kv_lora_rank=512,
+            rope_theta=800000.0,
+            rope_scaling=None,
+            max_position_embeddings=1048576,
+            rms_norm_eps=1e-5,
+            index_head_dim=128,
+            index_topk=2048,
+            index_kpool=4,
+            index_kpool_compress=True,
+            index_kpool_always_select_tail=True,
+            index_n_heads=32,
+            index_topk_freq=1,
+            index_topk_pattern=None,
+            index_skip_topk_offset=None,
+            index_share_for_mtp_iteration=False,
+            indexer_rope_interleave=True,
+            architectures=["Glm5NextForConditionalGeneration"],
+        )
+        values.update(overrides)
+        self.__dict__.update(values)
+
+
+class _RecordingBaseAttention(nn.Module):
+    init_calls = []
+
+    def __init__(self, **kwargs):
+        super().__init__()
+        type(self).init_calls.append(kwargs)
+        self.base_kwargs = kwargs
+        self.base_forward_dependency = object()
+        self.base_weight = nn.Parameter(torch.ones(1))
+        self.use_nsa = False
+        self.nsa_enable_prefill_cp = False
+        self.is_nextn = kwargs["is_nextn"]
+        self.rotary_emb = object()
+
+
+class _RecordingIndexerKPool(nn.Module):
+    init_calls = []
+
+    def __init__(self, **kwargs):
+        super().__init__()
+        type(self).init_calls.append(kwargs)
+        self.kwargs = kwargs
+        self.index_kpool_compress_ape = nn.Parameter(torch.zeros(4, 1))
+        self.index_kpool_compress_gate = nn.Parameter(torch.zeros(1, 1))
+        self.wk = nn.Linear(1, 1, bias=False)
+
+
+def _load_module(*, cp_enabled=False):
+    packages = {}
+    for name in (
+        "sglang",
+        "sglang.srt",
+        "sglang.srt.configs",
+        "sglang.srt.layers",
+        "sglang.srt.layers.attention",
+        "sglang.srt.layers.attention.nsa",
+        "sglang.srt.layers.quantization",
+        "sglang.srt.models",
+    ):
+        package = types.ModuleType(name)
+        package.__path__ = []
+        packages[name] = package
+
+    config_module = types.ModuleType("sglang.srt.configs.glm5_next")
+    config_module.Glm5NextTextConfig = _Glm5NextTextConfig
+    packages[config_module.__name__] = config_module
+
+    indexer_module = types.ModuleType(
+        "sglang.srt.layers.attention.nsa.nsa_indexer_kpool"
+    )
+    indexer_module.IndexerKPool = _RecordingIndexerKPool
+    packages[indexer_module.__name__] = indexer_module
+
+    nsa_utils = types.ModuleType("sglang.srt.layers.attention.nsa.utils")
+    nsa_utils.is_nsa_enable_prefill_cp = lambda: cp_enabled
+    packages[nsa_utils.__name__] = nsa_utils
+
+    quantization = types.ModuleType("sglang.srt.layers.quantization.base_config")
+    quantization.QuantizationConfig = type("QuantizationConfig", (), {})
+    packages[quantization.__name__] = quantization
+
+    deepseek = types.ModuleType("sglang.srt.models.deepseek_v2")
+    deepseek.DeepseekV2AttentionMLA = _RecordingBaseAttention
+    packages[deepseek.__name__] = deepseek
+
+    utils = types.ModuleType("sglang.srt.utils")
+    utils.add_prefix = lambda name, prefix: f"{prefix}.{name}" if prefix else name
+    packages[utils.__name__] = utils
+
+    module_name = f"_glm5_next_dsa_test_{int(cp_enabled)}"
+    spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    with patch.dict(sys.modules, packages):
+        spec.loader.exec_module(module)
+    return module
+
+
+def _build(attention_cls, config=None, **overrides):
+    config = config or _Glm5NextTextConfig()
+    kwargs = dict(
+        config=config,
+        hidden_size=4096,
+        num_heads=64,
+        qk_nope_head_dim=256,
+        qk_rope_head_dim=0,
+        v_head_dim=256,
+        q_lora_rank=1536,
+        kv_lora_rank=512,
+        rope_theta=800000.0,
+        max_position_embeddings=1048576,
+        layer_id=3,
+        prefix="model.layers.3.self_attn",
+        skip_rope=True,
+        is_nextn=False,
+    )
+    kwargs.update(overrides)
+    return attention_cls(**kwargs)
+
+
+class TestGlm5NextDSAAttention(unittest.TestCase):
+    def setUp(self):
+        _RecordingBaseAttention.init_calls.clear()
+        _RecordingIndexerKPool.init_calls.clear()
+        self.module = _load_module()
+
+    def test_rejects_non_glm_config_before_base_construction(self):
+        non_glm = SimpleNamespace(model_type="deepseek_v3")
+        self.assertFalse(self.module.is_glm5_next_dsa_config(non_glm))
+        with self.assertRaisesRegex(TypeError, "only accepts Glm5NextTextConfig"):
+            _build(self.module.Glm5NextDSAAttention, config=non_glm)
+        self.assertEqual(_RecordingBaseAttention.init_calls, [])
+
+    def test_constructs_zero_rope_kpool_from_real_text_config(self):
+        config = _Glm5NextTextConfig()
+        attention = _build(self.module.Glm5NextDSAAttention, config=config)
+
+        self.assertTrue(self.module.is_glm5_next_dsa_config(config))
+        self.assertTrue(attention.use_nsa)
+        self.assertTrue(attention.skip_rope)
+        self.assertIsNone(attention.rotary_emb)
+        self.assertFalse(attention.nsa_enable_prefill_cp)
+        self.assertFalse(attention.is_nextn)
+        self.assertFalse(attention.skip_topk)
+        self.assertFalse(attention.next_skip_topk)
+        self.assertIsNotNone(attention.base_forward_dependency)
+
+        base_kwargs = attention.base_kwargs
+        self.assertIsNot(base_kwargs["config"], config)
+        self.assertIsNone(base_kwargs["config"].index_topk)
+        self.assertEqual(config.index_topk, 2048)
+        self.assertTrue(base_kwargs["skip_rope"])
+        self.assertFalse(base_kwargs["is_nextn"])
+
+        indexer_kwargs = attention.indexer.kwargs
+        self.assertIs(indexer_kwargs["config"], config)
+        self.assertTrue(indexer_kwargs["skip_rope"])
+        self.assertEqual(indexer_kwargs["hidden_size"], 4096)
+        self.assertEqual(indexer_kwargs["index_n_heads"], 32)
+        self.assertEqual(indexer_kwargs["index_head_dim"], 128)
+        self.assertEqual(indexer_kwargs["rope_head_dim"], 0)
+        self.assertEqual(indexer_kwargs["index_topk"], 2048)
+        self.assertEqual(indexer_kwargs["q_lora_rank"], 1536)
+        self.assertEqual(indexer_kwargs["scale_fmt"], "ue8m0")
+        self.assertEqual(indexer_kwargs["block_size"], 128)
+        self.assertFalse(indexer_kwargs["is_neox_style"])
+        self.assertEqual(indexer_kwargs["prefix"], "model.layers.3.self_attn.indexer")
+        self.assertEqual(attention.index_topk_output_width, 2048 + 3)
+
+    def test_zero_rope_never_enters_base_fused_rope_metadata_path(self):
+        attention = _build(self.module.Glm5NextDSAAttention)
+
+        self.assertIsNone(attention.rotary_emb)
+        self.assertFalse(attention._fuse_rope_for_trtllm_mla(object()))
+
+    def test_checkpoint_parameters_stay_under_indexer_namespace(self):
+        attention = _build(self.module.Glm5NextDSAAttention)
+        names = set(dict(attention.named_parameters()))
+
+        self.assertIn("indexer.index_kpool_compress_ape", names)
+        self.assertIn("indexer.index_kpool_compress_gate", names)
+        self.assertIn("indexer.wk.weight", names)
+        self.assertFalse(any(name.startswith("dsa_indexer.") for name in names))
+
+    def test_kpool4_checkpoint_invariants_are_asserted(self):
+        cases = (
+            ("index_kpool", 2, "index_kpool=4"),
+            ("index_kpool_compress", False, "index_kpool_compress=True"),
+            (
+                "index_kpool_always_select_tail",
+                False,
+                "index_kpool_always_select_tail=True",
+            ),
+        )
+        for field, value, message in cases:
+            with self.subTest(field=field):
+                config = _Glm5NextTextConfig(**{field: value})
+                with self.assertRaisesRegex(AssertionError, message):
+                    _build(self.module.Glm5NextDSAAttention, config=config)
+
+    def test_rejects_cp_mtp_and_index_sharing_modes(self):
+        invalid_configs = (
+            ("index_topk_freq", 2),
+            ("index_topk_pattern", "N"),
+            ("index_skip_topk_offset", 1),
+            ("index_share_for_mtp_iteration", True),
+        )
+        for field, value in invalid_configs:
+            with self.subTest(field=field):
+                config = _Glm5NextTextConfig(**{field: value})
+                with self.assertRaises(ValueError):
+                    _build(self.module.Glm5NextDSAAttention, config=config)
+
+        with self.assertRaisesRegex(NotImplementedError, "MTP"):
+            _build(self.module.Glm5NextDSAAttention, is_nextn=True)
+
+        cp_module = _load_module(cp_enabled=True)
+        with self.assertRaisesRegex(NotImplementedError, "context parallel"):
+            _build(cp_module.Glm5NextDSAAttention)
+
+    def test_rejects_rope_or_dimension_drift(self):
+        with self.assertRaisesRegex(ValueError, "skip_rope=True"):
+            _build(self.module.Glm5NextDSAAttention, skip_rope=False)
+        with self.assertRaisesRegex(ValueError, "qk_rope_head_dim"):
+            _build(self.module.Glm5NextDSAAttention, qk_rope_head_dim=16)
+        with self.assertRaisesRegex(ValueError, "hidden_size"):
+            _build(self.module.Glm5NextDSAAttention, hidden_size=8192)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/test_glm5_next_dsa.py
+++ b/test/registered/unit/test_glm5_next_dsa.py
@@ -16,6 +16,7 @@ from torch import nn
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 MODULE_PATH = REPO_ROOT / "python/sglang/srt/models/glm5_next_dsa.py"
+NORM_PATH = REPO_ROOT / "python/sglang/srt/models/glm5_next_norm.py"
 
 
 class _Glm5NextTextConfig:
@@ -116,6 +117,13 @@ def _load_module(*, cp_enabled=False):
     deepseek.DeepseekV2AttentionMLA = _RecordingBaseAttention
     packages[deepseek.__name__] = deepseek
 
+    norm_name = "sglang.srt.models.glm5_next_norm"
+    norm_spec = importlib.util.spec_from_file_location(norm_name, NORM_PATH)
+    norm_module = importlib.util.module_from_spec(norm_spec)
+    assert norm_spec is not None and norm_spec.loader is not None
+    norm_spec.loader.exec_module(norm_module)
+    packages[norm_name] = norm_module
+
     utils = types.ModuleType("sglang.srt.utils")
     utils.add_prefix = lambda name, prefix: f"{prefix}.{name}" if prefix else name
     packages[utils.__name__] = utils
@@ -177,6 +185,12 @@ class TestGlm5NextDSAAttention(unittest.TestCase):
         self.assertFalse(attention.skip_topk)
         self.assertFalse(attention.next_skip_topk)
         self.assertIsNotNone(attention.base_forward_dependency)
+        self.assertIsInstance(
+            attention.q_a_layernorm, self.module.Glm5NextRMSNorm
+        )
+        self.assertIsInstance(
+            attention.kv_a_layernorm, self.module.Glm5NextRMSNorm
+        )
 
         base_kwargs = attention.base_kwargs
         self.assertIsNot(base_kwargs["config"], config)

--- a/test/registered/unit/test_glm5_next_indexer_logits.py
+++ b/test/registered/unit/test_glm5_next_indexer_logits.py
@@ -1,0 +1,151 @@
+"""CPU numerical contracts for the GLM-5-Next SM120 indexer fallback."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = (
+    REPO_ROOT / "python/sglang/srt/layers/attention/nsa/glm5_next_indexer_logits.py"
+)
+
+
+def _load_module():
+    name = "_glm5_next_indexer_logits_under_test"
+    spec = importlib.util.spec_from_file_location(name, MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+LOGITS = _load_module()
+
+
+def _independent_scores(q, k, scales, weights, ks, ke):
+    output = torch.full((q.shape[0], k.shape[0]), float("-inf"))
+    for qi in range(q.shape[0]):
+        for ki in range(int(ks[qi]), int(ke[qi])):
+            per_head = []
+            for head in range(q.shape[1]):
+                dot = torch.dot(
+                    q[qi, head].to(torch.bfloat16),
+                    k[ki].to(torch.bfloat16),
+                )
+                per_head.append(F.relu(dot).float() * weights[qi, head].float())
+            output[qi, ki] = torch.stack(per_head).sum() * scales[ki].float()
+    return output
+
+
+def _pack_pages(keys, scales):
+    pages = keys.shape[0]
+    buf = torch.zeros((pages, LOGITS.GLM5_NEXT_INDEX_PAGE_NBYTES), dtype=torch.uint8)
+    key_bytes = keys.contiguous().view(torch.uint8).reshape(pages, -1)
+    scale_bytes = scales.contiguous().view(torch.uint8).reshape(pages, -1)
+    buf[:, : LOGITS.GLM5_NEXT_INDEX_SCALE_OFFSET] = key_bytes
+    buf[:, LOGITS.GLM5_NEXT_INDEX_SCALE_OFFSET :] = scale_bytes
+    return buf.view(pages, 64, 1, 132)
+
+
+class TestGlm5NextIndexerLogits(unittest.TestCase):
+    def test_ragged_score_formula_masking_and_chunks(self):
+        torch.manual_seed(17)
+        num_queries, num_keys, num_heads, dim = 5, 11, 3, 128
+        q = (torch.randn(num_queries, num_heads, dim) * 3).to(torch.float8_e4m3fn)
+        k = (torch.randn(num_keys, dim) * 2).to(torch.float8_e4m3fn)
+        scales = torch.linspace(0.01, 0.11, num_keys)
+        weights = torch.tensor(
+            [
+                [0.5, -0.25, 1.0],
+                [-1.0, 0.75, 0.25],
+                [0.0, 1.5, -0.5],
+                [2.0, -1.0, 0.125],
+                [-0.5, -0.25, -0.125],
+            ],
+            dtype=torch.float32,
+        )
+        ks = torch.tensor([0, 1, 4, 7, 11], dtype=torch.int32)
+        ke = torch.tensor([3, 9, 11, 10, 11], dtype=torch.int32)
+
+        actual = LOGITS.glm5_next_eager_fp8_mqa_logits(
+            q,
+            (k, scales),
+            weights,
+            ks,
+            ke,
+            query_chunk_size=2,
+            key_chunk_size=3,
+        )
+        expected = _independent_scores(q, k, scales, weights, ks, ke)
+        torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+        self.assertTrue(torch.isneginf(actual[4]).all())
+
+    def test_paged_layout_page_order_lengths_and_chunks(self):
+        torch.manual_seed(23)
+        pages, heads, dim = 4, 2, 128
+        keys = (torch.randn(pages, 64, dim) * 2).to(torch.float8_e4m3fn)
+        scales = torch.linspace(0.005, 0.05, pages * 64).reshape(pages, 64)
+        cache = _pack_pages(keys, scales)
+        q = (torch.randn(2, 1, heads, dim) * 3).to(torch.float8_e4m3fn)
+        weights = torch.tensor([[0.5, -1.25], [-0.75, 2.0]])
+        page_table = torch.tensor([[2, 0], [3, 1]], dtype=torch.int32)
+        lengths = torch.tensor([[67], [5]], dtype=torch.int32)
+
+        actual = LOGITS.glm5_next_eager_fp8_paged_mqa_logits(
+            q,
+            cache,
+            weights,
+            lengths,
+            page_table,
+            max_seq_len=128,
+            key_chunk_size=64,
+        )
+
+        expected = torch.full_like(actual, float("-inf"))
+        for row, length in enumerate((67, 5)):
+            ordered_keys = torch.cat(
+                [keys[int(page)] for page in page_table[row]], dim=0
+            )[:length]
+            ordered_scales = torch.cat(
+                [scales[int(page)] for page in page_table[row]], dim=0
+            )[:length]
+            local = _independent_scores(
+                q[row, 0].unsqueeze(0),
+                ordered_keys,
+                ordered_scales,
+                weights[row].unsqueeze(0),
+                torch.tensor([0]),
+                torch.tensor([length]),
+            )
+            expected[row, :length] = local[0]
+
+        torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+        self.assertTrue(torch.isneginf(actual[0, 67:]).all())
+        self.assertTrue(torch.isneginf(actual[1, 5:]).all())
+
+    def test_contract_validation_and_cpu_route_is_disabled(self):
+        self.assertFalse(
+            LOGITS.use_glm5_next_eager_logits_on_device(torch.device("cpu"))
+        )
+        q = torch.zeros((1, 1, 64), dtype=torch.float8_e4m3fn)
+        k = torch.zeros((1, 64), dtype=torch.float8_e4m3fn)
+        with self.assertRaisesRegex(ValueError, "head_dim=128"):
+            LOGITS.glm5_next_eager_fp8_mqa_logits(
+                q,
+                (k, torch.ones(1)),
+                torch.ones((1, 1)),
+                torch.zeros(1, dtype=torch.int32),
+                torch.ones(1, dtype=torch.int32),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/test_glm5_next_indexer_logits.py
+++ b/test/registered/unit/test_glm5_next_indexer_logits.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import importlib.util
 import sys
 import unittest
@@ -88,6 +89,65 @@ class TestGlm5NextIndexerLogits(unittest.TestCase):
         torch.testing.assert_close(actual, expected, atol=0, rtol=0)
         self.assertTrue(torch.isneginf(actual[4]).all())
 
+    def test_ragged_row_iterator_matches_one_shot_with_partial_chunk(self):
+        torch.manual_seed(29)
+        num_queries, num_keys, num_heads, dim = 7, 17, 3, 128
+        q = torch.randn(num_queries, num_heads, dim).to(torch.float8_e4m3fn)
+        k = torch.randn(num_keys, dim).to(torch.float8_e4m3fn)
+        scales = torch.linspace(0.01, 0.17, num_keys)
+        weights = torch.randn(num_queries, num_heads)
+        ks = torch.tensor([0, 0, 1, 4, 8, 13, 17], dtype=torch.int32)
+        ke = torch.tensor([0, 5, 17, 9, 16, 17, 17], dtype=torch.int32)
+
+        expected = LOGITS.glm5_next_eager_fp8_mqa_logits(
+            q,
+            (k, scales),
+            weights,
+            ks,
+            ke,
+            query_chunk_size=num_queries,
+            key_chunk_size=4,
+        )
+        chunks = list(
+            LOGITS.iter_glm5_next_eager_fp8_mqa_logits(
+                q,
+                (k, scales),
+                weights,
+                ks,
+                ke,
+                query_chunk_size=3,
+                key_chunk_size=4,
+            )
+        )
+
+        self.assertEqual(
+            [(start, end) for start, end, _ in chunks], [(0, 3), (3, 6), (6, 7)]
+        )
+        actual = torch.cat([chunk for _, _, chunk in chunks], dim=0)
+        self.assertTrue(torch.equal(torch.isneginf(actual), torch.isneginf(expected)))
+        torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
+    def test_500k_query_row_plan_is_statically_bounded(self):
+        pooled_keys = ((500_000 // 4 + 63) // 64) * 64
+        ranges = list(
+            LOGITS.glm5_next_prefill_query_row_ranges(
+                4096,
+                query_chunk_size=LOGITS.GLM5_NEXT_PREFILL_QUERY_ROW_CHUNK,
+            )
+        )
+
+        self.assertEqual(len(ranges), 128)
+        self.assertEqual(ranges[0], (0, 32))
+        self.assertEqual(ranges[-1], (4064, 4096))
+        self.assertEqual(
+            [start for start, _ in ranges],
+            [0, *[end for _, end in ranges[:-1]]],
+        )
+        self.assertTrue(all(end - start <= 32 for start, end in ranges))
+        self.assertLessEqual(
+            max((end - start) * pooled_keys for start, end in ranges), 4_001_792
+        )
+
     def test_paged_layout_page_order_lengths_and_chunks(self):
         torch.manual_seed(23)
         pages, heads, dim = 4, 2, 128
@@ -145,6 +205,22 @@ class TestGlm5NextIndexerLogits(unittest.TestCase):
                 torch.zeros(1, dtype=torch.int32),
                 torch.ones(1, dtype=torch.int32),
             )
+
+    def test_paged_decode_source_has_no_host_sync_or_dynamic_python_loop(self):
+        tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+        paged = next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.FunctionDef)
+            and node.name == "glm5_next_eager_fp8_paged_mqa_logits"
+        )
+        source = ast.unparse(paged)
+
+        for host_sync in (".item()", ".cpu()", ".tolist()"):
+            self.assertNotIn(host_sync, source)
+        self.assertFalse(
+            any(isinstance(node, (ast.For, ast.While)) for node in ast.walk(paged))
+        )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/test_glm5_next_kda.py
+++ b/test/registered/unit/test_glm5_next_kda.py
@@ -1,4 +1,4 @@
-"""CPU-only contracts for the isolated GLM-5-Next KDA implementation."""
+"""Component contracts for the isolated GLM-5-Next KDA implementation."""
 
 from __future__ import annotations
 
@@ -43,9 +43,28 @@ def _load_ops():
 
 def _load_kernel_adapter(ops):
     class RecordingTritonKDAKernel:
-        def extend(self, *args, **kwargs):
-            self.extend_call = (args, kwargs)
-            return "chunk-kda-output"
+        pass
+
+    def recording_l2norm_fwd(x, eps=1e-6, output_dtype=None):
+        normalized = x.float()
+        normalized = normalized / torch.sqrt(
+            (normalized * normalized).sum(dim=-1, keepdim=True) + eps
+        )
+        if output_dtype is not None:
+            normalized = normalized.to(output_dtype)
+        calls = getattr(RecordingTritonKDAKernel, "l2norm_calls", [])
+        calls.append((x, output_dtype, normalized))
+        RecordingTritonKDAKernel.l2norm_calls = calls
+        return normalized
+
+    def recording_chunk_kda(**kwargs):
+        ordered_names = ("q", "k", "v", "g", "beta")
+        args = tuple(kwargs[name] for name in ordered_names)
+        remaining_kwargs = {
+            name: value for name, value in kwargs.items() if name not in ordered_names
+        }
+        RecordingTritonKDAKernel.extend_call = (args, remaining_kwargs)
+        return kwargs["v"]
 
     packages = {}
     for name in (
@@ -53,6 +72,7 @@ def _load_kernel_adapter(ops):
         "sglang.srt",
         "sglang.srt.layers",
         "sglang.srt.layers.attention",
+        "sglang.srt.layers.attention.fla",
         "sglang.srt.layers.attention.linear",
         "sglang.srt.layers.attention.linear.kernels",
     ):
@@ -62,10 +82,18 @@ def _load_kernel_adapter(ops):
 
     ops_name = "sglang.srt.layers.attention.linear.kernels.glm5_next_kda_ops"
     base_name = "sglang.srt.layers.attention.linear.kernels.kda_triton"
+    fla_kda_name = "sglang.srt.layers.attention.fla.kda"
+    l2norm_name = "sglang.srt.layers.attention.fla.l2norm"
     base_module = types.ModuleType(base_name)
     base_module.TritonKDAKernel = RecordingTritonKDAKernel
+    fla_kda_module = types.ModuleType(fla_kda_name)
+    fla_kda_module.chunk_kda = recording_chunk_kda
+    l2norm_module = types.ModuleType(l2norm_name)
+    l2norm_module.l2norm_fwd = recording_l2norm_fwd
     packages[ops_name] = ops
     packages[base_name] = base_module
+    packages[fla_kda_name] = fla_kda_module
+    packages[l2norm_name] = l2norm_module
 
     spec = importlib.util.spec_from_file_location(
         "_glm5_next_kda_adapter_test", KERNEL_PATH
@@ -117,7 +145,7 @@ def _small_decode_reference(
                     gate_scale[head_id]
                     * (raw_gate[0, token_id, head_id] + bias[head_id])
                 )
-                beta = torch.sigmoid(raw_beta[0, token_id, head_id].float())
+                beta = torch.sigmoid(raw_beta[0, token_id, head_id]).float()
                 state[head_id] *= gate.exp().unsqueeze(-1)
                 delta = v[0, token_id, head_id].float() - (k_row @ state[head_id])
                 delta *= beta
@@ -157,8 +185,128 @@ class TestGlm5NextKDAReference(unittest.TestCase):
                     )
 
         self.assertTrue(torch.allclose(gate, expected_gate, atol=1e-6, rtol=0))
-        expected_beta = 1.0 / (1.0 + torch.exp(-raw_beta.float()))
-        self.assertTrue(torch.equal(raw_beta.float().sigmoid(), expected_beta))
+        expected_beta = 1.0 / (1.0 + torch.exp(-raw_beta))
+        self.assertTrue(torch.equal(raw_beta.sigmoid(), expected_beta))
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required")
+    def test_safe_gate_fixed_cuda_launch_matches_reference_and_repeats(self):
+        generator = torch.Generator().manual_seed(20260812)
+        heads, head_dim = 4, 128
+        A_log_cpu = torch.randn(heads, generator=generator) * 0.1
+        dt_bias_cpu = torch.randn(heads * head_dim, generator=generator) * 0.2
+
+        for tokens in (1, 31, 32, 33, 4096):
+            with self.subTest(tokens=tokens):
+                raw_cpu = torch.randn(
+                    1,
+                    tokens,
+                    heads * head_dim,
+                    generator=generator,
+                    dtype=torch.bfloat16,
+                )
+                expected = self.ops._torch_safe_gate(
+                    raw_cpu,
+                    A_log_cpu,
+                    head_dim,
+                    dt_bias_cpu,
+                    -5.0,
+                )
+                raw = raw_cpu.cuda()
+                A_log = A_log_cpu.cuda()
+                dt_bias = dt_bias_cpu.cuda()
+                first = self.ops.glm5_next_safe_gate(
+                    raw,
+                    A_log,
+                    head_dim,
+                    dt_bias=dt_bias,
+                    lower_bound=-5.0,
+                )
+                second = self.ops.glm5_next_safe_gate(
+                    raw,
+                    A_log,
+                    head_dim,
+                    dt_bias=dt_bias,
+                    lower_bound=-5.0,
+                )
+                torch.cuda.synchronize()
+                torch.testing.assert_close(first.cpu(), expected, atol=2e-5, rtol=2e-5)
+                torch.testing.assert_close(second, first, atol=0, rtol=0)
+
+    def test_beta_rounds_in_projection_dtype_before_fp32_kda(self):
+        raw_beta = torch.tensor(
+            [[[-4.25, -2.0], [0.10009765625, 2.0]]],
+            dtype=torch.bfloat16,
+        )
+        released_glm_beta = raw_beta.sigmoid().float()
+        widened_first_beta = raw_beta.float().sigmoid()
+        self.assertFalse(torch.equal(released_glm_beta, widened_first_beta))
+
+        kernel_cls = _load_kernel_adapter(self.ops)
+        kernel = kernel_cls()
+        q = torch.ones(1, 2, 2, 2)
+        kernel.extend(
+            q,
+            q,
+            q,
+            torch.zeros(1, 2, 4, dtype=torch.bfloat16),
+            raw_beta,
+            A_log=torch.zeros(1, 1, 2, 1),
+            dt_bias=torch.zeros(4),
+            lower_bound=-5.0,
+            ssm_states=torch.zeros(2, 2, 2, 2),
+            cache_indices=torch.tensor([0, 1], dtype=torch.int32),
+            query_start_loc=torch.tensor([0, 1, 2], dtype=torch.int32),
+        )
+        args, _kwargs = kernel.extend_call
+        self.assertEqual(args[4].dtype, torch.float32)
+        self.assertTrue(torch.equal(args[4], released_glm_beta))
+
+        # Decode remains fused, but must contain the same source-dtype round.
+        ops_source = OPS_PATH.read_text(encoding="utf-8")
+        self.assertIn(
+            "tl.sigmoid(beta).to(raw_beta.dtype.element_ty).to(tl.float32)",
+            ops_source,
+        )
+
+    def test_prefill_chunk_core_uses_uniform_fp32_operands(self):
+        kernel_cls = _load_kernel_adapter(self.ops)
+        kernel = kernel_cls()
+        q = torch.tensor(
+            [[[[1.0, 2.0]], [[-3.0, 4.0]]]], dtype=torch.bfloat16
+        )
+        k = torch.tensor(
+            [[[[2.0, -1.0]], [[4.0, 3.0]]]], dtype=torch.bfloat16
+        )
+        v = torch.tensor(
+            [[[[0.5, -0.25]], [[1.5, 2.0]]]], dtype=torch.bfloat16
+        )
+        result = kernel.extend(
+            q,
+            k,
+            v,
+            torch.tensor([[[0.25, -0.5], [1.0, -1.5]]], dtype=torch.bfloat16),
+            torch.tensor([[[0.125], [-0.75]]], dtype=torch.bfloat16),
+            A_log=torch.zeros(1, 1, 1, 1),
+            dt_bias=torch.zeros(2),
+            lower_bound=-5.0,
+            ssm_states=torch.zeros(2, 1, 2, 2),
+            cache_indices=torch.tensor([1], dtype=torch.int32),
+            query_start_loc=torch.tensor([0, 2], dtype=torch.int32),
+        )
+
+        args, kwargs = kernel.extend_call
+        self.assertEqual({tensor.dtype for tensor in args}, {torch.float32})
+        self.assertFalse(kwargs["use_qk_l2norm_in_kernel"])
+        self.assertEqual(result.dtype, v.dtype)
+        expected_q = q.float() / torch.sqrt(
+            (q.float() * q.float()).sum(dim=-1, keepdim=True) + 1e-6
+        )
+        expected_k = k.float() / torch.sqrt(
+            (k.float() * k.float()).sum(dim=-1, keepdim=True) + 1e-6
+        )
+        self.assertTrue(torch.equal(args[0], expected_q))
+        self.assertTrue(torch.equal(args[1], expected_k))
+        self.assertTrue(torch.equal(args[2], v.float()))
 
     def test_prefill_and_decode_small_reference(self):
         torch.manual_seed(7)
@@ -167,7 +315,7 @@ class TestGlm5NextKDAReference(unittest.TestCase):
         k = torch.randn_like(q)
         v = torch.randn(1, tokens, heads, value_dim)
         raw_gate = torch.randn(1, tokens, heads, head_dim)
-        raw_beta = torch.randn(1, tokens, heads)
+        raw_beta = torch.randn(1, tokens, heads).to(torch.bfloat16)
         A_log = torch.tensor([0.0, math.log(1.5)]).view(1, 1, heads, 1)
         dt_bias = torch.linspace(-0.2, 0.3, heads * head_dim)
         query_start_loc = torch.tensor([0, 2, 3], dtype=torch.int32)
@@ -208,12 +356,160 @@ class TestGlm5NextKDAReference(unittest.TestCase):
             torch.allclose(actual_states, expected_states, atol=1e-6, rtol=1e-6)
         )
 
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required")
+    def test_bf16_beta_decode_graph_a_poison_a_resets_state_and_keeps_pointers(self):
+        generator = torch.Generator().manual_seed(20260812)
+        heads, head_dim, value_dim = 2, 8, 8
+
+        def random_bf16(shape, scale=1.0):
+            return (torch.randn(*shape, generator=generator) * scale).to(torch.bfloat16)
+
+        for batch_size in (1, 2, 4):
+            with self.subTest(batch_size=batch_size):
+                shapes = {
+                    "q": (1, batch_size, heads, head_dim),
+                    "k": (1, batch_size, heads, head_dim),
+                    "v": (1, batch_size, heads, value_dim),
+                    "raw_gate": (1, batch_size, heads, head_dim),
+                    "raw_beta": (1, batch_size, heads),
+                }
+                input_a_cpu = {
+                    name: random_bf16(shape, scale=0.25)
+                    for name, shape in shapes.items()
+                }
+                poison_cpu = {
+                    name: random_bf16(shape, scale=1.5)
+                    for name, shape in shapes.items()
+                }
+                # Include logits whose sigmoid differs depending on whether the
+                # activation is rounded in BF16 before widening to FP32.
+                input_a_cpu["raw_beta"].reshape(-1)[0] = -4.25
+                poison_cpu["raw_beta"].reshape(-1)[0] = 4.25
+                self.assertEqual(input_a_cpu["raw_beta"].dtype, torch.bfloat16)
+
+                A_log_cpu = torch.tensor([0.0, math.log(1.5)]).view(1, 1, heads, 1)
+                dt_bias_cpu = torch.linspace(-0.2, 0.3, heads * head_dim)
+                state_indices_cpu = torch.arange(1, batch_size + 1, dtype=torch.int32)
+                query_start_loc_cpu = torch.arange(batch_size + 1, dtype=torch.int32)
+                state_seed_cpu = (
+                    torch.randn(
+                        batch_size + 1,
+                        heads,
+                        head_dim,
+                        value_dim,
+                        generator=generator,
+                    )
+                    * 0.1
+                )
+                poison_state_cpu = (
+                    torch.randn(
+                        batch_size + 1,
+                        heads,
+                        head_dim,
+                        value_dim,
+                        generator=generator,
+                    )
+                    * 0.75
+                )
+
+                expected_state_cpu = state_seed_cpu.clone()
+                expected_output_cpu = _small_decode_reference(
+                    **input_a_cpu,
+                    A_log=A_log_cpu,
+                    dt_bias=dt_bias_cpu,
+                    lower_bound=-5.0,
+                    states=expected_state_cpu,
+                    state_indices=state_indices_cpu,
+                    query_start_loc=query_start_loc_cpu,
+                )
+
+                input_a = {name: tensor.cuda() for name, tensor in input_a_cpu.items()}
+                poison = {name: tensor.cuda() for name, tensor in poison_cpu.items()}
+                static_inputs = {
+                    name: tensor.clone() for name, tensor in input_a.items()
+                }
+                A_log = A_log_cpu.cuda()
+                dt_bias = dt_bias_cpu.cuda()
+                state_indices = state_indices_cpu.cuda()
+                query_start_loc = query_start_loc_cpu.cuda()
+                state_seed = state_seed_cpu.cuda()
+                poison_state = poison_state_cpu.cuda()
+                static_state = state_seed.clone()
+
+                def decode(state_source):
+                    return self.ops.glm5_next_safe_decode(
+                        A_log=A_log,
+                        dt_bias=dt_bias,
+                        lower_bound=-5.0,
+                        state_source=state_source,
+                        state_indices=state_indices,
+                        query_start_loc=query_start_loc,
+                        **static_inputs,
+                    )
+
+                # Establish an exact eager CUDA baseline and compile Triton
+                # before graph capture without consuming the static state.
+                eager_state = state_seed.clone()
+                eager_output = decode(eager_state)
+                torch.cuda.synchronize()
+                torch.testing.assert_close(
+                    eager_output.cpu(), expected_output_cpu, rtol=2e-2, atol=2e-2
+                )
+                torch.testing.assert_close(
+                    eager_state.cpu(), expected_state_cpu, rtol=2e-2, atol=2e-2
+                )
+
+                static_state.copy_(state_seed)
+                graph = torch.cuda.CUDAGraph()
+                with torch.cuda.graph(graph):
+                    static_output = decode(static_state)
+
+                stable_tensors = {
+                    **static_inputs,
+                    "A_log": A_log,
+                    "dt_bias": dt_bias,
+                    "state": static_state,
+                    "state_indices": state_indices,
+                    "query_start_loc": query_start_loc,
+                    "output": static_output,
+                }
+                stable_pointers = {
+                    name: tensor.data_ptr() for name, tensor in stable_tensors.items()
+                }
+
+                def replay(inputs, initial_state):
+                    for name, tensor in inputs.items():
+                        static_inputs[name].copy_(tensor)
+                    static_state.copy_(initial_state)
+                    graph.replay()
+                    torch.cuda.synchronize()
+                    for name, tensor in stable_tensors.items():
+                        self.assertEqual(tensor.data_ptr(), stable_pointers[name])
+                    return static_output.clone(), static_state.clone()
+
+                first_output, first_state = replay(input_a, state_seed)
+                poison_output, poison_result_state = replay(poison, poison_state)
+                second_output, second_state = replay(input_a, state_seed)
+
+                torch.testing.assert_close(first_output, eager_output, rtol=0, atol=0)
+                torch.testing.assert_close(first_state, eager_state, rtol=0, atol=0)
+                self.assertFalse(torch.equal(poison_output, first_output))
+                self.assertFalse(torch.equal(poison_result_state, first_state))
+                torch.testing.assert_close(second_output, first_output, rtol=0, atol=0)
+                torch.testing.assert_close(second_state, first_state, rtol=0, atol=0)
+                # Slot zero is the padding sentinel and must remain untouched.
+                torch.testing.assert_close(
+                    first_state[0], state_seed[0], rtol=0, atol=0
+                )
+
     def test_prefill_adapter_activates_raw_inputs_and_maps_padding_to_slot_zero(self):
         kernel_cls = _load_kernel_adapter(self.ops)
         kernel = kernel_cls()
-        q = torch.ones(1, 2, 2, 2)
+        q = torch.ones(1, 2, 2, 2, dtype=torch.bfloat16)
         raw_gate = torch.tensor([[[0.0, 1.0, -1.0, 2.0], [0.5, 0.0, 1.0, -0.5]]])
-        raw_beta = torch.tensor([[[0.0, 2.0], [-2.0, 1.0]]])
+        raw_beta = torch.tensor(
+            [[[0.10009765625, 2.0], [-2.0, 4.25]]], dtype=torch.bfloat16
+        )
         A_log = torch.zeros(1, 1, 2, 1)
         dt_bias = torch.zeros(4)
         cache_indices = torch.tensor([-1, 3], dtype=torch.int64)
@@ -232,7 +528,7 @@ class TestGlm5NextKDAReference(unittest.TestCase):
             query_start_loc=torch.tensor([0, 1, 2], dtype=torch.int32),
         )
 
-        self.assertEqual(result, "chunk-kda-output")
+        self.assertEqual(result.dtype, torch.bfloat16)
         args, kwargs = kernel.extend_call
         expected_gate = self.ops.glm5_next_safe_gate(
             raw_gate,
@@ -242,10 +538,19 @@ class TestGlm5NextKDAReference(unittest.TestCase):
             lower_bound=-5.0,
         )
         self.assertTrue(torch.equal(args[3], expected_gate))
-        self.assertTrue(torch.equal(args[4], raw_beta.float().sigmoid()))
+        self.assertTrue(torch.equal(args[4], raw_beta.sigmoid().float()))
+        self.assertEqual({tensor.dtype for tensor in args}, {torch.float32})
+        expected_qk = q.float() / math.sqrt(2.0 + 1e-6)
+        self.assertTrue(torch.allclose(args[0], expected_qk, atol=1e-7, rtol=0))
+        self.assertTrue(torch.equal(args[0], args[1]))
+        self.assertEqual(len(kernel.l2norm_calls), 2)
+        self.assertTrue(
+            all(call[1] is torch.float32 for call in kernel.l2norm_calls)
+        )
+        self.assertFalse(kwargs["use_qk_l2norm_in_kernel"])
         self.assertTrue(
             torch.equal(
-                kwargs["cache_indices"],
+                kwargs["initial_state_indices"],
                 torch.tensor([0, 3], dtype=torch.int32),
             )
         )
@@ -317,8 +622,25 @@ class TestGlm5NextKDAIsolation(unittest.TestCase):
             self.assertIsNone(keyword_defaults[lower_bound_arg])
 
         source = KERNEL_PATH.read_text(encoding="utf-8")
-        self.assertIn("beta.float().sigmoid()", source)
+        self.assertIn("beta.sigmoid().float()", source)
+        self.assertNotIn("beta.float().sigmoid()", source)
         self.assertIn("glm5_next_safe_gate", source)
+
+    def test_safe_gate_uses_one_deterministic_launch_configuration(self):
+        source = OPS_PATH.read_text(encoding="utf-8")
+        self.assertNotIn("@triton.autotune", source)
+        self.assertIn("_SAFE_GATE_BLOCK_T = 32", source)
+        self.assertIn("_SAFE_GATE_NUM_WARPS = 8", source)
+        self.assertIn("_SAFE_GATE_NUM_STAGES = 3", source)
+        self.assertIn(
+            "@triton.jit\ndef _glm5_next_safe_gate_kernel(",
+            source,
+        )
+        self.assertNotIn(
+            '@triton.jit(do_not_specialize=["T"])\n'
+            "def _glm5_next_safe_gate_kernel(",
+            source,
+        )
 
     def test_kimi_kernel_launch_autotune_tf32_and_padding_are_untouched(self):
         backend_source = KIMI_BACKEND_PATH.read_text(encoding="utf-8")
@@ -330,9 +652,11 @@ class TestGlm5NextKDAIsolation(unittest.TestCase):
         self.assertNotIn("trim_glm5_next_kda_padding", backend_source)
         self.assertNotIn("Glm5Next", kernel_source)
         self.assertNotIn("lower_bound", kernel_source)
+        self.assertNotIn("qk_l2norm_output_dtype", kernel_source)
         self.assertIn("BT_LIST_AUTOTUNE = [32, 64, 128]", fla_source)
         self.assertIn('key=["H", "D"]', fla_source)
         self.assertIn("allow_tf32=False", fla_source)
+        self.assertNotIn("qk_l2norm_output_dtype", fla_source)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/test_glm5_next_kda.py
+++ b/test/registered/unit/test_glm5_next_kda.py
@@ -626,12 +626,14 @@ class TestGlm5NextKDAIsolation(unittest.TestCase):
         self.assertNotIn("beta.float().sigmoid()", source)
         self.assertIn("glm5_next_safe_gate", source)
 
-    def test_safe_gate_uses_one_deterministic_launch_configuration(self):
+    def test_safe_gate_uses_architecture_static_launch_configurations(self):
         source = OPS_PATH.read_text(encoding="utf-8")
+        ops = _load_ops()
         self.assertNotIn("@triton.autotune", source)
-        self.assertIn("_SAFE_GATE_BLOCK_T = 32", source)
-        self.assertIn("_SAFE_GATE_NUM_WARPS = 8", source)
-        self.assertIn("_SAFE_GATE_NUM_STAGES = 3", source)
+        self.assertIn("def glm5_next_kda_launch_config(", source)
+        self.assertIn("if capability == (8, 6):", source)
+        self.assertIn("if capability == (8, 9):", source)
+        self.assertIn("return (32, 8, 3), (1, 3)", source)
         self.assertIn(
             "@triton.jit\ndef _glm5_next_safe_gate_kernel(",
             source,
@@ -640,6 +642,14 @@ class TestGlm5NextKDAIsolation(unittest.TestCase):
             '@triton.jit(do_not_specialize=["T"])\n'
             "def _glm5_next_safe_gate_kernel(",
             source,
+        )
+        self.assertEqual(
+            ops.glm5_next_kda_launch_config((8, 6)),
+            ((16, 4, 2), (4, 1)),
+        )
+        self.assertEqual(
+            ops.glm5_next_kda_launch_config((8, 9)),
+            ((32, 4, 3), (4, 1)),
         )
 
     def test_kimi_kernel_launch_autotune_tf32_and_padding_are_untouched(self):

--- a/test/registered/unit/test_glm5_next_kda.py
+++ b/test/registered/unit/test_glm5_next_kda.py
@@ -1,0 +1,339 @@
+"""CPU-only contracts for the isolated GLM-5-Next KDA implementation."""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import math
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import torch
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+OPS_PATH = REPO_ROOT / (
+    "python/sglang/srt/layers/attention/linear/kernels/glm5_next_kda_ops.py"
+)
+KERNEL_PATH = REPO_ROOT / (
+    "python/sglang/srt/layers/attention/linear/kernels/glm5_next_kda.py"
+)
+BACKEND_PATH = REPO_ROOT / (
+    "python/sglang/srt/layers/attention/linear/glm5_next_kda_backend.py"
+)
+KIMI_BACKEND_PATH = REPO_ROOT / (
+    "python/sglang/srt/layers/attention/linear/kda_backend.py"
+)
+KIMI_KERNEL_PATH = REPO_ROOT / (
+    "python/sglang/srt/layers/attention/linear/kernels/kda_triton.py"
+)
+KIMI_FLA_PATH = REPO_ROOT / "python/sglang/srt/layers/attention/fla/kda.py"
+
+
+def _load_ops():
+    spec = importlib.util.spec_from_file_location("_glm5_next_kda_ops_test", OPS_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_kernel_adapter(ops):
+    class RecordingTritonKDAKernel:
+        def extend(self, *args, **kwargs):
+            self.extend_call = (args, kwargs)
+            return "chunk-kda-output"
+
+    packages = {}
+    for name in (
+        "sglang",
+        "sglang.srt",
+        "sglang.srt.layers",
+        "sglang.srt.layers.attention",
+        "sglang.srt.layers.attention.linear",
+        "sglang.srt.layers.attention.linear.kernels",
+    ):
+        package = types.ModuleType(name)
+        package.__path__ = []
+        packages[name] = package
+
+    ops_name = "sglang.srt.layers.attention.linear.kernels.glm5_next_kda_ops"
+    base_name = "sglang.srt.layers.attention.linear.kernels.kda_triton"
+    base_module = types.ModuleType(base_name)
+    base_module.TritonKDAKernel = RecordingTritonKDAKernel
+    packages[ops_name] = ops
+    packages[base_name] = base_module
+
+    spec = importlib.util.spec_from_file_location(
+        "_glm5_next_kda_adapter_test", KERNEL_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    with patch.dict(sys.modules, packages):
+        spec.loader.exec_module(module)
+    return module.Glm5NextTritonKDAKernel
+
+
+def _small_decode_reference(
+    *,
+    q,
+    k,
+    v,
+    raw_gate,
+    raw_beta,
+    A_log,
+    dt_bias,
+    lower_bound,
+    states,
+    state_indices,
+    query_start_loc,
+):
+    """Independent matrix-form reference for the bounded delta recurrence."""
+
+    output = torch.empty_like(v)
+    head_dim = q.shape[-1]
+    scale = head_dim**-0.5
+    num_heads = q.shape[2]
+    bias = dt_bias.float().reshape(num_heads, head_dim)
+    gate_scale = A_log.float().reshape(num_heads).exp()
+
+    for sequence_id in range(query_start_loc.numel() - 1):
+        bos = int(query_start_loc[sequence_id])
+        eos = int(query_start_loc[sequence_id + 1])
+        state_id = int(state_indices[sequence_id])
+        state = states[state_id].float().clone()
+        for token_id in range(bos, eos):
+            for head_id in range(num_heads):
+                q_row = q[0, token_id, head_id].float()
+                k_row = k[0, token_id, head_id].float()
+                q_row /= torch.sqrt(q_row @ q_row + 1e-6)
+                k_row /= torch.sqrt(k_row @ k_row + 1e-6)
+                q_row *= scale
+
+                gate = lower_bound * torch.sigmoid(
+                    gate_scale[head_id]
+                    * (raw_gate[0, token_id, head_id] + bias[head_id])
+                )
+                beta = torch.sigmoid(raw_beta[0, token_id, head_id].float())
+                state[head_id] *= gate.exp().unsqueeze(-1)
+                delta = v[0, token_id, head_id].float() - (k_row @ state[head_id])
+                delta *= beta
+                state[head_id] += torch.outer(k_row, delta)
+                output[0, token_id, head_id] = q_row @ state[head_id]
+        states[state_id].copy_(state.to(states.dtype))
+    return output
+
+
+class TestGlm5NextKDAReference(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.ops = _load_ops()
+
+    def test_raw_gate_and_raw_beta_match_scalar_formula(self):
+        raw_gate = torch.tensor([[[0.0, 1.0, -1.0, 2.0], [0.5, -0.5, 1.5, -1.5]]])
+        raw_beta = torch.tensor([[[0.0, 2.0], [-2.0, 1.0]]])
+        A_log = torch.tensor([0.0, math.log(2.0)]).view(1, 1, 2, 1)
+        dt_bias = torch.tensor([0.25, -0.25, 0.5, -0.5])
+
+        gate = self.ops.glm5_next_safe_gate(
+            raw_gate,
+            A_log,
+            2,
+            dt_bias=dt_bias,
+            lower_bound=-5.0,
+        )
+        expected_gate = torch.empty(1, 2, 2, 2)
+        for token_id in range(2):
+            for head_id in range(2):
+                for dim_id in range(2):
+                    raw = float(raw_gate[0, token_id, head_id * 2 + dim_id])
+                    biased = raw + float(dt_bias[head_id * 2 + dim_id])
+                    scale = math.exp(float(A_log.reshape(-1)[head_id]))
+                    expected_gate[0, token_id, head_id, dim_id] = -5.0 / (
+                        1.0 + math.exp(-(scale * biased))
+                    )
+
+        self.assertTrue(torch.allclose(gate, expected_gate, atol=1e-6, rtol=0))
+        expected_beta = 1.0 / (1.0 + torch.exp(-raw_beta.float()))
+        self.assertTrue(torch.equal(raw_beta.float().sigmoid(), expected_beta))
+
+    def test_prefill_and_decode_small_reference(self):
+        torch.manual_seed(7)
+        tokens, heads, head_dim, value_dim = 3, 2, 2, 3
+        q = torch.randn(1, tokens, heads, head_dim)
+        k = torch.randn_like(q)
+        v = torch.randn(1, tokens, heads, value_dim)
+        raw_gate = torch.randn(1, tokens, heads, head_dim)
+        raw_beta = torch.randn(1, tokens, heads)
+        A_log = torch.tensor([0.0, math.log(1.5)]).view(1, 1, heads, 1)
+        dt_bias = torch.linspace(-0.2, 0.3, heads * head_dim)
+        query_start_loc = torch.tensor([0, 2, 3], dtype=torch.int32)
+        state_indices = torch.tensor([1, 3], dtype=torch.int32)
+        initial_states = torch.randn(5, heads, head_dim, value_dim) * 0.1
+        actual_states = initial_states.clone()
+        expected_states = initial_states.clone()
+
+        actual = self.ops.glm5_next_safe_decode(
+            A_log=A_log,
+            raw_gate=raw_gate,
+            dt_bias=dt_bias,
+            lower_bound=-5.0,
+            q=q,
+            k=k,
+            v=v,
+            raw_beta=raw_beta,
+            state_source=actual_states,
+            state_indices=state_indices,
+            query_start_loc=query_start_loc,
+        )
+        expected = _small_decode_reference(
+            q=q,
+            k=k,
+            v=v,
+            raw_gate=raw_gate,
+            raw_beta=raw_beta,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            lower_bound=-5.0,
+            states=expected_states,
+            state_indices=state_indices,
+            query_start_loc=query_start_loc,
+        )
+
+        self.assertTrue(torch.allclose(actual, expected, atol=1e-6, rtol=1e-6))
+        self.assertTrue(
+            torch.allclose(actual_states, expected_states, atol=1e-6, rtol=1e-6)
+        )
+
+    def test_prefill_adapter_activates_raw_inputs_and_maps_padding_to_slot_zero(self):
+        kernel_cls = _load_kernel_adapter(self.ops)
+        kernel = kernel_cls()
+        q = torch.ones(1, 2, 2, 2)
+        raw_gate = torch.tensor([[[0.0, 1.0, -1.0, 2.0], [0.5, 0.0, 1.0, -0.5]]])
+        raw_beta = torch.tensor([[[0.0, 2.0], [-2.0, 1.0]]])
+        A_log = torch.zeros(1, 1, 2, 1)
+        dt_bias = torch.zeros(4)
+        cache_indices = torch.tensor([-1, 3], dtype=torch.int64)
+
+        result = kernel.extend(
+            q,
+            q,
+            q,
+            raw_gate,
+            raw_beta,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            lower_bound=-5.0,
+            ssm_states=torch.zeros(4, 2, 2, 2),
+            cache_indices=cache_indices,
+            query_start_loc=torch.tensor([0, 1, 2], dtype=torch.int32),
+        )
+
+        self.assertEqual(result, "chunk-kda-output")
+        args, kwargs = kernel.extend_call
+        expected_gate = self.ops.glm5_next_safe_gate(
+            raw_gate,
+            A_log,
+            2,
+            dt_bias=dt_bias,
+            lower_bound=-5.0,
+        )
+        self.assertTrue(torch.equal(args[3], expected_gate))
+        self.assertTrue(torch.equal(args[4], raw_beta.float().sigmoid()))
+        self.assertTrue(
+            torch.equal(
+                kwargs["cache_indices"],
+                torch.tensor([0, 3], dtype=torch.int32),
+            )
+        )
+
+    def test_padding_trim_and_restore(self):
+        mixed_qkv = torch.arange(5 * 12, dtype=torch.float32).view(5, 12)
+        raw_gate = torch.arange(1 * 5 * 4, dtype=torch.float32).view(1, 5, 4)
+        raw_beta = torch.arange(1 * 5 * 2, dtype=torch.float32).view(1, 5, 2)
+        query_start_loc = torch.tensor([0, 2, 3], dtype=torch.int32)
+
+        qkv, gate, beta, physical = self.ops.trim_glm5_next_kda_padding(
+            mixed_qkv, raw_gate, raw_beta, query_start_loc
+        )
+        self.assertEqual(qkv.shape, (3, 12))
+        self.assertEqual(gate.shape, (1, 3, 4))
+        self.assertEqual(beta.shape, (1, 3, 2))
+        self.assertEqual(physical, 5)
+
+        logical_output = torch.ones(1, 3, 2, 4)
+        restored = self.ops.restore_glm5_next_kda_padding(logical_output, physical)
+        self.assertEqual(restored.shape, (1, 5, 2, 4))
+        self.assertTrue(torch.equal(restored[:, :3], logical_output))
+        self.assertEqual(torch.count_nonzero(restored[:, 3:]).item(), 0)
+
+    def test_large_decode_grid_splits_only_past_cuda_z_limit(self):
+        normal_grid, normal_split = self.ops.glm5_next_decode_grid(1, 4, 511, 128)
+        split_grid, split = self.ops.glm5_next_decode_grid(1, 4, 512, 128)
+        self.assertEqual(normal_grid, (1, 4, 65408))
+        self.assertFalse(normal_split)
+        self.assertEqual(split_grid, (4, 512, 128))
+        self.assertTrue(split)
+
+
+class TestGlm5NextKDAIsolation(unittest.TestCase):
+    def test_backend_contract_requires_raw_inputs_and_has_no_rope(self):
+        source = BACKEND_PATH.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        backend = next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.ClassDef) and node.name == "Glm5NextKDAAttnBackend"
+        )
+        module_doc = ast.get_docstring(tree)
+        self.assertIn("raw gate and raw beta logits", module_doc)
+        identifiers = {
+            node.id for node in ast.walk(backend) if isinstance(node, ast.Name)
+        } | {node.attr for node in ast.walk(backend) if isinstance(node, ast.Attribute)}
+        self.assertFalse(any("rope" in name.lower() for name in identifiers))
+        self.assertFalse(any("position" in name.lower() for name in identifiers))
+
+    def test_glm_kernel_requires_explicit_lower_bound(self):
+        tree = ast.parse(KERNEL_PATH.read_text(encoding="utf-8"))
+        kernel = next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.ClassDef) and node.name == "Glm5NextTritonKDAKernel"
+        )
+        methods = {
+            node.name: node for node in kernel.body if isinstance(node, ast.FunctionDef)
+        }
+        for method_name in ("decode", "extend"):
+            method = methods[method_name]
+            keyword_defaults = dict(
+                zip(method.args.kwonlyargs, method.args.kw_defaults)
+            )
+            lower_bound_arg = next(
+                arg for arg in method.args.kwonlyargs if arg.arg == "lower_bound"
+            )
+            self.assertIsNone(keyword_defaults[lower_bound_arg])
+
+        source = KERNEL_PATH.read_text(encoding="utf-8")
+        self.assertIn("beta.float().sigmoid()", source)
+        self.assertIn("glm5_next_safe_gate", source)
+
+    def test_kimi_kernel_launch_autotune_tf32_and_padding_are_untouched(self):
+        backend_source = KIMI_BACKEND_PATH.read_text(encoding="utf-8")
+        kernel_source = KIMI_KERNEL_PATH.read_text(encoding="utf-8")
+        fla_source = KIMI_FLA_PATH.read_text(encoding="utf-8")
+
+        self.assertNotIn("Glm5Next", backend_source)
+        self.assertNotIn("lower_bound", backend_source)
+        self.assertNotIn("trim_glm5_next_kda_padding", backend_source)
+        self.assertNotIn("Glm5Next", kernel_source)
+        self.assertNotIn("lower_bound", kernel_source)
+        self.assertIn("BT_LIST_AUTOTUNE = [32, 64, 128]", fla_source)
+        self.assertIn('key=["H", "D"]', fla_source)
+        self.assertIn("allow_tf32=False", fla_source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/test_glm5_next_kda_fp32_o_proj.py
+++ b/test/registered/unit/test_glm5_next_kda_fp32_o_proj.py
@@ -1,0 +1,256 @@
+"""CPU guards for GLM-5-Next's opt-in FP32 KDA output partial."""
+
+from __future__ import annotations
+
+import ast
+import copy
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+import torch
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MODEL_PATH = REPO_ROOT / "python/sglang/srt/models/glm5_next.py"
+
+
+def _compile_functions(*function_names, globals_):
+    tree = ast.parse(MODEL_PATH.read_text(encoding="utf-8"))
+    functions = {
+        node.name: copy.deepcopy(node)
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name in function_names
+    }
+    assert functions.keys() == set(function_names)
+    module = ast.fix_missing_locations(
+        ast.Module(
+            body=[
+                ast.ImportFrom(
+                    module="__future__",
+                    names=[ast.alias(name="annotations")],
+                    level=0,
+                ),
+                *(functions[name] for name in function_names),
+            ],
+            type_ignores=[],
+        )
+    )
+    namespace = {"__builtins__": __builtins__, **globals_}
+    exec(compile(module, str(MODEL_PATH), "exec"), namespace)
+    return tuple(namespace[name] for name in function_names)
+
+
+class _Unquantized:
+    pass
+
+
+class _FakeTensor:
+    def __init__(self, *, is_cuda=True, dtype=torch.bfloat16, device="cuda:0"):
+        self.is_cuda = is_cuda
+        self.dtype = dtype
+        self.device = torch.device(device)
+
+
+class _RowParallel:
+    def __init__(self):
+        self.quant_method = _Unquantized()
+        self.weight = _FakeTensor()
+        self.bias = None
+        self.reduce_results = False
+        self.input_is_parallel = True
+
+
+def _predicate():
+    (predicate,) = _compile_functions(
+        "_glm5_next_kda_can_use_fp32_o_proj",
+        globals_={
+            "nn": object(),
+            "torch": torch,
+            "RowParallelLinear": _RowParallel,
+            "UnquantizedLinearMethod": _Unquantized,
+        },
+    )
+    return predicate
+
+
+def test_fp32_partial_requires_every_glm_kda_contract_guard():
+    predicate = _predicate()
+    hidden_states = _FakeTensor()
+
+    assert predicate(_RowParallel(), hidden_states)
+
+    cases = (
+        lambda layer, hidden: setattr(layer, "quant_method", object()),
+        lambda layer, hidden: setattr(hidden, "is_cuda", False),
+        lambda layer, hidden: setattr(hidden, "dtype", torch.float32),
+        lambda layer, hidden: setattr(layer.weight, "is_cuda", False),
+        lambda layer, hidden: setattr(layer.weight, "device", torch.device("cuda:1")),
+        lambda layer, hidden: setattr(layer.weight, "dtype", torch.float32),
+        lambda layer, hidden: setattr(layer, "bias", object()),
+        lambda layer, hidden: setattr(layer, "reduce_results", True),
+        lambda layer, hidden: setattr(layer, "input_is_parallel", False),
+    )
+    for invalidate in cases:
+        layer = _RowParallel()
+        hidden = _FakeTensor()
+        invalidate(layer, hidden)
+        assert not predicate(layer, hidden)
+
+    assert not predicate(object(), hidden_states)
+
+
+def test_cpu_uses_original_row_parallel_forward():
+    calls = []
+
+    class CPUFallback(_RowParallel):
+        def __init__(self):
+            super().__init__()
+            self.weight = torch.eye(2, dtype=torch.bfloat16)
+
+        def __call__(self, hidden_states):
+            calls.append(hidden_states)
+            return hidden_states + 3, None
+
+    @contextmanager
+    def forbidden_symmetric_memory(*args, **kwargs):
+        del args, kwargs
+        raise AssertionError("CPU fallback must not enter symmetric memory")
+        yield
+
+    predicate, project = _compile_functions(
+        "_glm5_next_kda_can_use_fp32_o_proj",
+        "_glm5_next_kda_o_proj",
+        globals_={
+            "nn": object(),
+            "torch": torch,
+            "RowParallelLinear": _RowParallel,
+            "UnquantizedLinearMethod": _Unquantized,
+            "use_symmetric_memory": forbidden_symmetric_memory,
+            "get_tp_group": lambda: object(),
+            "is_allocation_symmetric": lambda: True,
+        },
+    )
+    del predicate
+    hidden_states = torch.ones(1, 2, dtype=torch.bfloat16)
+    output = project(CPUFallback(), hidden_states)
+
+    assert calls == [hidden_states]
+    torch.testing.assert_close(output, hidden_states + 3)
+
+
+def test_cuda_contract_mismatches_fail_closed_without_calling_fallback():
+    fallback_calls = []
+
+    class RecordingRow(_RowParallel):
+        def __call__(self, hidden_states):
+            fallback_calls.append(hidden_states)
+            return hidden_states, None
+
+    @contextmanager
+    def forbidden_symmetric_memory(*args, **kwargs):
+        del args, kwargs
+        raise AssertionError("invalid contract must fail before symmetric memory")
+        yield
+
+    predicate, project = _compile_functions(
+        "_glm5_next_kda_can_use_fp32_o_proj",
+        "_glm5_next_kda_o_proj",
+        globals_={
+            "nn": object(),
+            "torch": torch,
+            "RowParallelLinear": _RowParallel,
+            "UnquantizedLinearMethod": _Unquantized,
+            "use_symmetric_memory": forbidden_symmetric_memory,
+            "get_tp_group": lambda: object(),
+            "is_allocation_symmetric": lambda: True,
+        },
+    )
+    del predicate
+
+    cases = (
+        lambda layer, hidden: setattr(layer, "quant_method", object()),
+        lambda layer, hidden: setattr(hidden, "dtype", torch.float32),
+        lambda layer, hidden: setattr(layer.weight, "is_cuda", False),
+        lambda layer, hidden: setattr(layer.weight, "device", torch.device("cuda:1")),
+        lambda layer, hidden: setattr(layer.weight, "dtype", torch.float32),
+        lambda layer, hidden: setattr(layer, "bias", object()),
+        lambda layer, hidden: setattr(layer, "reduce_results", True),
+        lambda layer, hidden: setattr(layer, "input_is_parallel", False),
+    )
+    for invalidate in cases:
+        layer = RecordingRow()
+        hidden_states = _FakeTensor()
+        invalidate(layer, hidden_states)
+        with pytest.raises(RuntimeError, match="CUDA KDA o_proj requires"):
+            project(layer, hidden_states)
+
+    with pytest.raises(RuntimeError, match="CUDA KDA o_proj requires"):
+        project(object(), _FakeTensor())
+    assert fallback_calls == []
+
+
+def test_production_path_preserves_allocator_and_dtype_contracts():
+    source = MODEL_PATH.read_text(encoding="utf-8")
+    function_source = ast.get_source_segment(
+        source,
+        next(
+            node
+            for node in ast.parse(source).body
+            if isinstance(node, ast.FunctionDef)
+            and node.name == "_glm5_next_kda_o_proj"
+        ),
+    )
+    assert function_source is not None
+    assert "use_symmetric_memory(" in function_source
+    assert "get_tp_group(), disabled=not is_allocation_symmetric()" in function_source
+    assert "torch.mm(" in function_source
+    assert "out_dtype=torch.float32" in function_source
+
+    # Only KDA opts into the post-all-reduce BF16 cast; DSA explicitly keeps
+    # the communicator's default no-cast policy.
+    assert "torch.bfloat16 if config.is_kda_layer(layer_idx) else None" in source
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_cuda_fp32_partial_executes_without_bf16_output_round():
+    entries = []
+
+    class CUDARow(_RowParallel):
+        def __init__(self):
+            super().__init__()
+            self.weight = torch.randn(3, 4, device="cuda", dtype=torch.bfloat16)
+
+        def __call__(self, hidden_states):
+            raise AssertionError("eligible CUDA path must bypass ordinary forward")
+
+    @contextmanager
+    def symmetric_memory(group, *, disabled):
+        entries.append((group, disabled))
+        yield
+
+    group = object()
+    predicate, project = _compile_functions(
+        "_glm5_next_kda_can_use_fp32_o_proj",
+        "_glm5_next_kda_o_proj",
+        globals_={
+            "nn": object(),
+            "torch": torch,
+            "RowParallelLinear": _RowParallel,
+            "UnquantizedLinearMethod": _Unquantized,
+            "use_symmetric_memory": symmetric_memory,
+            "get_tp_group": lambda: group,
+            "is_allocation_symmetric": lambda: False,
+        },
+    )
+    del predicate
+    layer = CUDARow()
+    hidden_states = torch.randn(2, 4, device="cuda", dtype=torch.bfloat16)
+    output = project(layer, hidden_states)
+
+    assert entries == [(group, True)]
+    assert output.dtype is torch.float32
+    torch.testing.assert_close(
+        output,
+        torch.mm(hidden_states, layer.weight.t(), out_dtype=torch.float32),
+    )

--- a/test/registered/unit/test_glm5_next_kpool_pool_lifecycle.py
+++ b/test/registered/unit/test_glm5_next_kpool_pool_lifecycle.py
@@ -220,8 +220,39 @@ class TestGlm5NextKPoolMemoryPool(unittest.TestCase):
         self.assertEqual(tail_score.shape, tail_k.shape)
         self.assertEqual(tail_k.dtype, torch.bfloat16)
         self.assertEqual(tail_score.dtype, torch.bfloat16)
-        expected_bytes = 1024 + 2 * 2 * 6 * 4 * 128 * 2
+        latent_scale_bytes = 2 * (128 + 64) * 4 * 4
+        expected_bytes = 1024 + latent_scale_bytes + 2 * 2 * 6 * 4 * 128 * 2
         self.assertEqual(sparse.get_kv_size_bytes(), expected_bytes)
+
+    def test_scaled_fp8_latent_sidecar_is_compact_and_writable(self):
+        pool = _make_hybrid_pool()
+        for layer_id in (3, 7, 11):
+            scale = pool.get_latent_scale_buffer(layer_id)
+            self.assertEqual(scale.shape, (128 + 64, 4))
+            self.assertEqual(scale.dtype, torch.float32)
+
+        loc = torch.tensor([2, 9], dtype=torch.long)
+        values = torch.tensor(
+            [[[0.1, 0.2, 0.3, 0.4]], [[1.1, 1.2, 1.3, 1.4]]],
+            dtype=torch.float32,
+        )
+        pool.set_latent_scale_buffer(7, loc, values)
+        actual = pool.get_latent_scale_buffer(7)[loc]
+        self.assertTrue(torch.equal(actual, values.squeeze(1)))
+        self.assertEqual(torch.count_nonzero(pool.get_latent_scale_buffer(3)), 0)
+
+        with self.assertRaises(ValueError):
+            pool.get_latent_scale_buffer(0)
+
+    def test_speculative_cache_move_fails_closed(self):
+        pool = _make_hybrid_pool()
+        with self.assertRaisesRegex(
+            NotImplementedError, "MTP/speculative decoding is not supported"
+        ):
+            pool.move_kv_cache(
+                torch.tensor([5], dtype=torch.long),
+                torch.tensor([3], dtype=torch.long),
+            )
 
     def test_zero_rope_fp8_uses_raw_trtllm_cache_layout(self):
         pool = _make_hybrid_pool()
@@ -416,6 +447,28 @@ class TestGlm5NextKPoolLifecycle(unittest.TestCase):
                 tail_k, tail_score = pool.get_compress_tail_buffers(layer_id)
                 self.assertEqual(torch.count_nonzero(tail_k[row]).item(), 0)
                 self.assertEqual(torch.count_nonzero(tail_score[row]).item(), 0)
+
+    def test_cache_flush_resets_prepared_rows_and_tail_state(self):
+        pool = _make_hybrid_pool()
+        coordinator = COORDINATOR.attach_glm5_next_kpool_lifecycle(pool)
+        hook = REGISTERED_HOOKS["glm5_next_kpool"]
+
+        coordinator.prepare_kpool_request([1, 4])
+        for layer_id in (3, 7, 11):
+            tail_k, tail_score = pool.get_compress_tail_buffers(layer_id)
+            tail_k[1].fill_(17)
+            tail_k[4].fill_(19)
+            tail_score[1].fill_(23)
+            tail_score[4].fill_(29)
+
+        hook.on_cache_flush()
+
+        self.assertFalse(coordinator.is_prepared(1))
+        self.assertFalse(coordinator.is_prepared(4))
+        for layer_id in (3, 7, 11):
+            tail_k, tail_score = pool.get_compress_tail_buffers(layer_id)
+            self.assertEqual(torch.count_nonzero(tail_k[[1, 4]]).item(), 0)
+            self.assertEqual(torch.count_nonzero(tail_score[[1, 4]]).item(), 0)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/test_glm5_next_kpool_pool_lifecycle.py
+++ b/test/registered/unit/test_glm5_next_kpool_pool_lifecycle.py
@@ -48,9 +48,17 @@ class _FakeNSATokenToKVPool:
         )
         self.kv_cache_dim = kwargs["kv_cache_dim"]
         self.index_head_dim = kwargs["index_head_dim"]
+        self.index_cache_dtype = kwargs.get(
+            "index_cache_dtype", torch.float8_e4m3fn
+        )
+        self.index_cache_is_bf16 = self.index_cache_dtype == torch.bfloat16
         self.mem_usage = 0
         self.index_k_with_scale_buffer = [
-            torch.zeros((1, 132), dtype=torch.uint8) for _ in range(self.layer_num)
+            torch.zeros(
+                (1, 128 if self.index_cache_is_bf16 else 132),
+                dtype=torch.bfloat16 if self.index_cache_is_bf16 else torch.uint8,
+            )
+            for _ in range(self.layer_num)
         ]
 
     def get_kv_size_bytes(self):
@@ -168,10 +176,10 @@ def _load_sources():
 ) = _load_sources()
 
 
-def _make_hybrid_pool(req_pool_size=6):
+def _make_hybrid_pool(req_pool_size=6, dtype=torch.float8_e4m3fn):
     return POOL.Glm5NextHybridKVPool(
         size=128,
-        dtype=torch.float8_e4m3fn,
+        dtype=dtype,
         page_size=64,
         head_num=1,
         head_dim=256,
@@ -243,6 +251,21 @@ class TestGlm5NextKPoolMemoryPool(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             pool.get_latent_scale_buffer(0)
+
+    def test_sm86_bf16_cache_omits_all_fp8_scale_sidecars(self):
+        pool = _make_hybrid_pool(dtype=torch.bfloat16)
+        self.assertTrue(pool.index_cache_is_bf16)
+        self.assertEqual(pool.index_cache_dtype, torch.bfloat16)
+        self.assertEqual(
+            pool.get_index_k_with_scale_buffer(3).dtype, torch.bfloat16
+        )
+        self.assertIsNone(pool.get_latent_scale_buffer(3))
+        with self.assertRaisesRegex(RuntimeError, "only for GLM FP8 KV cache"):
+            pool.set_latent_scale_buffer(
+                3,
+                torch.tensor([1], dtype=torch.long),
+                torch.ones((1, 4), dtype=torch.float32),
+            )
 
     def test_speculative_cache_move_fails_closed(self):
         pool = _make_hybrid_pool()

--- a/test/registered/unit/test_glm5_next_kpool_pool_lifecycle.py
+++ b/test/registered/unit/test_glm5_next_kpool_pool_lifecycle.py
@@ -1,0 +1,422 @@
+"""CPU contracts for the isolated GLM-5-Next hybrid KPool state."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import torch
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+POOL_SOURCE = REPO_ROOT / "python/sglang/srt/mem_cache/glm5_next_memory_pool.py"
+COORDINATOR_SOURCE = (
+    REPO_ROOT / "python/sglang/srt/managers/glm5_next_kpool_coordinator.py"
+)
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeNSATokenToKVPool:
+    quant_block_size = 128
+
+    def __init__(self, **kwargs):
+        self.size = kwargs["size"]
+        self.page_size = kwargs["page_size"]
+        self.dtype = kwargs["dtype"]
+        self.layer_num = kwargs["layer_num"]
+        self.device = kwargs["device"]
+        self.start_layer = kwargs.get("start_layer") or 0
+        self.custom_mem_pool = None
+        self.memory_saver_adapter = SimpleNamespace(region=lambda tag: _NullContext())
+        self.nsa_kv_cache_store_fp8 = (
+            self.dtype == torch.float8_e4m3fn
+            and kwargs["kv_cache_dim"]
+            != kwargs["kv_lora_rank"] + kwargs["qk_rope_head_dim"]
+        )
+        self.kv_cache_dim = kwargs["kv_cache_dim"]
+        self.index_head_dim = kwargs["index_head_dim"]
+        self.mem_usage = 0
+        self.index_k_with_scale_buffer = [
+            torch.zeros((1, 132), dtype=torch.uint8) for _ in range(self.layer_num)
+        ]
+
+    def get_kv_size_bytes(self):
+        return 1024
+
+    def get_index_k_with_scale_buffer(self, layer_id):
+        return self.index_k_with_scale_buffer[layer_id - self.start_layer]
+
+    def get_index_k_continuous(self, layer_id, seq_len, page_indices):
+        return ("k", layer_id, seq_len, page_indices)
+
+    def get_index_k_scale_continuous(self, layer_id, seq_len, page_indices):
+        return ("scale", layer_id, seq_len, page_indices)
+
+    def get_index_k_scale_buffer(self, layer_id, seq_len, page_indices):
+        return ("both", layer_id, seq_len, page_indices)
+
+    def set_index_k_scale_buffer(self, layer_id, loc, index_k, index_k_scale) -> None:
+        self.last_index_write = (layer_id, loc, index_k, index_k_scale)
+
+
+class _FakeHybridLinearKVPool:
+    def _transfer_full_attention_id(self, layer_id):
+        if layer_id not in self.full_attention_layer_id_mapping:
+            raise ValueError(f"not a DSA layer: {layer_id}")
+        return self.full_attention_layer_id_mapping[layer_id]
+
+
+class _NullContext:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return False
+
+
+def _load_sources():
+    registered_pools = {}
+    registered_coordinators = {}
+    registered_hooks = {}
+
+    packages = {}
+    for name in (
+        "sglang",
+        "sglang.srt",
+        "sglang.srt.configs",
+        "sglang.srt.mem_cache",
+        "sglang.srt.managers",
+        "sglang.srt.model_executor",
+    ):
+        package = types.ModuleType(name)
+        package.__path__ = []
+        packages[name] = package
+
+    config = types.ModuleType("sglang.srt.configs.glm5_next")
+    config.is_glm5_next = lambda value: bool(getattr(value, "exact_glm", False))
+    config.uses_kpool4_compress = lambda value: bool(
+        getattr(value, "exact_kpool", False)
+    )
+
+    constants = types.ModuleType("sglang.srt.constants")
+    constants.GPU_MEMORY_TYPE_KV_CACHE = "kv_cache"
+
+    memory_pool = types.ModuleType("sglang.srt.mem_cache.memory_pool")
+    memory_pool.HybridLinearKVPool = _FakeHybridLinearKVPool
+    memory_pool.NSATokenToKVPool = _FakeNSATokenToKVPool
+
+    pool_registry = types.ModuleType("sglang.srt.mem_cache.pool_registry")
+
+    def register_pool(name, predicate, factory):
+        registered_pools[name] = (predicate, factory)
+
+    pool_registry.register_kv_pool_factory = register_pool
+
+    coordinator_registry = types.ModuleType("sglang.srt.managers.coordinator_registry")
+    coordinator_registry.register_request_coordinator = lambda name, factory: (
+        registered_coordinators.setdefault(name, factory)
+    )
+
+    hook_registry = types.ModuleType("sglang.srt.managers.forward_hooks_registry")
+    hook_registry.register_forward_hook = lambda name, hook: (
+        registered_hooks.setdefault(name, hook)
+    )
+
+    stubs = {
+        **packages,
+        config.__name__: config,
+        constants.__name__: constants,
+        memory_pool.__name__: memory_pool,
+        pool_registry.__name__: pool_registry,
+        coordinator_registry.__name__: coordinator_registry,
+        hook_registry.__name__: hook_registry,
+    }
+    with patch.dict(sys.modules, stubs):
+        coordinator = _load_module(
+            "_glm5_next_kpool_coordinator_under_test", COORDINATOR_SOURCE
+        )
+        pool = _load_module("_glm5_next_memory_pool_under_test", POOL_SOURCE)
+
+    return (
+        pool,
+        coordinator,
+        registered_pools,
+        registered_coordinators,
+        registered_hooks,
+    )
+
+
+(
+    POOL,
+    COORDINATOR,
+    REGISTERED_POOLS,
+    REGISTERED_COORDINATORS,
+    REGISTERED_HOOKS,
+) = _load_sources()
+
+
+def _make_hybrid_pool(req_pool_size=6):
+    return POOL.Glm5NextHybridKVPool(
+        size=128,
+        dtype=torch.float8_e4m3fn,
+        page_size=64,
+        head_num=1,
+        head_dim=256,
+        full_attention_layer_ids=[3, 7, 11],
+        device="cpu",
+        mamba_pool=object(),
+        kv_lora_rank=512,
+        qk_rope_head_dim=0,
+        index_head_dim=128,
+        kv_cache_dim=512,
+        req_pool_size=req_pool_size,
+    )
+
+
+class TestGlm5NextKPoolMemoryPool(unittest.TestCase):
+    def test_registration_predicate_is_exact_glm_and_kpool4(self):
+        self.assertIn("glm5_next_kpool4", REGISTERED_POOLS)
+        predicate, factory = REGISTERED_POOLS["glm5_next_kpool4"]
+        self.assertIs(factory, POOL.build_glm5_next_kv_pool)
+        self.assertTrue(
+            predicate(SimpleNamespace(exact_glm=True, exact_kpool=True), None)
+        )
+        self.assertFalse(
+            predicate(SimpleNamespace(exact_glm=True, exact_kpool=False), None)
+        )
+        self.assertFalse(
+            predicate(SimpleNamespace(exact_glm=False, exact_kpool=True), None)
+        )
+
+    def test_tail_shape_dtype_and_memory_accounting_follow_kernel_abi(self):
+        sparse = POOL.Glm5NextNSATokenToKVPool(
+            size=128,
+            page_size=64,
+            kv_lora_rank=512,
+            dtype=torch.float8_e4m3fn,
+            qk_rope_head_dim=0,
+            layer_num=2,
+            device="cpu",
+            index_head_dim=128,
+            enable_memory_saver=False,
+            kv_cache_dim=512,
+            req_pool_size=6,
+        )
+        tail_k, tail_score = sparse.get_compress_tail_buffers(0)
+        self.assertEqual(tail_k.shape, (6, 4, 128))
+        self.assertEqual(tail_score.shape, tail_k.shape)
+        self.assertEqual(tail_k.dtype, torch.bfloat16)
+        self.assertEqual(tail_score.dtype, torch.bfloat16)
+        expected_bytes = 1024 + 2 * 2 * 6 * 4 * 128 * 2
+        self.assertEqual(sparse.get_kv_size_bytes(), expected_bytes)
+
+    def test_zero_rope_fp8_uses_raw_trtllm_cache_layout(self):
+        pool = _make_hybrid_pool()
+        self.assertEqual(pool.kv_cache_dim, 512)
+        self.assertFalse(pool.nsa_kv_cache_store_fp8)
+
+        kwargs = dict(
+            size=128,
+            page_size=64,
+            kv_lora_rank=512,
+            dtype=torch.float8_e4m3fn,
+            qk_rope_head_dim=0,
+            layer_num=1,
+            device="cpu",
+            index_head_dim=128,
+            enable_memory_saver=False,
+            req_pool_size=2,
+        )
+        with self.assertRaisesRegex(ValueError, "TRTLLM raw KV layout"):
+            POOL.Glm5NextNSATokenToKVPool(**kwargs, kv_cache_dim=528)
+        with self.assertRaisesRegex(ValueError, "zero-RoPE"):
+            POOL.Glm5NextNSATokenToKVPool(
+                **{**kwargs, "qk_rope_head_dim": 64}, kv_cache_dim=576
+            )
+
+    def test_tail_rows_clear_for_every_compact_dsa_layer(self):
+        pool = _make_hybrid_pool()
+        for layer_id in (3, 7, 11):
+            tail_k, tail_score = pool.get_compress_tail_buffers(layer_id)
+            tail_k[1:3].fill_(3)
+            tail_score[1:3].fill_(5)
+
+        pool.clear_compress_tail_rows(torch.tensor([2, 1, 2]))
+        for layer_id in (3, 7, 11):
+            tail_k, tail_score = pool.get_compress_tail_buffers(layer_id)
+            self.assertEqual(torch.count_nonzero(tail_k[1:3]).item(), 0)
+            self.assertEqual(torch.count_nonzero(tail_score[1:3]).item(), 0)
+
+        with self.assertRaises(IndexError):
+            pool.clear_compress_tail_rows(6)
+
+    def test_global_dsa_ids_map_to_compact_index_and_kpool_calls(self):
+        pool = _make_hybrid_pool()
+        self.assertIs(
+            pool.get_index_k_with_scale_buffer(7),
+            pool.full_kv_pool.index_k_with_scale_buffer[1],
+        )
+        result = pool.get_index_k_continuous(11, 9, "pages")
+        self.assertEqual(result, ("k", 2, 9, "pages"))
+
+        pool.full_kv_pool.kpool_decode_update_index_cache = Mock()
+        pool.kpool_decode_update_index_cache(layer_id=7, marker="decode")
+        pool.full_kv_pool.kpool_decode_update_index_cache.assert_called_once_with(
+            layer_id=1, marker="decode"
+        )
+
+        with self.assertRaises(ValueError):
+            pool.get_index_k_with_scale_buffer(0)
+
+    def test_wrong_layouts_fail_before_allocating(self):
+        kwargs = dict(
+            size=128,
+            page_size=64,
+            kv_lora_rank=512,
+            dtype=torch.float8_e4m3fn,
+            qk_rope_head_dim=0,
+            layer_num=1,
+            device="cpu",
+            index_head_dim=128,
+            enable_memory_saver=False,
+            kv_cache_dim=512,
+            req_pool_size=2,
+        )
+        with self.assertRaisesRegex(ValueError, "page_size=64"):
+            POOL.Glm5NextNSATokenToKVPool(**{**kwargs, "page_size": 1})
+        with self.assertRaisesRegex(ValueError, "index_kpool=4"):
+            POOL.Glm5NextNSATokenToKVPool(**kwargs, index_kpool=2)
+        with self.assertRaisesRegex(ValueError, "always-selected tail"):
+            POOL.Glm5NextNSATokenToKVPool(
+                **kwargs, index_kpool_always_select_tail=False
+            )
+
+    def test_model_runner_factory_filters_pp_layers_and_attaches_lifecycle(self):
+        text_config = SimpleNamespace(
+            full_attention_layer_ids=[3, 7, 11],
+            index_head_dim=128,
+            index_kpool=4,
+            index_kpool_compress=True,
+            index_kpool_always_select_tail=True,
+        )
+        model_config = SimpleNamespace(
+            exact_glm=True,
+            exact_kpool=True,
+            hf_text_config=text_config,
+            head_dim=256,
+            kv_lora_rank=512,
+            qk_rope_head_dim=0,
+            get_num_kv_heads=lambda tp: 1,
+        )
+        runner = SimpleNamespace(
+            model_config=model_config,
+            server_args=SimpleNamespace(enable_memory_saver=False),
+            is_draft_worker=False,
+            use_mla_backend=True,
+            req_to_token_pool=SimpleNamespace(size=6, mamba_pool=object()),
+            start_layer=4,
+            end_layer=12,
+            max_total_num_tokens=128,
+            kv_cache_dtype=torch.float8_e4m3fn,
+            page_size=64,
+            device="cpu",
+            calculate_mla_kv_cache_dim=lambda: 512,
+        )
+
+        layers_package = types.ModuleType("sglang.srt.layers")
+        layers_package.__path__ = []
+        dp_attention = types.ModuleType("sglang.srt.layers.dp_attention")
+        dp_attention.get_attention_tp_size = lambda: 1
+        coordinator = types.ModuleType(
+            "sglang.srt.managers.glm5_next_kpool_coordinator"
+        )
+        lifecycle = object()
+        coordinator.attach_glm5_next_kpool_lifecycle = lambda pool: lifecycle
+        with patch.dict(
+            sys.modules,
+            {
+                "sglang.srt.layers": layers_package,
+                dp_attention.__name__: dp_attention,
+                coordinator.__name__: coordinator,
+            },
+        ):
+            pool = POOL.build_glm5_next_kv_pool(model_runner=runner)
+
+        self.assertEqual(pool.full_attention_layer_id_mapping, {7: 0, 11: 1})
+        self.assertIs(pool.mamba_pool, runner.req_to_token_pool.mamba_pool)
+        self.assertIs(pool.kpool_lifecycle_coordinator, lifecycle)
+
+
+class TestGlm5NextKPoolLifecycle(unittest.TestCase):
+    def tearDown(self):
+        COORDINATOR.detach_glm5_next_kpool_lifecycle()
+
+    def test_registration_is_inert_until_exact_pool_attaches(self):
+        self.assertIs(
+            REGISTERED_COORDINATORS["glm5_next_kpool"],
+            COORDINATOR.Glm5NextKPoolCoordinator,
+        )
+        self.assertIn("glm5_next_kpool", REGISTERED_HOOKS)
+        COORDINATOR.detach_glm5_next_kpool_lifecycle()
+        hook = REGISTERED_HOOKS["glm5_next_kpool"]
+        hook.on_request_finished(SimpleNamespace(req_pool_idx=1))
+        self.assertIsNone(COORDINATOR.get_glm5_next_kpool_coordinator())
+
+        with self.assertRaises(TypeError):
+            COORDINATOR.Glm5NextKPoolCoordinator(SimpleNamespace())
+
+    def test_prepare_is_pre_forward_but_post_prefill_admit_is_noop(self):
+        pool = _make_hybrid_pool()
+        coordinator = COORDINATOR.attach_glm5_next_kpool_lifecycle(pool)
+        tail_k, tail_score = pool.get_compress_tail_buffers(3)
+
+        tail_k[2].fill_(1)
+        tail_score[2].fill_(2)
+        coordinator.prepare_kpool_request(torch.tensor([2]))
+        self.assertEqual(torch.count_nonzero(tail_k[2]).item(), 0)
+        self.assertTrue(coordinator.is_prepared(2))
+
+        # SGLang's current admit event is after prefill.  Preserve the tail
+        # that prefill produced instead of accidentally clearing it.
+        tail_k[2].fill_(7)
+        tail_score[2].fill_(9)
+        coordinator.on_request_admit(SimpleNamespace(req_pool_idx=2))
+        self.assertEqual(torch.unique(tail_k[2]).tolist(), [7.0])
+        self.assertEqual(torch.unique(tail_score[2]).tolist(), [9.0])
+
+    def test_finish_and_retract_clear_before_request_row_release(self):
+        pool = _make_hybrid_pool()
+        coordinator = COORDINATOR.attach_glm5_next_kpool_lifecycle(pool)
+
+        for row, event in (
+            (1, coordinator.on_request_finished),
+            (4, coordinator.on_request_retract),
+        ):
+            coordinator.prepare_kpool_request(row)
+            for layer_id in (3, 7, 11):
+                tail_k, tail_score = pool.get_compress_tail_buffers(layer_id)
+                tail_k[row].fill_(11)
+                tail_score[row].fill_(13)
+            event(SimpleNamespace(req_pool_idx=row))
+            self.assertFalse(coordinator.is_prepared(row))
+            for layer_id in (3, 7, 11):
+                tail_k, tail_score = pool.get_compress_tail_buffers(layer_id)
+                self.assertEqual(torch.count_nonzero(tail_k[row]).item(), 0)
+                self.assertEqual(torch.count_nonzero(tail_score[row]).item(), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/test_glm5_next_loader_contract.py
+++ b/test/registered/unit/test_glm5_next_loader_contract.py
@@ -1,0 +1,276 @@
+"""CPU-only guards for GLM-5-Next's fail-closed checkpoint contract."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+STAGE3_TEST_PATH = REPO_ROOT / "test/registered/unit/test_glm5_next_stage3.py"
+
+
+def _load_stage3_support():
+    spec = importlib.util.spec_from_file_location(
+        "_glm5_next_loader_contract_stage3_support",
+        STAGE3_TEST_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeLoaderModel:
+    def __init__(
+        self,
+        model_module,
+        parameter_names,
+        *,
+        num_experts=2,
+        start_layer=0,
+        end_layer=45,
+        is_first_rank=True,
+        is_last_rank=True,
+    ):
+        self.config = SimpleNamespace(
+            n_routed_experts=num_experts,
+            num_hidden_layers=45,
+            num_nextn_predict_layers=1,
+        )
+        self.model = SimpleNamespace(
+            start_layer=start_layer,
+            end_layer=end_layer,
+        )
+        self.pp_group = SimpleNamespace(
+            is_first_rank=is_first_rank,
+            is_last_rank=is_last_rank,
+        )
+        self.packed_modules_mapping = (
+            model_module.Glm5NextForConditionalGeneration.packed_modules_mapping
+        )
+        self._parameters_for_test = {
+            name: torch.nn.Parameter(torch.empty(1)) for name in parameter_names
+        }
+        self.skipped_phase7_visual_weights = ()
+        self.skipped_session_ab_mtp_weights = ()
+        self.skipped_pipeline_parallel_weight_count = 0
+        self.checkpoint_runtime_default_parameters = ()
+
+    def named_parameters(self):
+        return self._parameters_for_test.items()
+
+    @staticmethod
+    def _load_kda_stacked_weight(name, loaded_weight, params_dict):
+        del name, loaded_weight, params_dict
+        return False
+
+
+@pytest.fixture(scope="module")
+def model_module():
+    support = _load_stage3_support()
+    config_module = support._load_config_module()
+    return support._load_model_module(config_module)
+
+
+def _consume(model_module, fake, names, *, require_complete=True):
+    weights = [(name, torch.empty(1)) for name in names]
+    return list(
+        model_module.Glm5NextForConditionalGeneration._normalized_text_weights(
+            fake,
+            weights,
+            require_complete=require_complete,
+        )
+    )
+
+
+def test_reverse_contract_covers_packed_experts_fp8_scales_and_runtime_defaults(
+    model_module,
+):
+    parameters = {
+        "model.layers.0.self_attn.qkv_proj.weight",
+        "model.layers.0.mlp.gate_up_proj.weight_scale_inv",
+        "model.layers.3.self_attn.fused_qkv_a_proj_with_mqa.weight_scale_inv",
+        "model.layers.3.mlp.experts.w13_weight",
+        "model.layers.3.mlp.experts.w13_weight_scale_inv",
+        "model.layers.3.mlp.experts.w2_weight",
+        "model.layers.3.mlp.experts.w2_weight_scale_inv",
+        "model.layers.3.self_attn.attn_mha.k_scale",
+        "model.layers.3.self_attn.attn_mha.v_scale",
+        "model.layers.3.self_attn.attn_mqa.k_scale",
+        "model.layers.3.self_attn.attn_mqa.v_scale",
+        "model.norm.weight",
+    }
+
+    expected, runtime_defaults = model_module._glm5_next_checkpoint_source_contract(
+        parameters,
+        num_experts=2,
+        packed_modules_mapping=(
+            model_module.Glm5NextForConditionalGeneration.packed_modules_mapping
+        ),
+    )
+
+    assert len(expected) == 20
+    assert len(runtime_defaults) == 4
+    assert "model.layers.0.self_attn.q_proj.weight" in expected
+    assert "model.layers.0.self_attn.k_proj.weight" in expected
+    assert "model.layers.0.self_attn.v_proj.weight" in expected
+    assert "model.layers.0.mlp.gate_proj.weight_scale_inv" in expected
+    assert "model.layers.0.mlp.up_proj.weight_scale_inv" in expected
+    assert "model.layers.3.self_attn.q_a_proj.weight_scale_inv" in expected
+    assert "model.layers.3.self_attn.kv_a_proj_with_mqa.weight_scale_inv" in expected
+    assert "model.layers.3.mlp.experts.1.up_proj.weight" in expected
+    assert "model.layers.3.mlp.experts.1.down_proj.weight_scale_inv" in expected
+
+    fake = _FakeLoaderModel(model_module, parameters)
+    outputs = _consume(model_module, fake, sorted(expected))
+    assert {name for name, _ in outputs} == expected
+    assert set(fake.checkpoint_runtime_default_parameters) == runtime_defaults
+
+
+def test_missing_direct_and_partial_packed_shards_fail_closed(model_module):
+    direct = _FakeLoaderModel(
+        model_module,
+        {"model.layers.3.self_attn.q_b_proj.weight"},
+    )
+    with pytest.raises(RuntimeError, match="missing 1 required"):
+        _consume(model_module, direct, [])
+
+    packed = _FakeLoaderModel(
+        model_module,
+        {"model.layers.0.self_attn.qkv_proj.weight"},
+    )
+    with pytest.raises(RuntimeError, match="v_proj.weight"):
+        _consume(
+            model_module,
+            packed,
+            [
+                "model.layers.0.self_attn.q_proj.weight",
+                "model.layers.0.self_attn.k_proj.weight",
+            ],
+        )
+
+
+def test_missing_one_expert_fp8_scale_shard_fails_closed(model_module):
+    fake = _FakeLoaderModel(
+        model_module,
+        {"model.layers.3.mlp.experts.w13_weight_scale_inv"},
+        num_experts=2,
+    )
+    with pytest.raises(
+        RuntimeError,
+        match=r"experts\.1\.up_proj\.weight_scale_inv",
+    ):
+        _consume(
+            model_module,
+            fake,
+            [
+                "model.layers.3.mlp.experts.0.gate_proj.weight_scale_inv",
+                "model.layers.3.mlp.experts.0.up_proj.weight_scale_inv",
+                "model.layers.3.mlp.experts.1.gate_proj.weight_scale_inv",
+            ],
+        )
+
+
+def test_unknown_local_text_duplicate_alias_and_layer46_are_rejected(model_module):
+    fake = _FakeLoaderModel(
+        model_module,
+        {"model.layers.3.self_attn.q_b_proj.weight"},
+    )
+    with pytest.raises(RuntimeError, match="unknown text tensor"):
+        _consume(
+            model_module,
+            fake,
+            ["model.layers.3.self_attn.q_typo.weight"],
+        )
+
+    top_level = _FakeLoaderModel(model_module, {"model.norm.weight"})
+    with pytest.raises(RuntimeError, match="duplicate normalized text tensor"):
+        _consume(
+            model_module,
+            top_level,
+            [
+                "model.language_model.norm.weight",
+                "model.norm.weight",
+            ],
+        )
+
+    with pytest.raises(RuntimeError, match="unknown text tensor"):
+        _consume(
+            model_module,
+            _FakeLoaderModel(model_module, set()),
+            ["model.layers.46.input_layernorm.weight"],
+            require_complete=False,
+        )
+
+
+def test_pp_nonowner_exact_mtp45_and_raw_visual_prefixes_are_the_only_skips(
+    model_module,
+):
+    fake = _FakeLoaderModel(
+        model_module,
+        {"model.layers.20.input_layernorm.weight"},
+        start_layer=20,
+        end_layer=25,
+        is_first_rank=False,
+        is_last_rank=False,
+    )
+    outputs = _consume(
+        model_module,
+        fake,
+        [
+            "model.layers.3.input_layernorm.weight",
+            "model.language_model.embed_tokens.weight",
+            "model.language_model.norm.weight",
+            "lm_head.weight",
+            "model.language_model.layers.45.eh_proj.weight",
+            "model.visual.blocks.0.attn.qkv.weight",
+            "visual.patch_embed.proj.weight",
+            "model.language_model.layers.20.input_layernorm.weight",
+        ],
+    )
+
+    assert [name for name, _ in outputs] == ["model.layers.20.input_layernorm.weight"]
+    assert fake.skipped_pipeline_parallel_weight_count == 4
+    assert fake.skipped_session_ab_mtp_weights == (
+        "model.language_model.layers.45.eh_proj.weight",
+    )
+    assert fake.skipped_phase7_visual_weights == (
+        "model.visual.blocks.0.attn.qkv.weight",
+        "visual.patch_embed.proj.weight",
+    )
+
+
+def test_visual_classification_checks_the_raw_prefix_only(model_module):
+    normalize = model_module.normalize_glm5_next_weight_name
+
+    assert normalize("model.visual.blocks.0.attn.qkv.weight") is None
+    assert normalize("visual.patch_embed.proj.weight") is None
+    assert normalize("model.language_model.visual.fake.weight") == (
+        "model.visual.fake.weight"
+    )
+    assert normalize("language_model.visual.fake.weight") == (
+        "model.visual.fake.weight"
+    )
+
+    with pytest.raises(RuntimeError, match="unknown text tensor"):
+        _consume(
+            model_module,
+            _FakeLoaderModel(model_module, set()),
+            ["model.language_model.visual.fake.weight"],
+            require_complete=False,
+        )
+
+
+def test_nextn_loader_entry_is_rejected_for_session_ab(model_module):
+    fake = _FakeLoaderModel(model_module, set())
+    with pytest.raises(RuntimeError, match="MTP/NextN"):
+        model_module.Glm5NextForConditionalGeneration.load_weights(
+            fake,
+            [],
+            is_nextn=True,
+        )

--- a/test/registered/unit/test_glm5_next_loader_contract.py
+++ b/test/registered/unit/test_glm5_next_loader_contract.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import importlib.util
+import sys
+import types
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -36,6 +38,7 @@ class _FakeLoaderModel:
         end_layer=45,
         is_first_rank=True,
         is_last_rank=True,
+        multimodal_enabled=False,
     ):
         self.config = SimpleNamespace(
             n_routed_experts=num_experts,
@@ -60,6 +63,9 @@ class _FakeLoaderModel:
         self.skipped_session_ab_mtp_weights = ()
         self.skipped_pipeline_parallel_weight_count = 0
         self.checkpoint_runtime_default_parameters = ()
+        self.multimodal_enabled = multimodal_enabled
+        self.visual_load_calls = []
+        self.mm_config = SimpleNamespace()
 
     def named_parameters(self):
         return self._parameters_for_test.items()
@@ -69,6 +75,13 @@ class _FakeLoaderModel:
         del name, loaded_weight, params_dict
         return False
 
+    def _load_visual_weight(
+        self, canonical_source_name, loaded_weight, params_dict
+    ):
+        del params_dict
+        assert loaded_weight.dtype is torch.bfloat16
+        self.visual_load_calls.append(canonical_source_name)
+
 
 @pytest.fixture(scope="module")
 def model_module():
@@ -77,8 +90,15 @@ def model_module():
     return support._load_model_module(config_module)
 
 
-def _consume(model_module, fake, names, *, require_complete=True):
-    weights = [(name, torch.empty(1)) for name in names]
+def _consume(
+    model_module,
+    fake,
+    names,
+    *,
+    require_complete=True,
+    dtype=torch.float32,
+):
+    weights = [(name, torch.empty(1, dtype=dtype)) for name in names]
     return list(
         model_module.Glm5NextForConditionalGeneration._normalized_text_weights(
             fake,
@@ -86,6 +106,328 @@ def _consume(model_module, fake, names, *, require_complete=True):
             require_complete=require_complete,
         )
     )
+
+
+def _visual_runtime_parameter_names(*, include_dead=True):
+    """Return the pinned GLM-5-Next visual runtime namespace.
+
+    Packed QKV and gate/up parameters deliberately appear once here: the
+    reverse contract must expand them into the checkpoint's source shards.
+    """
+
+    block_suffixes = (
+        "attn.k_norm.weight",
+        "attn.proj.bias",
+        "attn.proj.weight",
+        "attn.q_norm.weight",
+        "attn.qkv_proj.bias",
+        "attn.qkv_proj.weight",
+        "mlp.down_proj.bias",
+        "mlp.down_proj.weight",
+        "mlp.gate_up_proj.bias",
+        "mlp.gate_up_proj.weight",
+        "norm1.weight",
+        "norm2.weight",
+    )
+    names = {
+        f"visual.blocks.{layer_idx}.{suffix}"
+        for layer_idx in range(24)
+        for suffix in block_suffixes
+    }
+    names.update(
+        {
+            "visual.downsample.bias",
+            "visual.downsample.weight",
+            "visual.merger.down_proj.weight",
+            "visual.merger.gate_up_proj.weight",
+            "visual.merger.post_projection_norm.bias",
+            "visual.merger.post_projection_norm.weight",
+            "visual.merger.proj.weight",
+            "visual.patch_embed.proj.bias",
+            "visual.patch_embed.proj.weight",
+            "visual.post_layernorm.weight",
+        }
+    )
+    if include_dead:
+        names.update(
+            {
+                "visual.embeddings.position_embedding.weight",
+                "visual.post_conv_layernorm.weight",
+            }
+        )
+    return names
+
+
+def test_visual_reverse_contract_is_exactly_347_and_skips_dead_runtime_modules(
+    model_module,
+):
+    runtime_names = _visual_runtime_parameter_names()
+    expected = model_module._glm5_next_vision_checkpoint_source_contract(
+        runtime_names
+    )
+
+    assert len(runtime_names) == 300
+    assert len(expected) == 347
+    assert len(expected) == model_module.GLM5_NEXT_PINNED_VISION_SOURCE_TENSOR_COUNT
+
+    assert "model.visual.blocks.0.attn.qkv.weight" in expected
+    assert "model.visual.blocks.0.attn.qkv.bias" in expected
+    assert "model.visual.blocks.0.attn.qkv_proj.weight" not in expected
+    assert "model.visual.blocks.23.mlp.gate_proj.weight" in expected
+    assert "model.visual.blocks.23.mlp.up_proj.weight" in expected
+    assert "model.visual.merger.gate_proj.weight" in expected
+    assert "model.visual.merger.up_proj.weight" in expected
+    assert not any(name.startswith("model.visual.embeddings.") for name in expected)
+    assert not any(
+        name.startswith("model.visual.post_conv_layernorm.") for name in expected
+    )
+
+
+def test_enabled_visual_contract_consumes_all_347_bf16_sources(model_module):
+    runtime_names = _visual_runtime_parameter_names()
+    expected = model_module._glm5_next_vision_checkpoint_source_contract(
+        runtime_names
+    )
+    fake = _FakeLoaderModel(
+        model_module,
+        runtime_names,
+        multimodal_enabled=True,
+    )
+
+    outputs = _consume(
+        model_module,
+        fake,
+        sorted(expected),
+        dtype=torch.bfloat16,
+    )
+
+    assert outputs == []
+    assert fake.visual_load_calls == sorted(expected)
+    assert fake._checkpoint_expected_visual_source_names == expected
+    assert fake._checkpoint_seen_visual_source_names == expected
+
+
+def test_visual_duplicate_scope_resets_for_a_later_weight_update(model_module):
+    runtime_names = {
+        "visual.blocks.0.attn.qkv_proj.weight",
+        "visual.post_layernorm.weight",
+    }
+    expected = model_module._glm5_next_vision_checkpoint_source_contract(
+        runtime_names
+    )
+    fake = _FakeLoaderModel(
+        model_module,
+        runtime_names,
+        multimodal_enabled=True,
+    )
+
+    _consume(model_module, fake, sorted(expected), dtype=torch.bfloat16)
+    _consume(
+        model_module,
+        fake,
+        sorted(expected),
+        require_complete=False,
+        dtype=torch.bfloat16,
+    )
+
+    assert fake.visual_load_calls == sorted(expected) * 2
+    assert fake._checkpoint_seen_visual_source_names == expected
+
+
+def test_enabled_visual_contract_rejects_unknown_duplicate_dead_and_missing(
+    model_module,
+):
+    runtime_names = {
+        "visual.blocks.0.attn.qkv_proj.weight",
+        "visual.blocks.0.mlp.gate_up_proj.weight",
+        "visual.post_layernorm.weight",
+        "visual.embeddings.position_embedding.weight",
+        "visual.post_conv_layernorm.weight",
+    }
+    expected = model_module._glm5_next_vision_checkpoint_source_contract(
+        runtime_names
+    )
+    assert expected == {
+        "model.visual.blocks.0.attn.qkv.weight",
+        "model.visual.blocks.0.mlp.gate_proj.weight",
+        "model.visual.blocks.0.mlp.up_proj.weight",
+        "model.visual.post_layernorm.weight",
+    }
+
+    with pytest.raises(RuntimeError, match="rejected unknown tensor"):
+        _consume(
+            model_module,
+            _FakeLoaderModel(
+                model_module,
+                runtime_names,
+                multimodal_enabled=True,
+            ),
+            ["model.visual.typo.weight"],
+            require_complete=False,
+            dtype=torch.bfloat16,
+        )
+
+    with pytest.raises(RuntimeError, match="rejected unknown tensor"):
+        _consume(
+            model_module,
+            _FakeLoaderModel(
+                model_module,
+                runtime_names,
+                multimodal_enabled=True,
+            ),
+            ["model.visual.embeddings.position_embedding.weight"],
+            require_complete=False,
+            dtype=torch.bfloat16,
+        )
+
+    source_name = "model.visual.blocks.0.attn.qkv.weight"
+    with pytest.raises(RuntimeError, match="duplicate tensor"):
+        _consume(
+            model_module,
+            _FakeLoaderModel(
+                model_module,
+                runtime_names,
+                multimodal_enabled=True,
+            ),
+            [source_name, source_name.removeprefix("model.")],
+            require_complete=False,
+            dtype=torch.bfloat16,
+        )
+
+    with pytest.raises(RuntimeError, match="missing 4 required tensor"):
+        _consume(
+            model_module,
+            _FakeLoaderModel(
+                model_module,
+                runtime_names,
+                multimodal_enabled=True,
+            ),
+            [],
+        )
+
+
+def test_visual_weight_loader_maps_packed_shards_and_requires_bf16(
+    model_module,
+    monkeypatch,
+):
+    pad_calls = []
+    loader_calls = []
+
+    vision_utils = types.ModuleType(
+        "sglang.srt.layers.attention.vision_utils"
+    )
+
+    def pad_vit_attn_dummy_heads(mm_config, runtime_name, loaded_weight):
+        pad_calls.append((mm_config, runtime_name, loaded_weight.dtype))
+        return loaded_weight
+
+    vision_utils.pad_vit_attn_dummy_heads = pad_vit_attn_dummy_heads
+
+    weight_utils = types.ModuleType("sglang.srt.model_loader.weight_utils")
+
+    def default_weight_loader(param, loaded_weight):
+        loader_calls.append((param.runtime_name, (), loaded_weight.dtype))
+
+    weight_utils.default_weight_loader = default_weight_loader
+
+    package_names = (
+        "sglang",
+        "sglang.srt",
+        "sglang.srt.layers",
+        "sglang.srt.layers.attention",
+        "sglang.srt.model_loader",
+    )
+    packages = {}
+    for package_name in package_names:
+        package = types.ModuleType(package_name)
+        package.__path__ = []
+        packages[package_name] = package
+        monkeypatch.setitem(sys.modules, package_name, package)
+    packages["sglang"].srt = packages["sglang.srt"]
+    packages["sglang.srt"].layers = packages["sglang.srt.layers"]
+    packages["sglang.srt.layers"].attention = packages[
+        "sglang.srt.layers.attention"
+    ]
+    packages["sglang.srt.layers.attention"].vision_utils = vision_utils
+    packages["sglang.srt"].model_loader = packages["sglang.srt.model_loader"]
+    packages["sglang.srt.model_loader"].weight_utils = weight_utils
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang.srt.layers.attention.vision_utils",
+        vision_utils,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang.srt.model_loader.weight_utils",
+        weight_utils,
+    )
+
+    def make_param(runtime_name):
+        param = SimpleNamespace(runtime_name=runtime_name)
+
+        def weight_loader(param, loaded_weight, *shard_id):
+            loader_calls.append(
+                (param.runtime_name, shard_id, loaded_weight.dtype)
+            )
+
+        param.weight_loader = weight_loader
+        return param
+
+    params_dict = {
+        name: make_param(name)
+        for name in (
+            "visual.blocks.0.attn.qkv_proj.weight",
+            "visual.blocks.0.mlp.gate_up_proj.weight",
+            "visual.post_layernorm.weight",
+            "visual.embeddings.position_embedding.weight",
+        )
+    }
+    fake = SimpleNamespace(mm_config=object())
+    load_visual = (
+        model_module.Glm5NextForConditionalGeneration._load_visual_weight
+    )
+    sources = (
+        "model.visual.blocks.0.attn.qkv.weight",
+        "model.visual.blocks.0.mlp.gate_proj.weight",
+        "model.visual.blocks.0.mlp.up_proj.weight",
+        "model.visual.post_layernorm.weight",
+    )
+    for source_name in sources:
+        load_visual(
+            fake,
+            source_name,
+            torch.empty(1, dtype=torch.bfloat16),
+            params_dict,
+        )
+
+    assert [(name, shard) for name, shard, _ in loader_calls] == [
+        ("visual.blocks.0.attn.qkv_proj.weight", ()),
+        ("visual.blocks.0.mlp.gate_up_proj.weight", (0,)),
+        ("visual.blocks.0.mlp.gate_up_proj.weight", (1,)),
+        ("visual.post_layernorm.weight", ()),
+    ]
+    assert [name for _, name, _ in pad_calls] == [
+        "visual.blocks.0.attn.qkv_proj.weight",
+        "visual.blocks.0.mlp.gate_up_proj.weight",
+        "visual.blocks.0.mlp.gate_up_proj.weight",
+        "visual.post_layernorm.weight",
+    ]
+    assert all(dtype is torch.bfloat16 for _, _, dtype in loader_calls)
+
+    with pytest.raises(RuntimeError, match="must be BF16"):
+        load_visual(
+            fake,
+            sources[0],
+            torch.empty(1, dtype=torch.float32),
+            params_dict,
+        )
+    with pytest.raises(RuntimeError, match="unknown or dead runtime parameter"):
+        load_visual(
+            fake,
+            "model.visual.embeddings.position_embedding.weight",
+            torch.empty(1, dtype=torch.bfloat16),
+            params_dict,
+        )
 
 
 def test_reverse_contract_covers_packed_experts_fp8_scales_and_runtime_defaults(

--- a/test/registered/unit/test_glm5_next_moe.py
+++ b/test/registered/unit/test_glm5_next_moe.py
@@ -30,6 +30,12 @@ FUSED_MOE_PATH = (
     REPO_ROOT / "python/sglang/srt/layers/moe/fused_moe_triton/fused_moe.py"
 )
 TRITON_RUNNER_PATH = REPO_ROOT / "python/sglang/srt/layers/moe/moe_runner/triton.py"
+MOE_RUNNER_BASE_PATH = (
+    REPO_ROOT / "python/sglang/srt/layers/moe/moe_runner/base.py"
+)
+GLM_SWIGLU_PATH = (
+    REPO_ROOT / "python/sglang/srt/layers/moe/glm5_next_swiglu.py"
+)
 FP8_PATH = REPO_ROOT / "python/sglang/srt/layers/quantization/fp8.py"
 KT_EP_PATH = REPO_ROOT / "python/sglang/srt/layers/moe/kt_ep_wrapper.py"
 FLASHINFER_RUNNER_PATH = (
@@ -178,6 +184,7 @@ class _DeepseekV2MoEStub(nn.Module):
         prefix="",
         alt_stream=None,
         is_nextn=False,
+        glm5_next_hf_two_round_swiglu=False,
     ):
         super().__init__()
         del quant_config, alt_stream, is_nextn
@@ -187,6 +194,9 @@ class _DeepseekV2MoEStub(nn.Module):
         self.use_grouped_topk = config.n_group > config.topk_group
         self.gate = _GateStub(config)
         self.experts = _ExpertsStub(config)
+        self.experts.moe_runner_config.glm5_next_hf_two_round_swiglu = (
+            glm5_next_hf_two_round_swiglu
+        )
         self.topk = SimpleNamespace(
             topk_config=SimpleNamespace(
                 use_grouped_topk=self.use_grouped_topk,
@@ -206,6 +216,12 @@ class _DeepseekV2MoEStub(nn.Module):
 
     def forward(self, hidden_states, *args, **kwargs):
         self.base_forward_calls.append((args, kwargs))
+        quant_method = getattr(self.experts, "quant_method", None)
+        self.base_forward_mode_seen = getattr(
+            quant_method, "_glm5_next_forward_mode", None
+        )
+        if getattr(self, "raise_in_base_forward", False):
+            raise RuntimeError("base forward failed")
         return hidden_states + 1
 
 
@@ -299,6 +315,54 @@ class TestGlm5NextSwiGLU(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "even gate/up width"):
             self.module.Glm5NextSiluAndMul(10.0)(torch.randn(2, 7))
 
+    def test_bfloat16_materializes_silu_before_multiply(self):
+        # This pair separates Transformers' two BF16 operations from the
+        # former fused CUDA implementation, which rounded only once after an
+        # FP32 SiLU-and-multiply expression.
+        gate_up = torch.tensor(
+            [[-11.25, -6.125]],
+            dtype=torch.bfloat16,
+        )
+        actual = self.module.Glm5NextSiluAndMul(10.0)(gate_up)
+        gate, up = gate_up.chunk(2, dim=-1)
+        expected = F.silu(gate.clamp(max=10.0)) * up.clamp(-10.0, 10.0)
+        fused_one_round = (
+            F.silu(gate.float().clamp(max=10.0))
+            * up.float().clamp(-10.0, 10.0)
+        ).to(torch.bfloat16)
+
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+        self.assertNotEqual(actual.item(), fused_one_round.item())
+
+    def test_private_primitive_cpu_reference_and_output_reuse(self):
+        spec = importlib.util.spec_from_file_location(
+            "_glm5_next_private_swiglu_test", GLM_SWIGLU_PATH
+        )
+        private_module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(private_module)
+
+        gate_up = torch.tensor([[-11.25, -6.125]], dtype=torch.bfloat16)
+        output = torch.empty((1, 1), dtype=torch.bfloat16)
+        actual = private_module.glm5_next_hf_two_round_swiglu(
+            gate_up, 10.0, output=output
+        )
+        gate, up = gate_up.chunk(2, dim=-1)
+        expected = F.silu(gate.clamp(max=10.0)) * up.clamp(-10.0, 10.0)
+        fused_one_round = (
+            F.silu(gate.float().clamp(max=10.0))
+            * up.float().clamp(-10.0, 10.0)
+        ).to(torch.bfloat16)
+
+        self.assertIs(actual, output)
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+        self.assertNotEqual(actual.item(), fused_one_round.item())
+
+        with self.assertRaisesRegex(ValueError, "output shape mismatch"):
+            private_module.glm5_next_hf_two_round_swiglu(
+                gate_up, 10.0, output=torch.empty((1, 2), dtype=torch.bfloat16)
+            )
+
 
 class TestGlm5NextMLPAndMoE(unittest.TestCase):
     @classmethod
@@ -357,6 +421,9 @@ class TestGlm5NextMLPAndMoE(unittest.TestCase):
             moe.gate.e_score_correction_bias,
         )
         self.assertEqual(moe.experts.moe_runner_config.swiglu_limit, 10.0)
+        self.assertTrue(
+            moe.experts.moe_runner_config.glm5_next_hf_two_round_swiglu
+        )
         self.assertIsInstance(moe.shared_experts.act_fn, self.module.Glm5NextSiluAndMul)
         self.assertEqual(moe.shared_experts.swiglu_limit, 10.0)
         self.assertFalse(moe.shared_experts.reduce_results)
@@ -413,6 +480,31 @@ class TestGlm5NextMLPAndMoE(unittest.TestCase):
         )
         self.assertNotIn("forward_normal", self.module.Glm5NextMoE.__dict__)
         self.assertNotIn("forward_deepep", self.module.Glm5NextMoE.__dict__)
+
+    def test_required_layerwise_mode_is_scoped_to_one_base_forward(self):
+        moe = self.module.Glm5NextMoE(
+            config=_config(swiglu_limit=None), layer_id=3
+        )
+        quant_method = SimpleNamespace(
+            kt_config=SimpleNamespace(
+                is_glm5_next=True,
+                method="FP8",
+                gpu_prefill_token_threshold=4096,
+            )
+        )
+        moe.experts.quant_method = quant_method
+        forward_mode = object()
+        forward_batch = SimpleNamespace(forward_mode=forward_mode)
+
+        moe(torch.zeros(1, 4), forward_batch=forward_batch)
+
+        self.assertIs(moe.base_forward_mode_seen, forward_mode)
+        self.assertFalse(hasattr(quant_method, "_glm5_next_forward_mode"))
+
+        moe.raise_in_base_forward = True
+        with self.assertRaisesRegex(RuntimeError, "base forward failed"):
+            moe(torch.zeros(1, 4), forward_batch=forward_batch)
+        self.assertFalse(hasattr(quant_method, "_glm5_next_forward_mode"))
 
     def test_cpu_amx_moe_fails_fast_until_both_expert_abis_gain_limit(self):
         moe = self.module.Glm5NextMoE(config=_config(), layer_id=3)
@@ -481,6 +573,35 @@ class TestGlm5NextMLPAndMoE(unittest.TestCase):
 
 
 class TestExistingKernelReuseEvidence(unittest.TestCase):
+    def test_glm_two_round_flag_is_private_default_off_and_reaches_both_runners(self):
+        base_source = MOE_RUNNER_BASE_PATH.read_text(encoding="utf-8")
+        deepseek_source = DEEPSEEK_PATH.read_text(encoding="utf-8")
+        layer_source = FUSED_MOE_LAYER_PATH.read_text(encoding="utf-8")
+        fused_source = FUSED_MOE_PATH.read_text(encoding="utf-8")
+        triton_source = TRITON_RUNNER_PATH.read_text(encoding="utf-8")
+        kt_source = KT_EP_PATH.read_text(encoding="utf-8")
+        private_source = GLM_SWIGLU_PATH.read_text(encoding="utf-8")
+
+        private_flag = "glm5_next_hf_two_round_swiglu"
+        self.assertIn(f"{private_flag}: bool = False", base_source)
+        self.assertIn(f"{private_flag}: bool = False", deepseek_source)
+        self.assertIn(f"{private_flag}: bool = False", layer_source)
+        self.assertIn(f"{private_flag}={private_flag}", deepseek_source)
+        self.assertIn(f"{private_flag}={private_flag}", layer_source)
+        self.assertIn(f"moe_runner_config.{private_flag}", fused_source)
+        self.assertIn(f"self.config.{private_flag}", triton_source)
+        self.assertIn(
+            f'getattr(runner_config, "{private_flag}", False)', kt_source
+        )
+
+        # Two independent launches plus an in-place BF16 output reload are the
+        # source-level guard against a compiler collapsing both rounds again.
+        self.assertIn("_glm5_next_silu_to_bf16_kernel[grid]", private_source)
+        self.assertIn("_glm5_next_bf16_mul_kernel[grid]", private_source)
+        self.assertIn(
+            "activated_gate = tl.load(output_ptr + offsets", private_source
+        )
+
     def test_deepseek_base_supplies_noaux_shared_tp_and_ep_contracts(self):
         source = DEEPSEEK_PATH.read_text(encoding="utf-8")
         self.assertIn('if config.topk_method == "noaux_tc"', source)

--- a/test/registered/unit/test_glm5_next_moe.py
+++ b/test/registered/unit/test_glm5_next_moe.py
@@ -1,0 +1,565 @@
+"""CPU-only contracts for the isolated GLM-5-Next MLP/MoE adapter."""
+
+from __future__ import annotations
+
+import ast
+import copy
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = REPO_ROOT / "python/sglang/srt/models/glm5_next_moe.py"
+DEEPSEEK_PATH = REPO_ROOT / "python/sglang/srt/models/deepseek_v2.py"
+WEIGHT_LOADER_PATH = (
+    REPO_ROOT / "python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py"
+)
+FUSED_MOE_LAYER_PATH = (
+    REPO_ROOT / "python/sglang/srt/layers/moe/fused_moe_triton/layer.py"
+)
+FUSED_MOE_PATH = (
+    REPO_ROOT / "python/sglang/srt/layers/moe/fused_moe_triton/fused_moe.py"
+)
+TRITON_RUNNER_PATH = REPO_ROOT / "python/sglang/srt/layers/moe/moe_runner/triton.py"
+FP8_PATH = REPO_ROOT / "python/sglang/srt/layers/quantization/fp8.py"
+KT_EP_PATH = REPO_ROOT / "python/sglang/srt/layers/moe/kt_ep_wrapper.py"
+FLASHINFER_RUNNER_PATH = (
+    REPO_ROOT / "python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py"
+)
+TRITON_KERNELS_RUNNER_PATH = (
+    REPO_ROOT / "python/sglang/srt/layers/moe/moe_runner/triton_kernels.py"
+)
+MARLIN_RUNNER_PATH = REPO_ROOT / "python/sglang/srt/layers/moe/moe_runner/marlin.py"
+CPU_MOE_PATH = REPO_ROOT / "sgl-kernel/csrc/cpu/moe.cpp"
+CPU_EXTENSION_PATH = REPO_ROOT / "sgl-kernel/csrc/cpu/torch_extension_cpu.cpp"
+
+
+def _compile_top_level_function(path: Path, name: str):
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    function = copy.deepcopy(
+        next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.FunctionDef) and node.name == name
+        )
+    )
+    module = ast.fix_missing_locations(
+        ast.Module(
+            body=[
+                ast.ImportFrom(
+                    module="__future__",
+                    names=[ast.alias(name="annotations")],
+                    level=0,
+                ),
+                function,
+            ],
+            type_ignores=[],
+        )
+    )
+    namespace = {}
+    exec(compile(module, str(path), "exec"), namespace)
+    return namespace[name]
+
+
+class _Projection(nn.Module):
+    def __init__(self, output_size: int, input_size: int, prefix: str):
+        super().__init__()
+        self.weight = nn.Parameter(torch.empty(output_size, input_size))
+        self.weight_scale_inv = nn.Parameter(
+            torch.ones(max(1, output_size // 2), max(1, input_size // 2)),
+            requires_grad=False,
+        )
+        self.prefix = prefix
+
+    def forward(self, x, **kwargs):
+        del kwargs
+        return F.linear(x, self.weight), None
+
+
+class _UnclampedSiluAndMul(nn.Module):
+    def forward(self, gate_up):
+        gate, up = gate_up.chunk(2, dim=-1)
+        return F.silu(gate) * up
+
+
+class _DeepseekV2MLPStub(nn.Module):
+    def __init__(
+        self,
+        hidden_size,
+        intermediate_size,
+        hidden_act,
+        quant_config=None,
+        reduce_results=True,
+        prefix="",
+        tp_rank=None,
+        tp_size=None,
+    ):
+        super().__init__()
+        del quant_config, tp_rank
+        if hidden_act != "silu":
+            raise ValueError(hidden_act)
+        self.tp_size = tp_size
+        self.reduce_results = reduce_results
+        self.gate_up_proj = _Projection(
+            2 * intermediate_size, hidden_size, f"{prefix}.gate_up_proj"
+        )
+        self.down_proj = _Projection(
+            hidden_size, intermediate_size, f"{prefix}.down_proj"
+        )
+        self.act_fn = _UnclampedSiluAndMul()
+
+    def forward(self, x, **kwargs):
+        del kwargs
+        gate_up, _ = self.gate_up_proj(x)
+        activated = self.act_fn(gate_up)
+        output, _ = self.down_proj(activated)
+        return output
+
+
+class _GateStub(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.weight = nn.Parameter(
+            torch.empty(config.n_routed_experts, config.hidden_size)
+        )
+        self.e_score_correction_bias = nn.Parameter(
+            torch.empty(config.n_routed_experts, dtype=torch.float32)
+        )
+
+
+class _ExpertsStub(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.w13_weight = nn.Parameter(
+            torch.empty(
+                config.n_routed_experts,
+                2 * config.moe_intermediate_size,
+                config.hidden_size,
+            )
+        )
+        self.w2_weight = nn.Parameter(
+            torch.empty(
+                config.n_routed_experts,
+                config.hidden_size,
+                config.moe_intermediate_size,
+            )
+        )
+        self.w13_weight_scale_inv = nn.Parameter(
+            torch.ones(config.n_routed_experts, 1, 1), requires_grad=False
+        )
+        self.w2_weight_scale_inv = nn.Parameter(
+            torch.ones(config.n_routed_experts, 1, 1), requires_grad=False
+        )
+        self.moe_runner_config = SimpleNamespace(swiglu_limit=config.swiglu_limit)
+        if getattr(config, "kt_method", None) is not None:
+            self.quant_method = SimpleNamespace(
+                kt_config=SimpleNamespace(method=config.kt_method),
+                gpu_experts_mask=torch.tensor(
+                    config.kt_gpu_experts_mask, dtype=torch.bool
+                ),
+            )
+
+
+class _DeepseekV2MoEStub(nn.Module):
+    def __init__(
+        self,
+        config,
+        layer_id,
+        quant_config=None,
+        prefix="",
+        alt_stream=None,
+        is_nextn=False,
+    ):
+        super().__init__()
+        del quant_config, alt_stream, is_nextn
+        self.config = config
+        self.layer_id = layer_id
+        self.is_hash = False
+        self.use_grouped_topk = config.n_group > config.topk_group
+        self.gate = _GateStub(config)
+        self.experts = _ExpertsStub(config)
+        self.topk = SimpleNamespace(
+            topk_config=SimpleNamespace(
+                use_grouped_topk=self.use_grouped_topk,
+                num_expert_group=config.n_group,
+                topk_group=config.topk_group,
+                correction_bias=self.gate.e_score_correction_bias,
+            )
+        )
+        self.shared_experts = _DeepseekV2MLPStub(
+            hidden_size=config.hidden_size,
+            intermediate_size=(config.moe_intermediate_size * config.n_shared_experts),
+            hidden_act=config.hidden_act,
+            reduce_results=False,
+            prefix=f"{prefix}.shared_experts",
+        )
+        self.base_forward_calls = []
+
+    def forward(self, hidden_states, *args, **kwargs):
+        self.base_forward_calls.append((args, kwargs))
+        return hidden_states + 1
+
+
+def _load_module():
+    packages = {}
+    for name in (
+        "sglang",
+        "sglang.srt",
+        "sglang.srt.layers",
+        "sglang.srt.layers.quantization",
+        "sglang.srt.models",
+    ):
+        package = types.ModuleType(name)
+        package.__path__ = []
+        packages[name] = package
+
+    quantization = types.ModuleType("sglang.srt.layers.quantization.base_config")
+    quantization.QuantizationConfig = type("QuantizationConfig", (), {})
+    packages[quantization.__name__] = quantization
+
+    deepseek = types.ModuleType("sglang.srt.models.deepseek_v2")
+    deepseek.DeepseekV2MLP = _DeepseekV2MLPStub
+    deepseek.DeepseekV2MoE = _DeepseekV2MoEStub
+    packages[deepseek.__name__] = deepseek
+
+    module_name = "_glm5_next_moe_test"
+    spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    packages[module_name] = module
+    assert spec.loader is not None
+    with patch.dict(sys.modules, packages):
+        spec.loader.exec_module(module)
+    return module
+
+
+def _config(**overrides):
+    values = dict(
+        hidden_size=4,
+        intermediate_size=3,
+        moe_intermediate_size=2,
+        hidden_act="silu",
+        n_routed_experts=3,
+        num_experts_per_tok=2,
+        n_shared_experts=1,
+        n_group=1,
+        topk_group=1,
+        norm_topk_prob=True,
+        routed_scaling_factor=2.5,
+        scoring_func="sigmoid",
+        topk_method="noaux_tc",
+        swiglu_limit=10.0,
+    )
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+class TestGlm5NextSwiGLU(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.module = _load_module()
+
+    def test_cpu_numerics_match_clamp_before_silu_contract(self):
+        # gate = [12, -20, 2], up = [15, -15, .5].  The negative gate is
+        # intentionally below -limit: GLM must not lower-clamp it.
+        gate_up = torch.tensor(
+            [[12.0, -20.0, 2.0, 15.0, -15.0, 0.5]], dtype=torch.float32
+        )
+        actual = self.module.glm5_next_swiglu(gate_up, 10.0)
+        gate, up = gate_up.chunk(2, dim=-1)
+        expected = F.silu(gate.clamp(max=10.0)) * up.clamp(-10.0, 10.0)
+
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+        symmetric_gate_result = F.silu(gate.clamp(-10.0, 10.0)) * up.clamp(-10.0, 10.0)
+        self.assertNotEqual(actual[0, 1].item(), symmetric_gate_result[0, 1].item())
+
+    def test_limit_is_semantically_different_from_kimi_swiglu(self):
+        gate_up = torch.tensor([[100.0, 100.0]])
+        glm = self.module.glm5_next_swiglu(gate_up, 10.0)
+        kimi = F.silu(gate_up[:, :1]) * gate_up[:, 1:]
+
+        self.assertLess(glm.item(), kimi.item() / 50)
+
+    def test_none_retains_ordinary_swiglu_and_odd_width_is_rejected(self):
+        torch.manual_seed(0)
+        gate_up = torch.randn(2, 8, dtype=torch.float64)
+        gate, up = gate_up.chunk(2, dim=-1)
+        torch.testing.assert_close(
+            self.module.glm5_next_swiglu(gate_up, None),
+            F.silu(gate) * up,
+        )
+        with self.assertRaisesRegex(ValueError, "even gate/up width"):
+            self.module.Glm5NextSiluAndMul(10.0)(torch.randn(2, 7))
+
+
+class TestGlm5NextMLPAndMoE(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.module = _load_module()
+
+    def test_dense_mlp_preserves_projection_layout_and_is_numerically_clamped(self):
+        mlp = self.module.Glm5NextMLP(
+            hidden_size=2,
+            intermediate_size=2,
+            hidden_act="silu",
+            prefix="model.layers.0.mlp",
+            swiglu_limit=1.0,
+        )
+        with torch.no_grad():
+            mlp.gate_up_proj.weight.copy_(
+                torch.tensor(
+                    [
+                        [2.0, 0.0],
+                        [0.0, -3.0],
+                        [4.0, 0.0],
+                        [0.0, 5.0],
+                    ]
+                )
+            )
+            mlp.down_proj.weight.copy_(torch.tensor([[1.0, 2.0], [3.0, 4.0]]))
+
+        x = torch.tensor([[2.0, 2.0]])
+        gate_up = F.linear(x, mlp.gate_up_proj.weight)
+        gate, up = gate_up.chunk(2, dim=-1)
+        expected = F.linear(
+            F.silu(gate.clamp(max=1.0)) * up.clamp(-1.0, 1.0),
+            mlp.down_proj.weight,
+        )
+
+        torch.testing.assert_close(mlp(x), expected, rtol=0, atol=0)
+        self.assertEqual(mlp.gate_up_proj.prefix, "model.layers.0.mlp.gate_up_proj")
+        self.assertEqual(mlp.down_proj.prefix, "model.layers.0.mlp.down_proj")
+        self.assertFalse(mlp.down_proj is None)
+
+    def test_moe_forces_official_grouped_noaux_and_patches_only_shared_activation(self):
+        moe = self.module.Glm5NextMoE(
+            config=_config(),
+            layer_idx=3,
+            prefix="model.layers.3.mlp",
+        )
+
+        self.assertEqual(moe.layer_id, 3)
+        self.assertEqual(moe.layer_idx, 3)
+        self.assertTrue(moe.use_grouped_topk)
+        self.assertTrue(moe.topk.topk_config.use_grouped_topk)
+        self.assertEqual(moe.topk.topk_config.num_expert_group, 1)
+        self.assertEqual(moe.topk.topk_config.topk_group, 1)
+        self.assertIs(
+            moe.topk.topk_config.correction_bias,
+            moe.gate.e_score_correction_bias,
+        )
+        self.assertEqual(moe.experts.moe_runner_config.swiglu_limit, 10.0)
+        self.assertIsInstance(moe.shared_experts.act_fn, self.module.Glm5NextSiluAndMul)
+        self.assertEqual(moe.shared_experts.swiglu_limit, 10.0)
+        self.assertFalse(moe.shared_experts.reduce_results)
+
+    def test_hf_weight_names_keep_deepseek_packed_and_fused_expert_contract(self):
+        dense = self.module.Glm5NextMLP(
+            hidden_size=4,
+            intermediate_size=3,
+            hidden_act="silu",
+            swiglu_limit=10.0,
+        )
+        dense_names = set(dict(dense.named_parameters()))
+        self.assertIn("gate_up_proj.weight", dense_names)
+        self.assertIn("gate_up_proj.weight_scale_inv", dense_names)
+        self.assertIn("down_proj.weight", dense_names)
+        self.assertIn("down_proj.weight_scale_inv", dense_names)
+
+        moe = self.module.Glm5NextMoE(config=_config(), layer_id=3)
+        moe_names = set(dict(moe.named_parameters()))
+        expected_names = {
+            "gate.weight",
+            "gate.e_score_correction_bias",
+            "experts.w13_weight",
+            "experts.w2_weight",
+            "experts.w13_weight_scale_inv",
+            "experts.w2_weight_scale_inv",
+            "shared_experts.gate_up_proj.weight",
+            "shared_experts.down_proj.weight",
+        }
+        self.assertTrue(expected_names.issubset(moe_names))
+
+        loader_source = WEIGHT_LOADER_PATH.read_text(encoding="utf-8")
+        self.assertIn('("gate_up_proj", "gate_proj", 0)', loader_source)
+        self.assertIn('("gate_up_proj", "up_proj", 1)', loader_source)
+        self.assertIn("if self.num_fused_shared_experts > 0", loader_source)
+        self.assertIn('"mlp.shared_experts"', loader_source)
+        self.assertIn('f"mlp.experts.{self.config.n_routed_experts}"', loader_source)
+
+    def test_layer_id_alias_validation_and_base_forward_delegation(self):
+        with self.assertRaisesRegex(ValueError, "Conflicting GLM MoE layer ids"):
+            self.module.Glm5NextMoE(config=_config(), layer_id=3, layer_idx=4)
+        with self.assertRaisesRegex(TypeError, "requires layer_id"):
+            self.module.Glm5NextMoE(config=_config())
+
+        # A no-limit compatibility config is safe on CPU and proves the GLM
+        # wrapper delegates execution/reduction behavior to the base class.
+        moe = self.module.Glm5NextMoE(config=_config(swiglu_limit=None), layer_id=3)
+        hidden = torch.zeros(2, 4)
+        actual = moe(hidden, "forward-batch", use_reduce_scatter=True)
+        torch.testing.assert_close(actual, hidden + 1)
+        self.assertEqual(
+            moe.base_forward_calls,
+            [(("forward-batch",), {"use_reduce_scatter": True})],
+        )
+        self.assertNotIn("forward_normal", self.module.Glm5NextMoE.__dict__)
+        self.assertNotIn("forward_deepep", self.module.Glm5NextMoE.__dict__)
+
+    def test_cpu_amx_moe_fails_fast_until_both_expert_abis_gain_limit(self):
+        moe = self.module.Glm5NextMoE(config=_config(), layer_id=3)
+        with self.assertRaisesRegex(
+            NotImplementedError, "current AMX ABI has no swiglu_limit"
+        ):
+            moe(torch.zeros(1, 4))
+
+        extension_source = CPU_EXTENSION_PATH.read_text(encoding="utf-8")
+        cpu_source = CPU_MOE_PATH.read_text(encoding="utf-8")
+        fused_schema = extension_source.split('"fused_experts_cpu(Tensor', 1)[1].split(
+            ");", 1
+        )[0]
+        shared_schema = extension_source.split('"shared_expert_cpu(Tensor', 1)[1].split(
+            ");", 1
+        )[0]
+        self.assertNotIn("swiglu_limit", fused_schema)
+        self.assertNotIn("swiglu_limit", shared_schema)
+
+        # These are the two minimum C++ extension points: routed/shared paths
+        # both eventually call the same unclamped vector activation helper.
+        activation_body = cpu_source.split("inline void silu_and_mul(", 1)[1].split(
+            "template <typename scalar_t, int BLOCK_M", 1
+        )[0]
+        self.assertIn("x0 = x0 / (one + x0.neg().exp_u20())", activation_body)
+        self.assertNotIn("clamp", activation_body)
+
+    def test_kt_cpu_experts_accept_only_checkpoint_native_block_fp8(self):
+        for method in (
+            "AMXINT4",
+            "FP8_PERCHANNEL",
+            "MXFP4",
+            "MXFP8",
+            "RAWINT4",
+        ):
+            with self.subTest(method=method):
+                with self.assertRaisesRegex(
+                    NotImplementedError, "require --kt-method FP8"
+                ):
+                    self.module.Glm5NextMoE(
+                        config=_config(
+                            kt_method=method,
+                            kt_gpu_experts_mask=[True, False, True],
+                        ),
+                        layer_id=3,
+                    )
+
+        # The same format is harmless when every routed expert remains on GPU.
+        all_gpu = self.module.Glm5NextMoE(
+            config=_config(
+                kt_method="AMXINT4",
+                kt_gpu_experts_mask=[True, True, True],
+            ),
+            layer_id=3,
+        )
+        self.assertEqual(all_gpu.layer_id, 3)
+
+        supported = self.module.Glm5NextMoE(
+            config=_config(
+                kt_method="FP8",
+                kt_gpu_experts_mask=[False, False, False],
+            ),
+            layer_id=3,
+        )
+        self.assertEqual(supported.layer_id, 3)
+
+
+class TestExistingKernelReuseEvidence(unittest.TestCase):
+    def test_deepseek_base_supplies_noaux_shared_tp_and_ep_contracts(self):
+        source = DEEPSEEK_PATH.read_text(encoding="utf-8")
+        self.assertIn('if config.topk_method == "noaux_tc"', source)
+        self.assertIn("self.e_score_correction_bias = nn.Parameter", source)
+        self.assertIn("self.num_fused_shared_experts", source)
+        self.assertIn("self.shared_experts_is_fp8", source)
+        self.assertIn("self._enable_a2a_moe", source)
+        self.assertIn("return self.forward_deepep(", source)
+        self.assertIn("tensor_model_parallel_all_reduce(final_hidden_states)", source)
+
+    def test_standard_gpu_fp8_chain_carries_limit_to_exact_clamp(self):
+        deepseek_source = DEEPSEEK_PATH.read_text(encoding="utf-8")
+        layer_source = FUSED_MOE_LAYER_PATH.read_text(encoding="utf-8")
+        fp8_source = FP8_PATH.read_text(encoding="utf-8")
+        triton_source = TRITON_RUNNER_PATH.read_text(encoding="utf-8")
+        fused_source = FUSED_MOE_PATH.read_text(encoding="utf-8")
+
+        self.assertIn(
+            'swiglu_limit=getattr(config, "swiglu_limit", None)',
+            deepseek_source,
+        )
+        self.assertIn("swiglu_limit=swiglu_limit", layer_source)
+        self.assertIn("moe_runner_backend = MoeRunnerBackend.TRITON", fp8_source)
+        self.assertIn("moe_runner_config=runner_config", triton_source)
+        self.assertIn("swiglu_limit=moe_runner_config.swiglu_limit", fused_source)
+        self.assertIn("gate = gate.clamp(min=None, max=swiglu_limit)", fused_source)
+        self.assertIn(
+            "up = up.clamp(min=-swiglu_limit, max=swiglu_limit)",
+            fused_source,
+        )
+        self.assertIn("return F.silu(gate) * up", fused_source)
+
+    def test_kt_offload_preserves_limit_for_block_fp8_without_widening_others(self):
+        source = KT_EP_PATH.read_text(encoding="utf-8")
+        supports = _compile_top_level_function(
+            KT_EP_PATH, "_kt_supports_swiglu_parameters"
+        )
+
+        self.assertTrue(supports("FP8", True))
+        self.assertFalse(supports("FP8", False))
+        for method in ("MXFP4", "MXFP8"):
+            with self.subTest(method=method):
+                self.assertTrue(supports(method, False))
+        for method in (None, "BF16", "RAWINT4", "FP8_PERCHANNEL"):
+            with self.subTest(method=method):
+                self.assertFalse(supports(method, True))
+
+        self.assertIn('_cfg_swglim = getattr(_mrc, "swiglu_limit", None)', source)
+        self.assertIn("is_glm5_next: bool = False", source)
+        self.assertIn(
+            'is_glm5_next=getattr(server_args, "_glm5_next_session_ab_active", False)',
+            source,
+        )
+        self.assertIn("supports_swiglu_params = _kt_supports_swiglu_parameters", source)
+        self.assertIn("swiglu_limit=_kt_swiglu_limit", source)
+        self.assertIn("_kt_swiglu_limit = 0.0", source)
+
+    def test_deepgemm_ep_path_is_still_dsv4_gated_and_not_claimed_reusable(self):
+        path = REPO_ROOT / "python/sglang/srt/layers/moe/moe_runner/deep_gemm.py"
+        source = path.read_text(encoding="utf-8")
+        self.assertIn(
+            'is_2604b = envs.SGLANG_DSV4_2604_SUBMODE.get() == "2604B"', source
+        )
+        self.assertIn("swiglu_limit must be non-None iff submode=2604B", source)
+
+    def test_other_explicit_gpu_backends_do_not_yet_expose_glm_limit(self):
+        fp8_source = FP8_PATH.read_text(encoding="utf-8")
+        cutlass_call = fp8_source.split("output = cutlass_fused_experts_fp8(", 1)[
+            1
+        ].split("return StandardCombineInput(hidden_states=output)", 1)[0]
+        self.assertNotIn("swiglu_limit", cutlass_call)
+
+        flashinfer_source = FLASHINFER_RUNNER_PATH.read_text(encoding="utf-8")
+        triton_kernels_source = TRITON_KERNELS_RUNNER_PATH.read_text(encoding="utf-8")
+        marlin_source = MARLIN_RUNNER_PATH.read_text(encoding="utf-8")
+        self.assertNotIn("swiglu_limit", flashinfer_source)
+        self.assertNotIn("swiglu_limit", triton_kernels_source)
+        self.assertNotIn("swiglu_limit", marlin_source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/test_glm5_next_regression_guards.py
+++ b/test/registered/unit/test_glm5_next_regression_guards.py
@@ -19,6 +19,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import torch
+
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
@@ -257,6 +259,17 @@ class TestNonGlmRegressionBoundary(unittest.TestCase):
         ).read_text(encoding="utf-8")
         self.assertEqual(output_source.count('"glm5_next_kpool"'), 2)
         self.assertEqual(output_source.count('"is_glm5_next"'), 2)
+
+        flush_cache = _find_function(
+            _parse("python/sglang/srt/managers/scheduler.py"),
+            "flush_cache",
+            class_name="Scheduler",
+        )
+        flush_source = ast.unparse(flush_cache)
+        self.assertIn("getattr(self.model_config, 'is_glm5_next', False)", flush_source)
+        self.assertIn(
+            "dispatch_named('glm5_next_kpool', 'on_cache_flush')", flush_source
+        )
 
     def test_attention_tp_context_cleans_state_when_forward_raises(self):
         maybe_input_scattered = _compile_function(
@@ -537,12 +550,13 @@ class TestGlmKPoolMemoryAccounting(unittest.TestCase):
             calculate_mla_kv_cache_dim=lambda: 512,
         )
 
-    def test_exact_glm_cell_uses_raw_latent_kv_width(self):
+    def test_exact_glm_cell_counts_raw_latent_and_scale_sidecar(self):
         get_cell_size = self._cell_size_method()
         runner = self._runner(exact_glm=True)
 
-        # latent: 512 * 11; index: (128 FP8 + 4-byte scale) * 11
-        self.assertEqual(get_cell_size(runner, 11), 7084)
+        # latent: (512 FP8 + four FP32 scales) * 11;
+        # index: (128 FP8 + one FP32 scale) * 11.
+        self.assertEqual(get_cell_size(runner, 11), 7260)
 
     def test_non_glm_and_legacy_nsa_keep_historical_arithmetic(self):
         get_cell_size = self._cell_size_method()
@@ -584,14 +598,14 @@ class TestGlmKPoolMemoryAccounting(unittest.TestCase):
             )
         )
         exact._get_glm5_next_kpool_tail_size_bytes = types.MethodType(tail_size, exact)
-        exact.get_cell_size_per_token = lambda num_layers: 7084
+        exact.get_cell_size_per_token = lambda num_layers: 7260
 
         expected_tail_bytes = 11 * 2048 * 4 * 128 * 2 * 2
         self.assertEqual(
             tail_size(exact, num_layers=11, max_num_reqs=2048),
             expected_tail_bytes,
         )
-        expected_slots = (expected_tail_bytes + 7084 - 1) // 7084
+        expected_slots = (expected_tail_bytes + 7260 - 1) // 7260
         self.assertEqual(
             reserve(
                 exact,
@@ -677,6 +691,408 @@ class TestPoolRegistryOwnership(unittest.TestCase):
         )
         self.assertIsNone(
             registry.resolve_kv_pool_factory(legacy_glm, SimpleNamespace())
+        )
+
+
+class TestForwardContextPublication(unittest.TestCase):
+    def test_linear_sidecar_owns_runner_token_pool_reference(self):
+        init = _find_function(
+            _parse("python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py"),
+            "__init__",
+            "MambaAttnBackendBase",
+        )
+        assignments = {
+            ast.unparse(node.targets[0]): ast.unparse(node.value)
+            for node in ast.walk(init)
+            if isinstance(node, ast.Assign) and len(node.targets) == 1
+        }
+        annotated_assignments = {
+            ast.unparse(node.target): ast.unparse(node.value)
+            for node in ast.walk(init)
+            if isinstance(node, ast.AnnAssign) and node.value is not None
+        }
+
+        self.assertEqual(
+            assignments.get("self.token_to_kv_pool"),
+            "model_runner.token_to_kv_pool",
+        )
+        self.assertEqual(
+            annotated_assignments.get("self.req_to_token_pool"),
+            "model_runner.req_to_token_pool",
+        )
+
+    def test_native_sparse_backend_owns_runner_pool_references(self):
+        init = _find_function(
+            _parse("python/sglang/srt/layers/attention/nsa_backend.py"),
+            "__init__",
+            "NativeSparseAttnBackend",
+        )
+        assignments = {
+            ast.unparse(node.targets[0]): ast.unparse(node.value)
+            for node in ast.walk(init)
+            if isinstance(node, ast.Assign) and len(node.targets) == 1
+        }
+
+        self.assertEqual(
+            assignments.get("self.req_to_token_pool"),
+            "model_runner.req_to_token_pool",
+        )
+        self.assertEqual(
+            assignments.get("self.token_to_kv_pool"),
+            "model_runner.token_to_kv_pool",
+        )
+
+    def test_hybrid_backend_exposes_sidecar_pools_with_legacy_full_backend(self):
+        init = _compile_function(
+            "python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py",
+            "__init__",
+            class_name="HybridLinearAttnBackend",
+        )
+        token_pool = object()
+        req_pool = object()
+        linear_backend = SimpleNamespace(
+            token_to_kv_pool=token_pool,
+            req_to_token_pool=req_pool,
+        )
+        # Legacy full backends on this KT base do not all expose pool attrs.
+        # Construction must therefore use the shared linear sidecar contract.
+        full_backend = SimpleNamespace()
+        wrapper = SimpleNamespace()
+
+        init(wrapper, full_backend, linear_backend, [2, 6])
+
+        self.assertIs(wrapper.token_to_kv_pool, token_pool)
+        self.assertIs(wrapper.req_to_token_pool, req_pool)
+        self.assertIs(wrapper.full_attn_backend, full_backend)
+        self.assertIs(wrapper.linear_attn_backend, linear_backend)
+
+    def test_model_runner_publishes_context_and_preserves_overrides(self):
+        tree = _parse("python/sglang/srt/model_executor/model_runner.py")
+        forward_raw = _find_function(tree, "_forward_raw", "ModelRunner")
+        source = ast.unparse(forward_raw)
+
+        self.assertIn("has_forward_context()", source)
+        self.assertIn("self.model_config, 'is_glm5_next', False", source)
+        self.assertIn("ForwardContext(attn_backend=self.attn_backend)", source)
+        self.assertIn("with ctx_mgr", source)
+        self.assertIn("self._forward_raw_with_context", source)
+
+        delegated_calls = [
+            node
+            for node in ast.walk(forward_raw)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "_forward_raw_with_context"
+        ]
+        self.assertEqual(len(delegated_calls), 1)
+
+    def test_model_runner_forward_context_is_exact_glm_only(self):
+        active_context = False
+        calls: list[tuple[str, object | None]] = []
+
+        @contextmanager
+        def empty_context_stub():
+            calls.append(("empty", None))
+            yield
+
+        @contextmanager
+        def forward_context_stub(context):
+            calls.append(("forward", context.attn_backend))
+            yield
+
+        method = _compile_function(
+            "python/sglang/srt/model_executor/model_runner.py",
+            "_forward_raw",
+            class_name="ModelRunner",
+            globals_={
+                "empty_context": empty_context_stub,
+                "ForwardContext": SimpleNamespace,
+                "forward_context": forward_context_stub,
+                "has_forward_context": lambda: active_context,
+            },
+        )
+        backend = object()
+        result = object()
+        runner = SimpleNamespace(
+            model_config=SimpleNamespace(is_glm5_next=False),
+            attn_backend=backend,
+            _forward_raw_with_context=lambda *args: result,
+        )
+
+        self.assertIs(method(runner, object(), False, None), result)
+        self.assertEqual(calls, [("empty", None)])
+
+        calls.clear()
+        runner.model_config.is_glm5_next = True
+        self.assertIs(method(runner, object(), False, None), result)
+        self.assertEqual(calls, [("forward", backend)])
+
+        calls.clear()
+        active_context = True
+        self.assertIs(method(runner, object(), False, None), result)
+        self.assertEqual(calls, [("empty", None)])
+
+    def test_forward_context_scope_covers_metadata_and_model_forward(self):
+        tree = _parse("python/sglang/srt/model_executor/model_runner.py")
+        implementation = _find_function(
+            tree, "_forward_raw_with_context", "ModelRunner"
+        )
+        source = ast.unparse(implementation)
+        self.assertIn("self.forward_decode", source)
+        self.assertIn("self.forward_extend", source)
+        self.assertIn("self.forward_split_prefill", source)
+        self.assertIn("self.forward_idle", source)
+
+    def test_decode_graph_capture_publishes_selected_backend(self):
+        tree = _parse("python/sglang/srt/model_executor/cuda_graph_runner.py")
+        capture = next(
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef) and node.name == "_capture_one_stream"
+        )
+        source = ast.unparse(capture)
+
+        self.assertIn("self.model_runner.model_config, 'is_glm5_next', False", source)
+        self.assertIn("ForwardContext(attn_backend=attn_backend)", source)
+        self.assertIn("ctx_mgr = empty_context()", source)
+        self.assertIn("self.capture_one_batch_size", source)
+        self.assertLess(
+            source.index("ForwardContext(attn_backend=attn_backend)"),
+            source.index("self.capture_one_batch_size"),
+        )
+
+    def test_hybrid_backend_delegates_indexer_metadata(self):
+        method = _compile_function(
+            "python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py",
+            "get_indexer_metadata",
+            class_name="HybridLinearAttnBackend",
+        )
+        expected = object()
+        calls = []
+        backend = SimpleNamespace(
+            get_indexer_metadata=lambda layer_id, batch: (
+                calls.append((layer_id, batch)),
+                expected,
+            )[1]
+        )
+        wrapper = SimpleNamespace(full_attn_backend=backend)
+        batch = object()
+
+        self.assertIs(method(wrapper, 7, batch), expected)
+        self.assertEqual(calls, [(7, batch)])
+
+
+class TestKPoolBatchOwnedPool(unittest.TestCase):
+    _SOURCE = "python/sglang/srt/layers/attention/nsa/nsa_indexer_kpool.py"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.pool_from_batch = staticmethod(
+            _compile_function(cls._SOURCE, "_token_pool_from_batch")
+        )
+
+    def _compile_method(self, name):
+        def reject_ambient_pool():
+            raise AssertionError("ambient ForwardContext pool must not be read")
+
+        return _compile_function(
+            self._SOURCE,
+            name,
+            class_name="IndexerKPool",
+            globals_={
+                "_token_pool_from_batch": self.pool_from_batch,
+                # This makes the test fail if the old ambient lookup returns.
+                "get_token_to_kv_pool": reject_ambient_pool,
+            },
+        )
+
+    def test_pool_helper_returns_batch_pool_and_fails_closed(self):
+        pool = object()
+        self.assertIs(
+            self.pool_from_batch(SimpleNamespace(token_to_kv_pool=pool)), pool
+        )
+        for batch in (SimpleNamespace(), SimpleNamespace(token_to_kv_pool=None)):
+            with self.assertRaisesRegex(RuntimeError, "ForwardBatch.token_to_kv_pool"):
+                self.pool_from_batch(batch)
+
+    def test_extend_write_uses_batch_pool_not_ambient_context(self):
+        calls = []
+
+        class BatchPool:
+            def invalidate_index_buffer_for_layer(self, layer_id):
+                calls.append(("invalidate", layer_id))
+
+            def _is_layer_owned(self, layer_id):
+                calls.append(("owned", layer_id))
+                return True
+
+        empty = SimpleNamespace(is_empty=True)
+        batch_pool = BatchPool()
+        batch = SimpleNamespace(
+            seq_lens_cpu=[4],
+            extend_seq_lens_cpu=[4],
+            token_to_kv_pool=batch_pool,
+        )
+        metadata = SimpleNamespace(
+            attn_metadata=SimpleNamespace(
+                kpool_extend_plan=SimpleNamespace(writes=empty, tails=empty)
+            )
+        )
+
+        method = self._compile_method("_compress_write_extend")
+        result = method(
+            SimpleNamespace(),
+            SimpleNamespace(),
+            SimpleNamespace(),
+            None,
+            batch,
+            9,
+            metadata,
+        )
+
+        self.assertIsNone(result)
+        self.assertEqual(calls, [("invalidate", 9), ("owned", 9)])
+
+    def test_decode_write_uses_batch_pool_during_graph_compatible_forward(self):
+        calls = []
+
+        class BatchPool:
+            def invalidate_index_buffer_for_layer(self, layer_id):
+                calls.append(("invalidate", layer_id))
+
+            def _is_layer_owned(self, layer_id):
+                calls.append(("owned", layer_id))
+                return True
+
+            def kpool_decode_update_index_cache(self, **kwargs):
+                calls.append(("update", kwargs))
+
+        batch_pool = BatchPool()
+        batch = SimpleNamespace(
+            token_to_kv_pool=batch_pool,
+            req_pool_indices=[3, 4],
+            out_cache_loc=[30, 40],
+        )
+        metadata = SimpleNamespace(
+            get_page_table_64=lambda: "page-table",
+            get_seqlens_int32=lambda: [7, 8],
+        )
+        self_obj = SimpleNamespace(
+            index_kpool_compress_ape="ape",
+            scale_fmt=None,
+        )
+
+        method = self._compile_method("_compress_write_decode")
+        method(
+            self_obj,
+            SimpleNamespace(shape=(2, 128)),
+            "scores",
+            [6, 7],
+            batch,
+            11,
+            metadata,
+        )
+
+        self.assertEqual(calls[:2], [("invalidate", 11), ("owned", 11)])
+        self.assertEqual(calls[2][0], "update")
+        update = calls[2][1]
+        self.assertEqual(update["layer_id"], 11)
+        self.assertEqual(update["block_tables"], "page-table")
+        self.assertEqual(update["req_pool_indices"], [3, 4])
+        self.assertEqual(update["out_cache_loc"], [30, 40])
+
+    def test_indexer_kpool_has_no_runtime_ambient_pool_reads(self):
+        tree = _parse(self._SOURCE)
+        indexer = next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.ClassDef) and node.name == "IndexerKPool"
+        )
+        ambient_calls = [
+            node
+            for node in ast.walk(indexer)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "get_token_to_kv_pool"
+        ]
+        self.assertEqual(ambient_calls, [])
+
+    def test_kpool_ragged_row_chunks_slice_all_metadata_and_keep_padding(self):
+        iterator_calls = []
+
+        def fake_logits_rows(q_fp8, kv_fp8, weights, ks, ke):
+            iterator_calls.append((q_fp8, kv_fp8, weights, ks, ke))
+            for start, end in ((0, 2), (2, 4), (4, 5)):
+                yield start, end, torch.full((end - start, 7), float(start))
+
+        selector_calls = []
+
+        def select(logits, pool_lens, **kwargs):
+            selector_calls.append((logits.clone(), pool_lens.clone(), kwargs))
+            rows = logits.shape[0]
+            marker = kwargs["row_starts"].to(torch.int32).unsqueeze(1)
+            return marker.expand(rows, 11).clone()
+
+        method = _compile_function(
+            self._SOURCE,
+            "_topk_from_glm5_next_eager_logits_rows",
+            class_name="IndexerKPool",
+            globals_={
+                "torch": torch,
+                "iter_glm5_next_eager_fp8_mqa_logits": fake_logits_rows,
+            },
+        )
+        q = torch.zeros((5, 3, 128), dtype=torch.float32)
+        k = torch.zeros((7, 128), dtype=torch.float32)
+        scale = torch.ones(7)
+        weights = torch.ones((5, 3))
+        pool_lens = torch.tensor([1, 2, 3, 4, 5])
+        seq_lens = torch.tensor([4, 8, 12, 16, 20])
+        ks = torch.tensor([0, 1, 3, 6, 10])
+        ke = torch.tensor([1, 3, 6, 10, 15])
+        topk_offsets = torch.tensor([100, 101, 102, 103, 104])
+        page_table = torch.arange(80).reshape(10, 8)
+        page_rows = torch.tensor([9, 7, 5, 3, 1])
+        runner = SimpleNamespace(
+            index_topk=8,
+            index_kpool=4,
+            _topk_from_kpool_logits=select,
+        )
+
+        result = method(
+            runner,
+            q,
+            (k, scale),
+            weights,
+            pool_lens,
+            seq_lens,
+            ks,
+            ke,
+            total_q=7,
+            page_table=page_table,
+            topk_offsets=topk_offsets,
+            page_table_row_index=page_rows,
+        )
+
+        self.assertEqual(len(iterator_calls), 1)
+        self.assertEqual(len(selector_calls), 3)
+        for index, (start, end) in enumerate(((0, 2), (2, 4), (4, 5))):
+            logits, lengths, kwargs = selector_calls[index]
+            self.assertEqual(tuple(logits.shape), (end - start, 7))
+            self.assertTrue(torch.equal(lengths, pool_lens[start:end]))
+            self.assertTrue(torch.equal(kwargs["seq_lens"], seq_lens[start:end]))
+            self.assertTrue(torch.equal(kwargs["row_starts"], ks[start:end]))
+            self.assertTrue(
+                torch.equal(kwargs["topk_offsets"], topk_offsets[start:end])
+            )
+            self.assertTrue(
+                torch.equal(kwargs["page_table_row_index"], page_rows[start:end])
+            )
+            self.assertIs(kwargs["page_table"], page_table)
+            self.assertNotIn("out_rows", kwargs)
+        self.assertTrue(torch.equal(result[:5, 0], ks.to(torch.int32)))
+        self.assertTrue(
+            torch.equal(result[5:], torch.full((2, 11), -1, dtype=torch.int32))
         )
 
 

--- a/test/registered/unit/test_glm5_next_regression_guards.py
+++ b/test/registered/unit/test_glm5_next_regression_guards.py
@@ -1,0 +1,684 @@
+"""CPU-only regression guards for the GLM-5-Next integration boundary.
+
+These tests intentionally load or compile only the small production-code surface
+under test.  That keeps the guards runnable without importing the full SGLang
+package (and therefore without CUDA, Transformers, or optional serving deps).
+"""
+
+from __future__ import annotations
+
+import ast
+import copy
+import importlib.util
+import os
+import sys
+import types
+import unittest
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _parse(relative_path: str) -> ast.Module:
+    path = REPO_ROOT / relative_path
+    return ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+
+def _find_function(
+    tree: ast.Module, function_name: str, class_name: str | None = None
+) -> ast.FunctionDef:
+    container = tree.body
+    if class_name is not None:
+        class_node = next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.ClassDef) and node.name == class_name
+        )
+        container = class_node.body
+    return next(
+        node
+        for node in container
+        if isinstance(node, ast.FunctionDef) and node.name == function_name
+    )
+
+
+def _compile_function(
+    relative_path: str,
+    function_name: str,
+    *,
+    class_name: str | None = None,
+    globals_: dict | None = None,
+):
+    """Compile one function/method from production source with deferred annotations."""
+    function = copy.deepcopy(
+        _find_function(_parse(relative_path), function_name, class_name)
+    )
+    function.decorator_list = []
+    # Model-specific adjustment imports helpers at method entry.  The harness
+    # supplies those helpers directly and avoids importing the full package.
+    function.body = [
+        node
+        for node in function.body
+        if not isinstance(node, (ast.Import, ast.ImportFrom))
+    ]
+
+    body: list[ast.stmt] = [
+        ast.ImportFrom(
+            module="__future__",
+            names=[ast.alias(name="annotations")],
+            level=0,
+        )
+    ]
+    symbol_name = function_name
+    if class_name is None:
+        body.append(function)
+    else:
+        symbol_name = "_SourceHarness"
+        body.append(
+            ast.ClassDef(
+                name=symbol_name,
+                bases=[],
+                keywords=[],
+                body=[function],
+                decorator_list=[],
+            )
+        )
+
+    module = ast.fix_missing_locations(ast.Module(body=body, type_ignores=[]))
+    namespace = {"__builtins__": __builtins__}
+    if globals_:
+        namespace.update(globals_)
+    exec(compile(module, relative_path, "exec"), namespace)
+    compiled = namespace[symbol_name]
+    return compiled if class_name is None else getattr(compiled, function_name)
+
+
+def _load_attention_registry():
+    path = REPO_ROOT / "python/sglang/srt/layers/attention/attention_registry.py"
+    spec = importlib.util.spec_from_file_location("_glm_guard_attention_registry", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_pool_registry():
+    """Load the real registry with only its two eager imports stubbed."""
+
+    class MiniMaxPool:
+        pass
+
+    packages = {}
+    for name in ("sglang", "sglang.srt", "sglang.srt.configs", "sglang.srt.mem_cache"):
+        package = types.ModuleType(name)
+        package.__path__ = []
+        packages[name] = package
+
+    model_config = types.ModuleType("sglang.srt.configs.model_config")
+    model_config.is_minimax_sparse = lambda config: (
+        (getattr(config, "architectures", None) or [None])[0]
+        in {
+            "MiniMaxM3SparseForCausalLM",
+            "MiniMaxM3SparseForConditionalGeneration",
+        }
+    )
+    memory_pool = types.ModuleType("sglang.srt.mem_cache.memory_pool")
+    memory_pool.MiniMaxSparseKVPool = MiniMaxPool
+    packages[model_config.__name__] = model_config
+    packages[memory_pool.__name__] = memory_pool
+
+    path = REPO_ROOT / "python/sglang/srt/mem_cache/pool_registry.py"
+    spec = importlib.util.spec_from_file_location("_glm_guard_pool_registry", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    with patch.dict(sys.modules, packages):
+        spec.loader.exec_module(module)
+    return module, MiniMaxPool
+
+
+def _config(architecture: str, **kwargs):
+    return SimpleNamespace(
+        hf_config=SimpleNamespace(architectures=[architecture], **kwargs)
+    )
+
+
+class _LogStub:
+    def info(self, *args, **kwargs):
+        pass
+
+    def warning(self, *args, **kwargs):
+        pass
+
+
+class _EnvFieldStub:
+    def __init__(self, name: str):
+        self.name = name
+
+    def get(self):
+        return os.environ.get(self.name)
+
+    def is_set(self):
+        return self.name in os.environ
+
+    def set(self, value):
+        os.environ[self.name] = str(value)
+
+
+class _EnvsStub:
+    def __getattr__(self, name: str):
+        return _EnvFieldStub(name)
+
+
+def _server_adjustment_method():
+    model_config_path = "python/sglang/srt/configs/model_config.py"
+    model_config_tree = _parse(model_config_path)
+    predicate_name = (
+        "is_deepseek_nsa"
+        if any(
+            isinstance(node, ast.FunctionDef) and node.name == "is_deepseek_nsa"
+            for node in model_config_tree.body
+        )
+        else "is_deepseek_dsa"
+    )
+    dsa_predicate = _compile_function(model_config_path, predicate_name)
+    return _compile_function(
+        "python/sglang/srt/server_args.py",
+        "_handle_model_specific_adjustments",
+        class_name="ServerArgs",
+        globals_={
+            "ConnectorType": SimpleNamespace(INSTANCE="instance"),
+            "envs": _EnvsStub(),
+            "get_device_name": lambda: None,
+            "is_blackwell_supported": lambda: False,
+            "is_deepseek_dsa": dsa_predicate,
+            "is_deepseek_nsa": dsa_predicate,
+            "is_hip": lambda: False,
+            "is_npu": lambda: True,
+            "is_sm100_supported": lambda: False,
+            "logger": _LogStub(),
+            "parse_connector_type": lambda model_path: "local",
+        },
+    )
+
+
+def _server_stub(architecture: str, **config_kwargs):
+    server = SimpleNamespace(
+        attention_backend=None,
+        decode_attention_backend=None,
+        enable_flashinfer_allreduce_fusion=False,
+        enable_nsa_prefill_context_parallel=False,
+        enable_two_batch_overlap=False,
+        kv_cache_dtype="auto",
+        model_path="stub/model",
+        page_size=None,
+        prefill_attention_backend=None,
+    )
+    hf_config = SimpleNamespace(architectures=[architecture], **config_kwargs)
+    server.get_model_config = types.MethodType(
+        lambda self: SimpleNamespace(hf_config=hf_config), server
+    )
+    server.is_attention_backend_not_set = types.MethodType(
+        lambda self: (
+            self.attention_backend is None
+            and self.prefill_attention_backend is None
+            and self.decode_attention_backend is None
+        ),
+        server,
+    )
+    return server
+
+
+def _without_sglang_env():
+    clean_env = {
+        name: value
+        for name, value in os.environ.items()
+        if not name.startswith("SGLANG_") and not name.startswith("SGL_")
+    }
+    return patch.dict(os.environ, clean_env, clear=True)
+
+
+class TestNonGlmRegressionBoundary(unittest.TestCase):
+    def test_scheduler_glm_lifecycle_dispatches_are_exactly_gated(self):
+        release_req = _find_function(
+            _parse("python/sglang/srt/managers/schedule_batch.py"),
+            "release_req",
+            class_name="ScheduleBatch",
+        )
+        release_source = ast.unparse(release_req)
+        self.assertIn("_glm5_next_session_ab_active", release_source)
+        self.assertIn("dispatch_named('glm5_next_kpool'", release_source)
+
+        output_source = (
+            REPO_ROOT / "python/sglang/srt/managers/scheduler_output_processor_mixin.py"
+        ).read_text(encoding="utf-8")
+        self.assertEqual(output_source.count('"glm5_next_kpool"'), 2)
+        self.assertEqual(output_source.count('"is_glm5_next"'), 2)
+
+    def test_attention_tp_context_cleans_state_when_forward_raises(self):
+        maybe_input_scattered = _compile_function(
+            "python/sglang/srt/layers/communicator.py",
+            "maybe_input_scattered",
+            class_name="AttnTpContext",
+        )
+
+        class _Context:
+            input_scattered_ = False
+            attn_inputs_ = object()
+
+            @property
+            def input_scattered(self):
+                return self.input_scattered_
+
+            def use_input_scattered(self, forward_batch):
+                del forward_batch
+                return True
+
+        context = _Context()
+        guarded = contextmanager(maybe_input_scattered)
+        with self.assertRaisesRegex(RuntimeError, "injected forward failure"):
+            with guarded(context, object()):
+                self.assertTrue(context.input_scattered_)
+                raise RuntimeError("injected forward failure")
+
+        self.assertFalse(context.input_scattered_)
+        self.assertIsNone(context.attn_inputs_)
+
+    def test_named_lifecycle_dispatch_does_not_call_legacy_hooks(self):
+        path = REPO_ROOT / "python/sglang/srt/managers/forward_hooks_registry.py"
+        spec = importlib.util.spec_from_file_location(
+            "_glm_guard_forward_hooks_registry", path
+        )
+        registry = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(registry)
+
+        calls = []
+
+        class _Hook:
+            def __init__(self, name):
+                self.name = name
+
+            def on_request_finished(self, req):
+                calls.append((self.name, req))
+
+        req = object()
+        registry.register_forward_hook("legacy", _Hook("legacy"))
+        registry.register_forward_hook("glm5_next_kpool", _Hook("glm"))
+
+        registry.dispatch_named("glm5_next_kpool", "on_request_finished", req)
+        self.assertEqual(calls, [("glm", req)])
+
+        calls.clear()
+        registry.dispatch("on_request_finished", req)
+        self.assertEqual(calls, [("legacy", req), ("glm", req)])
+
+    def test_existing_attention_backend_registrations_are_not_replaced(self):
+        registry = _load_attention_registry()
+        expected = {
+            "aiter": "create_aiter_backend",
+            "ascend": "create_ascend_backend",
+            "compressed": "create_compressed_backend",
+            "cutlass_mla": "create_cutlass_mla_backend",
+            "dual_chunk_flash_attn": "create_dual_chunk_flash_attn_backend",
+            "fa3": "create_flashattention_v3_backend",
+            "fa4": "create_flashattention_v4_backend",
+            "flashinfer": "create_flashinfer_backend",
+            "flashmla": "create_flashmla_backend",
+            "flex_attention": "create_flex_attention_backend",
+            "intel_amx": "create_intel_amx_backend",
+            "intel_xpu": "create_intel_xpu_backend",
+            "nsa": "create_nsa_backend",
+            "torch_native": "create_torch_native_backend",
+            "triton": "create_triton_backend",
+            "trtllm_mha": "create_trtllm_mha_backend",
+            "trtllm_mla": "create_trtllm_mla_backend",
+            "wave": "create_wave_backend",
+        }
+        actual = {
+            name: factory.__name__
+            for name, factory in registry.ATTENTION_BACKENDS.items()
+        }
+        # GLM may add a backend, but it must not replace an existing mapping.
+        self.assertEqual({name: actual.get(name) for name in expected}, expected)
+
+    def test_server_args_defaults_and_non_glm_environment_stay_unchanged(self):
+        tree = _parse("python/sglang/srt/server_args.py")
+        server_args = next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.ClassDef) and node.name == "ServerArgs"
+        )
+        defaults = {
+            node.target.id: ast.literal_eval(node.value)
+            for node in server_args.body
+            if isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.value is not None
+            and node.target.id
+            in {
+                "attention_backend",
+                "decode_attention_backend",
+                "kv_cache_dtype",
+                "page_size",
+                "prefill_attention_backend",
+            }
+        }
+        self.assertEqual(
+            defaults,
+            {
+                "attention_backend": None,
+                "decode_attention_backend": None,
+                "kv_cache_dtype": "auto",
+                "page_size": None,
+                "prefill_attention_backend": None,
+            },
+        )
+
+        server = _server_stub("RegressionSentinelForCausalLM")
+        before_fields = {
+            name: getattr(server, name)
+            for name in (
+                "attention_backend",
+                "decode_attention_backend",
+                "kv_cache_dtype",
+                "page_size",
+                "prefill_attention_backend",
+            )
+        }
+        with _without_sglang_env():
+            before_env = {
+                name: value
+                for name, value in os.environ.items()
+                if name.startswith("SGLANG_") or name.startswith("SGL_")
+            }
+
+            _server_adjustment_method()(server)
+
+            self.assertEqual(
+                {name: getattr(server, name) for name in before_fields},
+                before_fields,
+            )
+            self.assertEqual(
+                {
+                    name: value
+                    for name, value in os.environ.items()
+                    if name.startswith("SGLANG_") or name.startswith("SGL_")
+                },
+                before_env,
+            )
+
+
+class TestLegacyAttentionRoutes(unittest.TestCase):
+    def test_index_kpool_one_keeps_legacy_nsa_backend_and_pool(self):
+        server = _server_stub("GlmMoeDsaForCausalLM", index_topk=2048, index_kpool=1)
+        with _without_sglang_env():
+            _server_adjustment_method()(server)
+        self.assertEqual(server.attention_backend, "nsa")
+
+        model_config_tree = _parse("python/sglang/srt/configs/model_config.py")
+        helper_names = {
+            node.name
+            for node in model_config_tree.body
+            if isinstance(node, ast.FunctionDef)
+        }
+        if "get_dsa_index_kpool" in helper_names:
+            get_index_kpool = _compile_function(
+                "python/sglang/srt/configs/model_config.py", "get_dsa_index_kpool"
+            )
+            self.assertEqual(get_index_kpool(server.get_model_config().hf_config), 1)
+
+        # The legacy branch must remain a direct NSATokenToKVPool fallback.  A
+        # future GLM kpool plugin may claim index_kpool > 1 before this branch.
+        init_pool = _find_function(
+            _parse("python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py"),
+            "init_memory_pool",
+            "ModelRunnerKVCacheMixin",
+        )
+        legacy_branches = [
+            node
+            for node in ast.walk(init_pool)
+            if isinstance(node, ast.If)
+            and "is_nsa_model" in ast.unparse(node.test)
+            and any(
+                isinstance(child, ast.Call)
+                and isinstance(child.func, ast.Name)
+                and child.func.id == "NSATokenToKVPool"
+                for child in ast.walk(ast.Module(body=node.body, type_ignores=[]))
+            )
+        ]
+        self.assertTrue(
+            legacy_branches,
+            "index_kpool=1 must retain the legacy NSATokenToKVPool fallback",
+        )
+
+    def test_lower_bound_none_uses_the_existing_kda_decode_kernel(self):
+        decode = _compile_function(
+            "python/sglang/srt/layers/attention/linear/kda_backend.py",
+            "decode",
+            class_name="KDAKernelDispatcher",
+            globals_={"TritonKDAKernel": type("TritonKDAKernel", (), {})},
+        )
+
+        calls = []
+
+        class ExistingKimiDecodeKernel:
+            def decode(self, *args, **kwargs):
+                calls.append((args, kwargs))
+                return "legacy-kimi-kda"
+
+        dispatcher = SimpleNamespace(decode_kernel=ExistingKimiDecodeKernel())
+        marker = object()
+        result = decode(
+            dispatcher,
+            marker,
+            marker,
+            marker,
+            marker,
+            marker,
+            A_log=marker,
+            dt_bias=marker,
+            ssm_states=marker,
+            cache_indices=marker,
+            query_start_loc=marker,
+            lower_bound=None,
+            regression_marker="kimi",
+        )
+
+        self.assertEqual(result, "legacy-kimi-kda")
+        self.assertEqual(len(calls), 1)
+        self.assertIsNone(calls[0][1].get("lower_bound"))
+        self.assertEqual(calls[0][1]["regression_marker"], "kimi")
+
+
+class TestGlmKPoolMemoryAccounting(unittest.TestCase):
+    @staticmethod
+    def _cell_size_method():
+        class FakeNSAPool:
+            quant_block_size = 128
+            index_k_with_scale_buffer_dtype = __import__("torch").uint8
+
+        return _compile_function(
+            "python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py",
+            "get_cell_size_per_token",
+            class_name="ModelRunnerKVCacheMixin",
+            globals_={
+                "NSATokenToKVPool": FakeNSAPool,
+                "get_nsa_index_head_dim": lambda config: 128,
+                "get_attention_tp_size": lambda: 1,
+                "is_deepseek_compressed": lambda config: False,
+                "is_deepseek_nsa": lambda config: bool(
+                    getattr(config, "legacy_nsa", False)
+                ),
+                "is_float4_e2m1fn_x2": lambda dtype: False,
+                "torch": __import__("torch"),
+            },
+        )
+
+    @staticmethod
+    def _runner(*, exact_glm: bool, legacy_nsa: bool = False):
+        torch = __import__("torch")
+        model_config = SimpleNamespace(
+            hf_config=SimpleNamespace(legacy_nsa=legacy_nsa),
+            is_glm5_next=exact_glm,
+            uses_kpool4_compress=exact_glm,
+            index_head_dim=128,
+            qk_nope_head_dim=256 if exact_glm else 128,
+            qk_rope_head_dim=0 if exact_glm else 64,
+            kv_lora_rank=512,
+        )
+        return SimpleNamespace(
+            kv_cache_dtype=torch.float8_e4m3fn,
+            model_config=model_config,
+            use_mla_backend=True,
+            calculate_mla_kv_cache_dim=lambda: 512,
+        )
+
+    def test_exact_glm_cell_uses_raw_latent_kv_width(self):
+        get_cell_size = self._cell_size_method()
+        runner = self._runner(exact_glm=True)
+
+        # latent: 512 * 11; index: (128 FP8 + 4-byte scale) * 11
+        self.assertEqual(get_cell_size(runner, 11), 7084)
+
+    def test_non_glm_and_legacy_nsa_keep_historical_arithmetic(self):
+        get_cell_size = self._cell_size_method()
+        non_glm = self._runner(exact_glm=False)
+        legacy_nsa = self._runner(exact_glm=False, legacy_nsa=True)
+
+        self.assertEqual(get_cell_size(non_glm, 11), (128 + 64) * 11)
+        self.assertEqual(
+            get_cell_size(legacy_nsa, 11),
+            (128 + 64) * 11 + (128 + 4) * 11,
+        )
+
+    def test_fixed_tail_is_reserved_once_and_only_for_exact_glm(self):
+        torch = __import__("torch")
+        source = "python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py"
+        tail_size = _compile_function(
+            source,
+            "_get_glm5_next_kpool_tail_size_bytes",
+            class_name="ModelRunnerKVCacheMixin",
+            globals_={"torch": torch},
+        )
+        reserve = _compile_function(
+            source,
+            "_reserve_glm5_next_kpool_tail",
+            class_name="ModelRunnerKVCacheMixin",
+            globals_={"logger": _LogStub()},
+        )
+
+        text_config = SimpleNamespace(
+            index_kpool=4,
+            index_head_dim=128,
+            index_kpool_compress=True,
+        )
+        exact = SimpleNamespace(
+            model_config=SimpleNamespace(
+                is_glm5_next=True,
+                uses_kpool4_compress=True,
+                hf_text_config=text_config,
+            )
+        )
+        exact._get_glm5_next_kpool_tail_size_bytes = types.MethodType(tail_size, exact)
+        exact.get_cell_size_per_token = lambda num_layers: 7084
+
+        expected_tail_bytes = 11 * 2048 * 4 * 128 * 2 * 2
+        self.assertEqual(
+            tail_size(exact, num_layers=11, max_num_reqs=2048),
+            expected_tail_bytes,
+        )
+        expected_slots = (expected_tail_bytes + 7084 - 1) // 7084
+        self.assertEqual(
+            reserve(
+                exact,
+                max_total_num_tokens=100_000,
+                num_layers=11,
+                max_num_reqs=2048,
+            ),
+            100_000 - expected_slots,
+        )
+
+        other = SimpleNamespace(
+            model_config=SimpleNamespace(
+                is_glm5_next=False,
+                uses_kpool4_compress=False,
+            )
+        )
+        self.assertEqual(tail_size(other, num_layers=11, max_num_reqs=2048), 0)
+
+        init_pool = _find_function(
+            _parse(source), "init_memory_pool", "ModelRunnerKVCacheMixin"
+        )
+        reserve_calls = [
+            node
+            for node in ast.walk(init_pool)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "_reserve_glm5_next_kpool_tail"
+        ]
+        self.assertEqual(len(reserve_calls), 1)
+
+
+class TestPoolRegistryOwnership(unittest.TestCase):
+    def test_glm_first_match_does_not_steal_minimax_or_dsv4(self):
+        registry, minimax_factory = _load_pool_registry()
+
+        class GlmKPool:
+            pass
+
+        class DeepSeekV4Pool:
+            pass
+
+        def glm_next_kpool_predicate(model_config, server_args):
+            hf_config = model_config.hf_config
+            return (
+                getattr(hf_config, "model_type", None) == "glm5_next"
+                and getattr(hf_config, "index_kpool", 1) > 1
+            )
+
+        def deepseek_v4_predicate(model_config, server_args):
+            return model_config.hf_config.architectures[0] in {
+                "DeepseekV4ForCausalLM",
+                "DeepseekV4ForCausalLMNextN",
+            }
+
+        # Deliberately put GLM first: first-match is safe only if ownership
+        # predicates are mutually exclusive and the GLM predicate is narrow.
+        registry._KV_POOL_FACTORIES[:] = [
+            ("glm5_next_kpool", glm_next_kpool_predicate, GlmKPool),
+            (
+                "minimax_m3_sparse",
+                registry._minimax_sparse_pool_predicate,
+                minimax_factory,
+            ),
+            ("deepseek_v4", deepseek_v4_predicate, DeepSeekV4Pool),
+        ]
+
+        minimax = _config("MiniMaxM3SparseForCausalLM", model_type="minimax_m3")
+        dsv4 = _config("DeepseekV4ForCausalLM", model_type="deepseek_v4")
+        legacy_glm = _config(
+            "GlmMoeDsaForCausalLM",
+            model_type="glm4_moe",
+            index_topk=2048,
+            index_kpool=1,
+        )
+
+        self.assertEqual(
+            registry.resolve_kv_pool_factory(minimax, SimpleNamespace())[0],
+            "minimax_m3_sparse",
+        )
+        self.assertEqual(
+            registry.resolve_kv_pool_factory(dsv4, SimpleNamespace())[0],
+            "deepseek_v4",
+        )
+        self.assertIsNone(
+            registry.resolve_kv_pool_factory(legacy_glm, SimpleNamespace())
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/test_glm5_next_regression_guards.py
+++ b/test/registered/unit/test_glm5_next_regression_guards.py
@@ -1020,8 +1020,8 @@ class TestKPoolBatchOwnedPool(unittest.TestCase):
     def test_kpool_ragged_row_chunks_slice_all_metadata_and_keep_padding(self):
         iterator_calls = []
 
-        def fake_logits_rows(q_fp8, kv_fp8, weights, ks, ke):
-            iterator_calls.append((q_fp8, kv_fp8, weights, ks, ke))
+        def fake_logits_rows(query, index_k, weights, ks, ke, *, k_scale=None):
+            iterator_calls.append((query, index_k, k_scale, weights, ks, ke))
             for start, end in ((0, 2), (2, 4), (4, 5)):
                 yield start, end, torch.full((end - start, 7), float(start))
 
@@ -1035,11 +1035,11 @@ class TestKPoolBatchOwnedPool(unittest.TestCase):
 
         method = _compile_function(
             self._SOURCE,
-            "_topk_from_glm5_next_eager_logits_rows",
+            "_topk_from_glm5_next_model_local_logits_rows",
             class_name="IndexerKPool",
             globals_={
                 "torch": torch,
-                "iter_glm5_next_eager_fp8_mqa_logits": fake_logits_rows,
+                "iter_glm5_next_triton_mqa_logits": fake_logits_rows,
             },
         )
         q = torch.zeros((5, 3, 128), dtype=torch.float32)
@@ -1057,12 +1057,14 @@ class TestKPoolBatchOwnedPool(unittest.TestCase):
             index_topk=8,
             index_kpool=4,
             _topk_from_kpool_logits=select,
+            _should_use_triton_logits=lambda _query: True,
         )
 
         result = method(
             runner,
             q,
-            (k, scale),
+            k,
+            scale,
             weights,
             pool_lens,
             seq_lens,

--- a/test/registered/unit/test_glm5_next_runtime_config_subprocess.py
+++ b/test/registered/unit/test_glm5_next_runtime_config_subprocess.py
@@ -1,0 +1,156 @@
+"""Real transformers-kt config smoke for the pinned GLM-5-Next layer names."""
+
+from __future__ import annotations
+
+import importlib.metadata
+import importlib.util
+import os
+import subprocess
+import sys
+import types
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CONFIG_PATH = REPO_ROOT / "python/sglang/srt/configs/glm5_next.py"
+PINNED_DIST = "transformers-kt"
+PINNED_VERSION = "5.6.0.post1"
+CHILD_FLAG = "--runtime-config-child"
+SKIP_EXIT_CODE = 77
+SUCCESS_MARKER = "GLM5_NEXT_RUNTIME_CONFIG_STRICT_OK"
+
+
+def _load_config_module():
+    for name, path in (
+        ("sglang", REPO_ROOT / "python/sglang"),
+        ("sglang.srt", REPO_ROOT / "python/sglang/srt"),
+        ("sglang.srt.configs", REPO_ROOT / "python/sglang/srt/configs"),
+    ):
+        package = types.ModuleType(name)
+        package.__path__ = [str(path)]
+        sys.modules[name] = package
+
+    mamba_utils = types.ModuleType("sglang.srt.configs.mamba_utils")
+    mamba_utils.KimiLinearCacheParams = type("KimiLinearCacheParams", (), {})
+    mamba_utils.KimiLinearStateShape = type("KimiLinearStateShape", (), {})
+    sys.modules[mamba_utils.__name__] = mamba_utils
+
+    module_name = "sglang.srt.configs.glm5_next"
+    spec = importlib.util.spec_from_file_location(module_name, CONFIG_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Cannot load production config: {CONFIG_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _child_main() -> int:
+    try:
+        version = importlib.metadata.version(PINNED_DIST)
+    except importlib.metadata.PackageNotFoundError:
+        print(f"skip: {PINNED_DIST} is not installed")
+        return SKIP_EXIT_CODE
+    if version != PINNED_VERSION:
+        print(f"skip: expected {PINNED_DIST}=={PINNED_VERSION}; got {version}")
+        return SKIP_EXIT_CODE
+
+    module = _load_config_module()
+    checkpoint_layer_types = [
+        "linear_attention"
+        if layer_idx % 4 != 3
+        else "deepseek_sparse_attention"
+        for layer_idx in range(45)
+    ]
+    kda_layers = [
+        index
+        for index, layer_type in enumerate(checkpoint_layer_types)
+        if layer_type == "linear_attention"
+    ]
+    full_attn_layers = [
+        index
+        for index, layer_type in enumerate(checkpoint_layer_types)
+        if layer_type == "deepseek_sparse_attention"
+    ]
+    linear_attn_config = {
+        "full_attn_layers": full_attn_layers,
+        "head_dim": 128,
+        "kda_layers": kda_layers,
+        "num_heads": 64,
+        "short_conv_kernel_size": 4,
+    }
+    text_config = {
+        "model_type": "glm5_next_text",
+        "num_hidden_layers": 45,
+        "layer_types": checkpoint_layer_types,
+        "linear_attn_config": linear_attn_config,
+    }
+    config = module.Glm5NextConfig.from_dict(
+        {
+            "model_type": "glm5_next",
+            "architectures": ["Glm5NextForConditionalGeneration"],
+            "num_hidden_layers": 45,
+            "layer_types": checkpoint_layer_types,
+            "linear_attn_config": linear_attn_config,
+            "text_config": text_config,
+            "vision_config": {"projection_intermediate_size": 10240},
+        }
+    )
+
+    generic_layer_types = [
+        "linear_attention" if layer_type == "linear_attention" else "sparse"
+        for layer_type in checkpoint_layer_types
+    ]
+    assert config.layer_types == generic_layer_types
+    assert config.text_config.layer_types == generic_layer_types
+    assert (
+        config.text_config._glm5_next_checkpoint_layer_types
+        == checkpoint_layer_types
+    )
+    assert config.text_config.linear_layer_ids == kda_layers
+    assert config.text_config.full_attention_layer_ids == full_attn_layers
+    assert len(kda_layers) == 34
+    assert len(full_attn_layers) == 11
+
+    # The strict validator must remain callable after construction, not merely
+    # be bypassed during ``from_dict``.
+    config.validate()
+    config.text_config.validate()
+    print(f"{SUCCESS_MARKER}: transformers-kt={version}; kda=34; dsa=11")
+    return 0
+
+
+def test_real_transformers_kt_accepts_checkpoint_layer_types():
+    import pytest
+
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "CUDA_VISIBLE_DEVICES": "",
+            "HF_HUB_OFFLINE": "1",
+            "TRANSFORMERS_OFFLINE": "1",
+            "PYTHONDONTWRITEBYTECODE": "1",
+        }
+    )
+    result = subprocess.run(
+        [sys.executable, str(Path(__file__).resolve()), CHILD_FLAG],
+        cwd=REPO_ROOT,
+        env=environment,
+        text=True,
+        capture_output=True,
+        timeout=60,
+        check=False,
+    )
+    details = "\n".join(
+        part for part in (result.stdout.strip(), result.stderr.strip()) if part
+    )
+    if result.returncode == SKIP_EXIT_CODE:
+        pytest.skip(details)
+    assert result.returncode == 0, details
+    assert SUCCESS_MARKER in result.stdout, details
+
+
+if __name__ == "__main__":
+    if sys.argv[1:] != [CHILD_FLAG]:
+        raise SystemExit(f"usage: {Path(__file__).name} {CHILD_FLAG}")
+    raise SystemExit(_child_main())

--- a/test/registered/unit/test_glm5_next_server_args_boundary.py
+++ b/test/registered/unit/test_glm5_next_server_args_boundary.py
@@ -1,0 +1,464 @@
+"""CPU-only guards for the exact GLM-5-Next Session AB launch boundary."""
+
+from __future__ import annotations
+
+import ast
+import copy
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SERVER_ARGS_PATH = REPO_ROOT / "python/sglang/srt/server_args.py"
+NSA_BACKEND_PATH = REPO_ROOT / "python/sglang/srt/layers/attention/nsa_backend.py"
+
+
+def _server_args_tree() -> ast.Module:
+    return ast.parse(
+        SERVER_ARGS_PATH.read_text(encoding="utf-8"), filename=str(SERVER_ARGS_PATH)
+    )
+
+
+def _find_function(name: str, *, class_name: str | None = None) -> ast.FunctionDef:
+    tree = _server_args_tree()
+    body = tree.body
+    if class_name is not None:
+        class_node = next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.ClassDef) and node.name == class_name
+        )
+        body = class_node.body
+    return next(
+        node for node in body if isinstance(node, ast.FunctionDef) and node.name == name
+    )
+
+
+def _compile_function(name: str, *, class_name: str | None = None, globals_=None):
+    function = copy.deepcopy(_find_function(name, class_name=class_name))
+    function.decorator_list = []
+    module_body: list[ast.stmt] = [
+        ast.ImportFrom(
+            module="__future__",
+            names=[ast.alias(name="annotations")],
+            level=0,
+        )
+    ]
+    symbol = name
+    if class_name is None:
+        module_body.append(function)
+    else:
+        symbol = "_ServerArgsHarness"
+        module_body.append(
+            ast.ClassDef(
+                name=symbol,
+                bases=[],
+                keywords=[],
+                body=[function],
+                decorator_list=[],
+            )
+        )
+    namespace = {"__builtins__": __builtins__}
+    namespace.update(globals_ or {})
+    module = ast.fix_missing_locations(ast.Module(body=module_body, type_ignores=[]))
+    exec(compile(module, str(SERVER_ARGS_PATH), "exec"), namespace)
+    compiled = namespace[symbol]
+    return compiled if class_name is None else getattr(compiled, name)
+
+
+class _LoggerStub:
+    def warning(self, *args, **kwargs):
+        pass
+
+
+def _boundary_args(**overrides):
+    values = dict(
+        speculative_algorithm=None,
+        enable_nsa_prefill_context_parallel=False,
+        disaggregation_mode="null",
+        enable_dp_attention=False,
+        enable_two_batch_overlap=False,
+        enable_piecewise_cuda_graph=False,
+        enable_hierarchical_cache=False,
+        enable_lmcache=False,
+        enable_hisparse=False,
+        enable_multimodal=None,
+        is_embedding=False,
+        dllm_algorithm=None,
+        dllm_algorithm_config=None,
+        quantization="fp8",
+        tp_size=1,
+        pp_size=1,
+        dp_size=1,
+        moe_dp_size=1,
+        attn_cp_size=1,
+        ep_size=1,
+        moe_a2a_backend="none",
+        moe_dense_tp_size=None,
+        moe_runner_backend="auto",
+        kt_weight_path=None,
+        kt_method=None,
+        disable_shared_experts_fusion=False,
+        disable_cuda_graph=False,
+        disable_radix_cache=False,
+    )
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+class TestGlm5NextSessionABOptions(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.validate = staticmethod(
+            _compile_function(
+                "_validate_glm5_next_session_ab_boundary", class_name="ServerArgs"
+            )
+        )
+
+    def test_defaults_resolve_to_correctness_first_moe_and_eager_mode(self):
+        args = _boundary_args()
+
+        self.validate(args)
+
+        self.assertEqual(args.moe_runner_backend, "triton")
+        self.assertTrue(args.disable_shared_experts_fusion)
+        self.assertTrue(args.disable_cuda_graph)
+        self.assertTrue(args.disable_radix_cache)
+        self.assertTrue(args._glm5_next_session_ab_active)
+
+    def test_prefix_cache_is_always_disabled_and_external_caches_are_rejected(self):
+        already_disabled = _boundary_args(disable_radix_cache=True)
+        self.validate(already_disabled)
+        self.assertTrue(already_disabled.disable_radix_cache)
+
+        cases = (
+            ({"enable_hierarchical_cache": True}, "HiCache"),
+            ({"enable_lmcache": True}, "LMCache"),
+            ({"enable_hisparse": True}, "HiSparse"),
+        )
+        for overrides, message in cases:
+            with self.subTest(overrides=overrides):
+                with self.assertRaisesRegex(ValueError, message):
+                    self.validate(_boundary_args(**overrides))
+
+    def test_multimodal_and_non_fp8_weights_are_deferred(self):
+        with self.assertRaisesRegex(ValueError, "Session D"):
+            self.validate(_boundary_args(enable_multimodal=True))
+
+        for quantization in (None, "mxfp8", "bf16", "compressed-tensors"):
+            with self.subTest(quantization=quantization):
+                with self.assertRaisesRegex(ValueError, "FP8 weight format"):
+                    self.validate(_boundary_args(quantization=quantization))
+
+    def test_non_generation_request_modes_are_rejected(self):
+        with self.assertRaisesRegex(ValueError, "is-embedding"):
+            self.validate(_boundary_args(is_embedding=True))
+
+        for overrides in (
+            {"dllm_algorithm": "LowConfidence"},
+            {"dllm_algorithm_config": "stub.yaml"},
+        ):
+            with self.subTest(overrides=overrides):
+                with self.assertRaisesRegex(ValueError, "diffusion-LLM"):
+                    self.validate(_boundary_args(**overrides))
+
+    def test_safe_cache_gate_composes_with_later_generic_validation(self):
+        args = _boundary_args()
+        args.disaggregation_decode_enable_offload_kvcache = False
+        args.swa_full_tokens_ratio = 0.9
+
+        self.validate(args)
+        generic_validate = _compile_function(
+            "_handle_cache_compatibility", class_name="ServerArgs"
+        )
+        generic_validate(args)
+
+        self.assertFalse(args.enable_hierarchical_cache)
+        self.assertTrue(args.disable_radix_cache)
+
+    def test_pd_dp_attention_tbo_spec_and_cp_are_rejected(self):
+        cases = (
+            ({"disaggregation_mode": "prefill"}, "PD/disaggregation"),
+            ({"disaggregation_mode": "decode"}, "PD/disaggregation"),
+            ({"enable_dp_attention": True}, "enable-dp-attention"),
+            ({"enable_two_batch_overlap": True}, "two-batch-overlap"),
+            (
+                {"enable_piecewise_cuda_graph": True},
+                "piecewise-cuda-graph",
+            ),
+            ({"speculative_algorithm": "EAGLE"}, "MTP/speculative"),
+            (
+                {"enable_nsa_prefill_context_parallel": True},
+                "context-parallel",
+            ),
+        )
+        for overrides, message in cases:
+            with self.subTest(overrides=overrides):
+                with self.assertRaisesRegex(ValueError, message):
+                    self.validate(_boundary_args(**overrides))
+
+    def test_only_tp1_structural_and_tp8_production_widths_are_accepted(self):
+        for tp_size in (1, 8):
+            with self.subTest(tp_size=tp_size):
+                args = _boundary_args(tp_size=tp_size)
+                self.validate(args)
+                self.assertEqual(args.tp_size, tp_size)
+
+        for tp_size in (2, 4, 16):
+            with self.subTest(tp_size=tp_size):
+                with self.assertRaisesRegex(ValueError, "TP=8 production"):
+                    self.validate(_boundary_args(tp_size=tp_size))
+
+    def test_only_tensor_parallel_topology_is_accepted(self):
+        cases = (
+            {"pp_size": 2},
+            {"dp_size": 2},
+            {"moe_dp_size": 2},
+            {"attn_cp_size": 2},
+            {"ep_size": 8},
+            {"moe_a2a_backend": "deepep"},
+            {"moe_dense_tp_size": 1},
+        )
+        for overrides in cases:
+            with self.subTest(overrides=overrides):
+                with self.assertRaisesRegex(ValueError, "tensor parallelism only"):
+                    self.validate(_boundary_args(**overrides))
+
+    def test_only_triton_moe_runner_is_accepted(self):
+        explicit_triton = _boundary_args(moe_runner_backend="triton")
+        self.validate(explicit_triton)
+        self.assertEqual(explicit_triton.moe_runner_backend, "triton")
+
+        for backend in (
+            "cutlass",
+            "deep_gemm",
+            "flashinfer_cutlass",
+            "flashinfer_trtllm",
+            "flashinfer_trtllm_routed",
+        ):
+            with self.subTest(backend=backend):
+                with self.assertRaisesRegex(ValueError, "swiglu_limit"):
+                    self.validate(_boundary_args(moe_runner_backend=backend))
+
+    def test_kt_offload_accepts_only_checkpoint_native_block_fp8(self):
+        args = _boundary_args(
+            moe_runner_backend="triton",
+            kt_weight_path="stub/experts",
+            kt_method="fp8",
+        )
+        self.validate(args)
+        self.assertEqual(args.moe_runner_backend, "triton")
+
+        for method in (
+            None,
+            "AMXINT4",
+            "FP8_PERCHANNEL",
+            "MXFP4",
+            "MXFP8",
+            "RAWINT4",
+        ):
+            with self.subTest(method=method):
+                with self.assertRaisesRegex(ValueError, "--kt-method FP8"):
+                    self.validate(
+                        _boundary_args(
+                            moe_runner_backend="triton",
+                            kt_weight_path="stub/experts",
+                            kt_method=method,
+                        )
+                    )
+
+
+class TestGlm5NextSessionABNSA(unittest.TestCase):
+    @staticmethod
+    def _configure():
+        return _compile_function(
+            "_configure_glm5_next_session_ab_nsa",
+            class_name="ServerArgs",
+            globals_={"logger": _LoggerStub()},
+        )
+
+    @staticmethod
+    def _args(**overrides):
+        values = dict(
+            kv_cache_dtype="fp8_e4m3",
+            nsa_prefill_backend=None,
+            nsa_decode_backend=None,
+        )
+        values.update(overrides)
+        return SimpleNamespace(**values)
+
+    def test_fp8_blackwell_sets_both_trtllm_dispatcher_paths(self):
+        configure = self._configure()
+        args = self._args()
+
+        configure(args, 12)
+
+        self.assertEqual(args.nsa_prefill_backend, "trtllm")
+        self.assertEqual(args.nsa_decode_backend, "trtllm")
+
+    def test_bf16_and_pre_blackwell_are_rejected(self):
+        for dtype in ("bf16", "bfloat16"):
+            with self.subTest(dtype=dtype):
+                with self.assertRaisesRegex(ValueError, "fp8_e4m3"):
+                    self._configure()(self._args(kv_cache_dtype=dtype), 12)
+
+        with self.assertRaisesRegex(ValueError, "Blackwell"):
+            self._configure()(self._args(), 9)
+
+    def test_non_trtllm_sparse_backend_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "both NSA prefill and decode"):
+            self._configure()(self._args(nsa_prefill_backend="flashmla_sparse"), 12)
+
+    def test_startup_does_not_require_new_flashinfer_abi(self):
+        configure = _find_function(
+            "_configure_glm5_next_session_ab_nsa", class_name="ServerArgs"
+        )
+        source = ast.unparse(configure)
+        self.assertNotIn("0.6.17", source)
+        self.assertNotIn("sparse_mla_top_k_lens", source)
+
+
+class TestGlm5NextBoundaryIsolation(unittest.TestCase):
+    def test_exact_gate_is_nested_under_exact_model_detection(self):
+        method = _find_function(
+            "_handle_model_specific_adjustments", class_name="ServerArgs"
+        )
+        exact_if_bodies = [
+            node.body
+            for node in ast.walk(method)
+            if isinstance(node, ast.If) and ast.unparse(node.test) == "is_glm5_next"
+        ]
+        self.assertTrue(exact_if_bodies)
+        self.assertTrue(
+            any(
+                any(
+                    isinstance(call.func, ast.Attribute)
+                    and call.func.attr == "_validate_glm5_next_session_ab_boundary"
+                    for statement in body
+                    for call in ast.walk(statement)
+                    if isinstance(call, ast.Call)
+                )
+                for body in exact_if_bodies
+            )
+        )
+
+    def test_non_glm_cache_moe_and_shared_fusion_defaults_are_unchanged(self):
+        tree = _server_args_tree()
+        server_args = next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.ClassDef) and node.name == "ServerArgs"
+        )
+        defaults = {
+            node.target.id: ast.literal_eval(node.value)
+            for node in server_args.body
+            if isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.value is not None
+            and node.target.id
+            in {
+                "moe_runner_backend",
+                "disable_shared_experts_fusion",
+                "disable_radix_cache",
+                "enable_hierarchical_cache",
+                "enable_lmcache",
+                "enable_hisparse",
+            }
+        }
+        self.assertEqual(
+            defaults,
+            {
+                "moe_runner_backend": "auto",
+                "enable_hierarchical_cache": False,
+                "enable_hisparse": False,
+                "enable_lmcache": False,
+                "disable_radix_cache": False,
+                "disable_shared_experts_fusion": False,
+            },
+        )
+
+    def test_generic_moe_normalization_revalidates_only_exact_glm(self):
+        method = _find_function("_handle_moe_kernel_config", class_name="ServerArgs")
+        exact_guards = [
+            node
+            for node in ast.walk(method)
+            if isinstance(node, ast.If)
+            and "_glm5_next_session_ab_active" in ast.unparse(node.test)
+        ]
+        self.assertEqual(len(exact_guards), 1)
+        self.assertTrue(
+            any(
+                isinstance(call.func, ast.Attribute)
+                and call.func.attr == "_validate_glm5_next_session_ab_boundary"
+                for call in ast.walk(exact_guards[0])
+                if isinstance(call, ast.Call)
+            )
+        )
+
+        normalize = _compile_function(
+            "_handle_moe_kernel_config",
+            class_name="ServerArgs",
+            globals_={
+                "get_bool_env_var": lambda name: False,
+                "is_hip": lambda: False,
+                "logger": _LoggerStub(),
+                "mxfp8_block_convert_required": lambda: False,
+            },
+        )
+        validate = _compile_function(
+            "_validate_glm5_next_session_ab_boundary", class_name="ServerArgs"
+        )
+
+        def make_args(*, exact_glm: bool, backend: str):
+            args = _boundary_args(moe_runner_backend="triton" if exact_glm else backend)
+            args.quantization = "fp8"
+            args.ep_size = 1
+            args.tp_size = 1
+            args._validate_glm5_next_session_ab_boundary = lambda: validate(args)
+            if exact_glm:
+                validate(args)
+                # Simulate a later generic rewrite after model-specific setup.
+                args.moe_runner_backend = backend
+            return args
+
+        with self.assertRaisesRegex(ValueError, "swiglu_limit"):
+            normalize(make_args(exact_glm=True, backend="deep_gemm"))
+
+        non_glm = make_args(exact_glm=False, backend="deep_gemm")
+        normalize(non_glm)
+        self.assertEqual(non_glm.moe_runner_backend, "deep_gemm")
+
+    def test_prefill_page_table_transform_is_glm_only(self):
+        tree = ast.parse(
+            NSA_BACKEND_PATH.read_text(encoding="utf-8"),
+            filename=str(NSA_BACKEND_PATH),
+        )
+        backend = next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.ClassDef) and node.name == "NativeSparseAttnBackend"
+        )
+        forward_extend = next(
+            node
+            for node in backend.body
+            if isinstance(node, ast.FunctionDef) and node.name == "forward_extend"
+        )
+        trtllm_calls = [
+            node
+            for node in ast.walk(forward_extend)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "_forward_trtllm"
+        ]
+        self.assertEqual(len(trtllm_calls), 1)
+        is_prefill = next(
+            keyword.value
+            for keyword in trtllm_calls[0].keywords
+            if keyword.arg == "is_prefill"
+        )
+        self.assertEqual(ast.unparse(is_prefill), "self.is_glm5_next")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/test_glm5_next_server_args_boundary.py
+++ b/test/registered/unit/test_glm5_next_server_args_boundary.py
@@ -11,6 +11,7 @@ from types import SimpleNamespace
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 SERVER_ARGS_PATH = REPO_ROOT / "python/sglang/srt/server_args.py"
+MODEL_RUNNER_PATH = REPO_ROOT / "python/sglang/srt/model_executor/model_runner.py"
 NSA_BACKEND_PATH = REPO_ROOT / "python/sglang/srt/layers/attention/nsa_backend.py"
 
 
@@ -98,7 +99,7 @@ def _boundary_args(**overrides):
         dllm_algorithm=None,
         dllm_algorithm_config=None,
         quantization="fp8",
-        tp_size=1,
+        tp_size=4,
         pp_size=1,
         dp_size=1,
         moe_dp_size=1,
@@ -247,16 +248,14 @@ class TestGlm5NextSessionABOptions(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, message):
                     self.validate(_boundary_args(**overrides))
 
-    def test_only_tp1_structural_and_tp8_production_widths_are_accepted(self):
-        for tp_size in (1, 8):
-            with self.subTest(tp_size=tp_size):
-                args = _boundary_args(tp_size=tp_size)
-                self.validate(args)
-                self.assertEqual(args.tp_size, tp_size)
+    def test_only_tp4_width_is_accepted(self):
+        args = _boundary_args(tp_size=4)
+        self.validate(args)
+        self.assertEqual(args.tp_size, 4)
 
-        for tp_size in (2, 4, 16):
+        for tp_size in (1, 2, 8, 16):
             with self.subTest(tp_size=tp_size):
-                with self.assertRaisesRegex(ValueError, "TP=8 production"):
+                with self.assertRaisesRegex(ValueError, "only TP=4"):
                     self.validate(_boundary_args(tp_size=tp_size))
 
     def test_only_tensor_parallel_topology_is_accepted(self):
@@ -317,29 +316,19 @@ class TestGlm5NextSessionABOptions(unittest.TestCase):
                         )
                     )
 
-    def test_layerwise_prefill_requires_tp8_and_static_experts(self):
+    def test_layerwise_prefill_requires_tp4_and_static_experts(self):
         accepted = _boundary_args(
-            tp_size=8,
+            tp_size=4,
             kt_weight_path="stub/experts",
             kt_method="fp8",
             kt_gpu_prefill_token_threshold=4096,
         )
         self.validate(accepted)
 
-        with self.assertRaisesRegex(ValueError, "requires TP=8"):
-            self.validate(
-                _boundary_args(
-                    tp_size=1,
-                    kt_weight_path="stub/experts",
-                    kt_method="fp8",
-                    kt_gpu_prefill_token_threshold=4096,
-                )
-            )
-
         with self.assertRaisesRegex(ValueError, "dynamic-expert-update"):
             self.validate(
                 _boundary_args(
-                    tp_size=8,
+                    tp_size=4,
                     kt_weight_path="stub/experts",
                     kt_method="fp8",
                     kt_gpu_prefill_token_threshold=4096,
@@ -347,13 +336,11 @@ class TestGlm5NextSessionABOptions(unittest.TestCase):
                 )
             )
 
-        structural = _boundary_args(
-            tp_size=1,
-            kt_weight_path="stub/experts",
-            kt_method="fp8",
-            kt_gpu_prefill_token_threshold=0,
-        )
-        self.validate(structural)
+    def test_glm_layerwise_context_is_not_eagerly_initialized_by_model_runner(self):
+        source = MODEL_RUNNER_PATH.read_text(encoding="utf-8")
+
+        self.assertNotIn("initialize_glm5_next_fp8_layerwise_prefill", source)
+        self.assertNotIn("glm5_next_fp8_layerwise_prefill_allocated_bytes", source)
 
 
 class TestGlm5NextSessionABNSA(unittest.TestCase):
@@ -540,7 +527,7 @@ class TestGlm5NextBoundaryIsolation(unittest.TestCase):
             args = _boundary_args(moe_runner_backend="triton" if exact_glm else backend)
             args.quantization = "fp8"
             args.ep_size = 1
-            args.tp_size = 1
+            args.tp_size = 4 if exact_glm else 1
             args._validate_glm5_next_session_ab_boundary = lambda: validate(args)
             if exact_glm:
                 validate(args)

--- a/test/registered/unit/test_glm5_next_server_args_boundary.py
+++ b/test/registered/unit/test_glm5_next_server_args_boundary.py
@@ -79,11 +79,21 @@ def _boundary_args(**overrides):
         disaggregation_mode="null",
         enable_dp_attention=False,
         enable_two_batch_overlap=False,
+        enable_mixed_chunk=False,
         enable_piecewise_cuda_graph=False,
         enable_hierarchical_cache=False,
         enable_lmcache=False,
         enable_hisparse=False,
         enable_multimodal=None,
+        mm_enable_dp_encoder=False,
+        encoder_only=False,
+        language_only=False,
+        encoder_urls=None,
+        enable_broadcast_mm_inputs_process=False,
+        enable_prefix_mm_cache=False,
+        enable_mm_global_cache=False,
+        keep_mm_feature_on_device=False,
+        mm_attention_backend=None,
         is_embedding=False,
         dllm_algorithm=None,
         dllm_algorithm_config=None,
@@ -155,14 +165,39 @@ class TestGlm5NextSessionABOptions(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, message):
                     self.validate(_boundary_args(**overrides))
 
-    def test_multimodal_and_non_fp8_weights_are_deferred(self):
-        with self.assertRaisesRegex(ValueError, "Session D"):
-            self.validate(_boundary_args(enable_multimodal=True))
+    def test_multimodal_default_and_explicit_modes_are_accepted(self):
+        for enable_multimodal in (None, True, False):
+            with self.subTest(enable_multimodal=enable_multimodal):
+                args = _boundary_args(enable_multimodal=enable_multimodal)
+                self.validate(args)
+                self.assertIs(args.enable_multimodal, enable_multimodal)
+
+    def test_non_fp8_weights_are_rejected(self):
 
         for quantization in (None, "mxfp8", "bf16", "compressed-tensors"):
             with self.subTest(quantization=quantization):
                 with self.assertRaisesRegex(ValueError, "FP8 weight format"):
                     self.validate(_boundary_args(quantization=quantization))
+
+    def test_unsupported_multimodal_execution_modes_are_rejected(self):
+        cases = (
+            ({"mm_enable_dp_encoder": True}, "mm-enable-dp-encoder"),
+            ({"encoder_only": True}, "encoder/language disaggregation"),
+            ({"language_only": True}, "encoder/language disaggregation"),
+            ({"encoder_urls": ["stub"]}, "encoder/language disaggregation"),
+            (
+                {"enable_broadcast_mm_inputs_process": True},
+                "execution/cache options",
+            ),
+            ({"enable_prefix_mm_cache": True}, "execution/cache options"),
+            ({"enable_mm_global_cache": True}, "execution/cache options"),
+            ({"keep_mm_feature_on_device": True}, "execution/cache options"),
+            ({"mm_attention_backend": "fa3"}, "execution/cache options"),
+        )
+        for overrides, message in cases:
+            with self.subTest(overrides=overrides):
+                with self.assertRaisesRegex(ValueError, message):
+                    self.validate(_boundary_args(**overrides))
 
     def test_non_generation_request_modes_are_rejected(self):
         with self.assertRaisesRegex(ValueError, "is-embedding"):
@@ -196,6 +231,7 @@ class TestGlm5NextSessionABOptions(unittest.TestCase):
             ({"disaggregation_mode": "decode"}, "PD/disaggregation"),
             ({"enable_dp_attention": True}, "enable-dp-attention"),
             ({"enable_two_batch_overlap": True}, "two-batch-overlap"),
+            ({"enable_mixed_chunk": True}, "enable-mixed-chunk"),
             (
                 {"enable_piecewise_cuda_graph": True},
                 "piecewise-cuda-graph",

--- a/test/registered/unit/test_glm5_next_server_args_boundary.py
+++ b/test/registered/unit/test_glm5_next_server_args_boundary.py
@@ -99,6 +99,8 @@ def _boundary_args(**overrides):
         moe_runner_backend="auto",
         kt_weight_path=None,
         kt_method=None,
+        kt_gpu_prefill_token_threshold=None,
+        kt_enable_dynamic_expert_update=False,
         disable_shared_experts_fusion=False,
         disable_cuda_graph=False,
         disable_radix_cache=False,
@@ -116,16 +118,27 @@ class TestGlm5NextSessionABOptions(unittest.TestCase):
             )
         )
 
-    def test_defaults_resolve_to_correctness_first_moe_and_eager_mode(self):
+    def test_defaults_enable_only_small_decode_graph_batches(self):
         args = _boundary_args()
 
         self.validate(args)
 
         self.assertEqual(args.moe_runner_backend, "triton")
         self.assertTrue(args.disable_shared_experts_fusion)
-        self.assertTrue(args.disable_cuda_graph)
+        self.assertFalse(args.disable_cuda_graph)
+        self.assertEqual(args.cuda_graph_bs, [1, 2, 4])
+        self.assertEqual(args.cuda_graph_max_bs, 4)
         self.assertTrue(args.disable_radix_cache)
         self.assertTrue(args._glm5_next_session_ab_active)
+
+    def test_explicit_cuda_graph_disable_is_preserved(self):
+        args = _boundary_args(disable_cuda_graph=True)
+
+        self.validate(args)
+
+        self.assertTrue(args.disable_cuda_graph)
+        self.assertFalse(hasattr(args, "cuda_graph_bs"))
+        self.assertFalse(hasattr(args, "cuda_graph_max_bs"))
 
     def test_prefix_cache_is_always_disabled_and_external_caches_are_rejected(self):
         already_disabled = _boundary_args(disable_radix_cache=True)
@@ -268,6 +281,44 @@ class TestGlm5NextSessionABOptions(unittest.TestCase):
                         )
                     )
 
+    def test_layerwise_prefill_requires_tp8_and_static_experts(self):
+        accepted = _boundary_args(
+            tp_size=8,
+            kt_weight_path="stub/experts",
+            kt_method="fp8",
+            kt_gpu_prefill_token_threshold=4096,
+        )
+        self.validate(accepted)
+
+        with self.assertRaisesRegex(ValueError, "requires TP=8"):
+            self.validate(
+                _boundary_args(
+                    tp_size=1,
+                    kt_weight_path="stub/experts",
+                    kt_method="fp8",
+                    kt_gpu_prefill_token_threshold=4096,
+                )
+            )
+
+        with self.assertRaisesRegex(ValueError, "dynamic-expert-update"):
+            self.validate(
+                _boundary_args(
+                    tp_size=8,
+                    kt_weight_path="stub/experts",
+                    kt_method="fp8",
+                    kt_gpu_prefill_token_threshold=4096,
+                    kt_enable_dynamic_expert_update=True,
+                )
+            )
+
+        structural = _boundary_args(
+            tp_size=1,
+            kt_weight_path="stub/experts",
+            kt_method="fp8",
+            kt_gpu_prefill_token_threshold=0,
+        )
+        self.validate(structural)
+
 
 class TestGlm5NextSessionABNSA(unittest.TestCase):
     @staticmethod
@@ -317,6 +368,45 @@ class TestGlm5NextSessionABNSA(unittest.TestCase):
         source = ast.unparse(configure)
         self.assertNotIn("0.6.17", source)
         self.assertNotIn("sparse_mla_top_k_lens", source)
+
+    def test_cuda_graph_kpool_metadata_is_initialized_and_updated(self):
+        tree = ast.parse(
+            NSA_BACKEND_PATH.read_text(encoding="utf-8"),
+            filename=str(NSA_BACKEND_PATH),
+        )
+        backend = next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.ClassDef) and node.name == "NativeSparseAttnBackend"
+        )
+        methods = {
+            node.name: ast.unparse(node)
+            for node in backend.body
+            if isinstance(node, ast.FunctionDef)
+        }
+
+        self.assertIn(
+            "self._init_glm5_next_kpool_graph_metadata(metadata, forward_mode)",
+            methods["init_forward_metadata_capture_cuda_graph"],
+        )
+        replay = methods["init_forward_metadata_replay_cuda_graph"]
+        self.assertIn(
+            "self._update_glm5_next_kpool_graph_metadata(metadata, forward_mode)",
+            replay,
+        )
+        self.assertLess(
+            replay.index("metadata.real_page_table[:new_rows, :new_cols].copy_"),
+            replay.index("self._update_glm5_next_kpool_graph_metadata"),
+        )
+
+        for method_name in (
+            "_init_glm5_next_kpool_graph_metadata",
+            "_update_glm5_next_kpool_graph_metadata",
+        ):
+            source = methods[method_name]
+            self.assertIn("self.is_glm5_next", source)
+            self.assertIn("self.nsa_index_kpool == 4", source)
+            self.assertIn("forward_mode.is_decode_or_idle()", source)
 
 
 class TestGlm5NextBoundaryIsolation(unittest.TestCase):

--- a/test/registered/unit/test_glm5_next_server_args_boundary.py
+++ b/test/registered/unit/test_glm5_next_server_args_boundary.py
@@ -113,6 +113,8 @@ def _boundary_args(**overrides):
         kt_weight_path=None,
         kt_method=None,
         kt_gpu_prefill_token_threshold=None,
+        kt_num_gpu_experts=None,
+        kt_gpu_experts_ratio=None,
         kt_enable_dynamic_expert_update=False,
         disable_shared_experts_fusion=False,
         disable_cuda_graph=False,
@@ -127,7 +129,11 @@ class TestGlm5NextSessionABOptions(unittest.TestCase):
     def setUpClass(cls):
         cls.validate = staticmethod(
             _compile_function(
-                "_validate_glm5_next_session_ab_boundary", class_name="ServerArgs"
+                "_validate_glm5_next_session_ab_boundary",
+                class_name="ServerArgs",
+                globals_={
+                    "GLM5_NEXT_SUPPORTED_TP_SIZES": frozenset((1, 2, 4, 8))
+                },
             )
         )
 
@@ -250,14 +256,16 @@ class TestGlm5NextSessionABOptions(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, message):
                     self.validate(_boundary_args(**overrides))
 
-    def test_only_tp4_width_is_accepted(self):
-        args = _boundary_args(tp_size=4)
-        self.validate(args)
-        self.assertEqual(args.tp_size, 4)
-
-        for tp_size in (1, 2, 8, 16):
+    def test_tp1_tp2_tp4_and_tp8_are_accepted(self):
+        for tp_size in (1, 2, 4, 8):
             with self.subTest(tp_size=tp_size):
-                with self.assertRaisesRegex(ValueError, "only TP=4"):
+                args = _boundary_args(tp_size=tp_size)
+                self.validate(args)
+                self.assertEqual(args.tp_size, tp_size)
+
+        for tp_size in (0, 3, 16):
+            with self.subTest(tp_size=tp_size):
+                with self.assertRaisesRegex(ValueError, "1, 2, 4, and 8"):
                     self.validate(_boundary_args(tp_size=tp_size))
 
     def test_only_tensor_parallel_topology_is_accepted(self):
@@ -318,14 +326,16 @@ class TestGlm5NextSessionABOptions(unittest.TestCase):
                         )
                     )
 
-    def test_layerwise_prefill_requires_tp4_and_static_experts(self):
-        accepted = _boundary_args(
-            tp_size=4,
-            kt_weight_path="stub/experts",
-            kt_method="fp8",
-            kt_gpu_prefill_token_threshold=4096,
-        )
-        self.validate(accepted)
+    def test_layerwise_prefill_accepts_supported_tp_sizes(self):
+        for tp_size in (1, 2, 4, 8):
+            with self.subTest(tp_size=tp_size):
+                accepted = _boundary_args(
+                    tp_size=tp_size,
+                    kt_weight_path="stub/experts",
+                    kt_method="fp8",
+                    kt_gpu_prefill_token_threshold=4096,
+                )
+                self.validate(accepted)
 
         with self.assertRaisesRegex(ValueError, "dynamic-expert-update"):
             self.validate(
@@ -337,6 +347,38 @@ class TestGlm5NextSessionABOptions(unittest.TestCase):
                     kt_enable_dynamic_expert_update=True,
                 )
             )
+
+    def test_layerwise_silently_normalizes_resident_gpu_experts_to_zero(self):
+        count = _boundary_args(
+            kt_weight_path="stub/experts",
+            kt_method="fp8",
+            kt_gpu_prefill_token_threshold=2048,
+            kt_num_gpu_experts=80,
+        )
+        self.validate(count)
+        self.assertEqual(count.kt_num_gpu_experts, 0)
+        self.assertIsNone(count.kt_gpu_experts_ratio)
+
+        ratio = _boundary_args(
+            kt_weight_path="stub/experts",
+            kt_method="fp8",
+            kt_gpu_prefill_token_threshold=2048,
+            kt_num_gpu_experts=80,
+            kt_gpu_experts_ratio=0.25,
+        )
+        self.validate(ratio)
+        self.assertEqual(ratio.kt_num_gpu_experts, 0)
+        self.assertIsNone(ratio.kt_gpu_experts_ratio)
+
+    def test_non_layerwise_gpu_expert_placement_is_preserved(self):
+        args = _boundary_args(
+            kt_weight_path="stub/experts",
+            kt_method="fp8",
+            kt_gpu_prefill_token_threshold=0,
+            kt_num_gpu_experts=80,
+        )
+        self.validate(args)
+        self.assertEqual(args.kt_num_gpu_experts, 80)
 
     def test_glm_layerwise_context_is_not_eagerly_initialized_by_model_runner(self):
         source = MODEL_RUNNER_PATH.read_text(encoding="utf-8")
@@ -433,8 +475,8 @@ class TestGlm5NextSessionABNSA(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "SM86, SM89, or Blackwell"):
             self._configure()(self._args(), (9, 0))
 
-    def test_consumer_gpu_rejects_layerwise_prefill(self):
-        with self.assertRaisesRegex(ValueError, "not adapted for SM86/SM89"):
+    def test_sm86_rejects_layerwise_prefill(self):
+        with self.assertRaisesRegex(ValueError, "not adapted for SM86"):
             self._configure()(
                 self._args(
                     kv_cache_dtype="bfloat16",
@@ -443,19 +485,28 @@ class TestGlm5NextSessionABNSA(unittest.TestCase):
                 (8, 6),
             )
 
-    def test_consumer_gpu_rejects_multimodal_but_blackwell_is_unchanged(self):
-        with self.assertRaisesRegex(ValueError, "text inference only"):
-            self._configure()(
-                self._args(
-                    kv_cache_dtype="bfloat16",
-                    enable_multimodal=True,
-                ),
-                (8, 6),
-            )
+    def test_sm89_accepts_layerwise_prefill(self):
+        args = self._args(kt_gpu_prefill_token_threshold=1)
 
-        blackwell = self._args(enable_multimodal=True)
-        self._configure()(blackwell, (12, 0))
-        self.assertTrue(blackwell.enable_multimodal)
+        self._configure()(args, (8, 9))
+
+        self.assertEqual(args.nsa_prefill_backend, "trtllm")
+        self.assertEqual(args.nsa_decode_backend, "trtllm")
+
+    def test_sm86_sm89_and_blackwell_accept_multimodal(self):
+        cases = (
+            ((8, 6), "bfloat16"),
+            ((8, 9), "fp8_e4m3"),
+            ((12, 0), "fp8_e4m3"),
+        )
+        for capability, kv_cache_dtype in cases:
+            with self.subTest(capability=capability):
+                args = self._args(
+                    kv_cache_dtype=kv_cache_dtype,
+                    enable_multimodal=True,
+                )
+                self._configure()(args, capability)
+                self.assertTrue(args.enable_multimodal)
 
     def test_non_trtllm_sparse_backend_is_rejected(self):
         with self.assertRaisesRegex(ValueError, "both NSA prefill and decode"):
@@ -599,7 +650,11 @@ class TestGlm5NextBoundaryIsolation(unittest.TestCase):
             },
         )
         validate = _compile_function(
-            "_validate_glm5_next_session_ab_boundary", class_name="ServerArgs"
+            "_validate_glm5_next_session_ab_boundary",
+            class_name="ServerArgs",
+            globals_={
+                "GLM5_NEXT_SUPPORTED_TP_SIZES": frozenset((1, 2, 4, 8))
+            },
         )
 
         def make_args(*, exact_glm: bool, backend: str):

--- a/test/registered/unit/test_glm5_next_server_args_boundary.py
+++ b/test/registered/unit/test_glm5_next_server_args_boundary.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import ast
 import copy
+import sys
 import unittest
 from pathlib import Path
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
+from unittest import mock
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -346,11 +348,49 @@ class TestGlm5NextSessionABOptions(unittest.TestCase):
 class TestGlm5NextSessionABNSA(unittest.TestCase):
     @staticmethod
     def _configure():
-        return _compile_function(
+        def get_glm5_next_gpu_profile(capability):
+            if capability == (8, 6):
+                return SimpleNamespace(
+                    value="sm86_bf16",
+                    kv_cache_dtype="bfloat16",
+                    index_cache_dtype="bfloat16",
+                    is_consumer_gpu=True,
+                )
+            if capability == (8, 9):
+                return SimpleNamespace(
+                    value="sm89_fp8",
+                    kv_cache_dtype="fp8_e4m3",
+                    index_cache_dtype="fp8_e4m3",
+                    is_consumer_gpu=True,
+                )
+            if capability[0] >= 10:
+                return SimpleNamespace(
+                    value="blackwell_fp8",
+                    kv_cache_dtype="fp8_e4m3",
+                    index_cache_dtype="fp8_e4m3",
+                    is_consumer_gpu=False,
+                )
+            raise ValueError("GLM-5-Next supports NVIDIA SM86, SM89, or Blackwell")
+
+        configure = _compile_function(
             "_configure_glm5_next_session_ab_nsa",
             class_name="ServerArgs",
             globals_={"logger": _LoggerStub()},
         )
+        glm5_next_config = ModuleType("sglang.srt.configs.glm5_next")
+        glm5_next_config.get_glm5_next_gpu_profile = get_glm5_next_gpu_profile
+        package_modules = {
+            "sglang": ModuleType("sglang"),
+            "sglang.srt": ModuleType("sglang.srt"),
+            "sglang.srt.configs": ModuleType("sglang.srt.configs"),
+            "sglang.srt.configs.glm5_next": glm5_next_config,
+        }
+
+        def invoke(self, capability):
+            with mock.patch.dict(sys.modules, package_modules):
+                return configure(self, capability)
+
+        return invoke
 
     @staticmethod
     def _args(**overrides):
@@ -358,6 +398,8 @@ class TestGlm5NextSessionABNSA(unittest.TestCase):
             kv_cache_dtype="fp8_e4m3",
             nsa_prefill_backend=None,
             nsa_decode_backend=None,
+            kt_gpu_prefill_token_threshold=0,
+            enable_multimodal=False,
         )
         values.update(overrides)
         return SimpleNamespace(**values)
@@ -366,23 +408,60 @@ class TestGlm5NextSessionABNSA(unittest.TestCase):
         configure = self._configure()
         args = self._args()
 
-        configure(args, 12)
+        configure(args, (12, 0))
 
         self.assertEqual(args.nsa_prefill_backend, "trtllm")
         self.assertEqual(args.nsa_decode_backend, "trtllm")
 
-    def test_bf16_and_pre_blackwell_are_rejected(self):
+    def test_architecture_specific_cache_dtype_policy(self):
+        sm86 = self._args(kv_cache_dtype="auto")
+        self._configure()(sm86, (8, 6))
+        self.assertEqual(sm86.kv_cache_dtype, "bfloat16")
+
+        sm89 = self._args(kv_cache_dtype="auto")
+        self._configure()(sm89, (8, 9))
+        self.assertEqual(sm89.kv_cache_dtype, "fp8_e4m3")
+
         for dtype in ("bf16", "bfloat16"):
             with self.subTest(dtype=dtype):
                 with self.assertRaisesRegex(ValueError, "fp8_e4m3"):
-                    self._configure()(self._args(kv_cache_dtype=dtype), 12)
+                    self._configure()(self._args(kv_cache_dtype=dtype), (8, 9))
 
-        with self.assertRaisesRegex(ValueError, "Blackwell"):
-            self._configure()(self._args(), 9)
+        with self.assertRaisesRegex(ValueError, "bfloat16"):
+            self._configure()(self._args(kv_cache_dtype="fp8_e4m3"), (8, 6))
+
+        with self.assertRaisesRegex(ValueError, "SM86, SM89, or Blackwell"):
+            self._configure()(self._args(), (9, 0))
+
+    def test_consumer_gpu_rejects_layerwise_prefill(self):
+        with self.assertRaisesRegex(ValueError, "not adapted for SM86/SM89"):
+            self._configure()(
+                self._args(
+                    kv_cache_dtype="bfloat16",
+                    kt_gpu_prefill_token_threshold=4096,
+                ),
+                (8, 6),
+            )
+
+    def test_consumer_gpu_rejects_multimodal_but_blackwell_is_unchanged(self):
+        with self.assertRaisesRegex(ValueError, "text inference only"):
+            self._configure()(
+                self._args(
+                    kv_cache_dtype="bfloat16",
+                    enable_multimodal=True,
+                ),
+                (8, 6),
+            )
+
+        blackwell = self._args(enable_multimodal=True)
+        self._configure()(blackwell, (12, 0))
+        self.assertTrue(blackwell.enable_multimodal)
 
     def test_non_trtllm_sparse_backend_is_rejected(self):
         with self.assertRaisesRegex(ValueError, "both NSA prefill and decode"):
-            self._configure()(self._args(nsa_prefill_backend="flashmla_sparse"), 12)
+            self._configure()(
+                self._args(nsa_prefill_backend="flashmla_sparse"), (12, 0)
+            )
 
     def test_startup_does_not_require_new_flashinfer_abi(self):
         configure = _find_function(

--- a/test/registered/unit/test_glm5_next_session_c_benchmark.py
+++ b/test/registered/unit/test_glm5_next_session_c_benchmark.py
@@ -1,0 +1,268 @@
+import importlib.util
+import json
+import math
+from pathlib import Path
+
+SCRIPT = Path(__file__).parents[3] / "scripts" / "glm5_next_session_c_benchmark.py"
+SPEC = importlib.util.spec_from_file_location("glm5_next_session_c_benchmark", SCRIPT)
+BENCHMARK = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(BENCHMARK)
+
+
+def test_fixture_is_stable_distinct_and_inside_normal_token_band():
+    first = BENCHMARK.build_fixture(128, 154880, salt=17)
+    repeated = BENCHMARK.build_fixture(128, 154880, salt=17)
+    other = BENCHMARK.build_fixture(128, 154880, salt=41)
+
+    assert first == repeated
+    assert first["input_sha256"] != other["input_sha256"]
+    assert min(first["input_ids"]) >= 1024
+    assert max(first["input_ids"]) < 154880 - 1024
+
+
+def test_long_context_contract_defaults_to_500k_plus_1024():
+    args = BENCHMARK.build_parser().parse_args(
+        ["long", "--label", "final", "--output", "/tmp/final.json"]
+    )
+
+    assert args.input_length == 500_000
+    assert args.output_length == 1024
+
+
+def test_long_context_contract_is_exact_not_a_minimum(monkeypatch, tmp_path):
+    monkeypatch.setattr(BENCHMARK, "flush_cache", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        BENCHMARK,
+        "run_streaming_request",
+        lambda *args, **kwargs: {"success": True},
+    )
+    output = tmp_path / "long.json"
+    args = BENCHMARK.build_parser().parse_args(
+        [
+            "long",
+            "--label",
+            "too-long",
+            "--output",
+            str(output),
+            "--input-length",
+            "500001",
+            "--output-length",
+            "1025",
+        ]
+    )
+
+    assert BENCHMARK.run_long(args) == 1
+    payload = json.loads(output.read_text())
+    assert not payload["contract"]["compliant"]
+    assert payload["contract"]["input_tokens"] == 500_000
+    assert payload["contract"]["output_tokens"] == 1024
+
+
+def test_percentile_matches_linear_interpolation():
+    values = [1.0, 2.0, 3.0, 4.0, 5.0]
+    assert BENCHMARK.percentile(values, 50) == 3.0
+    assert math.isclose(BENCHMARK.percentile(values, 95), 4.8)
+
+
+def test_server_metrics_are_recovered_from_sglang_meta_definition():
+    metrics = BENCHMARK.extract_server_metrics(
+        {"e2e_latency": 10.0, "decode_throughput": 20.0},
+        completion_tokens=100,
+    )
+
+    assert metrics["server_e2e_s"] == 10.0
+    assert metrics["server_output_throughput_tps"] == 20.0
+    assert metrics["server_decode_duration_s"] == 5.0
+    assert metrics["server_ttft_s"] == 5.0
+    assert math.isclose(metrics["server_mean_itl_s"], 5.0 / 99.0)
+    assert not metrics["server_metric_errors"]
+
+
+def test_missing_or_inconsistent_server_metrics_remain_null():
+    missing = BENCHMARK.extract_server_metrics(
+        {"e2e_latency": 10.0}, completion_tokens=100
+    )
+    assert missing["server_ttft_s"] is None
+    assert missing["server_mean_itl_s"] is None
+    assert missing["server_output_throughput_tps"] is None
+    assert any("--enable-metrics" in error for error in missing["server_metric_errors"])
+
+    inconsistent = BENCHMARK.extract_server_metrics(
+        {"e2e_latency": 1.0, "decode_throughput": 1.0},
+        completion_tokens=100,
+    )
+    assert inconsistent["server_ttft_s"] is None
+    assert inconsistent["server_mean_itl_s"] is None
+    assert any(
+        "inconsistent" in error for error in inconsistent["server_metric_errors"]
+    )
+
+
+class _FakeStreamingResponse:
+    status = 200
+
+    def __init__(self, messages):
+        self._lines = [
+            b"data: " + json.dumps(message).encode() + b"\n" for message in messages
+        ] + [b"data: [DONE]\n"]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def __iter__(self):
+        return iter(self._lines)
+
+    def getcode(self):
+        return self.status
+
+
+def test_streaming_request_collects_incremental_ids_and_separates_clocks():
+    messages = [
+        {
+            "output_ids": [7],
+            "meta_info": {"prompt_tokens": 3, "completion_tokens": 1},
+        },
+        {
+            "output_ids": [8],
+            "meta_info": {
+                "prompt_tokens": 3,
+                "completion_tokens": 2,
+                "finish_reason": {"type": "length"},
+                "e2e_latency": 4.0,
+                "decode_throughput": 1.0,
+            },
+        },
+    ]
+
+    def opener(request, timeout):
+        assert request.full_url == "http://example.test/generate"
+        assert timeout == 30
+        return _FakeStreamingResponse(messages)
+
+    timestamps = iter((0.0, 2.0, 3.0, 5.0))
+    result = BENCHMARK.run_streaming_request(
+        "http://example.test",
+        [1, 2, 3],
+        2,
+        timeout=30,
+        opener=opener,
+        clock=lambda: next(timestamps),
+    )
+
+    assert result["output_ids"] == [7, 8]
+    assert result["wall_e2e_s"] == 5.0
+    assert result["client_ttft_s"] == 2.0
+    assert result["client_mean_itl_s"] == 1.0
+    assert result["server_e2e_s"] == 4.0
+    assert result["server_ttft_s"] == 2.0
+    assert result["server_mean_itl_s"] == 2.0
+
+
+def _record(value: float, *, digest: str = "same"):
+    return {
+        "success": True,
+        "output_sha256": digest,
+        "wall_e2e_s": value * 10,
+        "server_e2e_s": value * 9,
+        "server_ttft_s": value * 2,
+        "server_mean_itl_s": value,
+        "server_output_throughput_tps": 1.0 / value,
+    }
+
+
+def test_summary_reports_median_p95_and_fails_closed_on_null():
+    records = [_record(value) for value in (1, 2, 3, 4, 5)]
+    summary = BENCHMARK.summarize_records(records, expected_count=5)
+    assert summary["pass"]
+    assert summary["metrics"]["server_mean_itl_s"]["median"] == 3.0
+    assert math.isclose(summary["metrics"]["server_mean_itl_s"]["p95"], 4.8)
+
+    records[-1]["server_mean_itl_s"] = None
+    incomplete = BENCHMARK.summarize_records(records, expected_count=5)
+    assert not incomplete["pass"]
+    assert incomplete["metrics"]["server_mean_itl_s"]["median"] is None
+    assert any("incomplete" in failure for failure in incomplete["failures"])
+
+
+def _collection(*, itls, throughputs, passed=True):
+    records = []
+    for itl, throughput in zip(itls, throughputs):
+        record = _record(itl)
+        record["server_output_throughput_tps"] = throughput
+        records.append(record)
+    summary = BENCHMARK.summarize_records(records, expected_count=5)
+    shape = {
+        "role": "decode",
+        "input_tokens": 4096,
+        "output_tokens": 256,
+        "fixture": {"input_sha256": "fixture"},
+        "summary": summary,
+    }
+    return {
+        "schema_version": BENCHMARK.SCHEMA_VERSION,
+        "kind": "glm5_next_session_c_benchmark",
+        "label": "candidate",
+        "contract": {
+            "request_concurrency": 1,
+            "warmups": BENCHMARK.DEFAULT_WARMUPS,
+            "measured": BENCHMARK.DEFAULT_MEASURED,
+            "flush_cache_before_each_request": True,
+            "server_metrics_required": True,
+            "requires_server_enable_metrics": True,
+            "metric_derivation": BENCHMARK.SERVER_METRIC_DERIVATION,
+            "compliant": True,
+        },
+        "shapes": [shape],
+        "pass": passed and summary["pass"],
+    }
+
+
+def test_graph_comparison_accepts_frozen_relative_gates():
+    eager = _collection(itls=[1.0] * 5, throughputs=[100.0] * 5)
+    graph = _collection(itls=[0.89] * 5, throughputs=[96.0] * 5)
+
+    result = BENCHMARK.compare_payloads(eager, graph)
+
+    assert result["pass"]
+    assert all(gate["pass"] for gate in result["gates"])
+
+
+def test_graph_comparison_rejects_slow_or_missing_metrics():
+    eager = _collection(itls=[1.0] * 5, throughputs=[100.0] * 5)
+    slow_graph = _collection(itls=[0.95] * 5, throughputs=[90.0] * 5)
+    slow_result = BENCHMARK.compare_payloads(eager, slow_graph)
+    assert not slow_result["pass"]
+    assert not all(gate["pass"] for gate in slow_result["gates"])
+
+    graph = _collection(itls=[0.89] * 5, throughputs=[96.0] * 5)
+    graph["shapes"][0]["summary"]["metrics"]["server_mean_itl_s"]["median"] = None
+    missing_result = BENCHMARK.compare_payloads(eager, graph)
+    assert not missing_result["pass"]
+    assert any(gate["reason"] for gate in missing_result["gates"])
+
+
+def test_summary_fails_closed_when_any_output_digest_is_missing():
+    records = [_record(value) for value in (1, 2, 3, 4, 5)]
+    records[-1].pop("output_sha256")
+
+    result = BENCHMARK.summarize_records(records, expected_count=5)
+
+    assert not result["pass"]
+    assert not result["output_digest_evidence_complete"]
+
+
+def test_graph_comparison_rejects_wrong_kind_or_contract():
+    eager = _collection(itls=[1.0] * 5, throughputs=[100.0] * 5)
+    graph = _collection(itls=[0.89] * 5, throughputs=[96.0] * 5)
+    graph["kind"] = "wrong"
+    graph["contract"]["compliant"] = False
+
+    result = BENCHMARK.compare_payloads(eager, graph)
+
+    assert not result["pass"]
+    assert any("kind" in failure for failure in result["failures"])
+    assert any("contract" in failure for failure in result["failures"])

--- a/test/registered/unit/test_glm5_next_session_c_final_acceptance.py
+++ b/test/registered/unit/test_glm5_next_session_c_final_acceptance.py
@@ -66,6 +66,63 @@ def test_layerwise_log_parser_and_progress_gate_accept_exact_rounds():
     )
 
 
+def test_layerwise_log_parser_ignores_per_layer_diagnostics():
+    lines = []
+    for epoch in range(2):
+        for layer in range(3, 45):
+            offset = layer - 3
+            lines.append(
+                "KT GLM-5-Next FP8 layerwise prefill: "
+                f"layer={layer} epoch={epoch} slot={offset % 2} "
+                f"{'prime' if layer == 3 else 'prefetch-hit'} "
+                f"apply_count={epoch * 42 + offset + 1} "
+                f"prime_count={epoch + 1} "
+                f"prefetch_hit_count={epoch * 41 + offset} "
+                f"completed_rounds={epoch + (layer == 44)} fallback_count=0"
+            )
+
+    summaries = ACCEPTANCE.parse_layerwise_summaries("\n".join(lines))
+
+    assert summaries == [
+        _summary(
+            epoch=0,
+            apply_count=42,
+            prime_count=1,
+            prefetch_hit_count=41,
+            completed_rounds=1,
+        ),
+        _summary(
+            epoch=1,
+            apply_count=84,
+            prime_count=2,
+            prefetch_hit_count=82,
+            completed_rounds=2,
+        ),
+    ]
+    assert not ACCEPTANCE.validate_layerwise_progress(
+        None, summaries, expected_rounds=2
+    )
+
+
+def test_layerwise_partial_round_does_not_become_a_summary():
+    text = "\n".join(
+        "KT GLM-5-Next FP8 layerwise prefill: "
+        f"layer={layer} epoch=0 slot={(layer - 3) % 2} "
+        f"{'prime' if layer == 3 else 'prefetch-hit'} "
+        f"apply_count={layer - 2} prime_count=1 "
+        f"prefetch_hit_count={layer - 3} completed_rounds=0 fallback_count=0"
+        for layer in range(3, 44)
+    )
+
+    summaries = ACCEPTANCE.parse_layerwise_summaries(text)
+    failures = ACCEPTANCE.validate_layerwise_progress(
+        None, summaries, expected_rounds=1
+    )
+
+    assert summaries == []
+    assert any("expected 1" in failure for failure in failures)
+
+
 def test_layerwise_progress_fails_closed_on_missing_round_or_fallback():
     previous = _summary(
         epoch=0,
@@ -169,6 +226,62 @@ def test_per_rank_graph_gate_rejects_decode_none_growth():
     )
     assert not result["pass"]
     assert any("decode_none" in item for item in result["failures"])
+
+
+def test_per_rank_graph_gate_treats_unpublished_decode_none_as_zero():
+    before = {
+        "decode_cuda_graph": {str(rank): 10.0 for rank in range(2)},
+        "decode_none": {},
+    }
+    after = {
+        "decode_cuda_graph": {str(rank): 17.0 for rank in range(2)},
+        "decode_none": {},
+    }
+
+    result = ACCEPTANCE.validate_graph_counter_progress(
+        before, after, tp_size=2, minimum_graph_delta_per_rank=7
+    )
+
+    assert result["pass"]
+    assert all(
+        item["decode_none_delta"] == 0
+        for item in result["per_rank"].values()
+    )
+
+
+def test_per_rank_graph_gate_rejects_lazy_decode_none_growth_and_disappearance():
+    graph_before = {"0": 10.0, "1": 10.0}
+    graph_after = {"0": 17.0, "1": 17.0}
+    appeared = ACCEPTANCE.validate_graph_counter_progress(
+        {"decode_cuda_graph": graph_before, "decode_none": {}},
+        {"decode_cuda_graph": graph_after, "decode_none": {"0": 1.0}},
+        tp_size=2,
+        minimum_graph_delta_per_rank=7,
+    )
+    disappeared = ACCEPTANCE.validate_graph_counter_progress(
+        {"decode_cuda_graph": graph_before, "decode_none": {"0": 1.0}},
+        {"decode_cuda_graph": graph_after, "decode_none": {}},
+        tp_size=2,
+        minimum_graph_delta_per_rank=7,
+    )
+
+    assert not appeared["pass"]
+    assert not disappeared["pass"]
+    assert appeared["per_rank"]["0"]["decode_none_delta"] == 1
+    assert disappeared["per_rank"]["0"]["decode_none_delta"] == -1
+
+
+def test_per_rank_graph_gate_rejects_unexpected_decode_none_rank():
+    graph = {"0": 10.0, "1": 10.0}
+    result = ACCEPTANCE.validate_graph_counter_progress(
+        {"decode_cuda_graph": graph, "decode_none": {}},
+        {"decode_cuda_graph": graph, "decode_none": {"2": 0.0}},
+        tp_size=2,
+        minimum_graph_delta_per_rank=0,
+    )
+
+    assert not result["pass"]
+    assert any("unexpected TP ranks" in item for item in result["failures"])
 
 
 def _bucket_payload(label, outputs):
@@ -375,6 +488,30 @@ def test_prefill_server_log_binds_explicit_threshold_and_tp8():
         "kt_gpu_prefill_token_threshold" in failure
         for failure in wrong_threshold["failures"]
     )
+
+
+def test_threshold_zero_rejects_nonfinal_layerwise_event():
+    threshold_0_log = "\n".join(
+        [
+            (
+                "server_args=ServerArgs(tp_size=8, chunked_prefill_size=4096, "
+                "kt_method='FP8', kt_gpu_prefill_token_threshold=0)"
+            ),
+            "The server is fired up and ready to roll!",
+            (
+                "KT GLM-5-Next FP8 layerwise prefill: layer=3 epoch=0 slot=0 "
+                "prime apply_count=1 prime_count=1 prefetch_hit_count=0 "
+                "completed_rounds=0 fallback_count=0"
+            ),
+        ]
+    )
+
+    result = ACCEPTANCE.validate_prefill_parity_server_log(
+        threshold_0_log, threshold=0
+    )
+
+    assert not result["pass"]
+    assert any("executed" in failure for failure in result["failures"])
 
 
 def test_completed_request_requires_length_finish_and_in_range_tokens():

--- a/test/registered/unit/test_glm5_next_session_c_final_acceptance.py
+++ b/test/registered/unit/test_glm5_next_session_c_final_acceptance.py
@@ -15,102 +15,55 @@ assert SPEC.loader is not None
 SPEC.loader.exec_module(ACCEPTANCE)
 
 
-def _summary(
-    *,
-    epoch,
-    apply_count,
-    prime_count,
-    prefetch_hit_count,
-    completed_rounds,
-    fallback_count=0,
-    slot=1,
-    load_kind="prefetch-hit",
-):
+def _round(*, round_index=0, layers=None, compute_ms=None):
+    layers = list(range(3, 45)) if layers is None else layers
+    compute_ms = [1.0] * len(layers) if compute_ms is None else compute_ms
     return {
-        "layer": 44,
-        "epoch": epoch,
-        "slot": slot,
-        "load_kind": load_kind,
-        "apply_count": apply_count,
-        "prime_count": prime_count,
-        "prefetch_hit_count": prefetch_hit_count,
-        "completed_rounds": completed_rounds,
-        "fallback_count": fallback_count,
+        "round_index": round_index,
+        "layers": layers,
+        "compute_ms": compute_ms,
+        "expert_update_ms": [None] * len(layers),
+        "complete": len(layers) == 42,
     }
 
 
 def test_layerwise_log_parser_and_progress_gate_accept_exact_rounds():
     text = "\n".join(
-        [
-            "noise",
-            "KT GLM-5-Next FP8 layerwise prefill: layer=44 epoch=3 slot=1 "
-            "prefetch-hit apply_count=168 prime_count=4 "
-            "prefetch_hit_count=164 completed_rounds=4 fallback_count=0",
-            "KT GLM-5-Next FP8 layerwise prefill: layer=44 epoch=4 slot=1 "
-            "prefetch-hit apply_count=210 prime_count=5 "
-            "prefetch_hit_count=205 completed_rounds=5 fallback_count=0",
+        ["noise"]
+        + [
+            "KT layerwise prefill: "
+            f"layer {layer} compute = {round_index + layer / 100:.2f} ms"
+            for round_index in range(2)
+            for layer in range(3, 45)
         ]
     )
     current = ACCEPTANCE.parse_layerwise_summaries(text)
-    previous = _summary(
-        epoch=2,
-        apply_count=126,
-        prime_count=3,
-        prefetch_hit_count=123,
-        completed_rounds=3,
-    )
 
     assert len(current) == 2
     assert not ACCEPTANCE.validate_layerwise_progress(
-        previous, current, expected_rounds=2
+        None, current, expected_rounds=2
     )
 
 
-def test_layerwise_log_parser_ignores_per_layer_diagnostics():
-    lines = []
-    for epoch in range(2):
-        for layer in range(3, 45):
-            offset = layer - 3
-            lines.append(
-                "KT GLM-5-Next FP8 layerwise prefill: "
-                f"layer={layer} epoch={epoch} slot={offset % 2} "
-                f"{'prime' if layer == 3 else 'prefetch-hit'} "
-                f"apply_count={epoch * 42 + offset + 1} "
-                f"prime_count={epoch + 1} "
-                f"prefetch_hit_count={epoch * 41 + offset} "
-                f"completed_rounds={epoch + (layer == 44)} fallback_count=0"
-            )
-
-    summaries = ACCEPTANCE.parse_layerwise_summaries("\n".join(lines))
-
-    assert summaries == [
-        _summary(
-            epoch=0,
-            apply_count=42,
-            prime_count=1,
-            prefetch_hit_count=41,
-            completed_rounds=1,
-        ),
-        _summary(
-            epoch=1,
-            apply_count=84,
-            prime_count=2,
-            prefetch_hit_count=82,
-            completed_rounds=2,
-        ),
-    ]
-    assert not ACCEPTANCE.validate_layerwise_progress(
-        None, summaries, expected_rounds=2
-    )
-
-
-def test_layerwise_partial_round_does_not_become_a_summary():
+def test_layerwise_log_parser_accepts_optional_expert_update_timing():
     text = "\n".join(
-        "KT GLM-5-Next FP8 layerwise prefill: "
-        f"layer={layer} epoch=0 slot={(layer - 3) % 2} "
-        f"{'prime' if layer == 3 else 'prefetch-hit'} "
-        f"apply_count={layer - 2} prime_count=1 "
-        f"prefetch_hit_count={layer - 3} completed_rounds=0 fallback_count=0"
+        "KT layerwise prefill: "
+        f"layer {layer} compute = 1.25 ms, expert update = 0.50 ms"
+        for layer in range(3, 45)
+    )
+
+    summaries = ACCEPTANCE.parse_layerwise_summaries(text)
+
+    assert len(summaries) == 1
+    assert summaries[0]["expert_update_ms"] == [0.5] * 42
+    assert not ACCEPTANCE.validate_layerwise_progress(
+        None, summaries, expected_rounds=1
+    )
+
+
+def test_layerwise_partial_round_is_retained_and_rejected():
+    text = "\n".join(
+        f"KT layerwise prefill: layer {layer} compute = 1.00 ms"
         for layer in range(3, 44)
     )
 
@@ -119,62 +72,28 @@ def test_layerwise_partial_round_does_not_become_a_summary():
         None, summaries, expected_rounds=1
     )
 
-    assert summaries == []
-    assert any("expected 1" in failure for failure in failures)
+    assert len(summaries) == 1
+    assert summaries[0]["complete"] is False
+    assert any("incomplete" in failure for failure in failures)
 
 
-def test_layerwise_progress_fails_closed_on_missing_round_or_fallback():
-    previous = _summary(
-        epoch=0,
-        apply_count=42,
-        prime_count=1,
-        prefetch_hit_count=41,
-        completed_rounds=1,
-    )
-    bad = _summary(
-        epoch=1,
-        apply_count=84,
-        prime_count=2,
-        prefetch_hit_count=82,
-        completed_rounds=2,
-        fallback_count=1,
-    )
-
+def test_layerwise_progress_fails_closed_on_missing_or_out_of_order_round():
+    bad = _round(layers=[3, 5, 4, *range(6, 45)])
     failures = ACCEPTANCE.validate_layerwise_progress(
-        previous, [bad], expected_rounds=2
+        None, [bad], expected_rounds=2
     )
 
     assert any("expected 2" in failure for failure in failures)
-    assert any("fallback_count" in failure for failure in failures)
+    assert any("ordered layers" in failure for failure in failures)
 
 
-def test_layerwise_progress_rejects_wrong_final_slot_or_load_kind():
-    wrong_slot = _summary(
-        epoch=0,
-        apply_count=42,
-        prime_count=1,
-        prefetch_hit_count=41,
-        completed_rounds=1,
-        slot=0,
-    )
-    wrong_kind = _summary(
-        epoch=0,
-        apply_count=42,
-        prime_count=1,
-        prefetch_hit_count=41,
-        completed_rounds=1,
-        load_kind="prime",
-    )
-
-    slot_failures = ACCEPTANCE.validate_layerwise_progress(
-        None, [wrong_slot], expected_rounds=1
-    )
-    kind_failures = ACCEPTANCE.validate_layerwise_progress(
-        None, [wrong_kind], expected_rounds=1
-    )
-
-    assert any("slot" in failure for failure in slot_failures)
-    assert any("load_kind" in failure for failure in kind_failures)
+def test_expected_layerwise_rounds_keeps_subthreshold_tail_hybrid():
+    assert ACCEPTANCE.expected_layerwise_rounds(128, 4096) == 0
+    assert ACCEPTANCE.expected_layerwise_rounds(4096, 4096) == 1
+    assert ACCEPTANCE.expected_layerwise_rounds(4097, 4096) == 1
+    assert ACCEPTANCE.expected_layerwise_rounds(8193, 4096) == 2
+    assert ACCEPTANCE.expected_layerwise_rounds(500_000, 4096) == 122
+    assert ACCEPTANCE.expected_layerwise_rounds(4096, 512) == 0
 
 
 def test_prometheus_graph_counter_sums_matching_modes_only():
@@ -379,7 +298,7 @@ def test_bucket_contract_defaults_are_exact():
     assert args.input_length == 128
     assert args.output_length == 8
     assert args.top_k == 64
-    assert args.tp_size == 8
+    assert args.tp_size == 4
 
 
 def test_final_long_contract_is_exact_not_a_minimum(monkeypatch, tmp_path):
@@ -422,53 +341,79 @@ def test_fatal_log_scan_ignores_info_but_rejects_runtime_failures():
     assert len(failures) == 3
 
 
-def _startup_log(*, threshold=1, allocation_first=True):
+def _startup_log(*, threshold=1024, lazy=True, include_allocation=True):
     server_args = (
-        "server_args=ServerArgs(tp_size=8, chunked_prefill_size=4096, "
+        "server_args=ServerArgs(tp_size=4, chunked_prefill_size=4096, "
         "kt_method='FP8', kt_gpu_prefill_token_threshold="
         f"{threshold})"
     )
     allocation = (
-        "KT GLM-5-Next FP8 layerwise prefill eagerly allocated two raw "
-        "E4M3+FP32 full-layer slots on cuda:0 before KV profiling "
-        f"(total=1.69 GiB, contract={'a' * 64}, fallback_count=0)"
+        "KT GLM-5-Next FP8 layerwise prefill lazily allocated generic "
+        "SharedFullContext: gpu_full_layer_slots=1 host_expert_slots=2 "
+        "gpu_slot_bytes=1812381696 host_buffer_bytes=12582912 device=cuda:0"
     )
     memory_pool = "Memory pool end. avail mem=12.34 GB"
-    ordered = (
-        [allocation, memory_pool] if allocation_first else [memory_pool, allocation]
-    )
-    return "\n".join(
-        [server_args, *ordered, "The server is fired up and ready to roll!"]
-    )
+    ready = "The server is fired up and ready to roll!"
+    ordered = [memory_pool, ready]
+    if include_allocation:
+        ordered = [*ordered, allocation] if lazy else [allocation, *ordered]
+    return "\n".join([server_args, *ordered])
 
 
-def test_layerwise_startup_requires_one_allocation_before_kv_pool_and_ready():
+def test_layerwise_startup_requires_one_lazy_single_gpu_two_host_allocation():
     result = ACCEPTANCE.validate_layerwise_startup(_startup_log())
 
     assert result["pass"]
-    assert result["allocation"]["total_gib"] == 1.69
-    assert result["allocation"]["fallback_count"] == 0
+    assert result["allocation"]["gpu_full_layer_slots"] == 1
+    assert result["allocation"]["host_expert_slots"] == 2
+    assert result["allocation"]["gpu_slot_bytes"] == 1812381696
 
-    wrong_order = ACCEPTANCE.validate_layerwise_startup(
-        _startup_log(allocation_first=False)
-    )
+    eager = ACCEPTANCE.validate_layerwise_startup(_startup_log(lazy=False))
     duplicate = ACCEPTANCE.validate_layerwise_startup(
-        _startup_log() + "\n" + _startup_log().splitlines()[1]
+        _startup_log() + "\n" + _startup_log().splitlines()[-1]
     )
-    assert not wrong_order["pass"]
-    assert any("does not precede" in failure for failure in wrong_order["failures"])
+    missing = ACCEPTANCE.validate_layerwise_startup(
+        _startup_log(include_allocation=False)
+    )
+    pending = ACCEPTANCE.validate_layerwise_startup(
+        _startup_log(include_allocation=False), require_allocation=False
+    )
+    assert not eager["pass"]
+    assert any("not lazy" in failure for failure in eager["failures"])
     assert not duplicate["pass"]
     assert any("exactly one" in failure for failure in duplicate["failures"])
+    assert not missing["pass"]
+    assert pending["pass"]
 
 
-def test_prefill_server_log_binds_explicit_threshold_and_tp8():
-    threshold_1 = ACCEPTANCE.validate_prefill_parity_server_log(
-        _startup_log(threshold=1), threshold=1
+def test_layerwise_startup_rejects_wrong_slots_and_legacy_protocol():
+    wrong_slots = _startup_log().replace(
+        "gpu_full_layer_slots=1 host_expert_slots=2",
+        "gpu_full_layer_slots=2 host_expert_slots=1",
+    )
+    legacy = _startup_log() + "\n" + (
+        "KT GLM-5-Next FP8 layerwise prefill eagerly allocated two raw "
+        "E4M3+FP32 full-layer slots"
+    )
+
+    slots_result = ACCEPTANCE.validate_layerwise_startup(wrong_slots)
+    legacy_result = ACCEPTANCE.validate_layerwise_startup(legacy)
+
+    assert not slots_result["pass"]
+    assert any("gpu_full_layer_slots" in item for item in slots_result["failures"])
+    assert any("host_expert_slots" in item for item in slots_result["failures"])
+    assert not legacy_result["pass"]
+    assert any("legacy" in item for item in legacy_result["failures"])
+
+
+def test_prefill_server_log_binds_explicit_threshold_and_tp4():
+    threshold_1024 = ACCEPTANCE.validate_prefill_parity_server_log(
+        _startup_log(threshold=1024), threshold=1024
     )
     threshold_0_log = "\n".join(
         [
             (
-                "server_args=ServerArgs(tp_size=8, chunked_prefill_size=4096, "
+                "server_args=ServerArgs(tp_size=4, chunked_prefill_size=4096, "
                 "kt_method='FP8', kt_gpu_prefill_token_threshold=0)"
             ),
             "The server is fired up and ready to roll!",
@@ -478,10 +423,10 @@ def test_prefill_server_log_binds_explicit_threshold_and_tp8():
         threshold_0_log, threshold=0
     )
 
-    assert threshold_1["pass"]
+    assert threshold_1024["pass"]
     assert threshold_0["pass"]
     wrong_threshold = ACCEPTANCE.validate_prefill_parity_server_log(
-        threshold_0_log, threshold=1
+        threshold_0_log, threshold=1024
     )
     assert not wrong_threshold["pass"]
     assert any(
@@ -494,14 +439,12 @@ def test_threshold_zero_rejects_nonfinal_layerwise_event():
     threshold_0_log = "\n".join(
         [
             (
-                "server_args=ServerArgs(tp_size=8, chunked_prefill_size=4096, "
+                "server_args=ServerArgs(tp_size=4, chunked_prefill_size=4096, "
                 "kt_method='FP8', kt_gpu_prefill_token_threshold=0)"
             ),
             "The server is fired up and ready to roll!",
             (
-                "KT GLM-5-Next FP8 layerwise prefill: layer=3 epoch=0 slot=0 "
-                "prime apply_count=1 prime_count=1 prefetch_hit_count=0 "
-                "completed_rounds=0 fallback_count=0"
+                "KT layerwise prefill: layer 3 compute = 1.25 ms"
             ),
         ]
     )
@@ -536,8 +479,6 @@ def test_completed_request_requires_length_finish_and_in_range_tokens():
 
 def _prefill_parity_payload(threshold):
     cases = []
-    previous = None
-    completed_rounds = 0
     for length in ACCEPTANCE.LAYERWISE_LENGTHS:
         fixture = ACCEPTANCE.build_fixture(
             length,
@@ -559,18 +500,9 @@ def _prefill_parity_payload(threshold):
                 ]
             )
         summaries = []
-        case_previous = copy.deepcopy(previous)
-        if threshold == 1:
-            for _ in range((length + 4095) // 4096):
-                completed_rounds += 1
-                previous = _summary(
-                    epoch=completed_rounds - 1,
-                    apply_count=completed_rounds * 42,
-                    prime_count=completed_rounds,
-                    prefetch_hit_count=completed_rounds * 41,
-                    completed_rounds=completed_rounds,
-                )
-                summaries.append(copy.deepcopy(previous))
+        expected_rounds = ACCEPTANCE.expected_layerwise_rounds(length, 4096)
+        if threshold == ACCEPTANCE.LAYERWISE_TOKEN_THRESHOLD:
+            summaries = [_round(round_index=index) for index in range(expected_rounds)]
         cases.append(
             {
                 "input_tokens": length,
@@ -582,9 +514,11 @@ def _prefill_parity_payload(threshold):
                 "completion_tokens": 16,
                 "top_logprobs": top_logprobs,
                 "expected_layerwise_rounds": (
-                    (length + 4095) // 4096 if threshold == 1 else 0
+                    expected_rounds
+                    if threshold == ACCEPTANCE.LAYERWISE_TOKEN_THRESHOLD
+                    else 0
                 ),
-                "previous_layerwise_summary": case_previous,
+                "previous_layerwise_summary": None,
                 "layerwise_summaries": summaries,
                 "server_log_window": {
                     "path": "/tmp/server.log",
@@ -598,7 +532,7 @@ def _prefill_parity_payload(threshold):
             }
         )
     server_args = {
-        "tp_size": "8",
+        "tp_size": "4",
         "chunked_prefill_size": "4096",
         "kt_method": "'FP8'",
         "kt_gpu_prefill_token_threshold": str(threshold),
@@ -613,7 +547,7 @@ def _prefill_parity_payload(threshold):
             "output_tokens": 16,
             "chunk_size": 4096,
             "fixture_seed": 20260811,
-            "tp_size": 8,
+            "tp_size": 4,
             "vocab_size": 154880,
             "collection_top_k": 256,
             "comparison_top_k": 64,
@@ -626,7 +560,11 @@ def _prefill_parity_payload(threshold):
         "server_evidence": {
             "threshold": threshold,
             "server_args": server_args,
-            "layerwise_startup": {"pass": True} if threshold == 1 else None,
+            "layerwise_startup": (
+                ACCEPTANCE.validate_layerwise_startup(_startup_log())
+                if threshold == ACCEPTANCE.LAYERWISE_TOKEN_THRESHOLD
+                else None
+            ),
             "path": "/tmp/server.log",
             "initial_size": 1024,
             "initial_sha256": "a" * 64,
@@ -639,7 +577,7 @@ def _prefill_parity_payload(threshold):
 
 def test_prefill_parity_comparison_accepts_exact_tokens_and_bounded_toplogprobs():
     baseline = _prefill_parity_payload(0)
-    candidate = _prefill_parity_payload(1)
+    candidate = _prefill_parity_payload(1024)
     for case in candidate["cases"]:
         for step in case["top_logprobs"]:
             for item in step:
@@ -653,7 +591,7 @@ def test_prefill_parity_comparison_accepts_exact_tokens_and_bounded_toplogprobs(
 
 def test_prefill_parity_comparison_rejects_token_or_toplogprob_drift():
     baseline = _prefill_parity_payload(0)
-    token_candidate = _prefill_parity_payload(1)
+    token_candidate = _prefill_parity_payload(1024)
     token_case = token_candidate["cases"][0]
     token_case["output_ids"][0] = 150000
     token_case["top_logprobs"][0][0]["token_id"] = 150000
@@ -664,7 +602,7 @@ def test_prefill_parity_comparison_rejects_token_or_toplogprob_drift():
     assert not token_result["pass"]
     assert any("greedy output token" in failure for failure in token_result["failures"])
 
-    logprob_candidate = _prefill_parity_payload(1)
+    logprob_candidate = _prefill_parity_payload(1024)
     logprob_candidate["cases"][0]["top_logprobs"][0][0]["logprob"] = -0.5
     logprob_result = ACCEPTANCE.compare_prefill_parity_payloads(
         baseline, logprob_candidate
@@ -677,7 +615,7 @@ def test_prefill_parity_comparison_rejects_token_or_toplogprob_drift():
 
 def test_prefill_parity_comparison_fails_closed_on_missing_top_evidence():
     baseline = _prefill_parity_payload(0)
-    candidate = _prefill_parity_payload(1)
+    candidate = _prefill_parity_payload(1024)
     candidate["cases"][0]["top_logprobs"][0].pop()
 
     result = ACCEPTANCE.compare_prefill_parity_payloads(baseline, candidate)
@@ -693,19 +631,19 @@ def test_prefill_parity_parser_defaults_freeze_matrix_seed_and_tp():
         [
             "prefill-parity",
             "--label",
-            "threshold-1",
+            "threshold-1024",
             "--output",
             "/tmp/prefill.json",
             "--server-log",
             "/tmp/server.log",
             "--threshold",
-            "1",
+            "1024",
         ]
     )
 
     assert args.lengths == [128, 4096, 4097, 8193]
     assert args.output_length == 16
     assert args.fixture_seed == 20260811
-    assert args.tp_size == 8
+    assert args.tp_size == 4
     assert args.vocab_size == 154880
     assert args.top_k == 256

--- a/test/registered/unit/test_glm5_next_session_c_final_acceptance.py
+++ b/test/registered/unit/test_glm5_next_session_c_final_acceptance.py
@@ -1,0 +1,574 @@
+import copy
+import importlib.util
+import json
+from pathlib import Path
+
+
+SCRIPT = (
+    Path(__file__).parents[3] / "scripts" / "glm5_next_session_c_final_acceptance.py"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "glm5_next_session_c_final_acceptance", SCRIPT
+)
+ACCEPTANCE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(ACCEPTANCE)
+
+
+def _summary(
+    *,
+    epoch,
+    apply_count,
+    prime_count,
+    prefetch_hit_count,
+    completed_rounds,
+    fallback_count=0,
+    slot=1,
+    load_kind="prefetch-hit",
+):
+    return {
+        "layer": 44,
+        "epoch": epoch,
+        "slot": slot,
+        "load_kind": load_kind,
+        "apply_count": apply_count,
+        "prime_count": prime_count,
+        "prefetch_hit_count": prefetch_hit_count,
+        "completed_rounds": completed_rounds,
+        "fallback_count": fallback_count,
+    }
+
+
+def test_layerwise_log_parser_and_progress_gate_accept_exact_rounds():
+    text = "\n".join(
+        [
+            "noise",
+            "KT GLM-5-Next FP8 layerwise prefill: layer=44 epoch=3 slot=1 "
+            "prefetch-hit apply_count=168 prime_count=4 "
+            "prefetch_hit_count=164 completed_rounds=4 fallback_count=0",
+            "KT GLM-5-Next FP8 layerwise prefill: layer=44 epoch=4 slot=1 "
+            "prefetch-hit apply_count=210 prime_count=5 "
+            "prefetch_hit_count=205 completed_rounds=5 fallback_count=0",
+        ]
+    )
+    current = ACCEPTANCE.parse_layerwise_summaries(text)
+    previous = _summary(
+        epoch=2,
+        apply_count=126,
+        prime_count=3,
+        prefetch_hit_count=123,
+        completed_rounds=3,
+    )
+
+    assert len(current) == 2
+    assert not ACCEPTANCE.validate_layerwise_progress(
+        previous, current, expected_rounds=2
+    )
+
+
+def test_layerwise_progress_fails_closed_on_missing_round_or_fallback():
+    previous = _summary(
+        epoch=0,
+        apply_count=42,
+        prime_count=1,
+        prefetch_hit_count=41,
+        completed_rounds=1,
+    )
+    bad = _summary(
+        epoch=1,
+        apply_count=84,
+        prime_count=2,
+        prefetch_hit_count=82,
+        completed_rounds=2,
+        fallback_count=1,
+    )
+
+    failures = ACCEPTANCE.validate_layerwise_progress(
+        previous, [bad], expected_rounds=2
+    )
+
+    assert any("expected 2" in failure for failure in failures)
+    assert any("fallback_count" in failure for failure in failures)
+
+
+def test_layerwise_progress_rejects_wrong_final_slot_or_load_kind():
+    wrong_slot = _summary(
+        epoch=0,
+        apply_count=42,
+        prime_count=1,
+        prefetch_hit_count=41,
+        completed_rounds=1,
+        slot=0,
+    )
+    wrong_kind = _summary(
+        epoch=0,
+        apply_count=42,
+        prime_count=1,
+        prefetch_hit_count=41,
+        completed_rounds=1,
+        load_kind="prime",
+    )
+
+    slot_failures = ACCEPTANCE.validate_layerwise_progress(
+        None, [wrong_slot], expected_rounds=1
+    )
+    kind_failures = ACCEPTANCE.validate_layerwise_progress(
+        None, [wrong_kind], expected_rounds=1
+    )
+
+    assert any("slot" in failure for failure in slot_failures)
+    assert any("load_kind" in failure for failure in kind_failures)
+
+
+def test_prometheus_graph_counter_sums_matching_modes_only():
+    metrics = """
+# HELP sglang:cuda_graph_passes_total graph passes
+sglang:cuda_graph_passes_total{tp_rank="0",mode="decode_cuda_graph"} 7
+sglang:cuda_graph_passes_total{tp_rank="1",mode="decode_cuda_graph"} 5
+sglang:cuda_graph_passes_total{tp_rank="0",mode="decode_none"} 99
+sglang:cuda_graph_passes_created{tp_rank="0",mode="decode_cuda_graph"} 1
+"""
+
+    assert ACCEPTANCE.decode_graph_counter(metrics) == 12
+    assert ACCEPTANCE.decode_graph_counter("# no samples\n") is None
+
+
+def test_per_rank_graph_parser_rejects_unofficial_rank_alias():
+    metrics = "\n".join(
+        [
+            'sglang:cuda_graph_passes_total{rank="0",mode="decode_cuda_graph"} 7',
+            'sglang:cuda_graph_passes_total{rank="0",mode="decode_none"} 0',
+        ]
+    )
+
+    counters = ACCEPTANCE.cuda_graph_counters_by_rank(metrics)
+    result = ACCEPTANCE.validate_graph_counter_progress(
+        counters, counters, tp_size=1, minimum_graph_delta_per_rank=0
+    )
+
+    assert not result["pass"]
+    assert any("exact TP ranks" in failure for failure in result["failures"])
+
+
+def test_per_rank_graph_gate_rejects_decode_none_growth():
+    before = {
+        "decode_cuda_graph": {str(rank): 10.0 for rank in range(2)},
+        "decode_none": {str(rank): 4.0 for rank in range(2)},
+    }
+    after = {
+        "decode_cuda_graph": {str(rank): 17.0 for rank in range(2)},
+        "decode_none": {str(rank): 4.0 for rank in range(2)},
+    }
+    assert ACCEPTANCE.validate_graph_counter_progress(
+        before, after, tp_size=2, minimum_graph_delta_per_rank=7
+    )["pass"]
+
+    after["decode_none"]["1"] += 1
+    result = ACCEPTANCE.validate_graph_counter_progress(
+        before, after, tp_size=2, minimum_graph_delta_per_rank=7
+    )
+    assert not result["pass"]
+    assert any("decode_none" in item for item in result["failures"])
+
+
+def _bucket_payload(label, outputs):
+    expanded = {
+        batch_size: [[token_ids[0] + step for step in range(8)] for token_ids in rows]
+        for batch_size, rows in outputs.items()
+    }
+    return {
+        "schema_version": ACCEPTANCE.SCHEMA_VERSION,
+        "kind": "session_c_exact_cuda_graph_buckets",
+        "label": label,
+        "pass": True,
+        "contract": {
+            "batch_sizes": [1, 2, 4],
+            "input_tokens": 128,
+            "output_tokens": 8,
+            "top_k": 64,
+            "vocab_size": ACCEPTANCE.DEFAULT_VOCAB_SIZE,
+            "fixture_seed": ACCEPTANCE.FIXTURE_SEED,
+            "require_decode_cuda_graph": True,
+            "compliant": True,
+        },
+        "cases": [
+            {
+                "batch_size": batch_size,
+                "input_rows_sha256": f"fixture-{batch_size}",
+                "output_rows": expanded[batch_size],
+                "top_k": 64,
+                "top_logprobs": [
+                    [
+                        [
+                            {"token_id": token_id, "logprob": -0.25 - rank}
+                            for rank, token_id in enumerate(range(64))
+                        ]
+                        for _ in range(8)
+                    ]
+                    for _ in rows
+                ],
+                "pass": True,
+            }
+            for batch_size, rows in outputs.items()
+        ],
+    }
+
+
+def test_bucket_comparison_requires_all_buckets_and_exact_outputs():
+    outputs = {1: [[1]], 2: [[2], [3]], 4: [[4], [5], [6], [7]]}
+    baseline = _bucket_payload("baseline", outputs)
+    candidate = _bucket_payload("candidate", copy.deepcopy(outputs))
+    assert ACCEPTANCE.compare_bucket_payloads(baseline, candidate)["pass"]
+
+    candidate["cases"][1]["output_rows"][0][0] = 99
+    result = ACCEPTANCE.compare_bucket_payloads(baseline, candidate)
+    assert not result["pass"]
+    assert any("batch 2" in failure for failure in result["failures"])
+
+
+def test_bucket_comparison_rejects_non_argmax_logprob_drift():
+    outputs = {1: [[1]], 2: [[2], [3]], 4: [[4], [5], [6], [7]]}
+    baseline = _bucket_payload("baseline", copy.deepcopy(outputs))
+    candidate = _bucket_payload("candidate", copy.deepcopy(outputs))
+    candidate["cases"][2]["top_logprobs"][0][0][0]["logprob"] = -0.5
+
+    result = ACCEPTANCE.compare_bucket_payloads(baseline, candidate)
+
+    assert not result["pass"]
+    assert any("top logprobs differ" in failure for failure in result["failures"])
+
+
+def test_final_contract_defaults_are_500k_plus_1024():
+    args = ACCEPTANCE.build_parser().parse_args(
+        [
+            "long",
+            "--label",
+            "final",
+            "--output",
+            "/tmp/final.json",
+            "--server-log",
+            "/tmp/server.log",
+        ]
+    )
+
+    assert args.input_length == 500_000
+    assert args.output_length == 1024
+    assert args.chunk_size == 4096
+
+
+def test_bucket_contract_defaults_are_exact():
+    args = ACCEPTANCE.build_parser().parse_args(
+        ["buckets", "--label", "candidate", "--output", "/tmp/buckets.json"]
+    )
+
+    assert args.vocab_size == ACCEPTANCE.DEFAULT_VOCAB_SIZE
+    assert args.fixture_seed == ACCEPTANCE.FIXTURE_SEED
+    assert args.input_length == 128
+    assert args.output_length == 8
+    assert args.top_k == 64
+    assert args.tp_size == 8
+
+
+def test_final_long_contract_is_exact_not_a_minimum(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        ACCEPTANCE,
+        "_capture_request_evidence",
+        lambda **kwargs: {"failures": [], "pass": True},
+    )
+    output = tmp_path / "long.json"
+    server_log = tmp_path / "server.log"
+    server_log.write_text("")
+    args = ACCEPTANCE.build_parser().parse_args(
+        [
+            "long",
+            "--label",
+            "too-long",
+            "--output",
+            str(output),
+            "--server-log",
+            str(server_log),
+            "--input-length",
+            "500001",
+            "--output-length",
+            "1025",
+        ]
+    )
+
+    assert ACCEPTANCE.run_long(args) == 1
+    payload = json.loads(output.read_text())
+    assert not payload["contract"]["compliant"]
+    assert payload["contract"]["input_tokens"] == 500_000
+    assert payload["contract"]["output_tokens"] == 1024
+
+
+def test_fatal_log_scan_ignores_info_but_rejects_runtime_failures():
+    assert not ACCEPTANCE.fatal_log_lines("INFO initialized fallback_count=0")
+    failures = ACCEPTANCE.fatal_log_lines(
+        "CUDA out of memory\nvalue is NaN\nTraceback (most recent call last)"
+    )
+    assert len(failures) == 3
+
+
+def _startup_log(*, threshold=1, allocation_first=True):
+    server_args = (
+        "server_args=ServerArgs(tp_size=8, chunked_prefill_size=4096, "
+        "kt_method='FP8', kt_gpu_prefill_token_threshold="
+        f"{threshold})"
+    )
+    allocation = (
+        "KT GLM-5-Next FP8 layerwise prefill eagerly allocated two raw "
+        "E4M3+FP32 full-layer slots on cuda:0 before KV profiling "
+        f"(total=1.69 GiB, contract={'a' * 64}, fallback_count=0)"
+    )
+    memory_pool = "Memory pool end. avail mem=12.34 GB"
+    ordered = (
+        [allocation, memory_pool] if allocation_first else [memory_pool, allocation]
+    )
+    return "\n".join(
+        [server_args, *ordered, "The server is fired up and ready to roll!"]
+    )
+
+
+def test_layerwise_startup_requires_one_allocation_before_kv_pool_and_ready():
+    result = ACCEPTANCE.validate_layerwise_startup(_startup_log())
+
+    assert result["pass"]
+    assert result["allocation"]["total_gib"] == 1.69
+    assert result["allocation"]["fallback_count"] == 0
+
+    wrong_order = ACCEPTANCE.validate_layerwise_startup(
+        _startup_log(allocation_first=False)
+    )
+    duplicate = ACCEPTANCE.validate_layerwise_startup(
+        _startup_log() + "\n" + _startup_log().splitlines()[1]
+    )
+    assert not wrong_order["pass"]
+    assert any("does not precede" in failure for failure in wrong_order["failures"])
+    assert not duplicate["pass"]
+    assert any("exactly one" in failure for failure in duplicate["failures"])
+
+
+def test_prefill_server_log_binds_explicit_threshold_and_tp8():
+    threshold_1 = ACCEPTANCE.validate_prefill_parity_server_log(
+        _startup_log(threshold=1), threshold=1
+    )
+    threshold_0_log = "\n".join(
+        [
+            (
+                "server_args=ServerArgs(tp_size=8, chunked_prefill_size=4096, "
+                "kt_method='FP8', kt_gpu_prefill_token_threshold=0)"
+            ),
+            "The server is fired up and ready to roll!",
+        ]
+    )
+    threshold_0 = ACCEPTANCE.validate_prefill_parity_server_log(
+        threshold_0_log, threshold=0
+    )
+
+    assert threshold_1["pass"]
+    assert threshold_0["pass"]
+    wrong_threshold = ACCEPTANCE.validate_prefill_parity_server_log(
+        threshold_0_log, threshold=1
+    )
+    assert not wrong_threshold["pass"]
+    assert any(
+        "kt_gpu_prefill_token_threshold" in failure
+        for failure in wrong_threshold["failures"]
+    )
+
+
+def test_completed_request_requires_length_finish_and_in_range_tokens():
+    good = {
+        "success": True,
+        "finish_reason": {"type": "length", "length": 16},
+        "output_ids": list(range(16)),
+    }
+    assert not ACCEPTANCE.validate_completed_request(
+        good, output_tokens=16, vocab_size=154880
+    )
+
+    bad = copy.deepcopy(good)
+    bad["finish_reason"] = {"type": "stop"}
+    bad["output_ids"][-1] = 154880
+    failures = ACCEPTANCE.validate_completed_request(
+        bad, output_tokens=16, vocab_size=154880
+    )
+    assert any("finish_reason" in failure for failure in failures)
+    assert any("out-of-range" in failure for failure in failures)
+
+
+def _prefill_parity_payload(threshold):
+    cases = []
+    previous = None
+    completed_rounds = 0
+    for length in ACCEPTANCE.LAYERWISE_LENGTHS:
+        fixture = ACCEPTANCE.build_fixture(
+            length,
+            ACCEPTANCE.DEFAULT_VOCAB_SIZE,
+            salt=89,
+            seed=ACCEPTANCE.LAYERWISE_FIXTURE_SEED,
+        )
+        fixture.pop("input_ids")
+        output_ids = [1000 + step for step in range(16)]
+        top_logprobs = []
+        for generated_id in output_ids:
+            top_logprobs.append(
+                [
+                    {
+                        "token_id": generated_id + rank,
+                        "logprob": -0.1 - rank,
+                    }
+                    for rank in range(ACCEPTANCE.PREFILL_PARITY_COLLECTION_TOP_K)
+                ]
+            )
+        summaries = []
+        case_previous = copy.deepcopy(previous)
+        if threshold == 1:
+            for _ in range((length + 4095) // 4096):
+                completed_rounds += 1
+                previous = _summary(
+                    epoch=completed_rounds - 1,
+                    apply_count=completed_rounds * 42,
+                    prime_count=completed_rounds,
+                    prefetch_hit_count=completed_rounds * 41,
+                    completed_rounds=completed_rounds,
+                )
+                summaries.append(copy.deepcopy(previous))
+        cases.append(
+            {
+                "input_tokens": length,
+                "fixture": fixture,
+                "output_ids": output_ids,
+                "output_sha256": ACCEPTANCE._sha256_token_rows([output_ids]),
+                "finish_reason": {"type": "length"},
+                "prompt_tokens": length,
+                "completion_tokens": 16,
+                "top_logprobs": top_logprobs,
+                "expected_layerwise_rounds": (
+                    (length + 4095) // 4096 if threshold == 1 else 0
+                ),
+                "previous_layerwise_summary": case_previous,
+                "layerwise_summaries": summaries,
+                "server_log_window": {
+                    "path": "/tmp/server.log",
+                    "start_offset": 10,
+                    "end_offset": 20,
+                    "sha256": "b" * 64,
+                    "fatal_lines": [],
+                },
+                "failures": [],
+                "pass": True,
+            }
+        )
+    server_args = {
+        "tp_size": "8",
+        "chunked_prefill_size": "4096",
+        "kt_method": "'FP8'",
+        "kt_gpu_prefill_token_threshold": str(threshold),
+    }
+    return {
+        "schema_version": ACCEPTANCE.SCHEMA_VERSION,
+        "kind": "glm5_next_session_c_prefill_threshold_collection",
+        "pass": True,
+        "contract": {
+            "threshold": threshold,
+            "lengths": list(ACCEPTANCE.LAYERWISE_LENGTHS),
+            "output_tokens": 16,
+            "chunk_size": 4096,
+            "fixture_seed": 20260811,
+            "tp_size": 8,
+            "vocab_size": 154880,
+            "collection_top_k": 256,
+            "comparison_top_k": 64,
+            "temperature": 0,
+            "ignore_eos": True,
+            "require_finish_reason_length": True,
+            "require_exact_greedy_tokens": True,
+            "compliant": True,
+        },
+        "server_evidence": {
+            "threshold": threshold,
+            "server_args": server_args,
+            "layerwise_startup": {"pass": True} if threshold == 1 else None,
+            "path": "/tmp/server.log",
+            "initial_size": 1024,
+            "initial_sha256": "a" * 64,
+            "pass": True,
+        },
+        "cases": cases,
+        "failures": [],
+    }
+
+
+def test_prefill_parity_comparison_accepts_exact_tokens_and_bounded_toplogprobs():
+    baseline = _prefill_parity_payload(0)
+    candidate = _prefill_parity_payload(1)
+    for case in candidate["cases"]:
+        for step in case["top_logprobs"]:
+            for item in step:
+                item["logprob"] += 0.001
+
+    result = ACCEPTANCE.compare_prefill_parity_payloads(baseline, candidate)
+
+    assert result["pass"]
+    assert len(result["diagnostics"]) == 4 * 16
+
+
+def test_prefill_parity_comparison_rejects_token_or_toplogprob_drift():
+    baseline = _prefill_parity_payload(0)
+    token_candidate = _prefill_parity_payload(1)
+    token_case = token_candidate["cases"][0]
+    token_case["output_ids"][0] = 150000
+    token_case["top_logprobs"][0][0]["token_id"] = 150000
+    token_case["output_sha256"] = ACCEPTANCE._sha256_token_rows(
+        [token_case["output_ids"]]
+    )
+    token_result = ACCEPTANCE.compare_prefill_parity_payloads(baseline, token_candidate)
+    assert not token_result["pass"]
+    assert any("greedy output token" in failure for failure in token_result["failures"])
+
+    logprob_candidate = _prefill_parity_payload(1)
+    logprob_candidate["cases"][0]["top_logprobs"][0][0]["logprob"] = -0.5
+    logprob_result = ACCEPTANCE.compare_prefill_parity_payloads(
+        baseline, logprob_candidate
+    )
+    assert not logprob_result["pass"]
+    assert any(
+        "top logprobs exceed" in failure for failure in logprob_result["failures"]
+    )
+
+
+def test_prefill_parity_comparison_fails_closed_on_missing_top_evidence():
+    baseline = _prefill_parity_payload(0)
+    candidate = _prefill_parity_payload(1)
+    candidate["cases"][0]["top_logprobs"][0].pop()
+
+    result = ACCEPTANCE.compare_prefill_parity_payloads(baseline, candidate)
+
+    assert not result["pass"]
+    assert any(
+        "top-logprob evidence is invalid" in failure for failure in result["failures"]
+    )
+
+
+def test_prefill_parity_parser_defaults_freeze_matrix_seed_and_tp():
+    args = ACCEPTANCE.build_parser().parse_args(
+        [
+            "prefill-parity",
+            "--label",
+            "threshold-1",
+            "--output",
+            "/tmp/prefill.json",
+            "--server-log",
+            "/tmp/server.log",
+            "--threshold",
+            "1",
+        ]
+    )
+
+    assert args.lengths == [128, 4096, 4097, 8193]
+    assert args.output_length == 16
+    assert args.fixture_seed == 20260811
+    assert args.tp_size == 8
+    assert args.vocab_size == 154880
+    assert args.top_k == 256

--- a/test/registered/unit/test_glm5_next_session_c_graph_acceptance.py
+++ b/test/registered/unit/test_glm5_next_session_c_graph_acceptance.py
@@ -48,7 +48,7 @@ class _FakeSGLang:
             return b"# graph counter deliberately absent\nsglang:running_requests 0\n"
         value = 10 if self.metrics_calls == 1 else 73
         lines = ["# TYPE sglang:cuda_graph_passes_total counter"]
-        for rank in range(8):
+        for rank in range(4):
             lines.append(
                 "sglang:cuda_graph_passes_total"
                 f'{{mode="decode_cuda_graph",tp_rank="{rank}"}} {value}'
@@ -141,6 +141,7 @@ def _collect(tmp_path, *, mode="graph", expose_graph_counter=True):
 
 
 def test_fixtures_are_stable_distinct_and_exact_graph_buckets():
+    assert _args(Path("/tmp")).tp_size == 4
     first = ACCEPTANCE.build_fixtures(154880)
     second = ACCEPTANCE.build_fixtures(154880)
 
@@ -276,7 +277,7 @@ def test_mocked_http_graph_acceptance_covers_exact_a_poison_a_contract(tmp_path)
 
     gate = payload["metrics"]["decode_cuda_graph_gate"]
     assert gate["pass"]
-    assert gate["delta"] == 504
+    assert gate["delta"] == 252
     assert all(item["graph_delta"] == 63 for item in gate["per_rank"].values())
     assert all(item["decode_none_delta"] == 0 for item in gate["per_rank"].values())
     assert gate["source"] == "HTTP /metrics only"

--- a/test/registered/unit/test_glm5_next_session_c_graph_acceptance.py
+++ b/test/registered/unit/test_glm5_next_session_c_graph_acceptance.py
@@ -1,0 +1,389 @@
+import copy
+import importlib.util
+import json
+from pathlib import Path
+
+
+SCRIPT = (
+    Path(__file__).parents[3] / "scripts" / "glm5_next_session_c_graph_acceptance.py"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "glm5_next_session_c_graph_acceptance", SCRIPT
+)
+ACCEPTANCE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(ACCEPTANCE)
+
+
+class _FakeResponse:
+    status = 200
+
+    def __init__(self, payload):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def getcode(self):
+        return self.status
+
+    def read(self):
+        return self.payload
+
+
+class _FakeSGLang:
+    def __init__(self, *, expose_graph_counter=True, nonfinite=False):
+        self.expose_graph_counter = expose_graph_counter
+        self.nonfinite = nonfinite
+        self.metrics_calls = 0
+        self.flush_calls = 0
+        self.generate_bodies = []
+
+    def _metrics(self):
+        self.metrics_calls += 1
+        if not self.expose_graph_counter:
+            return b"# graph counter deliberately absent\nsglang:running_requests 0\n"
+        value = 10 if self.metrics_calls == 1 else 73
+        lines = ["# TYPE sglang:cuda_graph_passes_total counter"]
+        for rank in range(8):
+            lines.append(
+                "sglang:cuda_graph_passes_total"
+                f'{{mode="decode_cuda_graph",tp_rank="{rank}"}} {value}'
+            )
+            lines.append(
+                "sglang:cuda_graph_passes_total"
+                f'{{mode="decode_none",tp_rank="{rank}"}} 99'
+            )
+        return ("\n".join(lines) + "\n").encode()
+
+    def _generate(self, body):
+        result = []
+        for row_index, input_ids in enumerate(body["input_ids"]):
+            prompt_token = input_ids[0]
+            output_ids = [prompt_token + step + 1 for step in range(8)]
+            output_top_logprobs = []
+            for step, output_id in enumerate(output_ids):
+                first_logprob = -0.1 - step / 100
+                if (
+                    self.nonfinite
+                    and not self.generate_bodies[:-1]
+                    and row_index == 0
+                    and step == 0
+                ):
+                    first_logprob = float("nan")
+                output_top_logprobs.append(
+                    [
+                        [first_logprob, output_id],
+                        [-1.1 - step / 100, output_id + 777],
+                    ]
+                )
+            result.append(
+                {
+                    "output_ids": output_ids,
+                    "meta_info": {
+                        "completion_tokens": 8,
+                        "output_top_logprobs": output_top_logprobs,
+                    },
+                }
+            )
+        return json.dumps(result).encode()
+
+    def __call__(self, request, timeout):
+        assert timeout == 30
+        if request.full_url.endswith("/metrics"):
+            assert request.get_method() == "GET"
+            return _FakeResponse(self._metrics())
+        if request.full_url.endswith("/flush_cache"):
+            assert request.get_method() == "POST"
+            assert json.loads(request.data) == {}
+            self.flush_calls += 1
+            return _FakeResponse(b"Cache flushed.\n")
+        if request.full_url.endswith("/generate"):
+            assert request.get_method() == "POST"
+            body = json.loads(request.data)
+            self.generate_bodies.append(body)
+            return _FakeResponse(self._generate(body))
+        raise AssertionError(f"unexpected URL: {request.full_url}")
+
+
+def _args(tmp_path, *, mode="graph", eager_json=None):
+    argv = [
+        "--base-url",
+        "http://example.test",
+        "--output",
+        str(tmp_path / f"{mode}.json"),
+        "--mode",
+        mode,
+        "--top-k",
+        "2",
+        "--request-timeout",
+        "30",
+    ]
+    if eager_json is not None:
+        argv.extend(["--eager-json", str(eager_json)])
+    return ACCEPTANCE.build_parser().parse_args(argv)
+
+
+def _collect(tmp_path, *, mode="graph", expose_graph_counter=True):
+    eager_json = None
+    if mode == "graph":
+        eager, _ = _collect(tmp_path, mode="eager")
+        eager_json = tmp_path / "eager-reference.json"
+        ACCEPTANCE._atomic_write_json(eager_json, eager)
+    fake = _FakeSGLang(expose_graph_counter=expose_graph_counter)
+    payload = ACCEPTANCE.collect_acceptance(
+        _args(tmp_path, mode=mode, eager_json=eager_json), opener=fake
+    )
+    return payload, fake
+
+
+def test_fixtures_are_stable_distinct_and_exact_graph_buckets():
+    first = ACCEPTANCE.build_fixtures(154880)
+    second = ACCEPTANCE.build_fixtures(154880)
+
+    assert first == second
+    assert [fixture["batch_size"] for fixture in first] == [1, 2, 4]
+    for fixture in first:
+        batch_size = fixture["batch_size"]
+        assert fixture["prompt_length"] == 1
+        assert len(fixture["a_tokens"]) == batch_size
+        assert len(fixture["poison_tokens"]) == batch_size
+        assert all(
+            a_token != poison_token
+            for a_token, poison_token in zip(
+                fixture["a_tokens"], fixture["poison_tokens"]
+            )
+        )
+
+
+def test_metrics_parser_accepts_real_and_compatible_counter_formats_only():
+    text = """
+# HELP sglang:cuda_graph_passes_total Forward passes by mode.
+sglang:cuda_graph_passes_total{mode="decode_cuda_graph",tp_rank="0"} 10
+sglang_cuda_graph_passes_total{forward_mode="decode_cuda_graph"} 3
+runtime_decode_cuda_graph_invocations_count 4
+sglang:cuda_graph_passes_total{mode="decode_none"} 100
+sglang:is_cuda_graph 1
+sglang:decode_cuda_graph_created 123
+cuda graph: True
+"""
+
+    counter = ACCEPTANCE.decode_cuda_graph_counter(text)
+
+    assert counter["available"]
+    assert counter["total"] == 17
+    assert {sample["name"] for sample in counter["samples"]} == {
+        "sglang:cuda_graph_passes_total",
+        "sglang_cuda_graph_passes_total",
+        "runtime_decode_cuda_graph_invocations_count",
+    }
+
+
+def test_metrics_gate_requires_two_http_counter_snapshots_and_growth():
+    def snapshot(total=None, *, success=True):
+        by_rank = (
+            {
+                "decode_cuda_graph": {"0": total},
+                "decode_none": {"0": 0},
+            }
+            if total is not None
+            else {"decode_cuda_graph": {}, "decode_none": {}}
+        )
+        return {
+            "success": success,
+            "decode_cuda_graph_counter": {
+                "available": total is not None,
+                "total": total,
+                "samples": [],
+            },
+            "cuda_graph_counters_by_rank": by_rank,
+        }
+
+    passing = ACCEPTANCE.compare_metric_snapshots(
+        snapshot(10), snapshot(19), tp_size=1, minimum_graph_delta_per_rank=9
+    )
+    assert passing["pass"]
+    assert passing["delta"] == 9
+    assert passing["source"] == "HTTP /metrics only"
+    assert passing["log_evidence_used"] is False
+
+    assert not ACCEPTANCE.compare_metric_snapshots(snapshot(None), snapshot(19))["pass"]
+    assert not ACCEPTANCE.compare_metric_snapshots(snapshot(19), snapshot(19))["pass"]
+    assert not ACCEPTANCE.decode_cuda_graph_counter("cuda graph: True\n")["available"]
+
+
+def test_mocked_http_graph_acceptance_covers_exact_a_poison_a_contract(tmp_path):
+    eager, _ = _collect(tmp_path, mode="eager")
+    eager_path = tmp_path / "eager-reference.json"
+    ACCEPTANCE._atomic_write_json(eager_path, eager)
+    args = _args(tmp_path, eager_json=eager_path)
+    fake = _FakeSGLang()
+
+    assert ACCEPTANCE.run(args, opener=fake) == 0
+
+    payload = json.loads(Path(args.output).read_text())
+    assert payload["pass"]
+    assert payload["collection_pass"]
+    assert [case["batch_size"] for case in payload["cases"]] == [1, 2, 4]
+    assert fake.metrics_calls == 2
+    assert fake.flush_calls == 1
+    assert len(fake.generate_bodies) == 9
+    assert [len(body["input_ids"]) for body in fake.generate_bodies] == [
+        1,
+        1,
+        1,
+        2,
+        2,
+        2,
+        4,
+        4,
+        4,
+    ]
+
+    for offset in range(0, len(fake.generate_bodies), 3):
+        a_before, poison, a_after = fake.generate_bodies[offset : offset + 3]
+        assert a_before["input_ids"] == a_after["input_ids"]
+        assert a_before["input_ids"] != poison["input_ids"]
+
+    for body in fake.generate_bodies:
+        assert all(len(row) == 1 for row in body["input_ids"])
+        assert body["sampling_params"] == {
+            "temperature": 0,
+            "max_new_tokens": 8,
+            "ignore_eos": True,
+            "skip_special_tokens": False,
+        }
+        assert body["return_logprob"] is True
+        assert body["top_logprobs_num"] == 2
+
+    for case in payload["cases"]:
+        assert [phase["phase"] for phase in case["phases"]] == [
+            "a_before",
+            "poison",
+            "a_after",
+        ]
+        assert case["a_poison_a"]["a_repeat"]["pass"]
+        assert case["a_poison_a"]["poison"]["observed"]
+        for phase in case["phases"]:
+            assert phase["raw_response"]
+            for sequence in phase["sequences"]:
+                assert len(sequence["generated_ids"]) == 8
+                assert len(sequence["steps"]) == 8
+                assert all(len(step["top_logprobs"]) == 2 for step in sequence["steps"])
+
+    gate = payload["metrics"]["decode_cuda_graph_gate"]
+    assert gate["pass"]
+    assert gate["delta"] == 504
+    assert all(item["graph_delta"] == 63 for item in gate["per_rank"].values())
+    assert all(item["decode_none_delta"] == 0 for item in gate["per_rank"].values())
+    assert gate["source"] == "HTTP /metrics only"
+    assert gate["log_evidence_used"] is False
+    assert payload["metrics"]["before"]["raw_text"]
+    assert payload["metrics"]["after"]["raw_text"]
+
+
+def test_eager_baseline_does_not_require_graph_counter(tmp_path):
+    payload, fake = _collect(tmp_path, mode="eager", expose_graph_counter=False)
+
+    assert payload["pass"]
+    assert payload["collection_pass"]
+    assert payload["metrics"]["decode_cuda_graph_gate"]["required"] is False
+    assert not payload["metrics"]["decode_cuda_graph_gate"]["pass"]
+    assert fake.metrics_calls == 2
+
+
+def test_graph_mode_fails_without_http_counter_even_when_outputs_pass(tmp_path):
+    payload, _ = _collect(tmp_path, mode="graph", expose_graph_counter=False)
+
+    assert payload["collection_pass"]
+    assert not payload["pass"]
+    gate = payload["metrics"]["decode_cuda_graph_gate"]
+    assert gate["required"] is True
+    assert not gate["pass"]
+    assert gate["source"] == "HTTP /metrics only"
+    assert gate["log_evidence_used"] is False
+    assert any(
+        "no decode_cuda_graph counter" in failure for failure in payload["failures"]
+    )
+
+
+def test_graph_mode_requires_eager_json_before_http(tmp_path):
+    fake = _FakeSGLang()
+    args = _args(tmp_path, mode="graph")
+
+    assert ACCEPTANCE.run(args, opener=fake) == 1
+    payload = json.loads(Path(args.output).read_text())
+    assert not payload["pass"]
+    assert any("--eager-json is required" in item for item in payload["failures"])
+    assert fake.metrics_calls == 0
+    assert fake.flush_calls == 0
+    assert not fake.generate_bodies
+
+
+def test_eager_graph_comparison_enforces_tokens_and_logprob_tolerance(tmp_path):
+    eager, _ = _collect(tmp_path, mode="eager")
+    graph, _ = _collect(tmp_path, mode="graph")
+
+    within_tolerance = copy.deepcopy(graph)
+    within_tolerance["cases"][0]["phases"][0]["sequences"][0]["steps"][0][
+        "top_logprobs"
+    ][0]["logprob"] += 0.01
+    assert ACCEPTANCE.compare_acceptance_payloads(eager, within_tolerance)["pass"]
+
+    token_mismatch = copy.deepcopy(graph)
+    token_mismatch["cases"][0]["phases"][0]["sequences"][0]["generated_ids"][0] += 1
+    token_result = ACCEPTANCE.compare_acceptance_payloads(eager, token_mismatch)
+    assert not token_result["pass"]
+    assert any(
+        "generated token mismatch" in failure for failure in token_result["failures"]
+    )
+
+    logprob_mismatch = copy.deepcopy(graph)
+    logprob_mismatch["cases"][0]["phases"][0]["sequences"][0]["steps"][0][
+        "top_logprobs"
+    ][0]["logprob"] += 1
+    logprob_result = ACCEPTANCE.compare_acceptance_payloads(eager, logprob_mismatch)
+    assert not logprob_result["pass"]
+    assert any("outside" in failure for failure in logprob_result["failures"])
+
+
+def test_graph_run_loads_eager_json_and_records_comparison_evidence(tmp_path):
+    eager, _ = _collect(tmp_path, mode="eager")
+    eager_path = tmp_path / "eager-reference.json"
+    ACCEPTANCE._atomic_write_json(eager_path, eager)
+    args = _args(tmp_path, mode="graph", eager_json=eager_path)
+
+    assert ACCEPTANCE.run(args, opener=_FakeSGLang()) == 0
+
+    graph = json.loads(Path(args.output).read_text())
+    assert graph["pass"]
+    assert graph["comparison"]["pass"]
+    assert graph["comparison"]["tokens_exact_required"] is True
+    assert graph["comparison"]["atol"] == 0.05
+    assert graph["comparison"]["rtol"] == 0.05
+    assert graph["comparison"]["eager_json"] == str(eager_path.resolve())
+    assert graph["comparison"]["eager_sha256"] == ACCEPTANCE._sha256_file(eager_path)
+
+
+def test_nonfinite_response_fails_but_complete_strict_json_is_preserved(tmp_path):
+    args = _args(tmp_path, mode="eager")
+    fake = _FakeSGLang(nonfinite=True)
+
+    assert ACCEPTANCE.run(args, opener=fake) == 1
+
+    serialized = Path(args.output).read_text()
+    assert "NaN" in serialized
+    payload = json.loads(
+        serialized,
+        parse_constant=lambda value: (_ for _ in ()).throw(AssertionError(value)),
+    )
+    assert not payload["pass"]
+    first_phase = payload["cases"][0]["phases"][0]
+    assert (
+        first_phase["raw_response"][0]["meta_info"]["output_top_logprobs"][0][0][0]
+        == "NaN"
+    )
+    assert any("non-finite logprob" in failure for failure in first_phase["failures"])

--- a/test/registered/unit/test_glm5_next_session_c_oracle.py
+++ b/test/registered/unit/test_glm5_next_session_c_oracle.py
@@ -1,0 +1,457 @@
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+
+SCRIPT = Path(__file__).parents[3] / "scripts" / "glm5_next_session_c_oracle.py"
+SPEC = importlib.util.spec_from_file_location("glm5_next_session_c_oracle", SCRIPT)
+ORACLE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(ORACLE)
+
+
+def _kda_conv_correction(source_dtype="torch.bfloat16"):
+    layer_ids = list(ORACLE.EXPECTED_HF_KDA_LAYER_IDS)
+    source_dtype_by_layer = {str(layer_id): source_dtype for layer_id in layer_ids}
+    return {
+        "glm5_next_kda_conv_fp32": {
+            "contract": ORACLE.HF_KDA_CONV_FP32_CONTRACT,
+            "source_dtype_by_layer": source_dtype_by_layer,
+            "converted_layer_ids": (
+                layer_ids if source_dtype == "torch.bfloat16" else []
+            ),
+            "already_fp32_layer_ids": (
+                layer_ids if source_dtype == "torch.float32" else []
+            ),
+            "runtime_dtype_by_layer": {
+                str(layer_id): "torch.float32" for layer_id in layer_ids
+            },
+            "verified_layer_ids": layer_ids,
+        }
+    }
+
+
+def _cache_audit(prompt_length, max_new_tokens):
+    steps = []
+    for step_index in range(max_new_tokens):
+        before = 0 if step_index == 0 else prompt_length + step_index - 1
+        input_length = prompt_length if step_index == 0 else 1
+        after = before + input_length
+        positions = list(range(before, after))
+        steps.append(
+            {
+                "step": step_index,
+                "input_length": input_length,
+                "attention_mask_length": after,
+                "cache_position": positions,
+                "position_ids": positions,
+                "before": {"sequence_length": before, "seen_tokens": before},
+                "after": {"sequence_length": after, "seen_tokens": after},
+            }
+        )
+    return {
+        "cache_class": "transformers.cache_utils.DynamicCache",
+        "use_cache": True,
+        "initial": {"sequence_length": 0, "seen_tokens": 0},
+        "steps": steps,
+    }
+
+
+def _payload(delta=0.0, token_id=7, *, candidate=False):
+    payload = {
+        "schema_version": ORACLE.SCHEMA_VERSION,
+        "kind": "sglang_http_result" if candidate else "patched_transformers_oracle",
+        "pass": True,
+        "fixture_seed": ORACLE.FIXTURE_SEED,
+        "max_new_tokens": 1,
+        "top_k": 2,
+        "cases": [
+            {
+                "name": "tokens_16",
+                "prompt_length": 16,
+                "input_sha256": "same",
+                "generated_ids": [token_id],
+                "steps": [
+                    {
+                        "token_id": token_id,
+                        "top_logprobs": [
+                            {"token_id": token_id, "logprob": -0.1 + delta},
+                            {"token_id": 8, "logprob": -1.0 + delta},
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+    if not candidate:
+        payload["repetitions"] = 2
+        payload["repeat_envelope"] = {"tokens_exact": True}
+        payload["cache_contract"] = ORACLE.HF_CACHE_CONTRACT
+        payload["oracle_corrections"] = _kda_conv_correction()
+        payload["cases"][0]["cache_audit"] = _cache_audit(16, 1)
+    return payload
+
+
+def _rollout_payload(generated_ids, deltas=None, *, candidate=False):
+    if deltas is None:
+        deltas = [0.0] * len(generated_ids)
+    assert len(generated_ids) == len(deltas)
+    payload = {
+        "schema_version": ORACLE.SCHEMA_VERSION,
+        "kind": "sglang_http_result" if candidate else "patched_transformers_oracle",
+        "pass": True,
+        "fixture_seed": ORACLE.FIXTURE_SEED,
+        "max_new_tokens": len(generated_ids),
+        "top_k": 2,
+        "cases": [
+            {
+                "name": "tokens_16",
+                "prompt_length": 16,
+                "input_sha256": "same",
+                "generated_ids": generated_ids,
+                "steps": [
+                    {
+                        "token_id": token_id,
+                        "top_logprobs": [
+                            {"token_id": 100 + step, "logprob": -0.1 + delta},
+                            {"token_id": 200 + step, "logprob": -1.0 + delta},
+                        ],
+                    }
+                    for step, (token_id, delta) in enumerate(zip(generated_ids, deltas))
+                ],
+            }
+        ],
+    }
+    if not candidate:
+        payload["repetitions"] = 2
+        payload["repeat_envelope"] = {"tokens_exact": True}
+        payload["cache_contract"] = ORACLE.HF_CACHE_CONTRACT
+        payload["oracle_corrections"] = _kda_conv_correction()
+        payload["cases"][0]["cache_audit"] = _cache_audit(16, len(generated_ids))
+    return payload
+
+
+class _FakeCache:
+    def __init__(self):
+        self.length = 0
+        self.seen_tokens = 0
+
+    def get_seq_length(self):
+        return self.length
+
+
+class _RolloutModel:
+    def __init__(self, cache, *, return_none=False, grow=False):
+        self.cache = cache
+        self.return_none = return_none
+        self.grow = grow
+        self.calls = []
+
+    def __call__(self, **kwargs):
+        self.calls.append(kwargs)
+        if self.grow:
+            increment = int(kwargs["input_ids"].shape[1])
+            self.cache.length += increment
+            self.cache.seen_tokens += increment
+        returned_cache = None if self.return_none else self.cache
+        logits = torch.tensor([[[0.0, 3.0, -2.0, 1.0]]])
+        return SimpleNamespace(logits=logits, past_key_values=returned_cache)
+
+
+def _small_fixture():
+    return {
+        "name": "tokens_3",
+        "prompt_length": 3,
+        "input_ids": [1, 2, 3],
+        "input_sha256": "test",
+    }
+
+
+def _fake_hf_model(conv_dtype=torch.bfloat16):
+    layer_types = [
+        (
+            "linear_attention"
+            if layer_id in ORACLE.EXPECTED_HF_KDA_LAYER_IDS
+            else "deepseek_sparse_attention"
+        )
+        for layer_id in range(ORACLE.EXPECTED_HF_LAYER_COUNT)
+    ]
+    layers = []
+    channels = ORACLE.EXPECTED_HF_KDA_CONV_WEIGHT_SHAPE[0]
+    for layer_id, layer_type in enumerate(layer_types):
+        self_attn = SimpleNamespace(layer_idx=layer_id)
+        if layer_type == "linear_attention":
+            self_attn.activation = "silu"
+            self_attn.conv1d = torch.nn.Conv1d(
+                channels,
+                channels,
+                kernel_size=4,
+                padding=3,
+                groups=channels,
+                bias=False,
+                device="meta",
+                dtype=conv_dtype,
+            )
+        layers.append(SimpleNamespace(self_attn=self_attn))
+    text_config = SimpleNamespace(
+        layer_types=layer_types,
+        linear_num_heads=64,
+        linear_head_dim=128,
+        linear_conv_kernel_dim=4,
+    )
+    return SimpleNamespace(
+        config=SimpleNamespace(text_config=text_config),
+        model=SimpleNamespace(language_model=SimpleNamespace(layers=layers)),
+    )
+
+
+def test_hf_kda_conv_repair_converts_and_attests_all_34_layers():
+    model = _fake_hf_model()
+
+    correction = ORACLE._repair_hf_kda_conv_weights(model)
+
+    assert correction == _kda_conv_correction()["glm5_next_kda_conv_fp32"]
+    assert not ORACLE._validate_serialized_hf_kda_conv_correction(
+        {"oracle_corrections": {"glm5_next_kda_conv_fp32": correction}}
+    )
+    for layer_id in ORACLE.EXPECTED_HF_KDA_LAYER_IDS:
+        conv1d = model.model.language_model.layers[layer_id].self_attn.conv1d
+        assert conv1d.weight.dtype == torch.float32
+        assert tuple(conv1d.weight.shape) == ORACLE.EXPECTED_HF_KDA_CONV_WEIGHT_SHAPE
+
+
+def test_hf_kda_conv_repair_accepts_already_fp32_weights():
+    model = _fake_hf_model(torch.float32)
+
+    correction = ORACLE._repair_hf_kda_conv_weights(model)
+
+    assert (
+        correction == _kda_conv_correction("torch.float32")["glm5_next_kda_conv_fp32"]
+    )
+
+
+@pytest.mark.parametrize(
+    ("mutation", "error"),
+    [
+        ("count", "KDA layer IDs differ"),
+        ("shape", "kernel_size"),
+        ("dtype", "neither BF16 nor FP32"),
+        ("activation", "does not use fused SiLU"),
+    ],
+)
+def test_hf_kda_conv_repair_fails_closed(mutation, error):
+    model = _fake_hf_model()
+    first_kda = model.model.language_model.layers[0].self_attn
+    channels = ORACLE.EXPECTED_HF_KDA_CONV_WEIGHT_SHAPE[0]
+    if mutation == "count":
+        model.config.text_config.layer_types[44] = "deepseek_sparse_attention"
+    elif mutation == "shape":
+        first_kda.conv1d = torch.nn.Conv1d(
+            channels,
+            channels,
+            kernel_size=3,
+            padding=2,
+            groups=channels,
+            bias=False,
+            device="meta",
+            dtype=torch.bfloat16,
+        )
+    elif mutation == "dtype":
+        first_kda.conv1d.weight.data = first_kda.conv1d.weight.data.to(torch.float16)
+    else:
+        first_kda.activation = "gelu"
+
+    with pytest.raises(RuntimeError, match=error):
+        ORACLE._repair_hf_kda_conv_weights(model)
+
+
+def test_hf_model_repairs_kda_conv_before_cpu_offload():
+    source = SCRIPT.read_text(encoding="utf-8")
+    load_model = source[
+        source.index("def _load_hf_model") : source.index("def _cache_counter")
+    ]
+
+    assert load_model.index("_repair_hf_kda_conv_weights(model)") < load_model.index(
+        "cpu_offload(model"
+    )
+
+
+def test_hf_rollout_rejects_none_cache(monkeypatch):
+    cache = _FakeCache()
+    model = _RolloutModel(cache, return_none=True)
+    monkeypatch.setattr(ORACLE, "_new_hf_dynamic_cache", lambda _model: cache)
+
+    with pytest.raises(RuntimeError, match="past_key_values=None"):
+        ORACLE._run_hf_case(
+            model, _small_fixture(), device="cpu", max_new_tokens=1, top_k=2
+        )
+
+
+def test_hf_rollout_rejects_stale_cache(monkeypatch):
+    cache = _FakeCache()
+    model = _RolloutModel(cache)
+    monkeypatch.setattr(ORACLE, "_new_hf_dynamic_cache", lambda _model: cache)
+
+    with pytest.raises(RuntimeError, match="expected exactly 3"):
+        ORACLE._run_hf_case(
+            model, _small_fixture(), device="cpu", max_new_tokens=1, top_k=2
+        )
+
+
+def test_hf_rollout_accepts_exactly_growing_cache_and_positions(monkeypatch):
+    cache = _FakeCache()
+    model = _RolloutModel(cache, grow=True)
+    monkeypatch.setattr(ORACLE, "_new_hf_dynamic_cache", lambda _model: cache)
+
+    case, logits = ORACLE._run_hf_case(
+        model, _small_fixture(), device="cpu", max_new_tokens=3, top_k=2
+    )
+
+    assert tuple(logits.shape) == (3, 4)
+    assert [call["input_ids"].shape[1] for call in model.calls] == [3, 1, 1]
+    assert [call["attention_mask"].shape[1] for call in model.calls] == [3, 4, 5]
+    assert [call["cache_position"].tolist() for call in model.calls] == [
+        [0, 1, 2],
+        [3],
+        [4],
+    ]
+    assert [call["position_ids"].tolist() for call in model.calls] == [
+        [[0, 1, 2]],
+        [[3]],
+        [[4]],
+    ]
+    assert [
+        step["after"]["sequence_length"] for step in case["cache_audit"]["steps"]
+    ] == [
+        3,
+        4,
+        5,
+    ]
+    assert not ORACLE._validate_serialized_cache_audit(case, max_new_tokens=3)
+
+
+def test_fixtures_are_stable_and_distinct():
+    first = ORACLE.build_fixtures(154856)
+    second = ORACLE.build_fixtures(154856)
+    assert first == second
+    assert [case["prompt_length"] for case in first] == [16, 128]
+    assert first[0]["input_sha256"] != first[1]["input_sha256"]
+    assert min(first[0]["input_ids"]) >= 1024
+    assert max(first[1]["input_ids"]) < 154856 - 1024
+
+
+def test_compare_accepts_bounded_logprob_delta():
+    result = ORACLE.compare_payloads(
+        _payload(),
+        _payload(delta=0.01, candidate=True),
+        atol=0.02,
+        rtol=0,
+        comparison_top_k=2,
+    )
+    assert result["pass"]
+    assert not result["failures"]
+
+
+def test_compare_rejects_token_mismatch_and_large_delta():
+    token_result = ORACLE.compare_payloads(
+        _payload(),
+        _payload(token_id=9, candidate=True),
+        atol=0.02,
+        rtol=0,
+        comparison_top_k=2,
+    )
+    assert not token_result["pass"]
+    assert any(
+        "generated token mismatch" in failure for failure in token_result["failures"]
+    )
+
+    delta_result = ORACLE.compare_payloads(
+        _payload(),
+        _payload(delta=0.2, candidate=True),
+        atol=0.02,
+        rtol=0,
+        comparison_top_k=2,
+    )
+    assert not delta_result["pass"]
+    assert any("outside" in failure for failure in delta_result["failures"])
+
+
+def test_compare_skips_logits_after_greedy_prefix_diverges():
+    oracle = _rollout_payload([7, 8, 9, 10])
+    # Step 1 is the first token mismatch.  Its logits still share the [7]
+    # prefix and are compared.  The intentionally huge later deltas must not
+    # be interpreted as model errors because those requests consumed [7, 8]
+    # and [7, 12], respectively.
+    candidate = _rollout_payload(
+        [7, 12, 13, 14], [0.0, 0.0, 100.0, 100.0], candidate=True
+    )
+
+    result = ORACLE.compare_payloads(
+        oracle, candidate, atol=0.02, rtol=0, comparison_top_k=2
+    )
+
+    assert not result["pass"]
+    assert result["failures"] == [
+        "tokens_16: generated token mismatch: [7, 8, 9, 10] != [7, 12, 13, 14]"
+    ]
+    assert [diagnostic["status"] for diagnostic in result["diagnostics"]] == [
+        "compared",
+        "compared",
+        "skipped_due_to_prefix_divergence",
+        "skipped_due_to_prefix_divergence",
+    ]
+    assert result["diagnostics"][2]["first_divergent_step"] == 1
+    assert result["diagnostics"][3]["first_divergent_step"] == 1
+
+
+def test_compare_checks_all_steps_when_rollout_tokens_match():
+    oracle = _rollout_payload([7, 8, 9])
+    candidate = _rollout_payload([7, 8, 9], [0.0, 0.0, 0.2], candidate=True)
+
+    result = ORACLE.compare_payloads(
+        oracle, candidate, atol=0.02, rtol=0, comparison_top_k=2
+    )
+
+    assert not result["pass"]
+    assert [diagnostic["status"] for diagnostic in result["diagnostics"]] == [
+        "compared",
+        "compared",
+        "compared",
+    ]
+    assert any("tokens_16 step 2" in failure for failure in result["failures"])
+
+
+def test_compare_rejects_wrong_kind_failed_or_mismatched_contract():
+    oracle = _payload()
+    candidate = _payload(candidate=True)
+    candidate["kind"] = "wrong"
+    candidate["pass"] = False
+    candidate["fixture_seed"] += 1
+
+    result = ORACLE.compare_payloads(
+        oracle, candidate, atol=0.02, rtol=0, comparison_top_k=2
+    )
+
+    assert not result["pass"]
+    assert any("kind" in failure for failure in result["failures"])
+    assert any("did not pass" in failure for failure in result["failures"])
+    assert any("fixture seed" in failure for failure in result["failures"])
+
+
+def test_compare_rejects_oracle_without_kda_conv_correction_provenance():
+    oracle = _payload()
+    del oracle["oracle_corrections"]
+
+    result = ORACLE.compare_payloads(
+        oracle,
+        _payload(candidate=True),
+        atol=0.02,
+        rtol=0,
+        comparison_top_k=2,
+    )
+
+    assert not result["pass"]
+    assert "missing oracle_corrections" in result["failures"]

--- a/test/registered/unit/test_glm5_next_session_c_qa_gsm_graph_acceptance.py
+++ b/test/registered/unit/test_glm5_next_session_c_qa_gsm_graph_acceptance.py
@@ -187,17 +187,17 @@ def test_metrics_allow_decode_none_counter_disappearance_but_not_increase():
     assert comparison["per_rank"]["1"]["decode_none_delta"] == -4
 
 
-def test_metrics_require_positive_cuda_graph_delta_on_all_eight_ranks():
-    before = acceptance.analyze_metrics(_metrics(graph=[10] * 8))
-    after = acceptance.analyze_metrics(_metrics(graph=[11] * 7 + [10]))
+def test_metrics_require_positive_cuda_graph_delta_on_all_four_ranks():
+    before = acceptance.analyze_metrics(_metrics(graph=[10] * 4))
+    after = acceptance.analyze_metrics(_metrics(graph=[11] * 3 + [10]))
 
     comparison = acceptance.compare_metrics(
-        before, after, tp_size=8, minimum_graph_delta_per_rank=1
+        before, after, tp_size=4, minimum_graph_delta_per_rank=1
     )
 
     assert comparison["pass"] is False
-    assert comparison["per_rank"]["7"]["pass"] is False
-    assert any("TP rank 7" in failure for failure in comparison["failures"])
+    assert comparison["per_rank"]["3"]["pass"] is False
+    assert any("TP rank 3" in failure for failure in comparison["failures"])
 
 
 def test_qa_requires_choice_content_usage_and_stop_finish():
@@ -340,6 +340,7 @@ def test_gsm_command_freezes_session_c_parameters(tmp_path: Path):
 
     command = acceptance.build_gsm_command(args)
 
+    assert args.tp_size == 4
     assert command[0] == args.python
     assert command[1] == "-c"
     assert command[2] == acceptance.GSM_BENCHMARK_WORKER

--- a/test/registered/unit/test_glm5_next_session_c_qa_gsm_graph_acceptance.py
+++ b/test/registered/unit/test_glm5_next_session_c_qa_gsm_graph_acceptance.py
@@ -1,0 +1,485 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "scripts/glm5_next_session_c_qa_gsm_graph_acceptance.py"
+SPEC = importlib.util.spec_from_file_location("qa_gsm_graph_acceptance", SCRIPT_PATH)
+assert SPEC is not None and SPEC.loader is not None
+acceptance = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(acceptance)
+
+
+def _metrics(
+    *,
+    graph: list[float],
+    decode_none: list[float] | None = None,
+    itl_sum: float | None = None,
+    itl_count: float | None = None,
+) -> str:
+    lines = ["# HELP sglang:cuda_graph_passes_total graph forward passes"]
+    for rank, value in enumerate(graph):
+        lines.append(
+            "sglang:cuda_graph_passes_total"
+            f'{{mode="decode_cuda_graph",tp_rank="{rank}"}} {value}'
+        )
+    if decode_none is not None:
+        for rank, value in enumerate(decode_none):
+            lines.append(
+                "sglang:cuda_graph_passes_total"
+                f'{{mode="decode_none",tp_rank="{rank}"}} {value}'
+            )
+    if itl_sum is not None:
+        lines.append(
+            f'sglang:inter_token_latency_seconds_sum{{model_name="glm"}} {itl_sum}'
+        )
+    if itl_count is not None:
+        lines.append(
+            f'sglang:inter_token_latency_seconds_count{{model_name="glm"}} {itl_count}'
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _qa_payload(*, content: str = "Water is H2O.", finish_reason: str = "stop"):
+    return {
+        "id": "chatcmpl-1",
+        "choices": [
+            {
+                "index": 0,
+                "finish_reason": finish_reason,
+                "message": {"role": "assistant", "content": content},
+            }
+        ],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    }
+
+
+def _write_gsm_artifacts(
+    result_path: Path,
+    raw_path: Path,
+    *,
+    correct_count: int,
+) -> None:
+    raw_rows = [
+        {
+            "prompt_id": index,
+            "prompt": f"Question {index}",
+            "output": f"Answer {index}",
+            "correct": index < correct_count,
+        }
+        for index in range(acceptance.GSM_QUESTIONS)
+    ]
+    summary = {
+        "task": "gsm8k",
+        "backend": "srt",
+        "num_gpus": 1,
+        "latency": 12.5,
+        "accuracy": round(correct_count / acceptance.GSM_QUESTIONS, 3),
+        "num_requests": acceptance.GSM_QUESTIONS,
+        "other": {
+            "num_questions": acceptance.GSM_QUESTIONS,
+            "parallel": acceptance.GSM_PARALLEL,
+        },
+    }
+    result_path.write_text(json.dumps(summary) + "\n", encoding="utf-8")
+    raw_path.write_text(
+        "\n".join(json.dumps(row) for row in raw_rows), encoding="utf-8"
+    )
+
+
+def _write_gsm_speed_artifact(path: Path, *, throughput: float = 12.5) -> None:
+    rows = [
+        {
+            "prompt_id": index,
+            "meta_info": {
+                "completion_tokens": 8,
+                "decode_throughput": throughput + index,
+            },
+        }
+        for index in range(acceptance.GSM_QUESTIONS)
+    ]
+    path.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
+
+
+def test_metrics_require_graph_on_every_rank_and_keep_itl_diagnostic():
+    before = acceptance.analyze_metrics(
+        _metrics(graph=[10, 11], decode_none=[3, 4], itl_sum=2.0, itl_count=20)
+    )
+    after = acceptance.analyze_metrics(
+        _metrics(graph=[13, 15], decode_none=[3, 4], itl_sum=4.0, itl_count=60)
+    )
+
+    comparison = acceptance.compare_metrics(
+        before, after, tp_size=2, minimum_graph_delta_per_rank=3
+    )
+
+    assert comparison["pass"] is True
+    assert comparison["per_rank"]["0"]["decode_cuda_graph_delta"] == 3
+    assert comparison["per_rank"]["1"]["decode_cuda_graph_delta"] == 4
+    assert comparison["per_rank"]["0"]["decode_none_delta"] == 0
+    assert comparison["inter_token_latency"]["decode_tokens_per_second"] == 20.0
+
+
+@pytest.mark.parametrize(
+    "after_text, expected_failure",
+    [
+        (
+            _metrics(graph=[12], decode_none=[3], itl_sum=3.0, itl_count=30),
+            "TP rank set mismatch",
+        ),
+        (
+            _metrics(graph=[12, 13], decode_none=[4, 4], itl_sum=3.0, itl_count=30),
+            "decode_none delta must not be positive",
+        ),
+    ],
+)
+def test_metrics_fail_closed_on_missing_graph_rank_or_positive_decode_none(
+    after_text: str, expected_failure: str
+):
+    before = acceptance.analyze_metrics(
+        _metrics(graph=[10, 11], decode_none=[3, 4], itl_sum=2.0, itl_count=20)
+    )
+    after = acceptance.analyze_metrics(after_text)
+
+    comparison = acceptance.compare_metrics(
+        before, after, tp_size=2, minimum_graph_delta_per_rank=1
+    )
+
+    assert comparison["pass"] is False
+    assert any(expected_failure in failure for failure in comparison["failures"])
+
+
+def test_metrics_treat_missing_decode_none_as_zero_and_itl_as_optional():
+    before = acceptance.analyze_metrics(_metrics(graph=[10, 11]))
+    after = acceptance.analyze_metrics(_metrics(graph=[12, 14]))
+
+    comparison = acceptance.compare_metrics(
+        before, after, tp_size=2, minimum_graph_delta_per_rank=1
+    )
+
+    assert comparison["pass"] is True
+    assert comparison["per_rank"]["0"]["decode_none_before"] == 0
+    assert comparison["per_rank"]["0"]["decode_none_after"] == 0
+    assert comparison["per_rank"]["1"]["decode_none_delta"] == 0
+    assert comparison["inter_token_latency"]["available"] is False
+    assert comparison["inter_token_latency"]["blocking"] is False
+    assert comparison["inter_token_latency"]["diagnostics"]
+
+
+def test_metrics_allow_decode_none_counter_disappearance_but_not_increase():
+    before = acceptance.analyze_metrics(_metrics(graph=[10, 11], decode_none=[3, 4]))
+    after = acceptance.analyze_metrics(_metrics(graph=[12, 13]))
+
+    comparison = acceptance.compare_metrics(
+        before, after, tp_size=2, minimum_graph_delta_per_rank=1
+    )
+
+    assert comparison["pass"] is True
+    assert comparison["per_rank"]["0"]["decode_none_delta"] == -3
+    assert comparison["per_rank"]["1"]["decode_none_delta"] == -4
+
+
+def test_metrics_require_positive_cuda_graph_delta_on_all_eight_ranks():
+    before = acceptance.analyze_metrics(_metrics(graph=[10] * 8))
+    after = acceptance.analyze_metrics(_metrics(graph=[11] * 7 + [10]))
+
+    comparison = acceptance.compare_metrics(
+        before, after, tp_size=8, minimum_graph_delta_per_rank=1
+    )
+
+    assert comparison["pass"] is False
+    assert comparison["per_rank"]["7"]["pass"] is False
+    assert any("TP rank 7" in failure for failure in comparison["failures"])
+
+
+def test_qa_requires_choice_content_usage_and_stop_finish():
+    valid = acceptance.validate_qa_response(
+        _qa_payload(), expected_content="H2O", expected_finish_reason="stop"
+    )
+    invalid_payload = _qa_payload(content="Water.", finish_reason="length")
+    invalid_payload["usage"]["total_tokens"] = 99
+    invalid = acceptance.validate_qa_response(
+        invalid_payload, expected_content="H2O", expected_finish_reason="stop"
+    )
+
+    assert valid["pass"] is True
+    assert invalid["pass"] is False
+    assert any("does not contain 'H2O'" in failure for failure in invalid["failures"])
+    assert any("finish_reason" in failure for failure in invalid["failures"])
+    assert any("total_tokens" in failure for failure in invalid["failures"])
+
+
+def test_qa_decode_speed_probe_requires_exact_field_and_positive_finite_value():
+    valid_payload = {
+        "text": "probe output",
+        "meta_info": {
+            "completion_tokens": acceptance.QA_SPEED_PROBE_MAX_NEW_TOKENS,
+            "decode_throughput": 12.5,
+        },
+    }
+    missing_field = {
+        "text": "probe output",
+        "meta_info": {
+            "completion_tokens": acceptance.QA_SPEED_PROBE_MAX_NEW_TOKENS,
+            "decode_tokens_per_second": 12.5,
+        },
+    }
+    non_finite = {
+        "text": "probe output",
+        "meta_info": {
+            "completion_tokens": acceptance.QA_SPEED_PROBE_MAX_NEW_TOKENS,
+            "decode_throughput": float("inf"),
+        },
+    }
+
+    valid = acceptance.validate_qa_speed_probe(valid_payload)
+    missing = acceptance.validate_qa_speed_probe(missing_field)
+    invalid = acceptance.validate_qa_speed_probe(non_finite)
+
+    assert valid["pass"] is True
+    assert valid["speed"]["decode_throughput"]["mean"] == 12.5
+    assert missing["pass"] is False
+    assert invalid["pass"] is False
+    assert any("meta_info.decode_throughput" in item for item in missing["failures"])
+
+
+def test_gsm_exact_200_rows_and_accuracy_is_non_blocking(tmp_path: Path):
+    result_path = tmp_path / "result.jsonl"
+    raw_path = tmp_path / "raw.jsonl"
+    _write_gsm_artifacts(result_path, raw_path, correct_count=0)
+
+    validation = acceptance.validate_gsm_artifacts(result_path, raw_path)
+
+    assert validation["pass"] is True
+    assert validation["raw_row_count"] == 200
+    assert validation["accuracy"] == {
+        "value": 0.0,
+        "raw_value": 0.0,
+        "blocking": False,
+        "minimum": None,
+    }
+    assert validation["artifacts"]["result"]["sha256"]
+    assert validation["artifacts"]["raw_result"]["sha256"]
+
+
+def test_gsm_decode_speed_requires_all_200_meta_info_rows(tmp_path: Path):
+    speed_path = tmp_path / "decode-speed.jsonl"
+    _write_gsm_speed_artifact(speed_path, throughput=10.0)
+
+    validation = acceptance.validate_gsm_decode_speed_artifact(speed_path)
+
+    assert validation["pass"] is True
+    assert validation["response_count"] == acceptance.GSM_QUESTIONS
+    assert validation["decode_throughput"]["valid_response_count"] == 200
+    assert validation["decode_throughput"]["minimum"] == 10.0
+    assert validation["decode_throughput"]["maximum"] == 209.0
+    assert validation["artifact"]["sha256"]
+
+
+@pytest.mark.parametrize("bad_value", [None, 0, -1, "inf", True])
+def test_gsm_decode_speed_fails_closed_for_any_bad_response(
+    tmp_path: Path, bad_value: object
+):
+    speed_path = tmp_path / "decode-speed.jsonl"
+    _write_gsm_speed_artifact(speed_path)
+    rows = [json.loads(line) for line in speed_path.read_text().splitlines()]
+    rows[137]["meta_info"]["decode_throughput"] = bad_value
+    speed_path.write_text(
+        "\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8"
+    )
+
+    validation = acceptance.validate_gsm_decode_speed_artifact(speed_path)
+
+    assert validation["pass"] is False
+    assert validation["decode_throughput"]["valid_response_count"] == 199
+    assert any("response 137" in item for item in validation["failures"])
+
+
+def test_gsm_fails_on_incomplete_output_and_non_exact_prompt_ids(tmp_path: Path):
+    result_path = tmp_path / "result.jsonl"
+    raw_path = tmp_path / "raw.jsonl"
+    _write_gsm_artifacts(result_path, raw_path, correct_count=100)
+    rows = [json.loads(line) for line in raw_path.read_text().splitlines()]
+    rows[7]["output"] = ""
+    rows[8]["prompt_id"] = 7
+    raw_path.write_text("\n".join(json.dumps(row) for row in rows), encoding="utf-8")
+
+    validation = acceptance.validate_gsm_artifacts(result_path, raw_path)
+
+    assert validation["pass"] is False
+    assert any("output is not a completed" in item for item in validation["failures"])
+    assert any("exactly 0..199" in item for item in validation["failures"])
+
+
+def test_gsm_command_freezes_session_c_parameters(tmp_path: Path):
+    args = acceptance.parse_args(
+        [
+            "gsm8k",
+            "--base-url",
+            "http://127.0.0.1:30100",
+            "--data-path",
+            str(tmp_path / "test.jsonl"),
+            "--result-file",
+            str(tmp_path / "result.jsonl"),
+            "--raw-result-file",
+            str(tmp_path / "raw.jsonl"),
+            "--work-dir",
+            str(tmp_path / "work"),
+            "--output",
+            str(tmp_path / "acceptance.json"),
+        ]
+    )
+
+    command = acceptance.build_gsm_command(args)
+
+    assert command[0] == args.python
+    assert command[1] == "-c"
+    assert command[2] == acceptance.GSM_BENCHMARK_WORKER
+    assert command[3] == str(args.benchmark_script)
+    assert command[4] == str(acceptance._gsm_decode_speed_path(args.output))
+    assert command[command.index("--num-questions") + 1] == "200"
+    assert command[command.index("--num-shots") + 1] == "5"
+    assert command[command.index("--parallel") + 1] == "1"
+    assert command[command.index("--max-new-tokens") + 1] == "512"
+    assert command[command.index("--temperature") + 1] == "0"
+    assert command[command.index("--top-p") + 1] == "1"
+
+
+def test_gsm_worker_wraps_checked_in_dumper_and_captures_meta_info(tmp_path: Path):
+    package = tmp_path / "sglang" / "test"
+    package.mkdir(parents=True)
+    (tmp_path / "sglang" / "__init__.py").write_text("", encoding="utf-8")
+    (package / "__init__.py").write_text("", encoding="utf-8")
+    (package / "test_utils.py").write_text(
+        """
+from pathlib import Path
+
+
+def dump_bench_raw_result(path, states, preds, labels):
+    Path(path).write_text("original dumper called", encoding="utf-8")
+""".lstrip(),
+        encoding="utf-8",
+    )
+    benchmark = tmp_path / "benchmark.py"
+    benchmark.write_text(
+        """
+import sys
+
+from sglang.test.test_utils import dump_bench_raw_result
+
+
+class State:
+    def __init__(self, value):
+        self.value = value
+
+    def get_meta_info(self, name):
+        assert name == "answer"
+        return {"completion_tokens": 8, "decode_throughput": self.value}
+
+
+states = [State(10.0), State(20.0)]
+dump_bench_raw_result(sys.argv[1], states, [0, 0], [0, 0])
+""".lstrip(),
+        encoding="utf-8",
+    )
+    raw_path = tmp_path / "raw.jsonl"
+    speed_path = tmp_path / "speed.jsonl"
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(tmp_path)
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            acceptance.GSM_BENCHMARK_WORKER,
+            str(benchmark),
+            str(speed_path),
+            str(raw_path),
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert raw_path.read_text() == "original dumper called"
+    rows = [json.loads(line) for line in speed_path.read_text().splitlines()]
+    assert [row["prompt_id"] for row in rows] == [0, 1]
+    assert [row["meta_info"]["decode_throughput"] for row in rows] == [10.0, 20.0]
+
+
+def test_metric_snapshot_preserves_exact_text_and_sha(tmp_path: Path):
+    body = _metrics(graph=[1], decode_none=[0], itl_sum=1.0, itl_count=2).encode()
+
+    class Response:
+        status = 200
+        headers = {"content-type": "text/plain"}
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def getcode(self):
+            return self.status
+
+        def read(self):
+            return body
+
+    raw_path = tmp_path / "before.prom"
+    snapshot = acceptance.fetch_metrics(
+        "http://server",
+        timeout=1,
+        raw_path=raw_path,
+        opener=lambda *_a, **_k: Response(),
+    )
+
+    assert raw_path.read_bytes() == body
+    assert snapshot["raw_text"].encode() == body
+    assert snapshot["raw_sha256"] == acceptance._sha256_bytes(body)
+
+
+def test_exception_artifact_keeps_strict_contract(tmp_path: Path, monkeypatch):
+    output = tmp_path / "qa.json"
+    argv = [
+        "qa",
+        "--base-url",
+        "http://server",
+        "--model",
+        "glm",
+        "--output",
+        str(output),
+        "--tp-size",
+        "2",
+    ]
+    parsed = acceptance.parse_args(argv)
+    monkeypatch.setattr(
+        acceptance,
+        "run_qa",
+        lambda _args: (_ for _ in ()).throw(RuntimeError("deliberate")),
+    )
+
+    returncode = acceptance.main(argv)
+    payload = json.loads(output.read_text())
+
+    assert returncode == 1
+    assert (
+        acceptance.validate_evidence_envelope(
+            payload,
+            expected_kind=acceptance.QA_KIND,
+            expected_contract=acceptance.qa_contract(parsed),
+        )
+        == []
+    )
+    assert payload["pass"] is False
+    assert payload["failures"] == ["RuntimeError: deliberate"]

--- a/test/registered/unit/test_glm5_next_session_d_contract.py
+++ b/test/registered/unit/test_glm5_next_session_d_contract.py
@@ -1,613 +1,202 @@
-"""CPU-only contracts for the frozen GLM-5-Next Session D boundary."""
+"""CPU-only contracts for the GLM-5-Next image/video boundary."""
 
 from __future__ import annotations
 
-import asyncio
 import ast
+import base64
+import binascii
 import copy
-import importlib.util
+import os
+import tempfile
+from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
+from urllib.parse import unquote, urlparse
 
 import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
-STAGE3_TEST_PATH = REPO_ROOT / "test/registered/unit/test_glm5_next_stage3.py"
-MODEL_CONFIG_PATH = REPO_ROOT / "python/sglang/srt/configs/model_config.py"
 PROCESSOR_PATH = REPO_ROOT / "python/sglang/srt/multimodal/processors/glm5_next.py"
+TOKENIZER_MANAGER_PATH = REPO_ROOT / "python/sglang/srt/managers/tokenizer_manager.py"
+MODEL_PATH = REPO_ROOT / "python/sglang/srt/models/glm5_next.py"
+SCHEDULE_BATCH_PATH = REPO_ROOT / "python/sglang/srt/managers/schedule_batch.py"
+FORWARD_BATCH_PATH = REPO_ROOT / "python/sglang/srt/model_executor/forward_batch_info.py"
+HF_UTILS_PATH = REPO_ROOT / "python/sglang/srt/utils/hf_transformers_utils.py"
 CHAT_TEMPLATE_PATH = REPO_ROOT / "examples/chat_template/glm5_next_multimodal.jinja"
-GLM_OCR_MODEL_PATH = REPO_ROOT / "python/sglang/srt/models/glm_ocr.py"
-GLM5_MODEL_PATH = REPO_ROOT / "python/sglang/srt/models/glm5_next.py"
 
 
-def _load_stage3_support():
-    spec = importlib.util.spec_from_file_location(
-        "_glm5_next_session_d_stage3_support", STAGE3_TEST_PATH
-    )
-    module = importlib.util.module_from_spec(spec)
-    assert spec.loader is not None
-    spec.loader.exec_module(module)
-    return module
-
-
-def _model_config_tree() -> ast.Module:
-    return ast.parse(
-        MODEL_CONFIG_PATH.read_text(encoding="utf-8"),
-        filename=str(MODEL_CONFIG_PATH),
-    )
-
-
-def _literal_assignment(tree: ast.Module, name: str):
-    node = next(
+def _class_method(path: Path, class_name: str, method_name: str):
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    cls = next(
         node
         for node in tree.body
-        if isinstance(node, ast.Assign)
-        and any(
-            isinstance(target, ast.Name) and target.id == name
-            for target in node.targets
-        )
+        if isinstance(node, ast.ClassDef) and node.name == class_name
     )
-    return ast.literal_eval(node.value)
-
-
-def _resolve_model_config_mm(architecture, requested, *, language_only=False):
-    """Execute the three MM-resolution statements copied from ModelConfig."""
-
-    tree = _model_config_tree()
-    model_config = next(
-        node
-        for node in tree.body
-        if isinstance(node, ast.ClassDef) and node.name == "ModelConfig"
-    )
-    init = next(
-        node
-        for node in model_config.body
-        if isinstance(node, ast.FunctionDef) and node.name == "__init__"
-    )
-    default_resolution = next(
-        node
-        for node in init.body
-        if isinstance(node, ast.If)
-        and ast.unparse(node.test) == "enable_multimodal is None"
-    )
-    effective_assignment = next(
-        node
-        for node in init.body
-        if isinstance(node, ast.Assign)
-        and any(
-            isinstance(target, ast.Attribute) and target.attr == "is_multimodal"
-            for target in node.targets
-        )
-    )
-    exact_glm_gate = next(
-        node
-        for node in init.body
-        if isinstance(node, ast.If)
-        and ast.unparse(node.test) == "self.is_glm5_next"
-        and "_glm5_next_multimodal_active" in ast.unparse(node)
-    )
-
-    multimodal_architectures = set(_literal_assignment(tree, "multimodal_model_archs"))
-    holder = SimpleNamespace(
-        hf_config=SimpleNamespace(
-            architectures=[architecture], model_type="test-model"
-        ),
-        is_glm5_next=architecture == "Glm5NextForConditionalGeneration",
-    )
-
-    class _Logger:
-        @staticmethod
-        def info(*args, **kwargs):
-            del args, kwargs
-
-    namespace = {
-        "self": holder,
-        "enable_multimodal": requested,
-        "language_only": language_only,
-        "logger": _Logger(),
-        "is_multimodal_model": lambda architectures: bool(
-            set(architectures) & multimodal_architectures
-        ),
-    }
-    selected = ast.fix_missing_locations(
-        ast.Module(
-            body=[
-                copy.deepcopy(default_resolution),
-                copy.deepcopy(effective_assignment),
-                copy.deepcopy(exact_glm_gate),
-            ],
-            type_ignores=[],
-        )
-    )
-    exec(compile(selected, str(MODEL_CONFIG_PATH), "exec"), namespace)
-    return namespace["enable_multimodal"], holder
-
-
-def _compile_max_pixels_resolver():
-    tree = ast.parse(
-        PROCESSOR_PATH.read_text(encoding="utf-8"), filename=str(PROCESSOR_PATH)
-    )
-    processor = next(
-        node
-        for node in tree.body
-        if isinstance(node, ast.ClassDef) and node.name == "Glm5NextSGLangProcessor"
-    )
-    method = copy.deepcopy(
+    return copy.deepcopy(
         next(
             node
-            for node in processor.body
-            if isinstance(node, ast.FunctionDef) and node.name == "_resolve_max_pixels"
+            for node in cls.body
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == method_name
         )
     )
-    method.decorator_list = []
-    module = ast.fix_missing_locations(ast.Module(body=[method], type_ignores=[]))
-    namespace = {
-        "GLM5_NEXT_MIN_PIXELS": 12_544,
-        "GLM5_NEXT_DEFAULT_MAX_PIXELS": 1_254_400,
-        "GLM5_NEXT_CHECKPOINT_MAX_PIXELS": 9_633_792,
-    }
-    exec(compile(module, str(PROCESSOR_PATH), "exec"), namespace)
-    return namespace["_resolve_max_pixels"]
 
 
-def _compile_checkpoint_image_config_parser():
-    tree = ast.parse(
-        PROCESSOR_PATH.read_text(encoding="utf-8"), filename=str(PROCESSOR_PATH)
-    )
-    processor = next(
-        node
-        for node in tree.body
-        if isinstance(node, ast.ClassDef) and node.name == "Glm5NextImageProcessor"
-    )
-    method = copy.deepcopy(
-        next(
-            node
-            for node in processor.body
-            if isinstance(node, ast.FunctionDef)
-            and node.name == "from_checkpoint_config"
-        )
-    )
-    method.decorator_list = []
-    module = ast.fix_missing_locations(ast.Module(body=[method], type_ignores=[]))
-    expected_values = {
-        "do_rescale": True,
-        "image_mean": [0.48145466, 0.4578275, 0.40821073],
-        "image_processor_type": "GlmgaImageProcessor",
-        "image_std": [0.26862954, 0.26130258, 0.27577711],
-        "merge_size": 2,
-        "patch_size": 14,
-        "patch_expand_factor": 2,
-        "temporal_patch_size": 2,
-    }
-    namespace = {
-        "Any": object,
-        "GLM5_NEXT_MIN_PIXELS": 12_544,
-        "GLM5_NEXT_DEFAULT_MAX_PIXELS": 1_254_400,
-        "GLM5_NEXT_CHECKPOINT_MAX_PIXELS": 9_633_792,
-        "_GLM5_NEXT_IMAGE_CONFIG_KEYS": frozenset({*expected_values, "size"}),
-        "_GLM5_NEXT_IMAGE_CONFIG_VALUES": expected_values,
-    }
-    exec(compile(module, str(PROCESSOR_PATH), "exec"), namespace)
-    return namespace["from_checkpoint_config"], expected_values
-
-
-def _compile_multi_image_request_harness(mrope_embedding):
-    tree = ast.parse(
-        PROCESSOR_PATH.read_text(encoding="utf-8"), filename=str(PROCESSOR_PATH)
-    )
-    processor = next(
-        node
-        for node in tree.body
-        if isinstance(node, ast.ClassDef) and node.name == "Glm5NextSGLangProcessor"
-    )
-    method_names = {
-        "_count_image_placeholders",
-        "_get_multi_image_mrope",
-        "process_mm_data_async",
-    }
-    methods = [
-        copy.deepcopy(node)
-        for node in processor.body
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
-        and node.name in method_names
+def _compile_method(path, class_name, method_name, namespace):
+    method = _class_method(path, class_name, method_name)
+    method.decorator_list = [
+        decorator
+        for decorator in method.decorator_list
+        if not isinstance(decorator, ast.Name) or decorator.id != "staticmethod"
     ]
-    assert {method.name for method in methods} == method_names
-    for method in methods:
-        method.decorator_list = []
-    module = ast.fix_missing_locations(ast.Module(body=methods, type_ignores=[]))
-    namespace = {
-        "MRotaryEmbedding": mrope_embedding,
-        "torch": pytest.importorskip("torch"),
-    }
-    exec(compile(module, str(PROCESSOR_PATH), "exec"), namespace)
-    return type(
-        "_Glm5NextMultiImageRequestHarness",
-        (),
-        {method_name: namespace[method_name] for method_name in method_names},
+    module = ast.fix_missing_locations(ast.Module(body=[method], type_ignores=[]))
+    exec(compile(module, str(path), "exec"), namespace)
+    return namespace[method_name]
+
+
+def test_processor_uses_transformers_kt_as_the_only_patchifier():
+    source = PROCESSOR_PATH.read_text(encoding="utf-8")
+    assert "transformers.models.glm5_next.image_processing_glm5_next" in source
+    assert "transformers.models.glm5_next.video_processing_glm5_next" in source
+    assert "class Glm5NextImageProcessor" not in source
+    assert "GLM5_NEXT_PATCH_EXPAND_FACTOR = 1" in source
+    assert "video_token_id=self.IM_TOKEN_ID" in source
+
+
+def test_image_pixel_override_is_fail_closed_at_factor_one():
+    resolve = _compile_method(
+        PROCESSOR_PATH,
+        "Glm5NextSGLangProcessor",
+        "_resolve_max_pixels",
+        {
+            "GLM5_NEXT_MIN_PIXELS": 12_544,
+            "GLM5_NEXT_DEFAULT_MAX_PIXELS": 6_272_000,
+            "GLM5_NEXT_CHECKPOINT_MAX_PIXELS": 6_272_000,
+        },
     )
-
-
-def test_exact_checkpoint_token_ids_and_vision_defaults():
-    config_module = _load_stage3_support()._load_config_module()
-    config = config_module.Glm5NextConfig()
-
-    assert (
-        config.image_token_id,
-        config.video_token_id,
-        config.image_start_token_id,
-        config.image_end_token_id,
-        config.video_start_token_id,
-        config.video_end_token_id,
-    ) == (154854, 154855, 154830, 154831, 154832, 154833)
-
-    expected_vision = {
-        "depth": 24,
-        "hidden_size": 1024,
-        "intermediate_size": 4096,
-        "num_heads": 16,
-        "in_channels": 3,
-        "patch_size": 14,
-        "temporal_patch_size": 2,
-        "spatial_merge_size": 2,
-        "out_hidden_size": 4096,
-        "projection_intermediate_size": 10240,
-        "rms_norm_eps": 1e-5,
-        "hidden_act": "silu",
-        "image_size": 448,
-        "initializer_range": 0.02,
-        "attention_dropout": 0.0,
-        "attention_bias": True,
-    }
-    assert {
-        key: getattr(config.vision_config, key) for key in expected_vision
-    } == expected_vision
-
-    overridden = config_module.Glm5NextConfig(
-        vision_config={"depth": 12, "future_checkpoint_field": 17}
-    )
-    assert overridden.vision_config.depth == 12
-    assert overridden.vision_config.future_checkpoint_field == 17
-
-
-def test_multimodal_default_explicit_off_and_non_glm_isolation():
-    effective, glm = _resolve_model_config_mm("Glm5NextForConditionalGeneration", None)
-    assert effective is True
-    assert glm.is_multimodal is True
-    assert glm.hf_config._glm5_next_multimodal_active is True
-
-    effective, glm = _resolve_model_config_mm("Glm5NextForConditionalGeneration", False)
-    assert effective is False
-    assert glm.is_multimodal is False
-    assert glm.hf_config._glm5_next_multimodal_active is False
-
-    _, language_stage = _resolve_model_config_mm(
-        "Glm5NextForConditionalGeneration", True, language_only=True
-    )
-    assert language_stage.is_multimodal is True
-    assert language_stage.hf_config._glm5_next_multimodal_active is False
-
-    comparisons = {
-        "Qwen3ForCausalLM": (True, False),
-        "Qwen3VLMoeForConditionalGeneration": (True, True),
-        "Glm4vForConditionalGeneration": (True, True),
-        "Gemma3ForConditionalGeneration": (False, False),
-    }
-    for architecture, expected in comparisons.items():
-        effective, holder = _resolve_model_config_mm(architecture, None)
-        assert (effective, holder.is_multimodal) == expected
-        assert not hasattr(holder.hf_config, "_glm5_next_multimodal_active")
-
-
-def test_glm5_registry_is_exact_and_no_longer_default_disabled():
-    tree = _model_config_tree()
-    architectures = _literal_assignment(tree, "multimodal_model_archs")
-    assert architectures.count("Glm5NextForConditionalGeneration") == 1
-
-    source = MODEL_CONFIG_PATH.read_text(encoding="utf-8")
-    init = next(
-        node
-        for node in next(
-            node
-            for node in tree.body
-            if isinstance(node, ast.ClassDef) and node.name == "ModelConfig"
-        ).body
-        if isinstance(node, ast.FunctionDef) and node.name == "__init__"
-    )
-    disabled_branch = next(
-        node
-        for node in init.body
-        if isinstance(node, ast.If)
-        and ast.unparse(node.test) == "enable_multimodal is None"
-    )
-    assert "Glm5NextForConditionalGeneration" not in ast.unparse(disabled_branch)
-    assert source.count('"Glm5NextForConditionalGeneration"') >= 1
-
-
-def test_pixel_cap_contract_is_fail_closed():
-    resolve = _compile_max_pixels_resolver()
-    assert resolve(None) == 1_254_400
-    assert resolve({}) == 1_254_400
-    assert resolve({"image": {"max_pixels": 9_633_792}}) == 9_633_792
+    assert resolve(None) == 6_272_000
     assert resolve({"image": {"max_pixels": 12_544}}) == 12_544
-
-    invalid = (
+    assert resolve({"image": {"max_pixels": 6_272_000}}) == 6_272_000
+    for invalid in (
         [],
         {"video": {}},
         {"image": []},
         {"image": {"min_pixels": 12_544}},
         {"image": {"max_pixels": True}},
         {"image": {"max_pixels": 12_543}},
-        {"image": {"max_pixels": 9_633_793}},
-    )
-    for value in invalid:
-        with pytest.raises(ValueError):
-            resolve(value)
-
-
-def test_pinned_checkpoint_image_metadata_is_exact_and_complete():
-    parse, expected_values = _compile_checkpoint_image_config_parser()
-
-    class _Constructed:
-        def __init__(self, **kwargs):
-            self.kwargs = kwargs
-
-    exact = {
-        **expected_values,
-        "size": {"shortest_edge": 12_544, "longest_edge": 9_633_792},
-    }
-    parsed = parse(_Constructed, exact)
-    assert parsed.kwargs["size"] == {
-        "shortest_edge": 12_544,
-        "longest_edge": 1_254_400,
-    }
-    assert parsed.kwargs["patch_expand_factor"] == 2
-    assert "image_processor_type" not in parsed.kwargs
-
-    malformed = []
-    missing = dict(exact)
-    missing.pop("patch_expand_factor")
-    malformed.append(missing)
-    unknown = dict(exact)
-    unknown["future_field"] = 1
-    malformed.append(unknown)
-    wrong_type = dict(exact)
-    wrong_type["image_processor_type"] = "Glm46VImageProcessor"
-    malformed.append(wrong_type)
-    wrong_size = dict(exact)
-    wrong_size["size"] = {"shortest_edge": 12_544}
-    malformed.append(wrong_size)
-
-    for value in malformed:
-        with pytest.raises(ValueError):
-            parse(_Constructed, value)
-
-
-def test_processor_and_shared_glm_ocr_changes_remain_isolated():
-    processor_source = PROCESSOR_PATH.read_text(encoding="utf-8")
-    processor_tree = ast.parse(processor_source, filename=str(PROCESSOR_PATH))
-    processor = next(
-        node
-        for node in processor_tree.body
-        if isinstance(node, ast.ClassDef) and node.name == "Glm5NextSGLangProcessor"
-    )
-    process_method = next(
-        node
-        for node in processor.body
-        if isinstance(node, ast.AsyncFunctionDef)
-        and node.name == "process_mm_data_async"
-    )
-    load_calls = [
-        node
-        for node in ast.walk(process_method)
-        if isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Attribute)
-        and node.func.attr == "load_mm_data"
-    ]
-    assert len(load_calls) == 1
-    assert not any(
-        isinstance(node, ast.Await) and node.value is load_calls[0]
-        for node in ast.walk(process_method)
-    )
-    return_node = next(
-        node for node in ast.walk(process_method) if isinstance(node, ast.Return)
-    )
-    assert isinstance(return_node.value, ast.Dict)
-    return_source = ast.unparse(return_node.value)
-    assert "self.IMAGE_START_TOKEN_ID" in return_source
-    assert "self.IMAGE_END_TOKEN_ID" in return_source
-
-    glm_ocr_source = GLM_OCR_MODEL_PATH.read_text(encoding="utf-8")
-    glm5_source = GLM5_MODEL_PATH.read_text(encoding="utf-8")
-    assert "num_dummy_heads=num_dummy_heads" in glm_ocr_source
-    assert 'getattr(vision_config, "num_dummy_heads", 0)' not in glm_ocr_source
-    assert "if merger_context_dim is None:" in glm_ocr_source
-    assert "num_dummy_heads=getattr(self.vision_config" in glm5_source
-    assert "merger_context_dim=self.vision_config.projection_intermediate_size" in (
-        glm5_source
-    )
-
-
-def test_glm5_multimodal_chat_template_preserves_image_order():
-    jinja2 = pytest.importorskip("jinja2")
-    source = CHAT_TEMPLATE_PATH.read_text(encoding="utf-8")
-
-    def raise_exception(message):
-        raise ValueError(message)
-
-    template = jinja2.Environment().from_string(source)
-    rendered = template.render(
-        messages=[
-            {
-                "role": "user",
-                "content": [
-                    {"type": "image"},
-                    {"type": "image"},
-                    {"type": "text", "text": "compare in order"},
-                ],
-            }
-        ],
-        add_generation_prompt=True,
-        raise_exception=raise_exception,
-    )
-    assert rendered == (
-        "[gMASK]<sop><|user|>\n<|image|><|image|>compare in order<|assistant|>\n"
-    )
-
-    text_only = template.render(
-        messages=[{"role": "user", "content": "hello"}],
-        add_generation_prompt=True,
-        raise_exception=raise_exception,
-    )
-    assert text_only == "[gMASK]<sop><|user|>\nhello<|assistant|>\n"
-
-    with pytest.raises(ValueError, match="only text and image"):
-        template.render(
-            messages=[
-                {"role": "user", "content": [{"type": "video"}]},
-            ],
-            add_generation_prompt=True,
-            raise_exception=raise_exception,
-        )
-
-
-def test_multi_image_request_cardinality_offsets_and_feature_contract():
-    torch = pytest.importorskip("torch")
-
-    class _MRotaryEmbedding:
-        @staticmethod
-        def get_rope_index_glm4v(input_ids, **kwargs):
-            del kwargs
-            seq_len = input_ids.shape[-1]
-            return (
-                torch.zeros((3, 1, seq_len), dtype=torch.long),
-                torch.zeros((1, 1), dtype=torch.long),
-            )
-
-    harness = _compile_multi_image_request_harness(_MRotaryEmbedding)
-
-    def run_request(
-        grids,
-        *,
-        image_data=None,
-        prompt_count=None,
-        loaded_count=None,
-        offsets_override=None,
-        feature_rows=None,
-        video_data=None,
-        audio_data=None,
-        adjacent_placeholders=False,
+        {"image": {"max_pixels": 6_272_001}},
     ):
-        image_count = len(grids)
-        image_data = (
-            [f"image-{index}" for index in range(image_count)]
-            if image_data is None
-            else image_data
-        )
-        prompt_count = len(image_data) if prompt_count is None else prompt_count
-        loaded_count = len(image_data) if loaded_count is None else loaded_count
-        grid_tensor = torch.tensor(grids, dtype=torch.long)
-        patch_counts = [int(grid.prod().item()) for grid in grid_tensor]
-        token_counts = [patch_count // 4 for patch_count in patch_counts]
+        with pytest.raises(ValueError):
+            resolve(invalid)
 
-        input_ids = [101]
-        offsets = []
-        for index, token_count in enumerate(token_counts):
-            start = len(input_ids)
-            input_ids.extend([7] * token_count)
-            offsets.append((start, len(input_ids) - 1))
-            if not adjacent_placeholders:
-                input_ids.append(102 + index)
-        if adjacent_placeholders:
-            offsets = [(1, len(input_ids) - 1)]
-            input_ids.append(102)
-        input_ids = torch.tensor(input_ids, dtype=torch.long)
-        if offsets_override is not None:
-            offsets = offsets_override
 
-        expected_feature_rows = sum(patch_counts)
-        feature_rows = expected_feature_rows if feature_rows is None else feature_rows
-        item = SimpleNamespace(
-            feature=torch.zeros((feature_rows, 1176), dtype=torch.float32),
-            offsets=offsets,
-            is_image=lambda: True,
-        )
-        ret = SimpleNamespace(
-            image_grid_thw=grid_tensor,
-            attention_mask=torch.ones_like(input_ids).unsqueeze(0),
-        )
-
-        processor = harness()
-        processor.VIDEO_TOKEN = "<|video|>"
-        processor.VIDEO_TOKEN_ID = 8
-        processor.IMAGE_TOKEN = "<|image|>"
-        processor.IM_TOKEN_ID = 7
-        processor.IMAGE_START_TOKEN_ID = 9
-        processor.IMAGE_END_TOKEN_ID = 10
-        processor.spatial_merge_size = 2
-        processor.hf_config = SimpleNamespace()
-        processor.mm_tokens = object()
-        processor.load_mm_data = lambda **kwargs: SimpleNamespace(
-            images=[object()] * loaded_count,
-            videos=[],
-            audios=[],
-        )
-        processor.process_and_combine_mm_data = lambda *args, **kwargs: (
-            [item],
-            input_ids,
-            ret,
-        )
-        prompt_separator = "" if adjacent_placeholders else " compare "
-        prompt = prompt_separator.join(["<|image|>"] * prompt_count)
-        request = SimpleNamespace(video_data=video_data)
-        result = asyncio.run(
-            processor.process_mm_data_async(
-                image_data,
-                [] if audio_data is None else audio_data,
-                prompt,
-                request,
-            )
-        )
-        return result
-
-    cases = (
-        [[1, 8, 20]],
-        [[1, 8, 20], [1, 4, 12]],
-        [[1, 4, 4]] * 4,
-        [[1, 4, 4]] * 8,
+def test_request_boundary_rejects_mixed_over_limit_and_audio_before_processor():
+    validate = _compile_method(
+        TOKENIZER_MANAGER_PATH,
+        "TokenizerManager",
+        "_validate_glm5_next_mm_boundary",
+        {},
     )
-    for grids in cases:
-        result = run_request(grids)
-        assert len(result["mm_items"][0].offsets) == len(grids)
-        assert tuple(result["mrope_positions"].shape) == (
-            3,
-            len(result["input_ids"]),
-        )
 
-    adjacent_result = run_request([[1, 8, 20], [1, 4, 12]], adjacent_placeholders=True)
-    assert adjacent_result["mm_items"][0].offsets == [(1, 40), (41, 52)]
-    assert adjacent_result["mrope_positions"][:, 0].tolist() == [0, 0, 0]
-    assert adjacent_result["mrope_positions"][:, 1].tolist() == [1, 1, 1]
-    assert adjacent_result["mrope_positions"][:, 40].tolist() == [1, 4, 10]
-    assert adjacent_result["mrope_positions"][:, 41].tolist() == [11, 11, 11]
-    assert adjacent_result["mrope_positions"][:, 52].tolist() == [11, 12, 16]
-    assert adjacent_result["mrope_positions"][:, 53].tolist() == [17, 17, 17]
-    assert adjacent_result["mrope_position_delta"].tolist() == [[-36]]
+    class Harness:
+        model_config = SimpleNamespace(is_glm5_next=True)
 
-    two_grids = [[1, 8, 20], [1, 4, 12]]
-    with pytest.raises(ValueError, match="at least one image"):
-        run_request(two_grids, image_data=[], prompt_count=0)
-    with pytest.raises(ValueError, match="count/placeholder count mismatch"):
-        run_request(two_grids, prompt_count=1)
-    with pytest.raises(ValueError, match="processor_output"):
-        run_request(two_grids, image_data=["image-0", {"format": "processor_output"}])
-    with pytest.raises(ValueError, match="does not support video"):
-        run_request(two_grids, video_data=["video-0"])
-    with pytest.raises(ValueError, match="does not support audio"):
-        run_request(two_grids, audio_data=["audio-0"])
-    with pytest.raises(ValueError, match="changed the request cardinality"):
-        run_request(two_grids, loaded_count=1)
-    with pytest.raises(RuntimeError, match="offsets do not cover"):
-        run_request(two_grids, offsets_override=[(1, 40), (42, 54)])
-    with pytest.raises(RuntimeError, match="feature/grid mismatch"):
-        run_request(two_grids, feature_rows=207)
+    valid = (
+        SimpleNamespace(image_data=[object()] * 8, video_data=None, audio_data=None),
+        SimpleNamespace(image_data=None, video_data=[object()], audio_data=None),
+    )
+    for request in valid:
+        validate(Harness(), request)
+
+    invalid = (
+        (SimpleNamespace(image_data=[1], video_data=[2], audio_data=None), "mix"),
+        (SimpleNamespace(image_data=list(range(9)), video_data=None, audio_data=None), "8 images"),
+        (SimpleNamespace(image_data=None, video_data=[1, 2], audio_data=None), "one video"),
+        (SimpleNamespace(image_data=None, video_data=None, audio_data=[1]), "audio"),
+    )
+    for request, message in invalid:
+        with pytest.raises(ValueError, match=message):
+            validate(Harness(), request)
+
+    non_glm = SimpleNamespace(model_config=SimpleNamespace(is_glm5_next=False))
+    validate(
+        non_glm,
+        SimpleNamespace(image_data=[1], video_data=[2], audio_data=[3]),
+    )
+
+
+def test_video_materialization_is_seekable_bounded_and_cleaned(monkeypatch, tmp_path):
+    materialize = _compile_method(
+        PROCESSOR_PATH,
+        "Glm5NextSGLangProcessor",
+        "_materialize_video",
+        {
+            "base64": base64,
+            "binascii": binascii,
+            "contextmanager": contextmanager,
+            "os": os,
+            "tempfile": tempfile,
+            "unquote": unquote,
+            "urlparse": urlparse,
+            "requests": SimpleNamespace(),
+        },
+    )
+    payload = b"\x00\x00\x00\x18ftypmp42test-video"
+    with materialize(payload) as path:
+        generated = Path(path)
+        assert generated.is_file()
+        assert generated.read_bytes() == payload
+    assert not generated.exists()
+
+    local = tmp_path / "local.mp4"
+    local.write_bytes(payload)
+    with materialize(f"file://{local}") as path:
+        assert path == str(local)
+    assert local.exists()
+
+    monkeypatch.setenv("SGLANG_GLM5_NEXT_MAX_VIDEO_BYTES", "4")
+    with pytest.raises(ValueError, match="byte limit"):
+        with materialize(payload):
+            pass
+
+
+def test_video_validation_and_vision_microbatch_contracts_are_explicit():
+    processor_source = PROCESSOR_PATH.read_text(encoding="utf-8")
+    model_source = MODEL_PATH.read_text(encoding="utf-8")
+    assert "one image-token block per temporal" in processor_source
+    assert "timestamped video token expansion changed unexpectedly" in processor_source
+    assert "metadata.timestamps[::2]" in processor_source
+    assert "max_patch_rows = 32_768" in model_source
+    assert "frame_grids.extend([(1, grid_h, grid_w)] * grid_t)" in model_source
+    assert "def get_video_feature" in model_source
+
+
+def test_multimodal_hybrid_prefill_marker_survives_chunked_prefill():
+    schedule_source = SCHEDULE_BATCH_PATH.read_text(encoding="utf-8")
+    forward_source = FORWARD_BATCH_PATH.read_text(encoding="utf-8")
+    assert schedule_source.count("glm5_next_force_hybrid_prefill") >= 4
+    assert "batch.forward_mode.is_extend()" in forward_source
+    assert "batch.multimodal_inputs or []" in forward_source
+
+
+def test_official_template_covers_media_tools_and_observations():
+    template = CHAT_TEMPLATE_PATH.read_text(encoding="utf-8")
+    for token in (
+        "<|begin_of_image|><|image|><|end_of_image|>",
+        "<|begin_of_video|><|video|><|end_of_video|>",
+        "<tool_call>",
+        "<arg_key>",
+        "<arg_value>",
+        "<tool_response>",
+        "<|observation|>",
+    ):
+        assert token in template
+
+
+def test_processor_loader_requires_the_new_checkpoint_classes():
+    source = HF_UTILS_PATH.read_text(encoding="utf-8")
+    assert "Glm5NextProcessor.from_pretrained" in source
+    assert "Glm5NextImageProcessor" in source
+    assert "Glm5NextVideoProcessor" in source
+    assert "Glm46VVideoProcessor()" not in source

--- a/test/registered/unit/test_glm5_next_session_d_contract.py
+++ b/test/registered/unit/test_glm5_next_session_d_contract.py
@@ -168,6 +168,7 @@ def test_video_validation_and_vision_microbatch_contracts_are_explicit():
     assert "timestamped video token expansion changed unexpectedly" in processor_source
     assert "metadata.timestamps[::2]" in processor_source
     assert "isinstance(video_metadata, (list, tuple))" in processor_source
+    assert "self._processor.image_token * tokens_per_frame" in processor_source
     assert "max_patch_rows = 32_768" in model_source
     assert "frame_grids.extend([(1, grid_h, grid_w)] * grid_t)" in model_source
     assert "def get_video_feature" in model_source

--- a/test/registered/unit/test_glm5_next_session_d_contract.py
+++ b/test/registered/unit/test_glm5_next_session_d_contract.py
@@ -178,8 +178,25 @@ def test_multimodal_hybrid_prefill_marker_survives_chunked_prefill():
     schedule_source = SCHEDULE_BATCH_PATH.read_text(encoding="utf-8")
     forward_source = FORWARD_BATCH_PATH.read_text(encoding="utf-8")
     assert schedule_source.count("glm5_next_force_hybrid_prefill") >= 4
+    assert "additional_stop_token_ids = getattr(" in schedule_source
+    assert 'self.tokenizer, "additional_stop_token_ids", None' in schedule_source
     assert "batch.forward_mode.is_extend()" in forward_source
     assert "batch.multimodal_inputs or []" in forward_source
+
+
+def test_finish_check_tolerates_tokenizer_without_optional_stop_ids():
+    check_finished = _compile_method(
+        SCHEDULE_BATCH_PATH,
+        "Req",
+        "_check_token_based_finish",
+        {"List": list},
+    )
+    request = SimpleNamespace(
+        sampling_params=SimpleNamespace(ignore_eos=False, stop_token_ids=None),
+        eos_token_ids=set(),
+        tokenizer=SimpleNamespace(eos_token_id=-1),
+    )
+    assert check_finished(request, [7]) is False
 
 
 def test_official_template_covers_media_tools_and_observations():

--- a/test/registered/unit/test_glm5_next_session_d_contract.py
+++ b/test/registered/unit/test_glm5_next_session_d_contract.py
@@ -167,6 +167,7 @@ def test_video_validation_and_vision_microbatch_contracts_are_explicit():
     assert "one image-token block per temporal" in processor_source
     assert "timestamped video token expansion changed unexpectedly" in processor_source
     assert "metadata.timestamps[::2]" in processor_source
+    assert "isinstance(video_metadata, (list, tuple))" in processor_source
     assert "max_patch_rows = 32_768" in model_source
     assert "frame_grids.extend([(1, grid_h, grid_w)] * grid_t)" in model_source
     assert "def get_video_feature" in model_source

--- a/test/registered/unit/test_glm5_next_session_d_contract.py
+++ b/test/registered/unit/test_glm5_next_session_d_contract.py
@@ -16,6 +16,7 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 STAGE3_TEST_PATH = REPO_ROOT / "test/registered/unit/test_glm5_next_stage3.py"
 MODEL_CONFIG_PATH = REPO_ROOT / "python/sglang/srt/configs/model_config.py"
 PROCESSOR_PATH = REPO_ROOT / "python/sglang/srt/multimodal/processors/glm5_next.py"
+CHAT_TEMPLATE_PATH = REPO_ROOT / "examples/chat_template/glm5_next_multimodal.jinja"
 GLM_OCR_MODEL_PATH = REPO_ROOT / "python/sglang/srt/models/glm_ocr.py"
 GLM5_MODEL_PATH = REPO_ROOT / "python/sglang/srt/models/glm5_next.py"
 
@@ -200,7 +201,11 @@ def _compile_multi_image_request_harness(mrope_embedding):
         for node in tree.body
         if isinstance(node, ast.ClassDef) and node.name == "Glm5NextSGLangProcessor"
     )
-    method_names = {"_count_image_placeholders", "process_mm_data_async"}
+    method_names = {
+        "_count_image_placeholders",
+        "_get_multi_image_mrope",
+        "process_mm_data_async",
+    }
     methods = [
         copy.deepcopy(node)
         for node in processor.body
@@ -211,7 +216,10 @@ def _compile_multi_image_request_harness(mrope_embedding):
     for method in methods:
         method.decorator_list = []
     module = ast.fix_missing_locations(ast.Module(body=methods, type_ignores=[]))
-    namespace = {"MRotaryEmbedding": mrope_embedding}
+    namespace = {
+        "MRotaryEmbedding": mrope_embedding,
+        "torch": pytest.importorskip("torch"),
+    }
     exec(compile(module, str(PROCESSOR_PATH), "exec"), namespace)
     return type(
         "_Glm5NextMultiImageRequestHarness",
@@ -420,6 +428,49 @@ def test_processor_and_shared_glm_ocr_changes_remain_isolated():
     )
 
 
+def test_glm5_multimodal_chat_template_preserves_image_order():
+    jinja2 = pytest.importorskip("jinja2")
+    source = CHAT_TEMPLATE_PATH.read_text(encoding="utf-8")
+
+    def raise_exception(message):
+        raise ValueError(message)
+
+    template = jinja2.Environment().from_string(source)
+    rendered = template.render(
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image"},
+                    {"type": "image"},
+                    {"type": "text", "text": "compare in order"},
+                ],
+            }
+        ],
+        add_generation_prompt=True,
+        raise_exception=raise_exception,
+    )
+    assert rendered == (
+        "[gMASK]<sop><|user|>\n<|image|><|image|>compare in order<|assistant|>\n"
+    )
+
+    text_only = template.render(
+        messages=[{"role": "user", "content": "hello"}],
+        add_generation_prompt=True,
+        raise_exception=raise_exception,
+    )
+    assert text_only == "[gMASK]<sop><|user|>\nhello<|assistant|>\n"
+
+    with pytest.raises(ValueError, match="only text and image"):
+        template.render(
+            messages=[
+                {"role": "user", "content": [{"type": "video"}]},
+            ],
+            add_generation_prompt=True,
+            raise_exception=raise_exception,
+        )
+
+
 def test_multi_image_request_cardinality_offsets_and_feature_contract():
     torch = pytest.importorskip("torch")
 
@@ -535,6 +586,13 @@ def test_multi_image_request_cardinality_offsets_and_feature_contract():
 
     adjacent_result = run_request([[1, 8, 20], [1, 4, 12]], adjacent_placeholders=True)
     assert adjacent_result["mm_items"][0].offsets == [(1, 40), (41, 52)]
+    assert adjacent_result["mrope_positions"][:, 0].tolist() == [0, 0, 0]
+    assert adjacent_result["mrope_positions"][:, 1].tolist() == [1, 1, 1]
+    assert adjacent_result["mrope_positions"][:, 40].tolist() == [1, 4, 10]
+    assert adjacent_result["mrope_positions"][:, 41].tolist() == [11, 11, 11]
+    assert adjacent_result["mrope_positions"][:, 52].tolist() == [11, 12, 16]
+    assert adjacent_result["mrope_positions"][:, 53].tolist() == [17, 17, 17]
+    assert adjacent_result["mrope_position_delta"].tolist() == [[-36]]
 
     two_grids = [[1, 8, 20], [1, 4, 12]]
     with pytest.raises(ValueError, match="at least one image"):

--- a/test/registered/unit/test_glm5_next_session_d_contract.py
+++ b/test/registered/unit/test_glm5_next_session_d_contract.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import ast
 import copy
 import importlib.util
@@ -188,6 +189,35 @@ def _compile_checkpoint_image_config_parser():
     }
     exec(compile(module, str(PROCESSOR_PATH), "exec"), namespace)
     return namespace["from_checkpoint_config"], expected_values
+
+
+def _compile_multi_image_request_harness(mrope_embedding):
+    tree = ast.parse(
+        PROCESSOR_PATH.read_text(encoding="utf-8"), filename=str(PROCESSOR_PATH)
+    )
+    processor = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "Glm5NextSGLangProcessor"
+    )
+    method_names = {"_count_image_placeholders", "process_mm_data_async"}
+    methods = [
+        copy.deepcopy(node)
+        for node in processor.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name in method_names
+    ]
+    assert {method.name for method in methods} == method_names
+    for method in methods:
+        method.decorator_list = []
+    module = ast.fix_missing_locations(ast.Module(body=methods, type_ignores=[]))
+    namespace = {"MRotaryEmbedding": mrope_embedding}
+    exec(compile(module, str(PROCESSOR_PATH), "exec"), namespace)
+    return type(
+        "_Glm5NextMultiImageRequestHarness",
+        (),
+        {method_name: namespace[method_name] for method_name in method_names},
+    )
 
 
 def test_exact_checkpoint_token_ids_and_vision_defaults():
@@ -388,3 +418,138 @@ def test_processor_and_shared_glm_ocr_changes_remain_isolated():
     assert "merger_context_dim=self.vision_config.projection_intermediate_size" in (
         glm5_source
     )
+
+
+def test_multi_image_request_cardinality_offsets_and_feature_contract():
+    torch = pytest.importorskip("torch")
+
+    class _MRotaryEmbedding:
+        @staticmethod
+        def get_rope_index_glm4v(input_ids, **kwargs):
+            del kwargs
+            seq_len = input_ids.shape[-1]
+            return (
+                torch.zeros((3, 1, seq_len), dtype=torch.long),
+                torch.zeros((1, 1), dtype=torch.long),
+            )
+
+    harness = _compile_multi_image_request_harness(_MRotaryEmbedding)
+
+    def run_request(
+        grids,
+        *,
+        image_data=None,
+        prompt_count=None,
+        loaded_count=None,
+        offsets_override=None,
+        feature_rows=None,
+        video_data=None,
+        audio_data=None,
+        adjacent_placeholders=False,
+    ):
+        image_count = len(grids)
+        image_data = (
+            [f"image-{index}" for index in range(image_count)]
+            if image_data is None
+            else image_data
+        )
+        prompt_count = len(image_data) if prompt_count is None else prompt_count
+        loaded_count = len(image_data) if loaded_count is None else loaded_count
+        grid_tensor = torch.tensor(grids, dtype=torch.long)
+        patch_counts = [int(grid.prod().item()) for grid in grid_tensor]
+        token_counts = [patch_count // 4 for patch_count in patch_counts]
+
+        input_ids = [101]
+        offsets = []
+        for index, token_count in enumerate(token_counts):
+            start = len(input_ids)
+            input_ids.extend([7] * token_count)
+            offsets.append((start, len(input_ids) - 1))
+            if not adjacent_placeholders:
+                input_ids.append(102 + index)
+        if adjacent_placeholders:
+            offsets = [(1, len(input_ids) - 1)]
+            input_ids.append(102)
+        input_ids = torch.tensor(input_ids, dtype=torch.long)
+        if offsets_override is not None:
+            offsets = offsets_override
+
+        expected_feature_rows = sum(patch_counts)
+        feature_rows = expected_feature_rows if feature_rows is None else feature_rows
+        item = SimpleNamespace(
+            feature=torch.zeros((feature_rows, 1176), dtype=torch.float32),
+            offsets=offsets,
+            is_image=lambda: True,
+        )
+        ret = SimpleNamespace(
+            image_grid_thw=grid_tensor,
+            attention_mask=torch.ones_like(input_ids).unsqueeze(0),
+        )
+
+        processor = harness()
+        processor.VIDEO_TOKEN = "<|video|>"
+        processor.VIDEO_TOKEN_ID = 8
+        processor.IMAGE_TOKEN = "<|image|>"
+        processor.IM_TOKEN_ID = 7
+        processor.IMAGE_START_TOKEN_ID = 9
+        processor.IMAGE_END_TOKEN_ID = 10
+        processor.spatial_merge_size = 2
+        processor.hf_config = SimpleNamespace()
+        processor.mm_tokens = object()
+        processor.load_mm_data = lambda **kwargs: SimpleNamespace(
+            images=[object()] * loaded_count,
+            videos=[],
+            audios=[],
+        )
+        processor.process_and_combine_mm_data = lambda *args, **kwargs: (
+            [item],
+            input_ids,
+            ret,
+        )
+        prompt_separator = "" if adjacent_placeholders else " compare "
+        prompt = prompt_separator.join(["<|image|>"] * prompt_count)
+        request = SimpleNamespace(video_data=video_data)
+        result = asyncio.run(
+            processor.process_mm_data_async(
+                image_data,
+                [] if audio_data is None else audio_data,
+                prompt,
+                request,
+            )
+        )
+        return result
+
+    cases = (
+        [[1, 8, 20]],
+        [[1, 8, 20], [1, 4, 12]],
+        [[1, 4, 4]] * 4,
+        [[1, 4, 4]] * 8,
+    )
+    for grids in cases:
+        result = run_request(grids)
+        assert len(result["mm_items"][0].offsets) == len(grids)
+        assert tuple(result["mrope_positions"].shape) == (
+            3,
+            len(result["input_ids"]),
+        )
+
+    adjacent_result = run_request([[1, 8, 20], [1, 4, 12]], adjacent_placeholders=True)
+    assert adjacent_result["mm_items"][0].offsets == [(1, 40), (41, 52)]
+
+    two_grids = [[1, 8, 20], [1, 4, 12]]
+    with pytest.raises(ValueError, match="at least one image"):
+        run_request(two_grids, image_data=[], prompt_count=0)
+    with pytest.raises(ValueError, match="count/placeholder count mismatch"):
+        run_request(two_grids, prompt_count=1)
+    with pytest.raises(ValueError, match="processor_output"):
+        run_request(two_grids, image_data=["image-0", {"format": "processor_output"}])
+    with pytest.raises(ValueError, match="does not support video"):
+        run_request(two_grids, video_data=["video-0"])
+    with pytest.raises(ValueError, match="does not support audio"):
+        run_request(two_grids, audio_data=["audio-0"])
+    with pytest.raises(ValueError, match="changed the request cardinality"):
+        run_request(two_grids, loaded_count=1)
+    with pytest.raises(RuntimeError, match="offsets do not cover"):
+        run_request(two_grids, offsets_override=[(1, 40), (42, 54)])
+    with pytest.raises(RuntimeError, match="feature/grid mismatch"):
+        run_request(two_grids, feature_rows=207)

--- a/test/registered/unit/test_glm5_next_session_d_contract.py
+++ b/test/registered/unit/test_glm5_next_session_d_contract.py
@@ -1,0 +1,390 @@
+"""CPU-only contracts for the frozen GLM-5-Next Session D boundary."""
+
+from __future__ import annotations
+
+import ast
+import copy
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+STAGE3_TEST_PATH = REPO_ROOT / "test/registered/unit/test_glm5_next_stage3.py"
+MODEL_CONFIG_PATH = REPO_ROOT / "python/sglang/srt/configs/model_config.py"
+PROCESSOR_PATH = REPO_ROOT / "python/sglang/srt/multimodal/processors/glm5_next.py"
+GLM_OCR_MODEL_PATH = REPO_ROOT / "python/sglang/srt/models/glm_ocr.py"
+GLM5_MODEL_PATH = REPO_ROOT / "python/sglang/srt/models/glm5_next.py"
+
+
+def _load_stage3_support():
+    spec = importlib.util.spec_from_file_location(
+        "_glm5_next_session_d_stage3_support", STAGE3_TEST_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _model_config_tree() -> ast.Module:
+    return ast.parse(
+        MODEL_CONFIG_PATH.read_text(encoding="utf-8"),
+        filename=str(MODEL_CONFIG_PATH),
+    )
+
+
+def _literal_assignment(tree: ast.Module, name: str):
+    node = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Name) and target.id == name
+            for target in node.targets
+        )
+    )
+    return ast.literal_eval(node.value)
+
+
+def _resolve_model_config_mm(architecture, requested, *, language_only=False):
+    """Execute the three MM-resolution statements copied from ModelConfig."""
+
+    tree = _model_config_tree()
+    model_config = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "ModelConfig"
+    )
+    init = next(
+        node
+        for node in model_config.body
+        if isinstance(node, ast.FunctionDef) and node.name == "__init__"
+    )
+    default_resolution = next(
+        node
+        for node in init.body
+        if isinstance(node, ast.If)
+        and ast.unparse(node.test) == "enable_multimodal is None"
+    )
+    effective_assignment = next(
+        node
+        for node in init.body
+        if isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Attribute) and target.attr == "is_multimodal"
+            for target in node.targets
+        )
+    )
+    exact_glm_gate = next(
+        node
+        for node in init.body
+        if isinstance(node, ast.If)
+        and ast.unparse(node.test) == "self.is_glm5_next"
+        and "_glm5_next_multimodal_active" in ast.unparse(node)
+    )
+
+    multimodal_architectures = set(_literal_assignment(tree, "multimodal_model_archs"))
+    holder = SimpleNamespace(
+        hf_config=SimpleNamespace(
+            architectures=[architecture], model_type="test-model"
+        ),
+        is_glm5_next=architecture == "Glm5NextForConditionalGeneration",
+    )
+
+    class _Logger:
+        @staticmethod
+        def info(*args, **kwargs):
+            del args, kwargs
+
+    namespace = {
+        "self": holder,
+        "enable_multimodal": requested,
+        "language_only": language_only,
+        "logger": _Logger(),
+        "is_multimodal_model": lambda architectures: bool(
+            set(architectures) & multimodal_architectures
+        ),
+    }
+    selected = ast.fix_missing_locations(
+        ast.Module(
+            body=[
+                copy.deepcopy(default_resolution),
+                copy.deepcopy(effective_assignment),
+                copy.deepcopy(exact_glm_gate),
+            ],
+            type_ignores=[],
+        )
+    )
+    exec(compile(selected, str(MODEL_CONFIG_PATH), "exec"), namespace)
+    return namespace["enable_multimodal"], holder
+
+
+def _compile_max_pixels_resolver():
+    tree = ast.parse(
+        PROCESSOR_PATH.read_text(encoding="utf-8"), filename=str(PROCESSOR_PATH)
+    )
+    processor = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "Glm5NextSGLangProcessor"
+    )
+    method = copy.deepcopy(
+        next(
+            node
+            for node in processor.body
+            if isinstance(node, ast.FunctionDef) and node.name == "_resolve_max_pixels"
+        )
+    )
+    method.decorator_list = []
+    module = ast.fix_missing_locations(ast.Module(body=[method], type_ignores=[]))
+    namespace = {
+        "GLM5_NEXT_MIN_PIXELS": 12_544,
+        "GLM5_NEXT_DEFAULT_MAX_PIXELS": 1_254_400,
+        "GLM5_NEXT_CHECKPOINT_MAX_PIXELS": 9_633_792,
+    }
+    exec(compile(module, str(PROCESSOR_PATH), "exec"), namespace)
+    return namespace["_resolve_max_pixels"]
+
+
+def _compile_checkpoint_image_config_parser():
+    tree = ast.parse(
+        PROCESSOR_PATH.read_text(encoding="utf-8"), filename=str(PROCESSOR_PATH)
+    )
+    processor = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "Glm5NextImageProcessor"
+    )
+    method = copy.deepcopy(
+        next(
+            node
+            for node in processor.body
+            if isinstance(node, ast.FunctionDef)
+            and node.name == "from_checkpoint_config"
+        )
+    )
+    method.decorator_list = []
+    module = ast.fix_missing_locations(ast.Module(body=[method], type_ignores=[]))
+    expected_values = {
+        "do_rescale": True,
+        "image_mean": [0.48145466, 0.4578275, 0.40821073],
+        "image_processor_type": "GlmgaImageProcessor",
+        "image_std": [0.26862954, 0.26130258, 0.27577711],
+        "merge_size": 2,
+        "patch_size": 14,
+        "patch_expand_factor": 2,
+        "temporal_patch_size": 2,
+    }
+    namespace = {
+        "Any": object,
+        "GLM5_NEXT_MIN_PIXELS": 12_544,
+        "GLM5_NEXT_DEFAULT_MAX_PIXELS": 1_254_400,
+        "GLM5_NEXT_CHECKPOINT_MAX_PIXELS": 9_633_792,
+        "_GLM5_NEXT_IMAGE_CONFIG_KEYS": frozenset({*expected_values, "size"}),
+        "_GLM5_NEXT_IMAGE_CONFIG_VALUES": expected_values,
+    }
+    exec(compile(module, str(PROCESSOR_PATH), "exec"), namespace)
+    return namespace["from_checkpoint_config"], expected_values
+
+
+def test_exact_checkpoint_token_ids_and_vision_defaults():
+    config_module = _load_stage3_support()._load_config_module()
+    config = config_module.Glm5NextConfig()
+
+    assert (
+        config.image_token_id,
+        config.video_token_id,
+        config.image_start_token_id,
+        config.image_end_token_id,
+        config.video_start_token_id,
+        config.video_end_token_id,
+    ) == (154854, 154855, 154830, 154831, 154832, 154833)
+
+    expected_vision = {
+        "depth": 24,
+        "hidden_size": 1024,
+        "intermediate_size": 4096,
+        "num_heads": 16,
+        "in_channels": 3,
+        "patch_size": 14,
+        "temporal_patch_size": 2,
+        "spatial_merge_size": 2,
+        "out_hidden_size": 4096,
+        "projection_intermediate_size": 10240,
+        "rms_norm_eps": 1e-5,
+        "hidden_act": "silu",
+        "image_size": 448,
+        "initializer_range": 0.02,
+        "attention_dropout": 0.0,
+        "attention_bias": True,
+    }
+    assert {
+        key: getattr(config.vision_config, key) for key in expected_vision
+    } == expected_vision
+
+    overridden = config_module.Glm5NextConfig(
+        vision_config={"depth": 12, "future_checkpoint_field": 17}
+    )
+    assert overridden.vision_config.depth == 12
+    assert overridden.vision_config.future_checkpoint_field == 17
+
+
+def test_multimodal_default_explicit_off_and_non_glm_isolation():
+    effective, glm = _resolve_model_config_mm("Glm5NextForConditionalGeneration", None)
+    assert effective is True
+    assert glm.is_multimodal is True
+    assert glm.hf_config._glm5_next_multimodal_active is True
+
+    effective, glm = _resolve_model_config_mm("Glm5NextForConditionalGeneration", False)
+    assert effective is False
+    assert glm.is_multimodal is False
+    assert glm.hf_config._glm5_next_multimodal_active is False
+
+    _, language_stage = _resolve_model_config_mm(
+        "Glm5NextForConditionalGeneration", True, language_only=True
+    )
+    assert language_stage.is_multimodal is True
+    assert language_stage.hf_config._glm5_next_multimodal_active is False
+
+    comparisons = {
+        "Qwen3ForCausalLM": (True, False),
+        "Qwen3VLMoeForConditionalGeneration": (True, True),
+        "Glm4vForConditionalGeneration": (True, True),
+        "Gemma3ForConditionalGeneration": (False, False),
+    }
+    for architecture, expected in comparisons.items():
+        effective, holder = _resolve_model_config_mm(architecture, None)
+        assert (effective, holder.is_multimodal) == expected
+        assert not hasattr(holder.hf_config, "_glm5_next_multimodal_active")
+
+
+def test_glm5_registry_is_exact_and_no_longer_default_disabled():
+    tree = _model_config_tree()
+    architectures = _literal_assignment(tree, "multimodal_model_archs")
+    assert architectures.count("Glm5NextForConditionalGeneration") == 1
+
+    source = MODEL_CONFIG_PATH.read_text(encoding="utf-8")
+    init = next(
+        node
+        for node in next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.ClassDef) and node.name == "ModelConfig"
+        ).body
+        if isinstance(node, ast.FunctionDef) and node.name == "__init__"
+    )
+    disabled_branch = next(
+        node
+        for node in init.body
+        if isinstance(node, ast.If)
+        and ast.unparse(node.test) == "enable_multimodal is None"
+    )
+    assert "Glm5NextForConditionalGeneration" not in ast.unparse(disabled_branch)
+    assert source.count('"Glm5NextForConditionalGeneration"') >= 1
+
+
+def test_pixel_cap_contract_is_fail_closed():
+    resolve = _compile_max_pixels_resolver()
+    assert resolve(None) == 1_254_400
+    assert resolve({}) == 1_254_400
+    assert resolve({"image": {"max_pixels": 9_633_792}}) == 9_633_792
+    assert resolve({"image": {"max_pixels": 12_544}}) == 12_544
+
+    invalid = (
+        [],
+        {"video": {}},
+        {"image": []},
+        {"image": {"min_pixels": 12_544}},
+        {"image": {"max_pixels": True}},
+        {"image": {"max_pixels": 12_543}},
+        {"image": {"max_pixels": 9_633_793}},
+    )
+    for value in invalid:
+        with pytest.raises(ValueError):
+            resolve(value)
+
+
+def test_pinned_checkpoint_image_metadata_is_exact_and_complete():
+    parse, expected_values = _compile_checkpoint_image_config_parser()
+
+    class _Constructed:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    exact = {
+        **expected_values,
+        "size": {"shortest_edge": 12_544, "longest_edge": 9_633_792},
+    }
+    parsed = parse(_Constructed, exact)
+    assert parsed.kwargs["size"] == {
+        "shortest_edge": 12_544,
+        "longest_edge": 1_254_400,
+    }
+    assert parsed.kwargs["patch_expand_factor"] == 2
+    assert "image_processor_type" not in parsed.kwargs
+
+    malformed = []
+    missing = dict(exact)
+    missing.pop("patch_expand_factor")
+    malformed.append(missing)
+    unknown = dict(exact)
+    unknown["future_field"] = 1
+    malformed.append(unknown)
+    wrong_type = dict(exact)
+    wrong_type["image_processor_type"] = "Glm46VImageProcessor"
+    malformed.append(wrong_type)
+    wrong_size = dict(exact)
+    wrong_size["size"] = {"shortest_edge": 12_544}
+    malformed.append(wrong_size)
+
+    for value in malformed:
+        with pytest.raises(ValueError):
+            parse(_Constructed, value)
+
+
+def test_processor_and_shared_glm_ocr_changes_remain_isolated():
+    processor_source = PROCESSOR_PATH.read_text(encoding="utf-8")
+    processor_tree = ast.parse(processor_source, filename=str(PROCESSOR_PATH))
+    processor = next(
+        node
+        for node in processor_tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "Glm5NextSGLangProcessor"
+    )
+    process_method = next(
+        node
+        for node in processor.body
+        if isinstance(node, ast.AsyncFunctionDef)
+        and node.name == "process_mm_data_async"
+    )
+    load_calls = [
+        node
+        for node in ast.walk(process_method)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "load_mm_data"
+    ]
+    assert len(load_calls) == 1
+    assert not any(
+        isinstance(node, ast.Await) and node.value is load_calls[0]
+        for node in ast.walk(process_method)
+    )
+    return_node = next(
+        node for node in ast.walk(process_method) if isinstance(node, ast.Return)
+    )
+    assert isinstance(return_node.value, ast.Dict)
+    return_source = ast.unparse(return_node.value)
+    assert "self.IMAGE_START_TOKEN_ID" in return_source
+    assert "self.IMAGE_END_TOKEN_ID" in return_source
+
+    glm_ocr_source = GLM_OCR_MODEL_PATH.read_text(encoding="utf-8")
+    glm5_source = GLM5_MODEL_PATH.read_text(encoding="utf-8")
+    assert "num_dummy_heads=num_dummy_heads" in glm_ocr_source
+    assert 'getattr(vision_config, "num_dummy_heads", 0)' not in glm_ocr_source
+    assert "if merger_context_dim is None:" in glm_ocr_source
+    assert "num_dummy_heads=getattr(self.vision_config" in glm5_source
+    assert "merger_context_dim=self.vision_config.projection_intermediate_size" in (
+        glm5_source
+    )

--- a/test/registered/unit/test_glm5_next_session_d_processor_subprocess.py
+++ b/test/registered/unit/test_glm5_next_session_d_processor_subprocess.py
@@ -171,6 +171,18 @@ def _assert_image_output(output, tokenizer, torch):
     assert int((output.mm_token_type_ids == 1).sum().item()) == 40
 
 
+def _assert_multi_image_output(output, tokenizer, torch, image_count):
+    image_token_id = tokenizer.convert_tokens_to_ids("<|image|>")
+    assert tuple(output.image_grid_thw.shape) == (image_count, 3)
+    patch_counts = [int(grid.prod().item()) for grid in output.image_grid_thw]
+    expected_tokens = sum(patch_count // 4 for patch_count in patch_counts)
+    assert tuple(output.pixel_values.shape) == (sum(patch_counts), 1176)
+    assert output.pixel_values.dtype == torch.float32
+    assert bool(output.pixel_values.isfinite().all())
+    assert int((output.input_ids == image_token_id).sum().item()) == expected_tokens
+    assert int((output.mm_token_type_ids == 1).sum().item()) == expected_tokens
+
+
 def _run_image_and_processor_parity(glm5_module, dependencies):
     np, torch, Image, hf_image_module, Glm46VVideoProcessor = dependencies
 
@@ -208,6 +220,17 @@ def _run_image_and_processor_parity(glm5_module, dependencies):
         return_mm_token_type_ids=True,
     )
     _assert_image_output(output, tokenizer, torch)
+    second_image = Image.fromarray(
+        np.arange(211 * 97 * 3, dtype=np.uint8).reshape(211, 97, 3),
+        "RGB",
+    )
+    multi_output = processor(
+        images=[image, second_image],
+        text=["<|image|> describe <|image|>"],
+        return_tensors="pt",
+        return_mm_token_type_ids=True,
+    )
+    _assert_multi_image_output(multi_output, tokenizer, torch, 2)
 
     reference_config = copy.deepcopy(CHECKPOINT_IMAGE_CONFIG)
     reference_config.pop("image_processor_type")
@@ -241,11 +264,18 @@ def _run_image_and_processor_parity(glm5_module, dependencies):
     hf_image_module.smart_resize = _expanded_smart_resize
     try:
         reference_output = reference(images=[image], return_tensors="pt")
+        reference_multi_output = reference(
+            images=[image, second_image], return_tensors="pt"
+        )
     finally:
         hf_image_module.smart_resize = original_smart_resize
 
     assert torch.equal(output.image_grid_thw, reference_output.image_grid_thw)
     assert torch.equal(output.pixel_values, reference_output.pixel_values)
+    assert torch.equal(
+        multi_output.image_grid_thw, reference_multi_output.image_grid_thw
+    )
+    assert torch.equal(multi_output.pixel_values, reference_multi_output.pixel_values)
 
     _assert_raises(
         ValueError,
@@ -256,7 +286,7 @@ def _run_image_and_processor_parity(glm5_module, dependencies):
         ),
         "does not support video input",
     )
-    return image, tokenizer, output
+    return [image, second_image], tokenizer, output
 
 
 def _install_hf_utils_stubs(PretrainedConfig):
@@ -384,7 +414,7 @@ def _write_processor_config(path: Path, processor_config: dict):
 
 def _run_get_processor_smoke(
     glm5_module,
-    image,
+    images,
     tokenizer,
     torch,
     PretrainedConfig,
@@ -455,18 +485,25 @@ def _run_get_processor_smoke(
         assert processor.image_processor.patch_expand_factor == 2
 
         output = processor(
-            images=[image],
+            images=[images[0]],
             text=["<|image|> describe"],
             return_tensors="pt",
             return_mm_token_type_ids=True,
         )
         _assert_image_output(output, processor.tokenizer, torch)
+        multi_output = processor(
+            images=images,
+            text=["<|image|> describe <|image|>"],
+            return_tensors="pt",
+            return_mm_token_type_ids=True,
+        )
+        _assert_multi_image_output(multi_output, processor.tokenizer, torch, 2)
         _assert_raises(
             ValueError,
             lambda: processor(
-                images=[image],
+                images=[images[0]],
                 text=["<|image|> describe"],
-                videos=[image],
+                videos=[images[0]],
             ),
             "does not support video input",
         )
@@ -510,12 +547,12 @@ def _child_main() -> int:
         hf_image_module,
         Glm46VVideoProcessor,
     )
-    image, tokenizer, _output = _run_image_and_processor_parity(
+    images, tokenizer, _output = _run_image_and_processor_parity(
         glm5_module, dependencies
     )
     _run_get_processor_smoke(
         glm5_module,
-        image,
+        images,
         tokenizer,
         torch,
         PretrainedConfig,
@@ -525,7 +562,8 @@ def _child_main() -> int:
     )
     print(
         f"{SUCCESS_MARKER}: transformers-kt={installed_version}; "
-        "resize=112x280; grid=[1,8,20]; patches=160; tokens=40"
+        "single_and_multi_image_parity=pass; resize=112x280; "
+        "grid=[1,8,20]; patches=160; tokens=40"
     )
     return 0
 

--- a/test/registered/unit/test_glm5_next_session_d_processor_subprocess.py
+++ b/test/registered/unit/test_glm5_next_session_d_processor_subprocess.py
@@ -1,605 +1,99 @@
-"""Pinned-wheel CPU smoke for the GLM-5-Next Session D processor.
-
-The production processor imports the full SGLang model and multimodal stack.
-This test intentionally runs in a child process and replaces only those SGLang
-imports with small type stubs.  The Transformers classes, the production
-``glm5_next.py`` file, and the production ``get_processor`` implementation are
-executed unchanged.  Keeping the harness in a subprocess prevents its module
-stubs and temporary AutoConfig registrations from leaking into other tests.
-"""
+"""Import smoke for the split transformers-kt/SGLang GLM-5-Next processor."""
 
 from __future__ import annotations
 
-import copy
-import importlib.metadata
-import importlib.util
-import json
-import logging
-import os
 import subprocess
 import sys
-import tempfile
-import types
+import textwrap
 from pathlib import Path
-from types import SimpleNamespace
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
-REPO_PYTHON = REPO_ROOT / "python"
-PROCESSOR_PATH = REPO_PYTHON / "sglang/srt/multimodal/processors/glm5_next.py"
-HF_UTILS_PATH = REPO_PYTHON / "sglang/srt/utils/hf_transformers_utils.py"
-
-PINNED_TRANSFORMERS_DIST = "transformers-kt"
-PINNED_TRANSFORMERS_VERSION = "5.6.0.post1"
-CHILD_FLAG = "--processor-smoke-child"
-SKIP_EXIT_CODE = 77
-SUCCESS_MARKER = "GLM5_SESSION_D_PROCESSOR_SMOKE_OK"
-
-CHECKPOINT_IMAGE_CONFIG = {
-    "do_rescale": True,
-    "image_mean": [0.48145466, 0.4578275, 0.40821073],
-    "image_processor_type": "GlmgaImageProcessor",
-    "image_std": [0.26862954, 0.26130258, 0.27577711],
-    "merge_size": 2,
-    "patch_size": 14,
-    "patch_expand_factor": 2,
-    "size": {"shortest_edge": 12_544, "longest_edge": 9_633_792},
-    "temporal_patch_size": 2,
-}
-
-CHECKPOINT_VIDEO_CONFIG = {
-    "do_rescale": True,
-    "fps": 2,
-    "image_mean": [0.48145466, 0.4578275, 0.40821073],
-    "image_std": [0.26862954, 0.26130258, 0.27577711],
-    "merge_size": 2,
-    "patch_expand_factor": 2,
-    "patch_size": 14,
-    "size": {"shortest_edge": 12_544, "longest_edge": 100_352_000},
-    "temporal_patch_size": 2,
-    "video_processor_type": "Glm5NextVideoProcessor",
-}
-
-TOKEN_STRINGS = (
-    "<unk>",
-    "<|image|>",
-    "<|video|>",
-    "<|begin_of_video|>",
-    "<|end_of_video|>",
-    "<|begin_of_image|>",
-    "<|end_of_image|>",
-    "describe",
-)
+PROCESSOR_PATH = REPO_ROOT / "python/sglang/srt/multimodal/processors/glm5_next.py"
 
 
-def _skip_child(reason: str) -> int:
-    print(f"GLM5_SESSION_D_PROCESSOR_SMOKE_SKIP: {reason}")
-    return SKIP_EXIT_CODE
+def test_production_processor_imports_transformers_kt_glm5_classes():
+    child = textwrap.dedent(
+        f"""
+        import importlib.util
+        import sys
+        import types
 
+        from transformers.models.glm5_next.image_processing_glm5_next import Glm5NextImageProcessor
+        from transformers.models.glm5_next.processing_glm5_next import Glm5NextProcessor
+        from transformers.models.glm5_next.video_processing_glm5_next import Glm5NextVideoProcessor
 
-def _module(name: str, **attributes):
-    module = types.ModuleType(name)
-    module.__dict__.update(attributes)
-    sys.modules[name] = module
-    return module
+        def package(name):
+            module = types.ModuleType(name)
+            module.__path__ = []
+            sys.modules[name] = module
+            return module
 
+        def module(name, **attrs):
+            value = types.ModuleType(name)
+            value.__dict__.update(attrs)
+            sys.modules[name] = value
+            return value
 
-def _package(name: str, path: Path | None = None):
-    module = _module(name)
-    module.__path__ = [] if path is None else [str(path)]
-    return module
+        for name in (
+            "sglang",
+            "sglang.srt",
+            "sglang.srt.layers",
+            "sglang.srt.models",
+            "sglang.srt.multimodal",
+            "sglang.srt.multimodal.processors",
+        ):
+            package(name)
 
+        class Stub:
+            pass
 
-def _load_production_processor():
-    """Load the production file without importing top-level ``sglang``."""
+        class BaseOutput:
+            def __init__(self, input_text, images=None, videos=None, audios=None):
+                self.input_text = input_text
+                self.images = images or []
+                self.videos = videos or []
+                self.audios = audios or []
 
-    _package("sglang", REPO_PYTHON / "sglang")
-    _package("sglang.srt", REPO_PYTHON / "sglang/srt")
-    for package_name in (
-        "sglang.srt.layers",
-        "sglang.srt.models",
-        "sglang.srt.multimodal",
-        "sglang.srt.multimodal.processors",
-    ):
-        _package(package_name)
-
-    class _Stub:
-        pass
-
-    _module(
-        "sglang.srt.layers.rotary_embedding",
-        MRotaryEmbedding=_Stub,
-    )
-    _module(
-        "sglang.srt.models.glm5_next",
-        Glm5NextForConditionalGeneration=_Stub,
-    )
-    _module(
-        "sglang.srt.multimodal.processors.base_processor",
-        MultimodalSpecialTokens=_Stub,
-    )
-    _module(
-        "sglang.srt.multimodal.processors.glm4v",
-        Glm4vImageProcessor=_Stub,
-    )
-
-    module_name = "sglang.srt.multimodal.processors.glm5_next"
-    spec = importlib.util.spec_from_file_location(module_name, PROCESSOR_PATH)
-    if spec is None or spec.loader is None:
-        raise RuntimeError(f"Cannot load production processor: {PROCESSOR_PATH}")
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[module_name] = module
-    spec.loader.exec_module(module)
-    return module
-
-
-def _make_tokenizer():
-    from tokenizers import Tokenizer
-    from tokenizers.models import WordLevel
-    from tokenizers.pre_tokenizers import WhitespaceSplit
-    from transformers import PreTrainedTokenizerFast
-
-    vocabulary = {token: index for index, token in enumerate(TOKEN_STRINGS)}
-    backend = Tokenizer(WordLevel(vocabulary, unk_token="<unk>"))
-    backend.pre_tokenizer = WhitespaceSplit()
-    return PreTrainedTokenizerFast(
-        tokenizer_object=backend,
-        unk_token="<unk>",
-        additional_special_tokens=list(TOKEN_STRINGS[1:7]),
-    )
-
-
-def _assert_raises(error_type, callback, message_fragment: str):
-    try:
-        callback()
-    except error_type as error:
-        if message_fragment not in str(error):
-            raise AssertionError(
-                f"Expected {message_fragment!r} in {error_type.__name__}: {error}"
-            ) from error
-    else:
-        raise AssertionError(f"Expected {error_type.__name__} to be raised")
-
-
-def _assert_image_output(output, tokenizer, torch):
-    image_token_id = tokenizer.convert_tokens_to_ids("<|image|>")
-    assert output.image_grid_thw.tolist() == [[1, 8, 20]]
-    assert tuple(output.pixel_values.shape) == (160, 1176)
-    assert output.pixel_values.dtype == torch.float32
-    assert bool(output.pixel_values.isfinite().all())
-    assert int((output.input_ids == image_token_id).sum().item()) == 40
-    assert int((output.mm_token_type_ids == 1).sum().item()) == 40
-
-
-def _assert_multi_image_output(output, tokenizer, torch, image_count):
-    image_token_id = tokenizer.convert_tokens_to_ids("<|image|>")
-    assert tuple(output.image_grid_thw.shape) == (image_count, 3)
-    patch_counts = [int(grid.prod().item()) for grid in output.image_grid_thw]
-    expected_tokens = sum(patch_count // 4 for patch_count in patch_counts)
-    assert tuple(output.pixel_values.shape) == (sum(patch_counts), 1176)
-    assert output.pixel_values.dtype == torch.float32
-    assert bool(output.pixel_values.isfinite().all())
-    assert int((output.input_ids == image_token_id).sum().item()) == expected_tokens
-    assert int((output.mm_token_type_ids == 1).sum().item()) == expected_tokens
-
-
-def _run_image_and_processor_parity(glm5_module, dependencies):
-    np, torch, Image, hf_image_module, Glm46VVideoProcessor = dependencies
-
-    image_processor = glm5_module.Glm5NextImageProcessor.from_checkpoint_config(
-        CHECKPOINT_IMAGE_CONFIG
-    )
-    assert image_processor.patch_expand_factor == 2
-    assert image_processor.size.shortest_edge == 12_544
-    assert image_processor.size.longest_edge == 1_254_400
-    assert image_processor.get_number_of_image_patches(123, 257) == 160
-    assert glm5_module.smart_resize(
-        num_frames=2,
-        height=123,
-        width=257,
-        temporal_factor=2,
-        factor=56,
-        min_pixels=12_544,
-        max_pixels=1_254_400,
-    ) == (112, 280)
-
-    tokenizer = _make_tokenizer()
-    processor = glm5_module.Glm5NextProcessor(
-        image_processor=image_processor,
-        tokenizer=tokenizer,
-        video_processor=Glm46VVideoProcessor(),
-    )
-    image = Image.fromarray(
-        np.arange(123 * 257 * 3, dtype=np.uint8).reshape(123, 257, 3),
-        "RGB",
-    )
-    output = processor(
-        images=[image],
-        text=["<|image|> describe"],
-        return_tensors="pt",
-        return_mm_token_type_ids=True,
-    )
-    _assert_image_output(output, tokenizer, torch)
-    second_image = Image.fromarray(
-        np.arange(211 * 97 * 3, dtype=np.uint8).reshape(211, 97, 3),
-        "RGB",
-    )
-    multi_output = processor(
-        images=[image, second_image],
-        text=["<|image|> describe <|image|>"],
-        return_tensors="pt",
-        return_mm_token_type_ids=True,
-    )
-    _assert_multi_image_output(multi_output, tokenizer, torch, 2)
-
-    reference_config = copy.deepcopy(CHECKPOINT_IMAGE_CONFIG)
-    reference_config.pop("image_processor_type")
-    reference_config.pop("patch_expand_factor")
-    reference_config["size"] = {
-        "shortest_edge": 12_544,
-        "longest_edge": 1_254_400,
-    }
-    reference = hf_image_module.Glm46VImageProcessor(**reference_config)
-    original_smart_resize = hf_image_module.smart_resize
-
-    def _expanded_smart_resize(
-        num_frames,
-        height,
-        width,
-        temporal_factor=2,
-        factor=28,
-        min_pixels=112 * 112,
-        max_pixels=14 * 14 * 2 * 2 * 2 * 6144,
-    ):
-        return original_smart_resize(
-            num_frames=num_frames,
-            height=height,
-            width=width,
-            temporal_factor=temporal_factor,
-            factor=factor * 2,
-            min_pixels=min_pixels,
-            max_pixels=max_pixels,
+        module("sglang.srt.layers.rotary_embedding", MRotaryEmbedding=Stub)
+        module(
+            "sglang.srt.models.glm5_next",
+            Glm5NextForConditionalGeneration=Stub,
+        )
+        module(
+            "sglang.srt.multimodal.processors.base_processor",
+            BaseMultiModalProcessorOutput=BaseOutput,
+            MultimodalSpecialTokens=Stub,
+        )
+        module(
+            "sglang.srt.multimodal.processors.glm4v",
+            Glm4vImageProcessor=Stub,
         )
 
-    hf_image_module.smart_resize = _expanded_smart_resize
-    try:
-        reference_output = reference(images=[image], return_tensors="pt")
-        reference_multi_output = reference(
-            images=[image, second_image], return_tensors="pt"
+        spec = importlib.util.spec_from_file_location(
+            "sglang.srt.multimodal.processors.glm5_next",
+            {str(PROCESSOR_PATH)!r},
         )
-    finally:
-        hf_image_module.smart_resize = original_smart_resize
+        production = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = production
+        spec.loader.exec_module(production)
 
-    assert torch.equal(output.image_grid_thw, reference_output.image_grid_thw)
-    assert torch.equal(output.pixel_values, reference_output.pixel_values)
-    assert torch.equal(
-        multi_output.image_grid_thw, reference_multi_output.image_grid_thw
+        assert production.Glm5NextImageProcessor is Glm5NextImageProcessor
+        assert production.Glm5NextProcessor is Glm5NextProcessor
+        assert production.Glm5NextVideoProcessor is Glm5NextVideoProcessor
+        assert production.GLM5_NEXT_PATCH_EXPAND_FACTOR == 1
+        assert production.GLM5_NEXT_DEFAULT_MAX_PIXELS == 6_272_000
+        print("GLM5_VIDEO_PROCESSOR_IMPORT_OK")
+        """
     )
-    assert torch.equal(multi_output.pixel_values, reference_multi_output.pixel_values)
-
-    _assert_raises(
-        ValueError,
-        lambda: processor(
-            images=[image],
-            text=["<|image|> describe"],
-            videos=[image],
-        ),
-        "does not support video input",
-    )
-    return [image, second_image], tokenizer, output
-
-
-def _install_hf_utils_stubs(PretrainedConfig):
-    class _EnvironmentValue:
-        @staticmethod
-        def get():
-            return "none"
-
-    _module(
-        "sglang.srt.environ",
-        envs=SimpleNamespace(SGLANG_APPLY_CONFIG_BACKUP=_EnvironmentValue()),
-    )
-    utils_module = _module(
-        "sglang.srt.utils",
-        get_bool_env_var=lambda _name: False,
-        is_remote_url=lambda _path: False,
-        logger=logging.getLogger("glm5-processor-smoke"),
-        lru_cache_frozenset=lambda maxsize=128: lambda function: function,
-        mistral_utils=SimpleNamespace(),
-    )
-    utils_module.__path__ = [str(REPO_PYTHON / "sglang/srt/utils")]
-
-    config_names = (
-        "AfmoeConfig",
-        "BailingHybridConfig",
-        "ChatGLMConfig",
-        "DbrxConfig",
-        "DeepseekVL2Config",
-        "DotsOCRConfig",
-        "DotsVLMConfig",
-        "ExaoneConfig",
-        "FalconH1Config",
-        "Glm5NextConfig",
-        "Glm5NextTextConfig",
-        "GraniteMoeHybridConfig",
-        "JetNemotronConfig",
-        "JetVLMConfig",
-        "KimiK25Config",
-        "KimiLinearConfig",
-        "KimiVLConfig",
-        "LongcatFlashConfig",
-        "MultiModalityConfig",
-        "NemotronH_Nano_VL_V2_Config",
-        "NemotronHConfig",
-        "Olmo3Config",
-        "Qwen3_5Config",
-        "Qwen3_5MoeConfig",
-        "Qwen3NextConfig",
-        "Step3p5Config",
-        "Step3VLConfig",
-    )
-    config_module = _package("sglang.srt.configs")
-    for index, name in enumerate(config_names):
-        setattr(
-            config_module,
-            name,
-            type(
-                name,
-                (PretrainedConfig,),
-                {"model_type": f"_glm5_processor_smoke_{index}"},
-            ),
-        )
-
-    specialized_configs = (
-        (
-            "sglang.srt.configs.deepseek_ocr",
-            "DeepseekVLV2Config",
-            "_glm5_processor_smoke_deepseek_ocr",
-        ),
-        (
-            "sglang.srt.configs.deepseek_v4",
-            "DeepSeekV4Config",
-            "_glm5_processor_smoke_deepseek_v4",
-        ),
-        (
-            "sglang.srt.configs.internvl",
-            "InternVLChatConfig",
-            "_glm5_processor_smoke_internvl",
-        ),
-    )
-    for module_name, class_name, model_type in specialized_configs:
-        config_class = type(
-            class_name,
-            (PretrainedConfig,),
-            {"model_type": model_type},
-        )
-        _module(module_name, **{class_name: config_class})
-
-    _module(
-        "sglang.srt.connector",
-        create_remote_connector=lambda _path: None,
-    )
-    _module(
-        "sglang.srt.multimodal.customized_mm_processor_utils",
-        _CUSTOMIZED_MM_PROCESSOR={},
-    )
-
-
-def _load_production_hf_utils(PretrainedConfig):
-    _install_hf_utils_stubs(PretrainedConfig)
-    module_name = "sglang.srt.utils.hf_transformers_utils"
-    spec = importlib.util.spec_from_file_location(module_name, HF_UTILS_PATH)
-    if spec is None or spec.loader is None:
-        raise RuntimeError(f"Cannot load production HF helpers: {HF_UTILS_PATH}")
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[module_name] = module
-    spec.loader.exec_module(module)
-
-    # This smoke targets the exact get_processor branch. Config parsing has
-    # separate Session D coverage and would otherwise require importing all of
-    # SGLang's production config dependencies in this isolated child process.
-    module.AutoConfig = SimpleNamespace(
-        from_pretrained=lambda *_args, **_kwargs: SimpleNamespace(
-            model_type="glm5_next"
-        )
-    )
-    return module
-
-
-def _write_processor_config(path: Path, processor_config: dict):
-    (path / "processor_config.json").write_text(
-        json.dumps(processor_config), encoding="utf-8"
-    )
-
-
-def _run_get_processor_smoke(
-    glm5_module,
-    images,
-    tokenizer,
-    torch,
-    PretrainedConfig,
-    Glm46VImageProcessor,
-    Glm46VProcessor,
-    Glm46VVideoProcessor,
-):
-    with tempfile.TemporaryDirectory(prefix="glm5-session-d-processor-") as tmp:
-        fixture_path = Path(tmp)
-        seed_processor = Glm46VProcessor(
-            image_processor=Glm46VImageProcessor(),
-            tokenizer=tokenizer,
-            video_processor=Glm46VVideoProcessor(),
-        )
-        seed_processor.save_pretrained(fixture_path)
-
-        processor_config = json.loads(
-            (fixture_path / "processor_config.json").read_text(encoding="utf-8")
-        )
-        processor_config["processor_class"] = "Glm46VProcessor"
-        processor_config["image_processor"] = copy.deepcopy(CHECKPOINT_IMAGE_CONFIG)
-        processor_config["video_processor"] = copy.deepcopy(CHECKPOINT_VIDEO_CONFIG)
-        _write_processor_config(fixture_path, processor_config)
-
-        _assert_raises(
-            ValueError,
-            lambda: Glm46VProcessor.from_pretrained(
-                fixture_path, local_files_only=True
-            ),
-            "Unrecognized image processor",
-        )
-
-        hf_utils = _load_production_hf_utils(PretrainedConfig)
-
-        wrong_class = copy.deepcopy(processor_config)
-        wrong_class["processor_class"] = "UnexpectedProcessor"
-        _write_processor_config(fixture_path, wrong_class)
-        _assert_raises(
-            ValueError,
-            lambda: hf_utils.get_processor(
-                str(fixture_path), local_files_only=True, revision="main"
-            ),
-            "expected processor_class='Glm46VProcessor'",
-        )
-
-        wrong_video = copy.deepcopy(processor_config)
-        wrong_video["video_processor"]["video_processor_type"] = (
-            "UnexpectedVideoProcessor"
-        )
-        _write_processor_config(fixture_path, wrong_video)
-        _assert_raises(
-            ValueError,
-            lambda: hf_utils.get_processor(
-                str(fixture_path), local_files_only=True, revision="main"
-            ),
-            "must retain its Glm5NextVideoProcessor declaration",
-        )
-
-        _write_processor_config(fixture_path, processor_config)
-        processor = hf_utils.get_processor(
-            str(fixture_path), local_files_only=True, revision="main"
-        )
-        assert isinstance(processor, glm5_module.Glm5NextProcessor)
-        assert isinstance(processor.image_processor, glm5_module.Glm5NextImageProcessor)
-        assert isinstance(processor.video_processor, Glm46VVideoProcessor)
-        assert processor.image_processor.size.shortest_edge == 12_544
-        assert processor.image_processor.size.longest_edge == 1_254_400
-        assert processor.image_processor.patch_expand_factor == 2
-
-        output = processor(
-            images=[images[0]],
-            text=["<|image|> describe"],
-            return_tensors="pt",
-            return_mm_token_type_ids=True,
-        )
-        _assert_image_output(output, processor.tokenizer, torch)
-        multi_output = processor(
-            images=images,
-            text=["<|image|> describe <|image|>"],
-            return_tensors="pt",
-            return_mm_token_type_ids=True,
-        )
-        _assert_multi_image_output(multi_output, processor.tokenizer, torch, 2)
-        _assert_raises(
-            ValueError,
-            lambda: processor(
-                images=[images[0]],
-                text=["<|image|> describe"],
-                videos=[images[0]],
-            ),
-            "does not support video input",
-        )
-
-
-def _child_main() -> int:
-    try:
-        installed_version = importlib.metadata.version(PINNED_TRANSFORMERS_DIST)
-    except importlib.metadata.PackageNotFoundError:
-        return _skip_child(f"{PINNED_TRANSFORMERS_DIST} is not installed")
-    if installed_version != PINNED_TRANSFORMERS_VERSION:
-        return _skip_child(
-            f"requires {PINNED_TRANSFORMERS_DIST}=={PINNED_TRANSFORMERS_VERSION}; "
-            f"found {installed_version}"
-        )
-
-    try:
-        import numpy as np
-        import torch
-        import torchvision  # noqa: F401
-        from PIL import Image
-        from transformers import PretrainedConfig
-        from transformers.models.glm46v import (
-            image_processing_glm46v as hf_image_module,
-        )
-        from transformers.models.glm46v.image_processing_glm46v import (
-            Glm46VImageProcessor,
-        )
-        from transformers.models.glm46v.processing_glm46v import Glm46VProcessor
-        from transformers.models.glm46v.video_processing_glm46v import (
-            Glm46VVideoProcessor,
-        )
-    except (ImportError, ModuleNotFoundError, OSError) as error:
-        return _skip_child(f"optional CPU processor dependency unavailable: {error}")
-
-    glm5_module = _load_production_processor()
-    dependencies = (
-        np,
-        torch,
-        Image,
-        hf_image_module,
-        Glm46VVideoProcessor,
-    )
-    images, tokenizer, _output = _run_image_and_processor_parity(
-        glm5_module, dependencies
-    )
-    _run_get_processor_smoke(
-        glm5_module,
-        images,
-        tokenizer,
-        torch,
-        PretrainedConfig,
-        Glm46VImageProcessor,
-        Glm46VProcessor,
-        Glm46VVideoProcessor,
-    )
-    print(
-        f"{SUCCESS_MARKER}: transformers-kt={installed_version}; "
-        "single_and_multi_image_parity=pass; resize=112x280; "
-        "grid=[1,8,20]; patches=160; tokens=40"
-    )
-    return 0
-
-
-def test_pinned_wheel_processor_smoke_in_isolated_subprocess():
-    import pytest
-
-    environment = os.environ.copy()
-    environment.update(
-        {
-            "CUDA_VISIBLE_DEVICES": "",
-            "HF_HUB_OFFLINE": "1",
-            "TRANSFORMERS_OFFLINE": "1",
-            "TOKENIZERS_PARALLELISM": "false",
-            "PYTHONDONTWRITEBYTECODE": "1",
-        }
-    )
-    result = subprocess.run(
-        [sys.executable, str(Path(__file__).resolve()), CHILD_FLAG],
-        cwd=REPO_ROOT,
-        env=environment,
+    completed = subprocess.run(
+        [sys.executable, "-c", child],
         text=True,
         capture_output=True,
-        timeout=120,
         check=False,
     )
-    details = "\n".join(
-        part for part in (result.stdout.strip(), result.stderr.strip()) if part
-    )
-    if result.returncode == SKIP_EXIT_CODE:
-        pytest.skip(details)
-    assert result.returncode == 0, details
-    assert SUCCESS_MARKER in result.stdout, details
-
-
-if __name__ == "__main__":
-    if sys.argv[1:] != [CHILD_FLAG]:
-        raise SystemExit(f"usage: {Path(__file__).name} {CHILD_FLAG}")
-    raise SystemExit(_child_main())
+    if completed.returncode:
+        raise AssertionError(
+            f"child import failed\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}"
+        )
+    assert "GLM5_VIDEO_PROCESSOR_IMPORT_OK" in completed.stdout

--- a/test/registered/unit/test_glm5_next_session_d_processor_subprocess.py
+++ b/test/registered/unit/test_glm5_next_session_d_processor_subprocess.py
@@ -1,0 +1,567 @@
+"""Pinned-wheel CPU smoke for the GLM-5-Next Session D processor.
+
+The production processor imports the full SGLang model and multimodal stack.
+This test intentionally runs in a child process and replaces only those SGLang
+imports with small type stubs.  The Transformers classes, the production
+``glm5_next.py`` file, and the production ``get_processor`` implementation are
+executed unchanged.  Keeping the harness in a subprocess prevents its module
+stubs and temporary AutoConfig registrations from leaking into other tests.
+"""
+
+from __future__ import annotations
+
+import copy
+import importlib.metadata
+import importlib.util
+import json
+import logging
+import os
+import subprocess
+import sys
+import tempfile
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+REPO_PYTHON = REPO_ROOT / "python"
+PROCESSOR_PATH = REPO_PYTHON / "sglang/srt/multimodal/processors/glm5_next.py"
+HF_UTILS_PATH = REPO_PYTHON / "sglang/srt/utils/hf_transformers_utils.py"
+
+PINNED_TRANSFORMERS_DIST = "transformers-kt"
+PINNED_TRANSFORMERS_VERSION = "5.6.0.post1"
+CHILD_FLAG = "--processor-smoke-child"
+SKIP_EXIT_CODE = 77
+SUCCESS_MARKER = "GLM5_SESSION_D_PROCESSOR_SMOKE_OK"
+
+CHECKPOINT_IMAGE_CONFIG = {
+    "do_rescale": True,
+    "image_mean": [0.48145466, 0.4578275, 0.40821073],
+    "image_processor_type": "GlmgaImageProcessor",
+    "image_std": [0.26862954, 0.26130258, 0.27577711],
+    "merge_size": 2,
+    "patch_size": 14,
+    "patch_expand_factor": 2,
+    "size": {"shortest_edge": 12_544, "longest_edge": 9_633_792},
+    "temporal_patch_size": 2,
+}
+
+CHECKPOINT_VIDEO_CONFIG = {
+    "do_rescale": True,
+    "fps": 2,
+    "image_mean": [0.48145466, 0.4578275, 0.40821073],
+    "image_std": [0.26862954, 0.26130258, 0.27577711],
+    "merge_size": 2,
+    "patch_expand_factor": 2,
+    "patch_size": 14,
+    "size": {"shortest_edge": 12_544, "longest_edge": 100_352_000},
+    "temporal_patch_size": 2,
+    "video_processor_type": "Glm5NextVideoProcessor",
+}
+
+TOKEN_STRINGS = (
+    "<unk>",
+    "<|image|>",
+    "<|video|>",
+    "<|begin_of_video|>",
+    "<|end_of_video|>",
+    "<|begin_of_image|>",
+    "<|end_of_image|>",
+    "describe",
+)
+
+
+def _skip_child(reason: str) -> int:
+    print(f"GLM5_SESSION_D_PROCESSOR_SMOKE_SKIP: {reason}")
+    return SKIP_EXIT_CODE
+
+
+def _module(name: str, **attributes):
+    module = types.ModuleType(name)
+    module.__dict__.update(attributes)
+    sys.modules[name] = module
+    return module
+
+
+def _package(name: str, path: Path | None = None):
+    module = _module(name)
+    module.__path__ = [] if path is None else [str(path)]
+    return module
+
+
+def _load_production_processor():
+    """Load the production file without importing top-level ``sglang``."""
+
+    _package("sglang", REPO_PYTHON / "sglang")
+    _package("sglang.srt", REPO_PYTHON / "sglang/srt")
+    for package_name in (
+        "sglang.srt.layers",
+        "sglang.srt.models",
+        "sglang.srt.multimodal",
+        "sglang.srt.multimodal.processors",
+    ):
+        _package(package_name)
+
+    class _Stub:
+        pass
+
+    _module(
+        "sglang.srt.layers.rotary_embedding",
+        MRotaryEmbedding=_Stub,
+    )
+    _module(
+        "sglang.srt.models.glm5_next",
+        Glm5NextForConditionalGeneration=_Stub,
+    )
+    _module(
+        "sglang.srt.multimodal.processors.base_processor",
+        MultimodalSpecialTokens=_Stub,
+    )
+    _module(
+        "sglang.srt.multimodal.processors.glm4v",
+        Glm4vImageProcessor=_Stub,
+    )
+
+    module_name = "sglang.srt.multimodal.processors.glm5_next"
+    spec = importlib.util.spec_from_file_location(module_name, PROCESSOR_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Cannot load production processor: {PROCESSOR_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_tokenizer():
+    from tokenizers import Tokenizer
+    from tokenizers.models import WordLevel
+    from tokenizers.pre_tokenizers import WhitespaceSplit
+    from transformers import PreTrainedTokenizerFast
+
+    vocabulary = {token: index for index, token in enumerate(TOKEN_STRINGS)}
+    backend = Tokenizer(WordLevel(vocabulary, unk_token="<unk>"))
+    backend.pre_tokenizer = WhitespaceSplit()
+    return PreTrainedTokenizerFast(
+        tokenizer_object=backend,
+        unk_token="<unk>",
+        additional_special_tokens=list(TOKEN_STRINGS[1:7]),
+    )
+
+
+def _assert_raises(error_type, callback, message_fragment: str):
+    try:
+        callback()
+    except error_type as error:
+        if message_fragment not in str(error):
+            raise AssertionError(
+                f"Expected {message_fragment!r} in {error_type.__name__}: {error}"
+            ) from error
+    else:
+        raise AssertionError(f"Expected {error_type.__name__} to be raised")
+
+
+def _assert_image_output(output, tokenizer, torch):
+    image_token_id = tokenizer.convert_tokens_to_ids("<|image|>")
+    assert output.image_grid_thw.tolist() == [[1, 8, 20]]
+    assert tuple(output.pixel_values.shape) == (160, 1176)
+    assert output.pixel_values.dtype == torch.float32
+    assert bool(output.pixel_values.isfinite().all())
+    assert int((output.input_ids == image_token_id).sum().item()) == 40
+    assert int((output.mm_token_type_ids == 1).sum().item()) == 40
+
+
+def _run_image_and_processor_parity(glm5_module, dependencies):
+    np, torch, Image, hf_image_module, Glm46VVideoProcessor = dependencies
+
+    image_processor = glm5_module.Glm5NextImageProcessor.from_checkpoint_config(
+        CHECKPOINT_IMAGE_CONFIG
+    )
+    assert image_processor.patch_expand_factor == 2
+    assert image_processor.size.shortest_edge == 12_544
+    assert image_processor.size.longest_edge == 1_254_400
+    assert image_processor.get_number_of_image_patches(123, 257) == 160
+    assert glm5_module.smart_resize(
+        num_frames=2,
+        height=123,
+        width=257,
+        temporal_factor=2,
+        factor=56,
+        min_pixels=12_544,
+        max_pixels=1_254_400,
+    ) == (112, 280)
+
+    tokenizer = _make_tokenizer()
+    processor = glm5_module.Glm5NextProcessor(
+        image_processor=image_processor,
+        tokenizer=tokenizer,
+        video_processor=Glm46VVideoProcessor(),
+    )
+    image = Image.fromarray(
+        np.arange(123 * 257 * 3, dtype=np.uint8).reshape(123, 257, 3),
+        "RGB",
+    )
+    output = processor(
+        images=[image],
+        text=["<|image|> describe"],
+        return_tensors="pt",
+        return_mm_token_type_ids=True,
+    )
+    _assert_image_output(output, tokenizer, torch)
+
+    reference_config = copy.deepcopy(CHECKPOINT_IMAGE_CONFIG)
+    reference_config.pop("image_processor_type")
+    reference_config.pop("patch_expand_factor")
+    reference_config["size"] = {
+        "shortest_edge": 12_544,
+        "longest_edge": 1_254_400,
+    }
+    reference = hf_image_module.Glm46VImageProcessor(**reference_config)
+    original_smart_resize = hf_image_module.smart_resize
+
+    def _expanded_smart_resize(
+        num_frames,
+        height,
+        width,
+        temporal_factor=2,
+        factor=28,
+        min_pixels=112 * 112,
+        max_pixels=14 * 14 * 2 * 2 * 2 * 6144,
+    ):
+        return original_smart_resize(
+            num_frames=num_frames,
+            height=height,
+            width=width,
+            temporal_factor=temporal_factor,
+            factor=factor * 2,
+            min_pixels=min_pixels,
+            max_pixels=max_pixels,
+        )
+
+    hf_image_module.smart_resize = _expanded_smart_resize
+    try:
+        reference_output = reference(images=[image], return_tensors="pt")
+    finally:
+        hf_image_module.smart_resize = original_smart_resize
+
+    assert torch.equal(output.image_grid_thw, reference_output.image_grid_thw)
+    assert torch.equal(output.pixel_values, reference_output.pixel_values)
+
+    _assert_raises(
+        ValueError,
+        lambda: processor(
+            images=[image],
+            text=["<|image|> describe"],
+            videos=[image],
+        ),
+        "does not support video input",
+    )
+    return image, tokenizer, output
+
+
+def _install_hf_utils_stubs(PretrainedConfig):
+    class _EnvironmentValue:
+        @staticmethod
+        def get():
+            return "none"
+
+    _module(
+        "sglang.srt.environ",
+        envs=SimpleNamespace(SGLANG_APPLY_CONFIG_BACKUP=_EnvironmentValue()),
+    )
+    utils_module = _module(
+        "sglang.srt.utils",
+        get_bool_env_var=lambda _name: False,
+        is_remote_url=lambda _path: False,
+        logger=logging.getLogger("glm5-processor-smoke"),
+        lru_cache_frozenset=lambda maxsize=128: lambda function: function,
+        mistral_utils=SimpleNamespace(),
+    )
+    utils_module.__path__ = [str(REPO_PYTHON / "sglang/srt/utils")]
+
+    config_names = (
+        "AfmoeConfig",
+        "BailingHybridConfig",
+        "ChatGLMConfig",
+        "DbrxConfig",
+        "DeepseekVL2Config",
+        "DotsOCRConfig",
+        "DotsVLMConfig",
+        "ExaoneConfig",
+        "FalconH1Config",
+        "Glm5NextConfig",
+        "Glm5NextTextConfig",
+        "GraniteMoeHybridConfig",
+        "JetNemotronConfig",
+        "JetVLMConfig",
+        "KimiK25Config",
+        "KimiLinearConfig",
+        "KimiVLConfig",
+        "LongcatFlashConfig",
+        "MultiModalityConfig",
+        "NemotronH_Nano_VL_V2_Config",
+        "NemotronHConfig",
+        "Olmo3Config",
+        "Qwen3_5Config",
+        "Qwen3_5MoeConfig",
+        "Qwen3NextConfig",
+        "Step3p5Config",
+        "Step3VLConfig",
+    )
+    config_module = _package("sglang.srt.configs")
+    for index, name in enumerate(config_names):
+        setattr(
+            config_module,
+            name,
+            type(
+                name,
+                (PretrainedConfig,),
+                {"model_type": f"_glm5_processor_smoke_{index}"},
+            ),
+        )
+
+    specialized_configs = (
+        (
+            "sglang.srt.configs.deepseek_ocr",
+            "DeepseekVLV2Config",
+            "_glm5_processor_smoke_deepseek_ocr",
+        ),
+        (
+            "sglang.srt.configs.deepseek_v4",
+            "DeepSeekV4Config",
+            "_glm5_processor_smoke_deepseek_v4",
+        ),
+        (
+            "sglang.srt.configs.internvl",
+            "InternVLChatConfig",
+            "_glm5_processor_smoke_internvl",
+        ),
+    )
+    for module_name, class_name, model_type in specialized_configs:
+        config_class = type(
+            class_name,
+            (PretrainedConfig,),
+            {"model_type": model_type},
+        )
+        _module(module_name, **{class_name: config_class})
+
+    _module(
+        "sglang.srt.connector",
+        create_remote_connector=lambda _path: None,
+    )
+    _module(
+        "sglang.srt.multimodal.customized_mm_processor_utils",
+        _CUSTOMIZED_MM_PROCESSOR={},
+    )
+
+
+def _load_production_hf_utils(PretrainedConfig):
+    _install_hf_utils_stubs(PretrainedConfig)
+    module_name = "sglang.srt.utils.hf_transformers_utils"
+    spec = importlib.util.spec_from_file_location(module_name, HF_UTILS_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Cannot load production HF helpers: {HF_UTILS_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+
+    # This smoke targets the exact get_processor branch. Config parsing has
+    # separate Session D coverage and would otherwise require importing all of
+    # SGLang's production config dependencies in this isolated child process.
+    module.AutoConfig = SimpleNamespace(
+        from_pretrained=lambda *_args, **_kwargs: SimpleNamespace(
+            model_type="glm5_next"
+        )
+    )
+    return module
+
+
+def _write_processor_config(path: Path, processor_config: dict):
+    (path / "processor_config.json").write_text(
+        json.dumps(processor_config), encoding="utf-8"
+    )
+
+
+def _run_get_processor_smoke(
+    glm5_module,
+    image,
+    tokenizer,
+    torch,
+    PretrainedConfig,
+    Glm46VImageProcessor,
+    Glm46VProcessor,
+    Glm46VVideoProcessor,
+):
+    with tempfile.TemporaryDirectory(prefix="glm5-session-d-processor-") as tmp:
+        fixture_path = Path(tmp)
+        seed_processor = Glm46VProcessor(
+            image_processor=Glm46VImageProcessor(),
+            tokenizer=tokenizer,
+            video_processor=Glm46VVideoProcessor(),
+        )
+        seed_processor.save_pretrained(fixture_path)
+
+        processor_config = json.loads(
+            (fixture_path / "processor_config.json").read_text(encoding="utf-8")
+        )
+        processor_config["processor_class"] = "Glm46VProcessor"
+        processor_config["image_processor"] = copy.deepcopy(CHECKPOINT_IMAGE_CONFIG)
+        processor_config["video_processor"] = copy.deepcopy(CHECKPOINT_VIDEO_CONFIG)
+        _write_processor_config(fixture_path, processor_config)
+
+        _assert_raises(
+            ValueError,
+            lambda: Glm46VProcessor.from_pretrained(
+                fixture_path, local_files_only=True
+            ),
+            "Unrecognized image processor",
+        )
+
+        hf_utils = _load_production_hf_utils(PretrainedConfig)
+
+        wrong_class = copy.deepcopy(processor_config)
+        wrong_class["processor_class"] = "UnexpectedProcessor"
+        _write_processor_config(fixture_path, wrong_class)
+        _assert_raises(
+            ValueError,
+            lambda: hf_utils.get_processor(
+                str(fixture_path), local_files_only=True, revision="main"
+            ),
+            "expected processor_class='Glm46VProcessor'",
+        )
+
+        wrong_video = copy.deepcopy(processor_config)
+        wrong_video["video_processor"]["video_processor_type"] = (
+            "UnexpectedVideoProcessor"
+        )
+        _write_processor_config(fixture_path, wrong_video)
+        _assert_raises(
+            ValueError,
+            lambda: hf_utils.get_processor(
+                str(fixture_path), local_files_only=True, revision="main"
+            ),
+            "must retain its Glm5NextVideoProcessor declaration",
+        )
+
+        _write_processor_config(fixture_path, processor_config)
+        processor = hf_utils.get_processor(
+            str(fixture_path), local_files_only=True, revision="main"
+        )
+        assert isinstance(processor, glm5_module.Glm5NextProcessor)
+        assert isinstance(processor.image_processor, glm5_module.Glm5NextImageProcessor)
+        assert isinstance(processor.video_processor, Glm46VVideoProcessor)
+        assert processor.image_processor.size.shortest_edge == 12_544
+        assert processor.image_processor.size.longest_edge == 1_254_400
+        assert processor.image_processor.patch_expand_factor == 2
+
+        output = processor(
+            images=[image],
+            text=["<|image|> describe"],
+            return_tensors="pt",
+            return_mm_token_type_ids=True,
+        )
+        _assert_image_output(output, processor.tokenizer, torch)
+        _assert_raises(
+            ValueError,
+            lambda: processor(
+                images=[image],
+                text=["<|image|> describe"],
+                videos=[image],
+            ),
+            "does not support video input",
+        )
+
+
+def _child_main() -> int:
+    try:
+        installed_version = importlib.metadata.version(PINNED_TRANSFORMERS_DIST)
+    except importlib.metadata.PackageNotFoundError:
+        return _skip_child(f"{PINNED_TRANSFORMERS_DIST} is not installed")
+    if installed_version != PINNED_TRANSFORMERS_VERSION:
+        return _skip_child(
+            f"requires {PINNED_TRANSFORMERS_DIST}=={PINNED_TRANSFORMERS_VERSION}; "
+            f"found {installed_version}"
+        )
+
+    try:
+        import numpy as np
+        import torch
+        import torchvision  # noqa: F401
+        from PIL import Image
+        from transformers import PretrainedConfig
+        from transformers.models.glm46v import (
+            image_processing_glm46v as hf_image_module,
+        )
+        from transformers.models.glm46v.image_processing_glm46v import (
+            Glm46VImageProcessor,
+        )
+        from transformers.models.glm46v.processing_glm46v import Glm46VProcessor
+        from transformers.models.glm46v.video_processing_glm46v import (
+            Glm46VVideoProcessor,
+        )
+    except (ImportError, ModuleNotFoundError, OSError) as error:
+        return _skip_child(f"optional CPU processor dependency unavailable: {error}")
+
+    glm5_module = _load_production_processor()
+    dependencies = (
+        np,
+        torch,
+        Image,
+        hf_image_module,
+        Glm46VVideoProcessor,
+    )
+    image, tokenizer, _output = _run_image_and_processor_parity(
+        glm5_module, dependencies
+    )
+    _run_get_processor_smoke(
+        glm5_module,
+        image,
+        tokenizer,
+        torch,
+        PretrainedConfig,
+        Glm46VImageProcessor,
+        Glm46VProcessor,
+        Glm46VVideoProcessor,
+    )
+    print(
+        f"{SUCCESS_MARKER}: transformers-kt={installed_version}; "
+        "resize=112x280; grid=[1,8,20]; patches=160; tokens=40"
+    )
+    return 0
+
+
+def test_pinned_wheel_processor_smoke_in_isolated_subprocess():
+    import pytest
+
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "CUDA_VISIBLE_DEVICES": "",
+            "HF_HUB_OFFLINE": "1",
+            "TRANSFORMERS_OFFLINE": "1",
+            "TOKENIZERS_PARALLELISM": "false",
+            "PYTHONDONTWRITEBYTECODE": "1",
+        }
+    )
+    result = subprocess.run(
+        [sys.executable, str(Path(__file__).resolve()), CHILD_FLAG],
+        cwd=REPO_ROOT,
+        env=environment,
+        text=True,
+        capture_output=True,
+        timeout=120,
+        check=False,
+    )
+    details = "\n".join(
+        part for part in (result.stdout.strip(), result.stderr.strip()) if part
+    )
+    if result.returncode == SKIP_EXIT_CODE:
+        pytest.skip(details)
+    assert result.returncode == 0, details
+    assert SUCCESS_MARKER in result.stdout, details
+
+
+if __name__ == "__main__":
+    if sys.argv[1:] != [CHILD_FLAG]:
+        raise SystemExit(f"usage: {Path(__file__).name} {CHILD_FLAG}")
+    raise SystemExit(_child_main())

--- a/test/registered/unit/test_glm5_next_sparse_attention.py
+++ b/test/registered/unit/test_glm5_next_sparse_attention.py
@@ -14,6 +14,9 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 FALLBACK_PATH = (
     REPO_ROOT / "python/sglang/srt/layers/attention/nsa/glm5_next_sparse_attention.py"
 )
+SCALED_FP8_PATH = (
+    REPO_ROOT / "python/sglang/srt/layers/attention/nsa/glm5_next_scaled_fp8.py"
+)
 BACKEND_PATH = REPO_ROOT / "python/sglang/srt/layers/attention/nsa_backend.py"
 
 
@@ -27,10 +30,206 @@ def _load_fallback_module():
     return module
 
 
+def _load_scaled_fp8_module():
+    spec = importlib.util.spec_from_file_location(
+        "_glm5_next_scaled_fp8_test", SCALED_FP8_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
 class TestGlm5NextSparseAttention(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.module = _load_fallback_module()
+        cls.scaled_fp8 = _load_scaled_fp8_module()
+
+    def test_block_scaled_fp8_reduces_latent_quantization_error(self):
+        torch.manual_seed(20260813)
+        blocks = [torch.randn(6, 128) * 1.0e-4 for _ in range(4)]
+        latent = torch.cat(blocks, dim=-1).to(torch.bfloat16)
+
+        raw = latent.to(torch.float8_e4m3fn).to(torch.bfloat16)
+        quantized, scale = self.scaled_fp8.glm5_next_quantize_latent_fp8(latent)
+        restored = self.scaled_fp8.glm5_next_dequantize_latent_fp8(quantized, scale)
+
+        raw_error = (raw.float() - latent.float()).square().mean()
+        scaled_error = (restored.float() - latent.float()).square().mean()
+        self.assertEqual(scale.shape, (6, 4))
+        self.assertEqual(scale.dtype, torch.float32)
+        self.assertLess(scaled_error.item(), raw_error.item() * 0.2)
+
+    def test_exact_glm_preparation_keeps_ephemeral_query_in_bf16(self):
+        torch.manual_seed(20260816)
+        query = torch.randn(2, 3, 512, dtype=torch.bfloat16)
+        key = torch.randn(2, 512, dtype=torch.bfloat16)
+        query_rope = torch.empty(2, 3, 0, dtype=torch.bfloat16)
+        key_rope = torch.empty(2, 0, dtype=torch.bfloat16)
+
+        prepared_q, key_fp8, key_rope_fp8, key_scale = (
+            self.scaled_fp8.glm5_next_mla_prepare_scaled_fp8_no_rope(
+                query, query_rope, key, key_rope
+            )
+        )
+
+        self.assertEqual(prepared_q.dtype, torch.bfloat16)
+        self.assertTrue(torch.equal(prepared_q, query))
+        self.assertEqual(key_fp8.dtype, torch.float8_e4m3fn)
+        self.assertEqual(key_rope_fp8.shape, (2, 0))
+        self.assertEqual(key_scale.shape, (2, 4))
+
+    def test_scaled_fp8_sparse_attention_tracks_bf16_oracle(self):
+        torch.manual_seed(20260814)
+        query_bf16 = (torch.randn(3, 2, 512) * 1.0e-4).to(torch.bfloat16)
+        kv_bf16 = (torch.randn(12, 512) * 1.0e-4).to(torch.bfloat16)
+        indices = torch.tensor(
+            [[0, 2, 7, -1], [1, 4, 8, 11], [3, 5, 9, -1]],
+            dtype=torch.int32,
+        )
+        sm_scale = 512**-0.5
+
+        kv_fp8, kv_scale = self.scaled_fp8.glm5_next_quantize_latent_fp8(kv_bf16)
+        actual = self.module.glm5_next_sparse_mla_reference(
+            query_bf16,
+            kv_fp8,
+            indices,
+            sm_scale=sm_scale,
+            kv_scale=kv_scale,
+        )
+
+        expected_rows = []
+        for row, query_row in zip(indices, query_bf16, strict=True):
+            selected = kv_bf16[row[row >= 0].long()].float()
+            scores = query_row.float() @ selected.T * sm_scale
+            expected_rows.append(torch.softmax(scores, dim=-1) @ selected)
+        expected = torch.stack(expected_rows).to(torch.bfloat16)
+        raw = self.module.glm5_next_sparse_mla_reference(
+            query_bf16.to(torch.float8_e4m3fn),
+            kv_bf16.to(torch.float8_e4m3fn),
+            indices,
+            sm_scale=sm_scale,
+        )
+        scaled_error = (actual.float() - expected.float()).abs().mean()
+        raw_error = (raw.float() - expected.float()).abs().mean()
+        self.assertLess(scaled_error.item(), raw_error.item() * 0.1)
+        torch.testing.assert_close(actual, expected, rtol=2e-2, atol=1e-5)
+
+    def test_bf16_query_reduces_typical_attention_error_vs_raw_fp8(self):
+        torch.manual_seed(44)
+        query = torch.randn(3, 2, 512, dtype=torch.bfloat16)
+        kv = torch.randn(12, 512, dtype=torch.bfloat16)
+        indices = torch.tensor([[0, 2, 7], [1, 4, 8], [3, 5, 9]], dtype=torch.int32)
+        sm_scale = 256**-0.5
+        kv_fp8, kv_scale = self.scaled_fp8.glm5_next_quantize_latent_fp8(kv)
+
+        expected = self.module.glm5_next_sparse_mla_reference(
+            query, kv, indices, sm_scale=sm_scale
+        )
+        scaled_kv = self.module.glm5_next_sparse_mla_reference(
+            query,
+            kv_fp8,
+            indices,
+            sm_scale=sm_scale,
+            kv_scale=kv_scale,
+        )
+        raw_qkv = self.module.glm5_next_sparse_mla_reference(
+            query.to(torch.float8_e4m3fn),
+            kv.to(torch.float8_e4m3fn),
+            indices,
+            sm_scale=sm_scale,
+        )
+
+        scaled_error = (scaled_kv.float() - expected.float()).norm()
+        raw_error = (raw_qkv.float() - expected.float()).norm()
+        self.assertLess(scaled_error.item(), raw_error.item() * 0.95)
+
+    def test_prefill_uses_bf16_current_rows_and_scaled_fp8_history(self):
+        torch.manual_seed(20260817)
+        query = torch.randn(3, 2, 512, dtype=torch.bfloat16)
+        kv_bf16 = torch.randn(10, 512, dtype=torch.bfloat16)
+        kv_fp8, kv_scale = self.scaled_fp8.glm5_next_quantize_latent_fp8(kv_bf16)
+        # Deliberately unsorted physical locations exercise allocator reuse.
+        current_locs = torch.tensor([7, 2, 9], dtype=torch.int64)
+        current_kv = kv_bf16[current_locs].clone()
+        indices = torch.tensor(
+            [[0, 2, 7, -1], [1, 4, 9, -1], [2, 5, 7, 9]], dtype=torch.int32
+        )
+        scale = 256**-0.5
+
+        actual = self.module.glm5_next_sparse_mla_reference(
+            query,
+            kv_fp8,
+            indices,
+            sm_scale=scale,
+            use_cuda_decode_kernel=False,
+            kv_scale=kv_scale,
+            current_chunk_kv=current_kv,
+            current_chunk_locs=current_locs,
+        )
+
+        reconstructed = self.scaled_fp8.glm5_next_dequantize_latent_fp8(
+            kv_fp8, kv_scale
+        )
+        mixed = reconstructed.clone()
+        mixed[current_locs] = current_kv
+        expected = self.module.glm5_next_sparse_mla_reference(
+            query,
+            mixed,
+            indices,
+            sm_scale=scale,
+            use_cuda_decode_kernel=False,
+        )
+        cache_only = self.module.glm5_next_sparse_mla_reference(
+            query,
+            kv_fp8,
+            indices,
+            sm_scale=scale,
+            use_cuda_decode_kernel=False,
+            kv_scale=kv_scale,
+        )
+
+        self.assertTrue(torch.equal(actual, expected))
+        self.assertFalse(torch.equal(actual, cache_only))
+
+    def test_current_chunk_overlay_is_prefill_only_and_fail_closed(self):
+        query = torch.zeros(1, 1, 512, dtype=torch.bfloat16)
+        kv_bf16 = torch.zeros(2, 512, dtype=torch.bfloat16)
+        kv_fp8, kv_scale = self.scaled_fp8.glm5_next_quantize_latent_fp8(kv_bf16)
+        indices = torch.tensor([[0]], dtype=torch.int32)
+
+        with self.assertRaisesRegex(ValueError, "provided together"):
+            self.module.glm5_next_sparse_mla_reference(
+                query,
+                kv_fp8,
+                indices,
+                sm_scale=1.0,
+                use_cuda_decode_kernel=False,
+                kv_scale=kv_scale,
+                current_chunk_kv=kv_bf16[:1],
+            )
+        with self.assertRaisesRegex(ValueError, "valid only for EXTEND"):
+            self.module.glm5_next_sparse_mla_reference(
+                query,
+                kv_fp8,
+                indices,
+                sm_scale=1.0,
+                use_cuda_decode_kernel=True,
+                kv_scale=kv_scale,
+                current_chunk_kv=kv_bf16[:1],
+                current_chunk_locs=torch.tensor([0]),
+            )
+        with self.assertRaisesRegex(ValueError, "scaled-FP8 cache"):
+            self.module.glm5_next_sparse_mla_reference(
+                query,
+                kv_bf16,
+                indices,
+                sm_scale=1.0,
+                use_cuda_decode_kernel=False,
+                current_chunk_kv=kv_bf16[:1],
+                current_chunk_locs=torch.tensor([0]),
+            )
 
     def test_chunked_h512_attention_matches_float_reference(self):
         torch.manual_seed(20260811)
@@ -104,6 +303,14 @@ class TestGlm5NextSparseAttention(unittest.TestCase):
                 torch.tensor([[2]], dtype=torch.int32),
                 sm_scale=1.0,
             )
+        with self.assertRaisesRegex(ValueError, "KV scale"):
+            self.module.glm5_next_sparse_mla_reference(
+                query,
+                kv,
+                torch.tensor([[0]], dtype=torch.int32),
+                sm_scale=1.0,
+                kv_scale=torch.ones(1, 3),
+            )
 
     def test_shared_backend_dispatch_is_exactly_glm_gated(self):
         tree = ast.parse(BACKEND_PATH.read_text(encoding="utf-8"))
@@ -119,9 +326,131 @@ class TestGlm5NextSparseAttention(unittest.TestCase):
         )
         source = ast.unparse(forward)
         self.assertIn("if self.is_glm5_next", source)
+        self.assertIn("self.is_glm5_next and self.device_capability == (12, 0)", source)
         self.assertIn("glm5_next_sparse_mla_reference", source)
+        self.assertIn("use_cuda_decode_kernel=not is_prefill", source)
+        self.assertIn("forward_batch.forward_mode.is_extend_without_speculative()", source)
+        self.assertIn("current_chunk_kv=glm5_current_chunk_kv", source)
+        self.assertIn("current_chunk_locs=glm5_current_chunk_locs", source)
         self.assertIn("self.nsa_index_topk + self.nsa_index_kpool - 1", source)
         self.assertIn("sparse_mla_top_k != expected_top_k", source)
+        self.assertLess(
+            source.index("glm5_next_sparse_mla_reference"),
+            source.index("padded_sparse_mla_top_k"),
+        )
+
+    def test_cuda_decode_kernel_is_an_explicit_dispatch_choice(self):
+        tree = ast.parse(FALLBACK_PATH.read_text(encoding="utf-8"))
+        helper = next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.FunctionDef)
+            and node.name == "glm5_next_sparse_mla_reference"
+        )
+        source = ast.unparse(helper)
+        self.assertIn("query.is_cuda and use_cuda_decode_kernel", source)
+        self.assertIn("use_cuda_decode_kernel: bool=True", source)
+
+    def test_cuda_launcher_source_has_no_host_sync(self):
+        tree = ast.parse(FALLBACK_PATH.read_text(encoding="utf-8"))
+        launcher = next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.FunctionDef)
+            and node.name == "_glm5_next_sparse_mla_cuda"
+        )
+        source = ast.unparse(launcher)
+        for host_sync in (".item()", ".cpu()", ".tolist()"):
+            self.assertNotIn(host_sync, source)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required")
+    def test_raw_fp8_cuda_kernel_matches_cpu_oracle_and_replays_graph(self):
+        torch.manual_seed(20260812)
+        query_cpu = (torch.randn(1, 2, 512) * 0.1).to(torch.float8_e4m3fn)
+        kv_cpu = (torch.randn(16, 512) * 0.1).to(torch.float8_e4m3fn)
+        first_indices_cpu = torch.tensor(
+            [[0, 3, 5, 9, -1, -1, -1, -1]], dtype=torch.int32
+        )
+        second_indices_cpu = torch.tensor(
+            [[1, 2, 7, 12, 15, -1, -1, -1]], dtype=torch.int32
+        )
+        scale = 512**-0.5
+
+        first_expected = self.module.glm5_next_sparse_mla_reference(
+            query_cpu,
+            kv_cpu,
+            first_indices_cpu,
+            sm_scale=scale,
+        )
+        second_expected = self.module.glm5_next_sparse_mla_reference(
+            query_cpu,
+            kv_cpu,
+            second_indices_cpu,
+            sm_scale=scale,
+        )
+
+        query = query_cpu.cuda()
+        kv = kv_cpu.cuda()
+        indices = first_indices_cpu.cuda()
+        # Warm up Triton compilation before capture.
+        self.module.glm5_next_sparse_mla_reference(query, kv, indices, sm_scale=scale)
+        torch.cuda.synchronize()
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            output = self.module.glm5_next_sparse_mla_reference(
+                query, kv, indices, sm_scale=scale
+            )
+        graph.replay()
+        torch.cuda.synchronize()
+        torch.testing.assert_close(output.cpu(), first_expected, rtol=3e-2, atol=3e-3)
+
+        indices.copy_(second_indices_cpu)
+        graph.replay()
+        torch.cuda.synchronize()
+        torch.testing.assert_close(output.cpu(), second_expected, rtol=3e-2, atol=3e-3)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required")
+    def test_scaled_fp8_cuda_kernel_matches_oracle_and_replays_graph(self):
+        torch.manual_seed(20260815)
+        query_bf16 = (torch.randn(1, 2, 512) * 0.02).to(torch.bfloat16)
+        kv_bf16 = (torch.randn(16, 512) * 0.02).to(torch.bfloat16)
+        kv_fp8, kv_scale = self.scaled_fp8.glm5_next_quantize_latent_fp8(kv_bf16)
+        indices_cpu = torch.tensor([[0, 3, 5, 9, 14, -1, -1, -1]], dtype=torch.int32)
+        scale = 512**-0.5
+        expected = self.module.glm5_next_sparse_mla_reference(
+            query_bf16,
+            kv_fp8,
+            indices_cpu,
+            sm_scale=scale,
+            kv_scale=kv_scale,
+        )
+
+        query = query_bf16.cuda()
+        kv = kv_fp8.cuda()
+        indices = indices_cpu.cuda()
+        kv_scale_cuda = kv_scale.cuda()
+        self.module.glm5_next_sparse_mla_reference(
+            query,
+            kv,
+            indices,
+            sm_scale=scale,
+            kv_scale=kv_scale_cuda,
+        )
+        torch.cuda.synchronize()
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            output = self.module.glm5_next_sparse_mla_reference(
+                query,
+                kv,
+                indices,
+                sm_scale=scale,
+                kv_scale=kv_scale_cuda,
+            )
+        graph.replay()
+        torch.cuda.synchronize()
+        torch.testing.assert_close(output.cpu(), expected, rtol=3e-2, atol=3e-3)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/test_glm5_next_sparse_attention.py
+++ b/test/registered/unit/test_glm5_next_sparse_attention.py
@@ -1,0 +1,128 @@
+"""CPU numerical tests for the eager GLM-5-Next sparse MLA fallback."""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import unittest
+from pathlib import Path
+
+import torch
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+FALLBACK_PATH = (
+    REPO_ROOT / "python/sglang/srt/layers/attention/nsa/glm5_next_sparse_attention.py"
+)
+BACKEND_PATH = REPO_ROOT / "python/sglang/srt/layers/attention/nsa_backend.py"
+
+
+def _load_fallback_module():
+    spec = importlib.util.spec_from_file_location(
+        "_glm5_next_sparse_attention_test", FALLBACK_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestGlm5NextSparseAttention(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.module = _load_fallback_module()
+
+    def test_chunked_h512_attention_matches_float_reference(self):
+        torch.manual_seed(20260811)
+        query = torch.randn(5, 3, 512, dtype=torch.bfloat16) * 0.1
+        kv = torch.randn(2, 4, 512, dtype=torch.bfloat16) * 0.1
+        indices = torch.tensor(
+            [
+                [0, 2, -1, -1],
+                [1, 3, 5, -1],
+                [7, -1, -1, -1],
+                [0, 4, 6, 7],
+                [2, 5, -1, -1],
+            ],
+            dtype=torch.int32,
+        )
+        scale = 512**-0.5
+
+        actual = self.module.glm5_next_sparse_mla_reference(
+            query,
+            kv,
+            indices,
+            sm_scale=scale,
+            chunk_size=2,
+        )
+
+        flat_kv = kv.reshape(-1, 512).float()
+        expected_rows = []
+        for row, query_row in zip(indices, query, strict=True):
+            selected = flat_kv[row[row >= 0].long()]
+            scores = query_row.float() @ selected.T * scale
+            expected_rows.append(torch.softmax(scores, dim=-1) @ selected)
+        expected = torch.stack(expected_rows).to(torch.bfloat16)
+
+        torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-3)
+        self.assertEqual(actual.dtype, torch.bfloat16)
+
+    def test_padding_values_and_empty_rows_are_ignored(self):
+        query = torch.ones(2, 1, 512, dtype=torch.bfloat16)
+        kv = (
+            torch.arange(6 * 512, dtype=torch.float32)
+            .reshape(6, 512)
+            .to(torch.bfloat16)
+        )
+        indices = torch.tensor([[1, 4, -1, -1], [-1, -1, -1, -1]], dtype=torch.int32)
+
+        output = self.module.glm5_next_sparse_mla_reference(
+            query,
+            kv,
+            indices,
+            sm_scale=0.0,
+        )
+
+        expected = (kv[1].float() + kv[4].float()).mul(0.5).to(torch.bfloat16)
+        torch.testing.assert_close(output[0, 0], expected)
+        self.assertTrue(torch.equal(output[1], torch.zeros_like(output[1])))
+
+    def test_rejects_invalid_layout_and_out_of_range_indices(self):
+        query = torch.zeros(1, 1, 512, dtype=torch.bfloat16)
+        kv = torch.zeros(2, 512, dtype=torch.bfloat16)
+        with self.assertRaisesRegex(TypeError, "int32"):
+            self.module.glm5_next_sparse_mla_reference(
+                query,
+                kv,
+                torch.zeros(1, 1, dtype=torch.int64),
+                sm_scale=1.0,
+            )
+        with self.assertRaisesRegex(IndexError, "exceeds"):
+            self.module.glm5_next_sparse_mla_reference(
+                query,
+                kv,
+                torch.tensor([[2]], dtype=torch.int32),
+                sm_scale=1.0,
+            )
+
+    def test_shared_backend_dispatch_is_exactly_glm_gated(self):
+        tree = ast.parse(BACKEND_PATH.read_text(encoding="utf-8"))
+        backend = next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.ClassDef) and node.name == "NativeSparseAttnBackend"
+        )
+        forward = next(
+            node
+            for node in backend.body
+            if isinstance(node, ast.FunctionDef) and node.name == "_forward_trtllm"
+        )
+        source = ast.unparse(forward)
+        self.assertIn("if self.is_glm5_next", source)
+        self.assertIn("glm5_next_sparse_mla_reference", source)
+        self.assertIn("self.nsa_index_topk + self.nsa_index_kpool - 1", source)
+        self.assertIn("sparse_mla_top_k != expected_top_k", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/test_glm5_next_sparse_attention.py
+++ b/test/registered/unit/test_glm5_next_sparse_attention.py
@@ -326,7 +326,13 @@ class TestGlm5NextSparseAttention(unittest.TestCase):
         )
         source = ast.unparse(forward)
         self.assertIn("if self.is_glm5_next", source)
-        self.assertIn("self.is_glm5_next and self.device_capability == (12, 0)", source)
+        self.assertIn(
+            "self.is_glm5_next and self.device_capability in _GLM5_NEXT_NATIVE_CUDA_CAPS",
+            source,
+        )
+        self.assertIn(
+            "self.device_capability in _GLM5_NEXT_SCALED_FP8_CUDA_CAPS", source
+        )
         self.assertIn("glm5_next_sparse_mla_reference", source)
         self.assertIn("use_cuda_decode_kernel=not is_prefill", source)
         self.assertIn("forward_batch.forward_mode.is_extend_without_speculative()", source)
@@ -365,6 +371,10 @@ class TestGlm5NextSparseAttention(unittest.TestCase):
 
     @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required")
     def test_raw_fp8_cuda_kernel_matches_cpu_oracle_and_replays_graph(self):
+        if torch.cuda.get_device_capability() < (8, 9):
+            self.skipTest("this legacy route requires native FP8")
+        if torch.cuda.get_device_capability() == (8, 9):
+            self.skipTest("consumer profiles use BF16 or scaled FP8 cache")
         torch.manual_seed(20260812)
         query_cpu = (torch.randn(1, 2, 512) * 0.1).to(torch.float8_e4m3fn)
         kv_cpu = (torch.randn(16, 512) * 0.1).to(torch.float8_e4m3fn)
@@ -412,6 +422,8 @@ class TestGlm5NextSparseAttention(unittest.TestCase):
 
     @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required")
     def test_scaled_fp8_cuda_kernel_matches_oracle_and_replays_graph(self):
+        if torch.cuda.get_device_capability() < (8, 9):
+            self.skipTest("pre-SM89 GPUs use an unscaled BF16 latent cache")
         torch.manual_seed(20260815)
         query_bf16 = (torch.randn(1, 2, 512) * 0.02).to(torch.bfloat16)
         kv_bf16 = (torch.randn(16, 512) * 0.02).to(torch.bfloat16)

--- a/test/registered/unit/test_glm5_next_stage3.py
+++ b/test/registered/unit/test_glm5_next_stage3.py
@@ -20,6 +20,7 @@ from torch import nn
 REPO_ROOT = Path(__file__).resolve().parents[3]
 CONFIG_PATH = REPO_ROOT / "python/sglang/srt/configs/glm5_next.py"
 MODEL_PATH = REPO_ROOT / "python/sglang/srt/models/glm5_next.py"
+NORM_PATH = REPO_ROOT / "python/sglang/srt/models/glm5_next_norm.py"
 MODEL_CONFIG_PATH = REPO_ROOT / "python/sglang/srt/configs/model_config.py"
 
 
@@ -67,6 +68,8 @@ def _load_model_module(config_module):
         "sglang",
         "sglang.srt",
         "sglang.srt.configs",
+        "sglang.srt.distributed",
+        "sglang.srt.distributed.device_communicators",
         "sglang.srt.eplb",
         "sglang.srt.layers",
         "sglang.srt.layers.quantization",
@@ -81,6 +84,13 @@ def _load_model_module(config_module):
 
     packages["sglang.srt.configs.glm5_next"] = config_module
 
+    norm_name = "sglang.srt.models.glm5_next_norm"
+    norm_spec = importlib.util.spec_from_file_location(norm_name, NORM_PATH)
+    norm_module = importlib.util.module_from_spec(norm_spec)
+    assert norm_spec is not None and norm_spec.loader is not None
+    norm_spec.loader.exec_module(norm_module)
+    packages[norm_name] = norm_module
+
     pp_group = SimpleNamespace(
         is_first_rank=True,
         is_last_rank=True,
@@ -88,9 +98,22 @@ def _load_model_module(config_module):
         world_size=1,
     )
     distributed = types.ModuleType("sglang.srt.distributed")
+    distributed.__path__ = []
     distributed.get_pp_group = lambda: pp_group
     distributed.get_tensor_model_parallel_world_size = lambda: 1
+    distributed.get_tp_group = lambda: object()
     packages[distributed.__name__] = distributed
+
+    @contextmanager
+    def use_symmetric_memory(*args, **kwargs):
+        del args, kwargs
+        yield
+
+    pynccl_allocator = types.ModuleType(
+        "sglang.srt.distributed.device_communicators.pynccl_allocator"
+    )
+    pynccl_allocator.use_symmetric_memory = use_symmetric_memory
+    packages[pynccl_allocator.__name__] = pynccl_allocator
 
     expert_distribution = types.ModuleType("sglang.srt.eplb.expert_distribution")
     expert_distribution.get_global_expert_distribution_recorder = lambda: None
@@ -150,6 +173,28 @@ def _load_model_module(config_module):
     communicator_mhc.MHCLayerCommunicator = _MHCLayerCommunicator
     packages[communicator_mhc.__name__] = communicator_mhc
 
+    dp_attention = types.ModuleType("sglang.srt.layers.dp_attention")
+    dp_attention.get_attention_tp_rank = lambda: 0
+    dp_attention.is_allocation_symmetric = lambda: False
+    packages[dp_attention.__name__] = dp_attention
+
+    class _ReplicatedLinear(nn.Module):
+        def __init__(self, input_size, output_size, **kwargs):
+            super().__init__()
+            self.input_size = input_size
+            self.output_size = output_size
+            self.kwargs = kwargs
+
+        def forward(self, hidden_states):
+            return hidden_states.new_empty(
+                (*hidden_states.shape[:-1], self.output_size)
+            ), None
+
+    linear = types.ModuleType("sglang.srt.layers.linear")
+    linear.ReplicatedLinear = _ReplicatedLinear
+    linear.RowParallelLinear = type("RowParallelLinear", (), {})
+    packages[linear.__name__] = linear
+
     class _Layer(nn.Module):
         def __init__(self, *args, **kwargs):
             super().__init__()
@@ -165,6 +210,10 @@ def _load_model_module(config_module):
     base_config = types.ModuleType("sglang.srt.layers.quantization.base_config")
     base_config.QuantizationConfig = type("QuantizationConfig", (), {})
     packages[base_config.__name__] = base_config
+
+    unquant = types.ModuleType("sglang.srt.layers.quantization.unquant")
+    unquant.UnquantizedLinearMethod = type("UnquantizedLinearMethod", (), {})
+    packages[unquant.__name__] = unquant
 
     layer_utils = types.ModuleType("sglang.srt.layers.utils")
     layer_utils.PPMissingLayer = _Layer
@@ -192,9 +241,14 @@ def _load_model_module(config_module):
         def __init__(self, *, config, **kwargs):
             super().__init__()
             self.config = config
+            self.hidden_size = config.hidden_size
             self.num_heads = config.linear_attn_config["num_heads"]
             self.head_dim = config.linear_attn_config["head_dim"]
             self.head_v_dim = config.v_head_dim
+            self.local_num_heads = self.num_heads
+            self.attn_tp_size = 1
+            self.do_fuse_qkvbfg = False
+            self.f_a_proj = _ReplicatedLinear(self.hidden_size, self.head_dim)
             self.o_proj = SimpleNamespace(reduce_results=True)
             self.attn = SimpleNamespace(lower_bound=None)
 
@@ -460,6 +514,32 @@ class TestGlm5NextModelBoundary(unittest.TestCase):
         self.assertEqual(result.linear_head_dim, 128)
         self.assertEqual(result.v_head_dim, 128)
 
+    def test_kda_beta_projection_is_replicated_then_head_sliced(self):
+        config_module = _load_config_module()
+        model_module = _load_model_module(config_module)
+        config = config_module.Glm5NextTextConfig()
+
+        attention = model_module.Glm5NextLinearAttention(
+            layer_idx=0,
+            hidden_size=config.hidden_size,
+            config=config,
+            quant_config=object(),
+            prefix="model.layers.0.self_attn",
+        )
+
+        self.assertEqual(attention.b_proj.input_size, config.hidden_size)
+        self.assertEqual(attention.b_proj.output_size, 64)
+        self.assertEqual(attention._beta_head_start, 0)
+        self.assertEqual(attention._beta_heads_per_rank, 64)
+        self.assertEqual(
+            attention.b_proj.kwargs["prefix"],
+            "model.layers.0.self_attn.b_proj",
+        )
+
+        source = MODEL_PATH.read_text(encoding="utf-8")
+        self.assertIn("beta = beta.narrow(", source)
+        self.assertNotIn("tensor_model_parallel_all_gather(beta", source)
+
     def test_weight_prefix_and_phase7_visual_whitelist_are_exact(self):
         normalize = _compile_function(MODEL_PATH, "normalize_glm5_next_weight_name")
         normalize.__globals__["GLM5_NEXT_PHASE7_VISUAL_WEIGHT_PREFIXES"] = (
@@ -556,6 +636,8 @@ class TestGlm5NextMHCModelBoundary(unittest.TestCase):
         last = self.model_module.Glm5NextDecoderLayer(self._config(), layer_idx=1)
 
         expected_shapes = {
+            "input_layernorm.weight": (4,),
+            "post_attention_layernorm.weight": (4,),
             "hc_attn_base": (8,),
             "hc_attn_scale": (3,),
             "hc_attn_fn": (8, 8),
@@ -563,9 +645,10 @@ class TestGlm5NextMHCModelBoundary(unittest.TestCase):
             "hc_ffn_scale": (3,),
             "hc_ffn_fn": (8, 8),
         }
-        self.assertEqual(set(dict(first.named_parameters())), set(expected_shapes))
+        named_parameters = dict(first.named_parameters())
+        self.assertEqual(set(named_parameters), set(expected_shapes))
         for name, shape in expected_shapes.items():
-            parameter = getattr(first, name)
+            parameter = named_parameters[name]
             self.assertEqual(tuple(parameter.shape), shape)
             self.assertEqual(parameter.dtype, torch.float32)
 
@@ -577,12 +660,117 @@ class TestGlm5NextMHCModelBoundary(unittest.TestCase):
         self.assertIs(first.layer_communicator.kwargs["hc_attn_pre"].__self__, first)
         self.assertIs(first.layer_communicator.kwargs["hc_ffn_pre"].__self__, first)
         self.assertIs(first.layer_communicator.kwargs["hc_post"].__self__, first)
+        self.assertIs(
+            first.layer_communicator.kwargs["attn_all_reduce_output_dtype"],
+            torch.bfloat16,
+        )
+        self.assertIsNone(
+            last.layer_communicator.kwargs["attn_all_reduce_output_dtype"]
+        )
         self.assertIsNone(first.layer_communicator.kwargs["qkv_latent_func"])
         dsa_latent_func = last.layer_communicator.kwargs["qkv_latent_func"]
         self.assertIs(dsa_latent_func.__self__, last.self_attn)
         self.assertIs(
             dsa_latent_func.__func__, last.self_attn.prepare_qkv_latent.__func__
         )
+
+    def test_glm_norm_matches_checkpoint_bf16_rounding_boundary(self):
+        norm = self.model_module.Glm5NextRMSNorm(17, eps=1e-6).to(torch.bfloat16)
+        generator = torch.Generator().manual_seed(0)
+        hidden_states = torch.randn(3, 17, generator=generator).to(torch.bfloat16)
+        with torch.no_grad():
+            norm.weight.copy_(
+                torch.randn(17, generator=generator).to(torch.bfloat16)
+            )
+
+        actual = norm(hidden_states)
+        hidden_states_fp32 = hidden_states.float()
+        normalized_fp32 = hidden_states_fp32 * torch.rsqrt(
+            hidden_states_fp32.pow(2).mean(-1, keepdim=True) + 1e-6
+        )
+        expected = norm.weight * normalized_fp32.to(torch.bfloat16)
+        shared_optimized_order = (norm.weight.float() * normalized_fp32).to(
+            torch.bfloat16
+        )
+
+        self.assertEqual(actual.dtype, torch.bfloat16)
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+        self.assertFalse(torch.equal(actual, shared_optimized_order))
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required")
+    def test_glm_norm_cuda_graph_bs_1_2_4_replays_dynamic_inputs_in_place(self):
+        hidden_size = 17
+        generator = torch.Generator().manual_seed(20260812)
+        weight = torch.randn(hidden_size, generator=generator).to(torch.bfloat16)
+
+        def checkpoint_reference(norm, hidden_states):
+            hidden_states_fp32 = hidden_states.float()
+            normalized_fp32 = hidden_states_fp32 * torch.rsqrt(
+                hidden_states_fp32.pow(2).mean(-1, keepdim=True) + 1e-6
+            )
+            return norm.weight * normalized_fp32.to(hidden_states.dtype)
+
+        for batch_size in (1, 2, 4):
+            with self.subTest(batch_size=batch_size):
+                norm = self.model_module.Glm5NextRMSNorm(hidden_size, eps=1e-6).to(
+                    device="cuda", dtype=torch.bfloat16
+                )
+                with torch.no_grad():
+                    norm.weight.copy_(weight)
+
+                input_a = torch.randn(batch_size, hidden_size, generator=generator).to(
+                    device="cuda", dtype=torch.bfloat16
+                )
+                poison = torch.randn(batch_size, hidden_size, generator=generator).to(
+                    device="cuda", dtype=torch.bfloat16
+                )
+                static_input = input_a.clone()
+                expected_a = checkpoint_reference(norm, input_a)
+
+                # Warm up all kernels and allocator paths before capture.
+                norm(static_input)
+                torch.cuda.synchronize()
+
+                graph = torch.cuda.CUDAGraph()
+                with torch.cuda.graph(graph):
+                    static_output = norm(static_input)
+
+                stable_pointers = {
+                    "input": static_input.data_ptr(),
+                    "output": static_output.data_ptr(),
+                    "weight": norm.weight.data_ptr(),
+                }
+
+                def replay(value):
+                    static_input.copy_(value)
+                    graph.replay()
+                    torch.cuda.synchronize()
+                    self.assertEqual(static_input.data_ptr(), stable_pointers["input"])
+                    self.assertEqual(
+                        static_output.data_ptr(), stable_pointers["output"]
+                    )
+                    self.assertEqual(norm.weight.data_ptr(), stable_pointers["weight"])
+                    return static_output.clone()
+
+                first_a = replay(input_a)
+                poison_output = replay(poison)
+                second_a = replay(input_a)
+
+                torch.testing.assert_close(first_a, expected_a, rtol=0, atol=0)
+                self.assertFalse(torch.equal(poison_output, first_a))
+                torch.testing.assert_close(second_a, first_a, rtol=0, atol=0)
+
+    def test_all_glm_decoder_and_final_norms_are_model_local(self):
+        model = self.model_module.Glm5NextModel(self._config())
+
+        for layer in model.layers:
+            self.assertIsInstance(
+                layer.input_layernorm, self.model_module.Glm5NextRMSNorm
+            )
+            self.assertIsInstance(
+                layer.post_attention_layernorm, self.model_module.Glm5NextRMSNorm
+            )
+        self.assertIsInstance(model.norm, self.model_module.Glm5NextRMSNorm)
 
     def test_top_level_forward_owns_dsa_latent_context_lifetime(self):
         model = self.model_module.Glm5NextForConditionalGeneration(self._config())
@@ -627,10 +815,6 @@ class TestGlm5NextMHCModelBoundary(unittest.TestCase):
             calls.append(("pre", kwargs))
             return "pre-result"
 
-        def hc_post(**kwargs):
-            calls.append(("post", kwargs))
-            return "post-result"
-
         packages = {}
         for name in (
             "sglang",
@@ -643,29 +827,64 @@ class TestGlm5NextMHCModelBoundary(unittest.TestCase):
             packages[name] = module
         mhc = types.ModuleType("sglang.kernels.ops.layernorm.mhc")
         mhc.hc_pre = hc_pre
-        mhc.hc_post = hc_post
         packages[mhc.__name__] = mhc
 
         x = torch.zeros(1, 8)
         with patch.dict(sys.modules, packages):
             self.assertEqual(layer.hc_attn_pre(x, "weight", 1e-4), "pre-result")
             self.assertEqual(layer.hc_ffn_pre(x, "weight", 1e-4), "pre-result")
-            self.assertEqual(
-                layer.hc_post("x", "residual", "h_res", "h_post"),
-                "post-result",
-            )
 
         attn_kwargs = calls[0][1]
         ffn_kwargs = calls[1][1]
-        post_kwargs = calls[2][1]
         self.assertIs(attn_kwargs["hc_fn"], layer.hc_attn_fn)
         self.assertIs(attn_kwargs["hc_scale"], layer.hc_attn_scale)
         self.assertIs(attn_kwargs["hc_base"], layer.hc_attn_base)
         self.assertIs(ffn_kwargs["hc_fn"], layer.hc_ffn_fn)
         self.assertIs(ffn_kwargs["hc_scale"], layer.hc_ffn_scale)
         self.assertIs(ffn_kwargs["hc_base"], layer.hc_ffn_base)
-        self.assertEqual(post_kwargs["hc_mult"], 2)
         self.assertEqual(attn_kwargs["sinkhorn_iters"], 20)
+
+    def test_hc_post_uses_glm_bf16_matmul_semantics(self):
+        layer = self.model_module.Glm5NextDecoderLayer(self._config(), layer_idx=0)
+        generator = torch.Generator().manual_seed(0)
+        tokens, hc_mult, hidden_size = 3, layer.config.hc_mult, 17
+        hidden_states = (
+            torch.randn(tokens, hidden_size, generator=generator) * 3
+        ).to(torch.bfloat16)
+        residual_streams = (
+            torch.randn(tokens, hc_mult, hidden_size, generator=generator) * 3
+        ).to(torch.bfloat16)
+        residual = residual_streams.flatten(1)
+        h_post = torch.randn(tokens, hc_mult, generator=generator)
+        h_res_matrix = torch.randn(tokens, hc_mult, hc_mult, generator=generator)
+        h_res = h_res_matrix.flatten(1)
+
+        actual = layer.hc_post(hidden_states, residual, h_res, h_post)
+        expected = (
+            h_post.to(torch.bfloat16).unsqueeze(-1) * hidden_states.unsqueeze(1)
+            + torch.matmul(
+                h_res_matrix.to(torch.bfloat16).transpose(-1, -2),
+                residual_streams,
+            )
+        ).flatten(1)
+        elementwise_sum = (
+            h_post.to(torch.bfloat16).unsqueeze(-1) * hidden_states.unsqueeze(1)
+            + (
+                h_res_matrix.to(torch.bfloat16)
+                .transpose(-1, -2)
+                .unsqueeze(-1)
+                * residual_streams.unsqueeze(1)
+            ).sum(dim=2)
+        ).flatten(1)
+        late_cast = (
+            h_post.unsqueeze(-1) * hidden_states.float().unsqueeze(1)
+            + torch.matmul(h_res_matrix.transpose(-1, -2), residual_streams.float())
+        ).to(torch.bfloat16).flatten(1)
+
+        self.assertEqual(actual.dtype, torch.bfloat16)
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+        self.assertFalse(torch.equal(actual, elementwise_sum))
+        self.assertFalse(torch.equal(actual, late_cast))
 
     def test_mhc_layer_forward_orders_attention_mlp_and_post(self):
         layer = self.model_module.Glm5NextDecoderLayer(self._config(), layer_idx=0)

--- a/test/registered/unit/test_glm5_next_stage3.py
+++ b/test/registered/unit/test_glm5_next_stage3.py
@@ -429,6 +429,26 @@ class TestGlm5NextConfig(unittest.TestCase):
             self.config_module.Glm5NextCapabilities(False, False, False, False, False),
         )
 
+    def test_consumer_gpu_profiles_select_exact_cache_precision(self):
+        sm86 = self.config_module.get_glm5_next_gpu_profile((8, 6))
+        self.assertEqual(sm86.value, "sm86_bf16")
+        self.assertEqual(sm86.kv_cache_dtype, "bfloat16")
+        self.assertEqual(sm86.index_cache_dtype, "bfloat16")
+        self.assertTrue(sm86.is_consumer_gpu)
+
+        sm89 = self.config_module.get_glm5_next_gpu_profile((8, 9))
+        self.assertEqual(sm89.value, "sm89_fp8")
+        self.assertEqual(sm89.kv_cache_dtype, "fp8_e4m3")
+        self.assertEqual(sm89.index_cache_dtype, "fp8_e4m3")
+        self.assertTrue(sm89.is_consumer_gpu)
+
+        blackwell = self.config_module.get_glm5_next_gpu_profile((12, 0))
+        self.assertEqual(blackwell.value, "blackwell_fp8")
+        self.assertFalse(blackwell.is_consumer_gpu)
+
+        with self.assertRaisesRegex(ValueError, "SM86, SM89, or Blackwell"):
+            self.config_module.get_glm5_next_gpu_profile((9, 0))
+
     def test_nested_vision_config_is_data_only(self):
         root = self.config_module.Glm5NextConfig(
             vision_config={"depth": 24, "hidden_size": 1536}

--- a/test/registered/unit/test_glm5_next_stage3.py
+++ b/test/registered/unit/test_glm5_next_stage3.py
@@ -22,6 +22,7 @@ CONFIG_PATH = REPO_ROOT / "python/sglang/srt/configs/glm5_next.py"
 MODEL_PATH = REPO_ROOT / "python/sglang/srt/models/glm5_next.py"
 NORM_PATH = REPO_ROOT / "python/sglang/srt/models/glm5_next_norm.py"
 MODEL_CONFIG_PATH = REPO_ROOT / "python/sglang/srt/configs/model_config.py"
+MM_UTILS_PATH = REPO_ROOT / "python/sglang/srt/managers/mm_utils.py"
 
 
 class _PretrainedConfigStub:
@@ -605,7 +606,16 @@ class TestGlm5NextModelBoundary(unittest.TestCase):
             )
         )
         self.assertEqual(ast.unparse(entry.value), "[Glm5NextForConditionalGeneration]")
-        self.assertNotIn("sglang.srt.models.glm_ocr", source)
+        top_level_imports = [
+            ast.unparse(node)
+            for node in tree.body
+            if isinstance(node, (ast.Import, ast.ImportFrom))
+        ]
+        self.assertFalse(
+            any("sglang.srt.models.glm_ocr" in item for item in top_level_imports)
+        )
+        self.assertIn("from sglang.srt.models.glm_ocr import GlmOcrVisionModel", source)
+        self.assertIn("if self.multimodal_enabled:", source)
         self.assertNotIn('if "visual" in name', source)
 
 
@@ -806,6 +816,222 @@ class TestGlm5NextMHCModelBoundary(unittest.TestCase):
         self.assertEqual(
             attn_context.init_calls[-1], (self._config().q_lora_rank, True)
         )
+
+    def test_multimodal_embed_routine_is_scoped_to_image_extend(self):
+        model = self.model_module.Glm5NextForConditionalGeneration(self._config())
+        model.multimodal_enabled = True
+        calls = []
+
+        class _Inner(nn.Module):
+            def forward(inner_self, *args):
+                del inner_self, args
+                calls.append("direct")
+                return torch.ones(1, 4)
+
+        class _Logits(nn.Module):
+            def forward(inner_self, input_ids, hidden_states, lm_head, batch):
+                del inner_self, input_ids, lm_head, batch
+                return hidden_states
+
+        model.model = _Inner()
+        model.logits_processor = _Logits()
+
+        managers = types.ModuleType("sglang.srt.managers")
+        managers.__path__ = []
+        mm_utils = types.ModuleType("sglang.srt.managers.mm_utils")
+
+        def general_mm_embed_routine(**kwargs):
+            del kwargs
+            calls.append("multimodal")
+            return torch.ones(1, 4)
+
+        mm_utils.general_mm_embed_routine = general_mm_embed_routine
+
+        def batch(mode):
+            return SimpleNamespace(
+                forward_mode=SimpleNamespace(name=mode),
+                contains_image_inputs=lambda: True,
+                contains_video_inputs=lambda: False,
+                contains_audio_inputs=lambda: False,
+            )
+
+        with patch.dict(
+            sys.modules,
+            {
+                "sglang.srt.managers": managers,
+                "sglang.srt.managers.mm_utils": mm_utils,
+            },
+        ):
+            model(
+                input_ids=torch.tensor([0]),
+                positions=torch.tensor([0]),
+                forward_batch=batch("EXTEND"),
+            )
+            self.assertEqual(calls, ["multimodal"])
+
+            decode_batch = batch("DECODE")
+            model(
+                input_ids=torch.tensor([0]),
+                positions=torch.tensor([0]),
+                forward_batch=decode_batch,
+            )
+            self.assertEqual(calls, ["multimodal", "direct"])
+            self.assertFalse(decode_batch.glm5_next_has_image_inputs)
+
+    def test_general_mm_embed_routine_matches_inner_model_input_embed_abi(self):
+        general_mm_embed_routine = _compile_function(
+            MM_UTILS_PATH, "general_mm_embed_routine"
+        )
+        model = self.model_module.Glm5NextModel(self._config())
+        embedding_weight = torch.arange(32, dtype=torch.float32).reshape(8, 4)
+        model.embed_tokens = nn.Embedding.from_pretrained(embedding_weight)
+
+        class _Stage(nn.Module):
+            def forward(inner_self, **kwargs):
+                del inner_self
+                return kwargs["hidden_states"], kwargs["residual"]
+
+        model.layers = nn.ModuleList([_Stage(), _Stage()])
+        model.norm = nn.Identity()
+        expected_embedding = embedding_weight[3:4].clone()
+        general_mm_embed_routine.__globals__["embed_mm_inputs"] = (
+            lambda **kwargs: (expected_embedding, {})
+        )
+        forward_batch = SimpleNamespace(
+            forward_mode=SimpleNamespace(
+                is_decode=lambda: False,
+                is_target_verify=lambda: False,
+            ),
+            contains_mm_inputs=lambda: True,
+            mm_inputs=[SimpleNamespace(mm_items=[])],
+            extend_prefix_lens_cpu=[0],
+            extend_seq_lens_cpu=[1],
+            input_embeds=None,
+        )
+        recorder = SimpleNamespace(with_current_layer=lambda layer_idx: nullcontext())
+        model_globals = self.model_module.Glm5NextModel.forward.__globals__
+
+        with patch.dict(
+            model_globals,
+            {"get_global_expert_distribution_recorder": lambda: recorder},
+        ):
+            output = general_mm_embed_routine(
+                input_ids=torch.tensor([3]),
+                positions=torch.tensor([0]),
+                forward_batch=forward_batch,
+                language_model=model,
+            )
+
+        torch.testing.assert_close(output, expected_embedding)
+        self.assertIsNone(forward_batch.mm_inputs)
+        self.assertIs(forward_batch.mm_input_embeds, expected_embedding)
+
+    def test_mrope_metadata_does_not_replace_kpool_logical_positions(self):
+        config = self._config()
+        config.rope_scaling = {"mrope_section": [0, 0, 0]}
+        model = self.model_module.Glm5NextForConditionalGeneration(config)
+        model.multimodal_enabled = True
+        seen = {}
+
+        class _Inner(nn.Module):
+            def forward(inner_self, *args):
+                del inner_self
+                seen["direct_positions"] = args[1]
+                return torch.ones(1, 4)
+
+        class _Logits(nn.Module):
+            def forward(inner_self, input_ids, hidden_states, lm_head, batch):
+                del inner_self, input_ids, lm_head, batch
+                return hidden_states
+
+        model.model = _Inner()
+        model.logits_processor = _Logits()
+
+        managers = types.ModuleType("sglang.srt.managers")
+        managers.__path__ = []
+        mm_utils = types.ModuleType("sglang.srt.managers.mm_utils")
+
+        def general_mm_embed_routine(**kwargs):
+            seen["multimodal_positions"] = kwargs["positions"]
+            return torch.ones(1, 4)
+
+        mm_utils.general_mm_embed_routine = general_mm_embed_routine
+
+        def batch(mode, mrope_positions):
+            return SimpleNamespace(
+                forward_mode=SimpleNamespace(name=mode),
+                mrope_positions=mrope_positions,
+                contains_image_inputs=lambda: True,
+                contains_video_inputs=lambda: False,
+                contains_audio_inputs=lambda: False,
+            )
+
+        extend_mrope_positions = torch.tensor([[1], [2], [3]])
+        decode_mrope_positions = torch.tensor(
+            [[4, 5, 6, 7], [8, 9, 10, 11], [12, 13, 14, 15]]
+        )
+        extend_logical_positions = torch.tensor([99])
+        decode_logical_positions = torch.tensor([20, 21, 22, 23])
+        with patch.dict(
+            sys.modules,
+            {
+                "sglang.srt.managers": managers,
+                "sglang.srt.managers.mm_utils": mm_utils,
+            },
+        ):
+            model(
+                input_ids=torch.tensor([0]),
+                positions=extend_logical_positions,
+                forward_batch=batch("EXTEND", extend_mrope_positions),
+            )
+            model(
+                input_ids=torch.tensor([0, 0, 0, 0]),
+                positions=decode_logical_positions,
+                forward_batch=batch("DECODE", decode_mrope_positions),
+            )
+
+        self.assertIs(seen["multimodal_positions"], extend_logical_positions)
+        self.assertIs(seen["direct_positions"], decode_logical_positions)
+        self.assertEqual(tuple(seen["direct_positions"].shape), (4,))
+
+    def test_idle_with_retained_image_metadata_bypasses_mrope_and_vision(self):
+        config = self._config()
+        config.rope_scaling = {"mrope_section": [0, 0, 0]}
+        model = self.model_module.Glm5NextForConditionalGeneration(config)
+        model.multimodal_enabled = True
+        seen = {}
+
+        class _Inner(nn.Module):
+            def forward(inner_self, *args):
+                del inner_self
+                seen["positions"] = args[1]
+                return torch.ones(0, 4)
+
+        class _Logits(nn.Module):
+            def forward(inner_self, input_ids, hidden_states, lm_head, batch):
+                del inner_self, input_ids, lm_head, batch
+                return hidden_states
+
+        model.model = _Inner()
+        model.logits_processor = _Logits()
+        logical_positions = torch.empty(0, dtype=torch.int64)
+        idle_batch = SimpleNamespace(
+            forward_mode=SimpleNamespace(name="IDLE"),
+            mrope_positions=None,
+            contains_image_inputs=lambda: True,
+            contains_video_inputs=lambda: False,
+            contains_audio_inputs=lambda: False,
+        )
+
+        output = model(
+            input_ids=torch.empty(0, dtype=torch.int64),
+            positions=logical_positions,
+            forward_batch=idle_batch,
+        )
+
+        self.assertEqual(tuple(output.shape), (0, 4))
+        self.assertIs(seen["positions"], logical_positions)
+        self.assertFalse(idle_batch.glm5_next_has_image_inputs)
 
     def test_callbacks_select_the_matching_checkpoint_parameters(self):
         layer = self.model_module.Glm5NextDecoderLayer(self._config(), layer_idx=0)
@@ -1018,7 +1244,7 @@ class TestGlm5NextMHCModelBoundary(unittest.TestCase):
                 input_ids=None,
                 positions=torch.tensor([0]),
                 forward_batch=object(),
-                inputs_embeds=torch.ones(1, 4),
+                input_embeds=torch.ones(1, 4),
             )
 
         self.assertEqual(widths, [4, 8, 4])

--- a/test/registered/unit/test_glm5_next_stage3.py
+++ b/test/registered/unit/test_glm5_next_stage3.py
@@ -1,0 +1,828 @@
+"""CPU-only tests for the GLM-5-Next phase-3 model boundary."""
+
+from __future__ import annotations
+
+import ast
+import copy
+import importlib.util
+import sys
+import types
+import unittest
+from contextlib import contextmanager, nullcontext
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+from torch import nn
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CONFIG_PATH = REPO_ROOT / "python/sglang/srt/configs/glm5_next.py"
+MODEL_PATH = REPO_ROOT / "python/sglang/srt/models/glm5_next.py"
+MODEL_CONFIG_PATH = REPO_ROOT / "python/sglang/srt/configs/model_config.py"
+
+
+class _PretrainedConfigStub:
+    model_type = ""
+
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+def _load_config_module():
+    packages = {}
+    for name in ("sglang", "sglang.srt", "sglang.srt.configs"):
+        module = types.ModuleType(name)
+        module.__path__ = []
+        packages[name] = module
+
+    transformers = types.ModuleType("transformers")
+    transformers.__path__ = []
+    configuration_utils = types.ModuleType("transformers.configuration_utils")
+    configuration_utils.PretrainedConfig = _PretrainedConfigStub
+    transformers.configuration_utils = configuration_utils
+    packages["transformers"] = transformers
+    packages[configuration_utils.__name__] = configuration_utils
+
+    mamba_utils = types.ModuleType("sglang.srt.configs.mamba_utils")
+    mamba_utils.KimiLinearCacheParams = type("KimiLinearCacheParams", (), {})
+    mamba_utils.KimiLinearStateShape = type("KimiLinearStateShape", (), {})
+    packages[mamba_utils.__name__] = mamba_utils
+
+    module_name = "_glm5_next_stage3_config"
+    spec = importlib.util.spec_from_file_location(module_name, CONFIG_PATH)
+    module = importlib.util.module_from_spec(spec)
+    packages[module_name] = module
+    assert spec.loader is not None
+    with patch.dict(sys.modules, packages):
+        spec.loader.exec_module(module)
+    return module
+
+
+def _load_model_module(config_module):
+    packages = {}
+    package_names = (
+        "sglang",
+        "sglang.srt",
+        "sglang.srt.configs",
+        "sglang.srt.eplb",
+        "sglang.srt.layers",
+        "sglang.srt.layers.quantization",
+        "sglang.srt.model_executor",
+        "sglang.srt.models",
+        "sglang.srt.models.deepseek_common",
+    )
+    for name in package_names:
+        module = types.ModuleType(name)
+        module.__path__ = []
+        packages[name] = module
+
+    packages["sglang.srt.configs.glm5_next"] = config_module
+
+    pp_group = SimpleNamespace(
+        is_first_rank=True,
+        is_last_rank=True,
+        rank_in_group=0,
+        world_size=1,
+    )
+    distributed = types.ModuleType("sglang.srt.distributed")
+    distributed.get_pp_group = lambda: pp_group
+    distributed.get_tensor_model_parallel_world_size = lambda: 1
+    packages[distributed.__name__] = distributed
+
+    expert_distribution = types.ModuleType("sglang.srt.eplb.expert_distribution")
+    expert_distribution.get_global_expert_distribution_recorder = lambda: None
+    packages[expert_distribution.__name__] = expert_distribution
+
+    class _ScatterMode:
+        SCATTERED = object()
+        TP_ATTN_FULL = object()
+        FULL = object()
+
+    class _LayerScatterModes:
+        @classmethod
+        def init_new(cls, **kwargs):
+            del kwargs
+            return SimpleNamespace(
+                layer_input_mode=_ScatterMode.FULL,
+                attn_mode=_ScatterMode.FULL,
+                mlp_mode=_ScatterMode.FULL,
+                middle_residual_mode=_ScatterMode.FULL,
+                layer_output_mode=_ScatterMode.FULL,
+            )
+
+    class _AttnTpContext:
+        def __init__(self):
+            self.active = False
+            self.init_calls = []
+            self.entries = 0
+            self.exits = 0
+
+        def init_context(self, q_lora_rank, is_nsa):
+            self.init_calls.append((q_lora_rank, is_nsa))
+
+        @contextmanager
+        def maybe_input_scattered(self, forward_batch):
+            del forward_batch
+            self.entries += 1
+            self.active = True
+            try:
+                yield
+            finally:
+                self.active = False
+                self.exits += 1
+
+    attn_tp_context = _AttnTpContext()
+
+    communicator = types.ModuleType("sglang.srt.layers.communicator")
+    communicator.LayerScatterModes = _LayerScatterModes
+    communicator.ScatterMode = _ScatterMode
+    communicator.get_attn_tp_context = lambda: attn_tp_context
+    packages[communicator.__name__] = communicator
+
+    class _MHCLayerCommunicator:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    communicator_mhc = types.ModuleType("sglang.srt.layers.communicator_mhc")
+    communicator_mhc.MHCLayerCommunicator = _MHCLayerCommunicator
+    packages[communicator_mhc.__name__] = communicator_mhc
+
+    class _Layer(nn.Module):
+        def __init__(self, *args, **kwargs):
+            super().__init__()
+
+    layernorm = types.ModuleType("sglang.srt.layers.layernorm")
+    layernorm.RMSNorm = _Layer
+    packages[layernorm.__name__] = layernorm
+
+    logits_processor = types.ModuleType("sglang.srt.layers.logits_processor")
+    logits_processor.LogitsProcessor = _Layer
+    packages[logits_processor.__name__] = logits_processor
+
+    base_config = types.ModuleType("sglang.srt.layers.quantization.base_config")
+    base_config.QuantizationConfig = type("QuantizationConfig", (), {})
+    packages[base_config.__name__] = base_config
+
+    layer_utils = types.ModuleType("sglang.srt.layers.utils")
+    layer_utils.PPMissingLayer = _Layer
+    packages[layer_utils.__name__] = layer_utils
+
+    embedding = types.ModuleType("sglang.srt.layers.vocab_parallel_embedding")
+    embedding.ParallelLMHead = _Layer
+    embedding.VocabParallelEmbedding = _Layer
+    packages[embedding.__name__] = embedding
+
+    forward_info = types.ModuleType("sglang.srt.model_executor.forward_batch_info")
+    forward_info.ForwardBatch = type("ForwardBatch", (), {})
+    forward_info.PPProxyTensors = dict
+    packages[forward_info.__name__] = forward_info
+
+    deepseek_loader = types.ModuleType(
+        "sglang.srt.models.deepseek_common.deepseek_weight_loader"
+    )
+    deepseek_loader.DeepseekV2WeightLoaderMixin = type(
+        "DeepseekV2WeightLoaderMixin", (), {}
+    )
+    packages[deepseek_loader.__name__] = deepseek_loader
+
+    class _KimiDeltaAttention(nn.Module):
+        def __init__(self, *, config, **kwargs):
+            super().__init__()
+            self.config = config
+            self.num_heads = config.linear_attn_config["num_heads"]
+            self.head_dim = config.linear_attn_config["head_dim"]
+            self.head_v_dim = config.v_head_dim
+            self.o_proj = SimpleNamespace(reduce_results=True)
+            self.attn = SimpleNamespace(lower_bound=None)
+
+    class _KimiMlaAttention(nn.Module):
+        def __init__(self, *, v_head_dim, reduce_results=True, **kwargs):
+            super().__init__()
+            self.head_v_dim = v_head_dim
+            self.o_proj = SimpleNamespace(reduce_results=reduce_results)
+
+        def prepare_qkv_latent(self, hidden_states, forward_batch):
+            return hidden_states, forward_batch
+
+    class _KimiDecoderLayer(nn.Module):
+        def forward(self, **kwargs):
+            self.kimi_forward_kwargs = kwargs
+            return kwargs["hidden_states"], kwargs["residual"]
+
+    class _KimiLinearModel(nn.Module):
+        def forward(self, **kwargs):
+            self.kimi_forward_kwargs = kwargs
+            return "kimi-model-forward"
+
+    kimi = types.ModuleType("sglang.srt.models.kimi_linear")
+    kimi.KimiDecoderLayer = _KimiDecoderLayer
+    kimi.KimiDeltaAttention = _KimiDeltaAttention
+    kimi.KimiLinearModel = _KimiLinearModel
+    kimi.KimiMLAAttention = _KimiMlaAttention
+    kimi.KimiMLP = _Layer
+    kimi.KimiMoE = _Layer
+    packages[kimi.__name__] = kimi
+
+    glm_dsa = types.ModuleType("sglang.srt.models.glm5_next_dsa")
+    glm_dsa.Glm5NextDSAAttention = _KimiMlaAttention
+    packages[glm_dsa.__name__] = glm_dsa
+
+    class _Glm5NextMLP(_Layer):
+        pass
+
+    class _Glm5NextMoE(_Layer):
+        def forward(self, hidden_states, forward_batch=None, **kwargs):
+            self.forward_batch = forward_batch
+            self.forward_kwargs = kwargs
+            return hidden_states + 2
+
+    glm_moe = types.ModuleType("sglang.srt.models.glm5_next_moe")
+    glm_moe.Glm5NextMLP = _Glm5NextMLP
+    glm_moe.Glm5NextMoE = _Glm5NextMoE
+    packages[glm_moe.__name__] = glm_moe
+
+    model_transformers = types.ModuleType("sglang.srt.models.transformers")
+    model_transformers.maybe_prefix = lambda prefix, name: (
+        f"{prefix}.{name}" if prefix else name
+    )
+    packages[model_transformers.__name__] = model_transformers
+
+    utils = types.ModuleType("sglang.srt.utils")
+
+    def make_layers(count, factory, *, prefix, **kwargs):
+        return (
+            nn.ModuleList(factory(i, f"{prefix}.{i}") for i in range(count)),
+            0,
+            count,
+        )
+
+    utils.make_layers = make_layers
+    packages[utils.__name__] = utils
+
+    class _BumpAllocator:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    common = types.ModuleType("sglang.srt.utils.common")
+    common.BumpAllocator = _BumpAllocator
+    packages[common.__name__] = common
+
+    module_name = "_glm5_next_stage3_model"
+    spec = importlib.util.spec_from_file_location(module_name, MODEL_PATH)
+    module = importlib.util.module_from_spec(spec)
+    packages[module_name] = module
+    assert spec.loader is not None
+    with patch.dict(sys.modules, packages):
+        spec.loader.exec_module(module)
+    return module
+
+
+def _compile_function(path: Path, name: str, class_name: str | None = None):
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    body = tree.body
+    if class_name is not None:
+        class_node = next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.ClassDef) and node.name == class_name
+        )
+        body = class_node.body
+    function = copy.deepcopy(
+        next(
+            node
+            for node in body
+            if isinstance(node, ast.FunctionDef) and node.name == name
+        )
+    )
+    function.decorator_list = []
+    output_body: list[ast.stmt] = [
+        ast.ImportFrom(
+            module="__future__",
+            names=[ast.alias(name="annotations")],
+            level=0,
+        )
+    ]
+    symbol_name = name
+    if class_name is None:
+        output_body.append(function)
+    else:
+        symbol_name = "_Harness"
+        output_body.append(
+            ast.ClassDef(
+                name=symbol_name,
+                bases=[],
+                keywords=[],
+                body=[function],
+                decorator_list=[],
+            )
+        )
+    compiled = ast.fix_missing_locations(ast.Module(body=output_body, type_ignores=[]))
+    namespace = {"copy": copy}
+    exec(compile(compiled, str(path), "exec"), namespace)
+    value = namespace[symbol_name]
+    return value if class_name is None else getattr(value, name)
+
+
+class TestGlm5NextConfig(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.config_module = _load_config_module()
+
+    def test_actual_fp8_defaults_partition_45_layers_as_34_kda_11_dsa(self):
+        config = self.config_module.Glm5NextTextConfig()
+
+        self.assertEqual(config.num_hidden_layers, 45)
+        self.assertEqual(config.linear_num_heads, 64)
+        self.assertEqual(config.linear_head_dim, 128)
+        self.assertEqual(len(config.linear_layer_ids), 34)
+        self.assertEqual(len(config.full_attention_layer_ids), 11)
+        self.assertEqual(
+            config.full_attention_layer_ids,
+            list(range(3, 45, 4)),
+        )
+        self.assertEqual(
+            sorted(config.linear_layer_ids + config.full_attention_layer_ids),
+            list(range(45)),
+        )
+
+    def test_glm_capabilities_are_exact_and_non_glm_defaults_false(self):
+        root = self.config_module.Glm5NextConfig()
+        capabilities = self.config_module.get_glm5_next_capabilities(root)
+
+        self.assertTrue(capabilities.is_glm5_next)
+        self.assertTrue(capabilities.uses_kpool4_compress)
+        self.assertTrue(capabilities.uses_kda_safe_gate)
+        self.assertTrue(capabilities.uses_zero_rope_mla)
+        self.assertTrue(capabilities.uses_mhc)
+
+        non_glm = SimpleNamespace(
+            model_type="kimi_linear",
+            architectures=["KimiLinearForCausalLM"],
+            index_kpool=4,
+            index_kpool_compress=True,
+            index_kpool_always_select_tail=True,
+            linear_attn_config={"kda_layers": [0], "gate_lower_bound": -5.0},
+            qk_rope_head_dim=0,
+            full_attention_layer_ids=[1],
+            mhc=True,
+        )
+        self.assertEqual(
+            self.config_module.get_glm5_next_capabilities(non_glm),
+            self.config_module.Glm5NextCapabilities(False, False, False, False, False),
+        )
+
+    def test_nested_vision_config_is_data_only(self):
+        root = self.config_module.Glm5NextConfig(
+            vision_config={"depth": 24, "hidden_size": 1536}
+        )
+
+        self.assertEqual(root.vision_config.model_type, "glm_ocr_vision")
+        self.assertEqual(root.vision_config.depth, 24)
+        self.assertEqual(root.vision_config.hidden_size, 1536)
+        self.assertFalse(
+            any(name.startswith("transformers.models.glm_ocr") for name in sys.modules)
+        )
+
+    def test_invalid_layer_partition_fails_early(self):
+        with self.assertRaisesRegex(ValueError, "layer_types"):
+            self.config_module.Glm5NextTextConfig(layer_types=["linear_attention"])
+
+
+class TestGlm5NextModelBoundary(unittest.TestCase):
+    def test_model_config_routes_glm_to_mla_shape_derivation(self):
+        tree = ast.parse(
+            MODEL_CONFIG_PATH.read_text(encoding="utf-8"),
+            filename=str(MODEL_CONFIG_PATH),
+        )
+        model_config = next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.ClassDef) and node.name == "ModelConfig"
+        )
+        derive_shapes = next(
+            node
+            for node in model_config.body
+            if isinstance(node, ast.FunctionDef) and node.name == "_derive_model_shapes"
+        )
+        source = ast.unparse(derive_shapes)
+
+        self.assertIn("Glm5NextForConditionalGeneration", source)
+        self.assertIn("if self.is_glm5_next", source)
+        self.assertIn("self.hf_text_config.index_head_dim", source)
+
+    def test_model_import_and_45_layer_construction_are_text_only(self):
+        config_module = _load_config_module()
+        model_module = _load_model_module(config_module)
+        root_config = config_module.Glm5NextConfig()
+
+        # The production dimensions include all mHC parameters.  Meta tensors
+        # validate the exact 45-layer construction without allocating them.
+        with torch.device("meta"):
+            model = model_module.Glm5NextForConditionalGeneration(root_config)
+        kda_layers = [
+            layer
+            for layer in model.model.layers
+            if isinstance(layer.self_attn, model_module.Glm5NextLinearAttention)
+        ]
+        dsa_layers = [
+            layer
+            for layer in model.model.layers
+            if not isinstance(layer.self_attn, model_module.Glm5NextLinearAttention)
+        ]
+
+        self.assertEqual(len(model.model.layers), 45)
+        self.assertEqual(len(kda_layers), 34)
+        self.assertEqual(len(dsa_layers), 11)
+        self.assertTrue(all(layer.self_attn.num_heads == 64 for layer in kda_layers))
+        self.assertTrue(all(layer.self_attn.head_dim == 128 for layer in kda_layers))
+        self.assertTrue(all(layer.self_attn.head_v_dim == 128 for layer in kda_layers))
+        self.assertTrue(all(layer.self_attn.head_v_dim == 256 for layer in dsa_layers))
+        self.assertEqual(root_config.text_config.v_head_dim, 256)
+        self.assertIsNone(model.visual)
+
+    def test_kda_compatibility_view_is_non_mutating_and_128_wide(self):
+        build_config = _compile_function(MODEL_PATH, "_kda_construction_config")
+        source = SimpleNamespace(
+            linear_attn_config={"num_heads": 64, "head_dim": 128},
+            linear_num_heads=1,
+            linear_head_dim=1,
+            v_head_dim=256,
+        )
+
+        result = build_config(source)
+
+        self.assertIsNot(result, source)
+        self.assertEqual(source.v_head_dim, 256)
+        self.assertEqual(result.linear_num_heads, 64)
+        self.assertEqual(result.linear_head_dim, 128)
+        self.assertEqual(result.v_head_dim, 128)
+
+    def test_weight_prefix_and_phase7_visual_whitelist_are_exact(self):
+        normalize = _compile_function(MODEL_PATH, "normalize_glm5_next_weight_name")
+        normalize.__globals__["GLM5_NEXT_PHASE7_VISUAL_WEIGHT_PREFIXES"] = (
+            "visual.",
+            "model.visual.",
+        )
+
+        self.assertEqual(
+            normalize("model.language_model.layers.3.self_attn.q_b_proj.weight"),
+            "model.layers.3.self_attn.q_b_proj.weight",
+        )
+        self.assertEqual(
+            normalize("language_model.embed_tokens.weight"),
+            "model.embed_tokens.weight",
+        )
+        self.assertIsNone(normalize("model.visual.blocks.0.attn.qkv.weight"))
+        self.assertIsNone(normalize("visual.patch_embed.proj.weight"))
+        self.assertEqual(
+            normalize("model.language_model.layers.0.visual_gate.weight"),
+            "model.layers.0.visual_gate.weight",
+        )
+
+    def test_fp8_qkv_scale_uses_the_same_shard_mapping_as_weight(self):
+        load_stacked = _compile_function(
+            MODEL_PATH,
+            "_load_kda_stacked_weight",
+            class_name="Glm5NextForConditionalGeneration",
+        )
+        calls = []
+
+        class Param:
+            pass
+
+        param = Param()
+        param.weight_loader = lambda param, tensor, shard: calls.append(
+            (param, tensor, shard)
+        )
+        tensor = object()
+        params = {
+            "model.layers.0.self_attn.qkv_proj.weight_scale_inv": param,
+        }
+
+        loaded = load_stacked(
+            object(),
+            "model.layers.0.self_attn.q_proj.weight_scale_inv",
+            tensor,
+            params,
+        )
+
+        self.assertTrue(loaded)
+        self.assertEqual(calls, [(param, tensor, "q")])
+
+    def test_model_registration_and_lazy_vision_import_boundary(self):
+        source = MODEL_PATH.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(MODEL_PATH))
+        entry = next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.Assign)
+            and any(
+                isinstance(target, ast.Name) and target.id == "EntryClass"
+                for target in node.targets
+            )
+        )
+        self.assertEqual(ast.unparse(entry.value), "[Glm5NextForConditionalGeneration]")
+        self.assertNotIn("sglang.srt.models.glm_ocr", source)
+        self.assertNotIn('if "visual" in name', source)
+
+
+class TestGlm5NextMHCModelBoundary(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.config_module = _load_config_module()
+        cls.model_module = _load_model_module(cls.config_module)
+
+    def _config(self, mhc=True):
+        return self.config_module.Glm5NextTextConfig(
+            hidden_size=4,
+            intermediate_size=8,
+            num_hidden_layers=2,
+            num_attention_heads=2,
+            n_routed_experts=None,
+            mhc=mhc,
+            hc_mult=2,
+            linear_num_heads=2,
+            linear_head_dim=2,
+            v_head_dim=2,
+            qk_nope_head_dim=2,
+            layer_types=["linear_attention", "deepseek_sparse_attention"],
+        )
+
+    def test_mhc_parameters_and_communicator_layer_boundaries(self):
+        first = self.model_module.Glm5NextDecoderLayer(self._config(), layer_idx=0)
+        last = self.model_module.Glm5NextDecoderLayer(self._config(), layer_idx=1)
+
+        expected_shapes = {
+            "hc_attn_base": (8,),
+            "hc_attn_scale": (3,),
+            "hc_attn_fn": (8, 8),
+            "hc_ffn_base": (8,),
+            "hc_ffn_scale": (3,),
+            "hc_ffn_fn": (8, 8),
+        }
+        self.assertEqual(set(dict(first.named_parameters())), set(expected_shapes))
+        for name, shape in expected_shapes.items():
+            parameter = getattr(first, name)
+            self.assertEqual(tuple(parameter.shape), shape)
+            self.assertEqual(parameter.dtype, torch.float32)
+
+        self.assertFalse(first.self_attn.o_proj.reduce_results)
+        self.assertTrue(first.layer_communicator.kwargs["is_first_layer"])
+        self.assertFalse(first.layer_communicator.kwargs["is_last_layer"])
+        self.assertFalse(last.layer_communicator.kwargs["is_first_layer"])
+        self.assertTrue(last.layer_communicator.kwargs["is_last_layer"])
+        self.assertIs(first.layer_communicator.kwargs["hc_attn_pre"].__self__, first)
+        self.assertIs(first.layer_communicator.kwargs["hc_ffn_pre"].__self__, first)
+        self.assertIs(first.layer_communicator.kwargs["hc_post"].__self__, first)
+        self.assertIsNone(first.layer_communicator.kwargs["qkv_latent_func"])
+        dsa_latent_func = last.layer_communicator.kwargs["qkv_latent_func"]
+        self.assertIs(dsa_latent_func.__self__, last.self_attn)
+        self.assertIs(
+            dsa_latent_func.__func__, last.self_attn.prepare_qkv_latent.__func__
+        )
+
+    def test_top_level_forward_owns_dsa_latent_context_lifetime(self):
+        model = self.model_module.Glm5NextForConditionalGeneration(self._config())
+        attn_context = self.model_module.get_attn_tp_context()
+
+        class _Inner(nn.Module):
+            def forward(inner_self, *args):
+                del inner_self, args
+                self.assertTrue(attn_context.active)
+                return torch.ones(1, 4)
+
+        class _Logits(nn.Module):
+            def forward(inner_self, input_ids, hidden_states, lm_head, batch):
+                del inner_self, input_ids, lm_head, batch
+                self.assertFalse(attn_context.active)
+                return hidden_states
+
+        model.model = _Inner()
+        model.logits_processor = _Logits()
+        entries_before = attn_context.entries
+        exits_before = attn_context.exits
+
+        output = model(
+            input_ids=torch.tensor([0]),
+            positions=torch.tensor([0]),
+            forward_batch=object(),
+        )
+
+        self.assertEqual(tuple(output.shape), (1, 4))
+        self.assertFalse(attn_context.active)
+        self.assertEqual(attn_context.entries, entries_before + 1)
+        self.assertEqual(attn_context.exits, exits_before + 1)
+        self.assertEqual(
+            attn_context.init_calls[-1], (self._config().q_lora_rank, True)
+        )
+
+    def test_callbacks_select_the_matching_checkpoint_parameters(self):
+        layer = self.model_module.Glm5NextDecoderLayer(self._config(), layer_idx=0)
+        calls = []
+
+        def hc_pre(**kwargs):
+            calls.append(("pre", kwargs))
+            return "pre-result"
+
+        def hc_post(**kwargs):
+            calls.append(("post", kwargs))
+            return "post-result"
+
+        packages = {}
+        for name in (
+            "sglang",
+            "sglang.kernels",
+            "sglang.kernels.ops",
+            "sglang.kernels.ops.layernorm",
+        ):
+            module = types.ModuleType(name)
+            module.__path__ = []
+            packages[name] = module
+        mhc = types.ModuleType("sglang.kernels.ops.layernorm.mhc")
+        mhc.hc_pre = hc_pre
+        mhc.hc_post = hc_post
+        packages[mhc.__name__] = mhc
+
+        x = torch.zeros(1, 8)
+        with patch.dict(sys.modules, packages):
+            self.assertEqual(layer.hc_attn_pre(x, "weight", 1e-4), "pre-result")
+            self.assertEqual(layer.hc_ffn_pre(x, "weight", 1e-4), "pre-result")
+            self.assertEqual(
+                layer.hc_post("x", "residual", "h_res", "h_post"),
+                "post-result",
+            )
+
+        attn_kwargs = calls[0][1]
+        ffn_kwargs = calls[1][1]
+        post_kwargs = calls[2][1]
+        self.assertIs(attn_kwargs["hc_fn"], layer.hc_attn_fn)
+        self.assertIs(attn_kwargs["hc_scale"], layer.hc_attn_scale)
+        self.assertIs(attn_kwargs["hc_base"], layer.hc_attn_base)
+        self.assertIs(ffn_kwargs["hc_fn"], layer.hc_ffn_fn)
+        self.assertIs(ffn_kwargs["hc_scale"], layer.hc_ffn_scale)
+        self.assertIs(ffn_kwargs["hc_base"], layer.hc_ffn_base)
+        self.assertEqual(post_kwargs["hc_mult"], 2)
+        self.assertEqual(attn_kwargs["sinkhorn_iters"], 20)
+
+    def test_mhc_layer_forward_orders_attention_mlp_and_post(self):
+        layer = self.model_module.Glm5NextDecoderLayer(self._config(), layer_idx=0)
+        calls = []
+
+        class _Communicator:
+            def prepare_attn(self, hidden_states, residual, forward_batch):
+                calls.append("prepare_attn")
+                self_outer.assertEqual(tuple(hidden_states.shape), (1, 4))
+                self_outer.assertIsNone(residual)
+                return hidden_states, hidden_states.repeat(1, 2)
+
+            def prepare_mlp(self, hidden_states, residual, forward_batch):
+                calls.append("prepare_mlp")
+                self_outer.assertEqual(tuple(residual.shape), (1, 8))
+                return hidden_states, residual
+
+            def postprocess_layer(self, hidden_states, residual, forward_batch):
+                calls.append("postprocess")
+                return residual + hidden_states.repeat(1, 2), None
+
+        class _Attention(nn.Module):
+            def forward(self, **kwargs):
+                calls.append("attention")
+                return kwargs["hidden_states"] + 1
+
+        class _MLP(nn.Module):
+            def forward(self, hidden_states):
+                calls.append("mlp")
+                return hidden_states + 2
+
+        self_outer = self
+        layer.layer_communicator = _Communicator()
+        layer.self_attn = _Attention()
+        layer.mlp = _MLP()
+        output, residual = layer(
+            positions=torch.tensor([0]),
+            hidden_states=torch.ones(1, 4),
+            forward_batch=object(),
+            residual=None,
+            zero_allocator=object(),
+        )
+
+        self.assertEqual(
+            calls,
+            ["prepare_attn", "attention", "prepare_mlp", "mlp", "postprocess"],
+        )
+        self.assertEqual(tuple(output.shape), (1, 8))
+        self.assertIsNone(residual)
+
+    def test_mhc_sparse_moe_receives_forward_batch(self):
+        layer = self.model_module.Glm5NextDecoderLayer(self._config(), layer_idx=0)
+        forward_batch = object()
+
+        class _Communicator:
+            def prepare_attn(self, hidden_states, residual, batch):
+                self_outer.assertIs(batch, forward_batch)
+                return hidden_states, hidden_states.repeat(1, 2)
+
+            def prepare_mlp(self, hidden_states, residual, batch):
+                self_outer.assertIs(batch, forward_batch)
+                return hidden_states, residual
+
+            def postprocess_layer(self, hidden_states, residual, batch):
+                self_outer.assertIs(batch, forward_batch)
+                return hidden_states.repeat(1, 2), None
+
+        class _Attention(nn.Module):
+            def forward(self, **kwargs):
+                return kwargs["hidden_states"]
+
+        self_outer = self
+        layer.layer_communicator = _Communicator()
+        layer.self_attn = _Attention()
+        layer.mlp = self.model_module.Glm5NextMoE()
+
+        output, residual = layer(
+            positions=torch.tensor([0]),
+            hidden_states=torch.ones(1, 4),
+            forward_batch=forward_batch,
+            residual=None,
+            zero_allocator=object(),
+        )
+
+        self.assertIs(layer.mlp.forward_batch, forward_batch)
+        self.assertEqual(tuple(output.shape), (1, 8))
+        self.assertIsNone(residual)
+
+    def test_non_mhc_overrides_fail_closed_before_execution(self):
+        for disabled_value in (False, 1):
+            with self.subTest(disabled_value=disabled_value):
+                with self.assertRaisesRegex(ValueError, "requires.*mhc=True"):
+                    self.model_module.Glm5NextDecoderLayer(
+                        self._config(mhc=disabled_value), layer_idx=0
+                    )
+                with self.assertRaisesRegex(ValueError, "requires.*mhc=True"):
+                    self.model_module.Glm5NextModel(self._config(mhc=disabled_value))
+
+    def test_mhc_model_keeps_expanded_state_until_the_last_layer(self):
+        model = self.model_module.Glm5NextModel(self._config())
+        widths = []
+
+        class _Stage(nn.Module):
+            def __init__(self, layer_idx):
+                super().__init__()
+                self.layer_idx = layer_idx
+
+            def forward(self, **kwargs):
+                hidden_states = kwargs["hidden_states"]
+                widths.append(hidden_states.shape[-1])
+                self_outer.assertIsNone(kwargs["residual"])
+                if self.layer_idx == 0:
+                    return hidden_states.repeat(1, 2), None
+                return hidden_states[:, :4], None
+
+        class _Norm(nn.Module):
+            def forward(self, hidden_states):
+                widths.append(hidden_states.shape[-1])
+                return hidden_states + 1
+
+        self_outer = self
+        model.layers = nn.ModuleList([_Stage(0), _Stage(1)])
+        model.norm = _Norm()
+        recorder = SimpleNamespace(with_current_layer=lambda layer_idx: nullcontext())
+        model_globals = self.model_module.Glm5NextModel.forward.__globals__
+        with patch.dict(
+            model_globals,
+            {"get_global_expert_distribution_recorder": lambda: recorder},
+        ):
+            output = model(
+                input_ids=None,
+                positions=torch.tensor([0]),
+                forward_batch=object(),
+                inputs_embeds=torch.ones(1, 4),
+            )
+
+        self.assertEqual(widths, [4, 8, 4])
+        self.assertEqual(tuple(output.shape), (1, 4))
+        self.assertFalse(hasattr(model, "kimi_forward_kwargs"))
+
+    def test_scattered_mhc_modes_fail_during_layer_construction(self):
+        scattered = self.model_module.ScatterMode.SCATTERED
+        modes = SimpleNamespace(
+            layer_input_mode=scattered,
+            attn_mode=self.model_module.ScatterMode.FULL,
+            mlp_mode=self.model_module.ScatterMode.FULL,
+            middle_residual_mode=self.model_module.ScatterMode.FULL,
+            layer_output_mode=self.model_module.ScatterMode.FULL,
+        )
+        with patch.object(
+            self.model_module.LayerScatterModes,
+            "init_new",
+            return_value=modes,
+        ):
+            with self.assertRaisesRegex(NotImplementedError, "scattered"):
+                self.model_module.Glm5NextDecoderLayer(self._config(), layer_idx=0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit/test_glm5_next_fp8_layerwise_prefill.py
+++ b/test/unit/test_glm5_next_fp8_layerwise_prefill.py
@@ -1,0 +1,1002 @@
+"""CPU-only contracts for exact GLM-5-Next block-FP8 layerwise prefill."""
+
+import ast
+import importlib.util
+import inspect
+import subprocess
+import sys
+import types
+import unittest
+from collections import namedtuple
+from multiprocessing import shared_memory
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+
+
+def _module(name, **attributes):
+    module = types.ModuleType(name)
+    module.__dict__.update(attributes)
+    return module
+
+
+def _package(name):
+    module = _module(name)
+    module.__path__ = []
+    return module
+
+
+def _identity_compile(fn=None, **_kwargs):
+    if fn is None:
+        return lambda wrapped: wrapped
+    return fn
+
+
+def _load_test_target():
+    tp_group = SimpleNamespace(cpu_group=object(), device_group=object(), first_rank=0)
+    stubs = {
+        "sglang": _package("sglang"),
+        "sglang.srt": _package("sglang.srt"),
+        "sglang.srt.layers": _package("sglang.srt.layers"),
+        "sglang.srt.layers.moe": _package("sglang.srt.layers.moe"),
+        "sglang.srt.layers.quantization": _package("sglang.srt.layers.quantization"),
+        "sglang.srt.distributed": _module(
+            "sglang.srt.distributed",
+            get_tensor_model_parallel_rank=lambda: 0,
+            get_tensor_model_parallel_world_size=lambda: 1,
+            get_tp_group=lambda: tp_group,
+        ),
+        "sglang.srt.layers.quantization.base_config": _module(
+            "sglang.srt.layers.quantization.base_config",
+            FusedMoEMethodBase=object,
+        ),
+        "sglang.srt.layers.quantization.marlin_utils": _module(
+            "sglang.srt.layers.quantization.marlin_utils",
+            marlin_permute_scales=lambda value, *_args, **_kwargs: value,
+        ),
+        "sglang.srt.layers.moe.quant_method_registry": _module(
+            "sglang.srt.layers.moe.quant_method_registry",
+            register_moe_quant_wrapper=lambda *_args, **_kwargs: None,
+        ),
+        "sglang.srt.utils": _module(
+            "sglang.srt.utils",
+            get_compiler_backend=lambda: "eager",
+            is_cuda=lambda: False,
+        ),
+        "kt_kernel": _module(
+            "kt_kernel",
+            KTMoEWrapper=object,
+            generate_gpu_experts_masks=lambda *_args, **_kwargs: None,
+        ),
+    }
+    target_path = (
+        Path(__file__).resolve().parents[2]
+        / "python/sglang/srt/layers/moe/kt_ep_wrapper.py"
+    )
+    module_name = "_kt_ep_wrapper_glm5_next_fp8_test_target"
+    spec = importlib.util.spec_from_file_location(module_name, target_path)
+    target = importlib.util.module_from_spec(spec)
+    with (
+        mock.patch.dict(sys.modules, stubs),
+        mock.patch.object(torch, "compile", _identity_compile),
+    ):
+        sys.modules[module_name] = target
+        try:
+            spec.loader.exec_module(target)
+        finally:
+            sys.modules.pop(module_name, None)
+    target._test_tp_group = tp_group
+    return target
+
+
+kt_ep_wrapper = _load_test_target()
+
+
+class _RecordingEvent:
+    def __init__(self, name, log):
+        self.name = name
+        self.log = log
+
+    def record(self, stream=None):
+        self.log.append(("record", self.name, getattr(stream, "name", stream)))
+
+
+class _RecordingStream:
+    def __init__(self, name, log):
+        self.name = name
+        self.log = log
+
+    def wait_event(self, event):
+        self.log.append(("wait_event", self.name, event.name))
+
+    def synchronize(self):
+        self.log.append(("synchronize", self.name))
+
+
+class _StateSlot:
+    def __init__(self, index, log):
+        self.index = index
+        self.state = "EMPTY"
+        self.layer_idx = None
+        self.epoch = -1
+        self.has_consumed_event = False
+        self.reuse_guard = None
+        self.ready_event = _RecordingEvent(f"ready{index}", log)
+        self.consumed_event = _RecordingEvent(f"consumed{index}", log)
+
+    def invalidate(self):
+        self.state = "EMPTY"
+        self.layer_idx = None
+        self.epoch = -1
+
+
+class _StandardCombineInput:
+    def __init__(self, hidden_states):
+        self.hidden_states = hidden_states
+
+
+_TopkOutput = namedtuple(
+    "_TopkOutput", ["topk_weights", "topk_ids", "token_expert_indices"]
+)
+_DispatchOutput = namedtuple("_DispatchOutput", ["hidden_states", "topk_output"])
+
+
+def _runtime_stubs():
+    return {
+        "sglang": _package("sglang"),
+        "sglang.srt": _package("sglang.srt"),
+        "sglang.srt.layers": _package("sglang.srt.layers"),
+        "sglang.srt.layers.moe": _package("sglang.srt.layers.moe"),
+        "sglang.srt.eplb": _package("sglang.srt.eplb"),
+        "sglang.srt.eplb.expert_distribution": _module(
+            "sglang.srt.eplb.expert_distribution",
+            get_global_expert_distribution_recorder=lambda: mock.Mock(),
+        ),
+        "sglang.srt.layers.moe.token_dispatcher": _module(
+            "sglang.srt.layers.moe.token_dispatcher",
+            StandardCombineInput=_StandardCombineInput,
+        ),
+    }
+
+
+class TestGlm5NextFp8Gates(unittest.TestCase):
+    def setUp(self):
+        kt_ep_wrapper._GLM5_NEXT_FP8_PREFILL_LAYER_REGISTRY.clear()
+        kt_ep_wrapper._GLM5_NEXT_FP8_LAYERWISE_MANAGERS.clear()
+
+    @staticmethod
+    def _wrapper(*, exact=True, method="FP8", threshold=4096, mode="EXTEND"):
+        wrapper = object.__new__(kt_ep_wrapper.KTEPWrapperMethod)
+        wrapper.tp_rank = 1
+        wrapper.kt_config = SimpleNamespace(
+            layer_idx=3,
+            method=method,
+            is_glm5_next=exact,
+            kt_enable_dynamic_expert_update=False,
+        )
+        wrapper.gpu_prefill_token_threshold = threshold
+        wrapper._glm5_next_forward_mode = SimpleNamespace(name=mode)
+        wrapper._glm5_next_fp8_pipeline_signature = ("glm", "cuda:0")
+        wrapper.gpu_experts_mask = torch.tensor([True])
+        wrapper.gpu_experts_mask_cuda = torch.tensor([True])
+        wrapper.logical_to_gpu_index_cuda = torch.tensor([0], dtype=torch.int32)
+        wrapper.num_gpu_experts = 1
+        wrapper._cpu_stream = None
+        wrapper.gpu_method = SimpleNamespace(
+            apply=lambda _layer, dispatch: _StandardCombineInput(
+                torch.full_like(dispatch.hidden_states, 7)
+            )
+        )
+        return wrapper
+
+    @staticmethod
+    def _dispatch(num_tokens):
+        hidden = torch.zeros((num_tokens, 2))
+        topk = _TopkOutput(
+            topk_weights=torch.ones((num_tokens, 1)),
+            topk_ids=torch.zeros((num_tokens, 1), dtype=torch.long),
+            token_expert_indices=None,
+        )
+        return _DispatchOutput(hidden_states=hidden, topk_output=topk)
+
+    def _apply(self, wrapper, num_tokens):
+        with (
+            mock.patch.dict(sys.modules, _runtime_stubs()),
+            mock.patch.object(
+                kt_ep_wrapper,
+                "mask_and_remap_expert_ids",
+                side_effect=lambda ids, *_args: ids,
+            ),
+        ):
+            return wrapper.apply(SimpleNamespace(), self._dispatch(num_tokens))
+
+    def test_gate_is_exact_glm_block_fp8_only(self):
+        self.assertTrue(
+            kt_ep_wrapper._glm5_next_fp8_pipeline_requested(self._wrapper())
+        )
+        self.assertFalse(
+            kt_ep_wrapper._glm5_next_fp8_pipeline_requested(self._wrapper(exact=False))
+        )
+        self.assertFalse(
+            kt_ep_wrapper._glm5_next_fp8_pipeline_requested(
+                self._wrapper(method="MXFP4")
+            )
+        )
+        self.assertFalse(
+            kt_ep_wrapper._glm5_next_fp8_pipeline_requested(self._wrapper(threshold=0))
+        )
+
+    def test_every_extend_chunk_uses_required_manager_below_threshold(self):
+        wrapper = self._wrapper(threshold=4096, mode="EXTEND")
+        manager = mock.Mock()
+        manager.apply.return_value = "required-layerwise"
+        kt_ep_wrapper._GLM5_NEXT_FP8_LAYERWISE_MANAGERS[
+            wrapper._glm5_next_fp8_pipeline_signature
+        ] = manager
+
+        result = self._apply(wrapper, num_tokens=17)
+
+        self.assertEqual(result, "required-layerwise")
+        manager.apply.assert_called_once()
+
+    def test_decode_and_idle_never_touch_manager(self):
+        for mode in ("DECODE", "IDLE"):
+            with self.subTest(mode=mode):
+                wrapper = self._wrapper(mode=mode)
+                manager = mock.Mock()
+                kt_ep_wrapper._GLM5_NEXT_FP8_LAYERWISE_MANAGERS[
+                    wrapper._glm5_next_fp8_pipeline_signature
+                ] = manager
+
+                result = self._apply(wrapper, num_tokens=1)
+
+                manager.apply.assert_not_called()
+                manager.abort_round.assert_not_called()
+                torch.testing.assert_close(
+                    result.hidden_states, torch.full((1, 2), 7.0)
+                )
+
+    def test_unsupported_modes_and_missing_manager_fail_closed(self):
+        for mode in ("MIXED", "TARGET_VERIFY", "SPLIT_PREFILL", "DLLM_EXTEND"):
+            with self.subTest(mode=mode):
+                with self.assertRaisesRegex(RuntimeError, "supports only plain EXTEND"):
+                    self._apply(self._wrapper(mode=mode), num_tokens=8)
+
+        with self.assertRaisesRegex(RuntimeError, "refusing fallback"):
+            self._apply(self._wrapper(mode="EXTEND"), num_tokens=8)
+
+    def test_generic_fp8_does_not_enter_glm_manager(self):
+        wrapper = self._wrapper(exact=False, mode="EXTEND")
+        manager = mock.Mock()
+        kt_ep_wrapper._GLM5_NEXT_FP8_LAYERWISE_MANAGERS[
+            wrapper._glm5_next_fp8_pipeline_signature
+        ] = manager
+
+        result = self._apply(wrapper, num_tokens=1)
+
+        manager.apply.assert_not_called()
+        torch.testing.assert_close(result.hidden_states, torch.full((1, 2), 7.0))
+
+
+class TestGlm5NextFp8Manager(unittest.TestCase):
+    def setUp(self):
+        kt_ep_wrapper._GLM5_NEXT_FP8_PREFILL_LAYER_REGISTRY.clear()
+        kt_ep_wrapper._GLM5_NEXT_FP8_LAYERWISE_MANAGERS.clear()
+
+    def _manager(self):
+        signature = ("glm", "state")
+        log = []
+        methods = {
+            layer_idx: SimpleNamespace(
+                kt_config=SimpleNamespace(layer_idx=layer_idx), tp_rank=1
+            )
+            for layer_idx in range(3, 45)
+        }
+        layers = {layer_idx: object() for layer_idx in methods}
+        kt_ep_wrapper._GLM5_NEXT_FP8_PREFILL_LAYER_REGISTRY[signature] = {
+            layer_idx: (methods[layer_idx], layers[layer_idx]) for layer_idx in methods
+        }
+        manager = object.__new__(kt_ep_wrapper._Glm5NextFp8LayerwisePrefillManager)
+        manager.signature = signature
+        manager.context = SimpleNamespace(
+            gpu_layer=object(),
+            gpu_method=SimpleNamespace(
+                apply=lambda _layer, dispatch: (
+                    log.append(("compute", dispatch)) or dispatch
+                )
+            ),
+        )
+        manager.slots = (_StateSlot(0, log), _StateSlot(1, log))
+        manager.device = torch.device("cpu")
+        manager.epoch = -1
+        manager.last_layer_position = None
+        manager.current_slot_index = None
+        manager.round_active = False
+        manager.failure_reason = None
+        manager.visited_layer_indices = []
+        manager.apply_count = 0
+        manager.prime_count = 0
+        manager.prefetch_hit_count = 0
+        manager.completed_round_count = 0
+        manager.fallback_count = 0
+
+        def load_slot(slot, layer_idx, _method, _layer):
+            log.append(("load", layer_idx, slot.index, manager.epoch))
+            slot.state = "READY"
+            slot.layer_idx = layer_idx
+            slot.epoch = manager.epoch
+            slot.reuse_guard = "ready"
+
+        return manager, methods, layers, log, load_slot
+
+    def test_two_slots_cover_every_moe_layer_and_complete_epoch(self):
+        manager, methods, layers, log, load_slot = self._manager()
+        stream = _RecordingStream("main", log)
+        with (
+            mock.patch.object(manager, "_load_slot", side_effect=load_slot),
+            mock.patch.object(
+                manager,
+                "_bind_slot",
+                side_effect=lambda slot: log.append(("bind", slot.index)),
+            ),
+            mock.patch.object(manager, "_record_raw_backing_on_stream"),
+            mock.patch.object(manager, "_commit_tp_runtime_phase"),
+            mock.patch.object(torch.cuda, "current_stream", return_value=stream),
+        ):
+            for layer_idx in range(3, 45):
+                self.assertEqual(
+                    manager.apply(
+                        methods[layer_idx], layers[layer_idx], f"layer-{layer_idx}"
+                    ),
+                    f"layer-{layer_idx}",
+                )
+
+        self.assertEqual(manager.apply_count, 42)
+        self.assertEqual(manager.prime_count, 1)
+        self.assertEqual(manager.prefetch_hit_count, 41)
+        self.assertEqual(manager.completed_round_count, 1)
+        self.assertEqual(manager.fallback_count, 0)
+        self.assertFalse(manager.round_active)
+        self.assertEqual(
+            [entry[2] for entry in log if entry[0] == "load"],
+            [index % 2 for index in range(42)],
+        )
+
+    def test_two_consecutive_extend_epochs_keep_monotonic_state(self):
+        manager, methods, layers, _log, load_slot = self._manager()
+        with (
+            mock.patch.object(manager, "_load_slot", side_effect=load_slot),
+            mock.patch.object(manager, "_bind_slot"),
+            mock.patch.object(manager, "_record_raw_backing_on_stream"),
+            mock.patch.object(manager, "_commit_tp_runtime_phase"),
+            mock.patch.object(
+                torch.cuda,
+                "current_stream",
+                return_value=_RecordingStream("main", []),
+            ),
+        ):
+            for _epoch in range(2):
+                for layer_idx in range(3, 45):
+                    manager.apply(
+                        methods[layer_idx], layers[layer_idx], layer_idx
+                    )
+
+        self.assertEqual(manager.epoch, 1)
+        self.assertEqual(manager.apply_count, 84)
+        self.assertEqual(manager.prime_count, 2)
+        self.assertEqual(manager.prefetch_hit_count, 82)
+        self.assertEqual(manager.completed_round_count, 2)
+        self.assertEqual(manager.fallback_count, 0)
+        self.assertFalse(manager.round_active)
+
+    def test_skip_poison_is_sticky_and_never_falls_back(self):
+        manager, methods, layers, _log, load_slot = self._manager()
+        with (
+            mock.patch.object(manager, "_load_slot", side_effect=load_slot),
+            mock.patch.object(manager, "_bind_slot"),
+            mock.patch.object(manager, "_record_raw_backing_on_stream"),
+            mock.patch.object(manager, "_commit_tp_runtime_phase"),
+            mock.patch.object(
+                torch.cuda,
+                "current_stream",
+                return_value=_RecordingStream("main", []),
+            ),
+        ):
+            manager.apply(methods[3], layers[3], object())
+            with self.assertRaisesRegex(RuntimeError, "layer order mismatch"):
+                manager.apply(methods[5], layers[5], object())
+            with self.assertRaisesRegex(RuntimeError, "manager is poisoned"):
+                manager.apply(methods[4], layers[4], object())
+
+        self.assertEqual(manager.fallback_count, 0)
+
+    def test_manager_uses_events_without_global_cuda_synchronize(self):
+        target_path = (
+            Path(__file__).resolve().parents[2]
+            / "python/sglang/srt/layers/moe/kt_ep_wrapper.py"
+        )
+        module_source = target_path.read_text(encoding="utf-8")
+        tree = ast.parse(module_source)
+        node = next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.ClassDef)
+            and node.name == "_Glm5NextFp8LayerwisePrefillManager"
+        )
+        source = ast.get_source_segment(module_source, node)
+        self.assertNotIn("torch.cuda.synchronize", source)
+        self.assertIn("self.transfer_stream", source)
+        self.assertIn("__atomic_load_8", source)
+        self.assertIn("__atomic_store_8", source)
+        self.assertIn("_CONTROL_CACHELINE_BYTES = 64", source)
+        self.assertIn("slot.ready_event", source)
+        self.assertIn("slot.ready_event.synchronize()", source)
+        self.assertIn("slot.consumed_event", source)
+        self.assertNotIn("get_tp_group().device_group", source)
+        load_source = inspect.getsource(
+            kt_ep_wrapper._Glm5NextFp8LayerwisePrefillManager._load_slot
+        )
+        self.assertNotIn("dist.all_reduce", load_source)
+
+    def test_atomic_control_is_cacheline_isolated_and_process_shared(self):
+        manager_type = kt_ep_wrapper._Glm5NextFp8LayerwisePrefillManager
+        offsets, control_nbytes = manager_type._build_control_offsets(2)
+        flat_offsets = sorted(
+            offset for group in offsets.values() for offset in group
+        )
+        self.assertTrue(
+            all(
+                right - left == manager_type._CONTROL_CACHELINE_BYTES
+                for left, right in zip(flat_offsets, flat_offsets[1:])
+            )
+        )
+
+        payload_offset = control_nbytes
+        handle = shared_memory.SharedMemory(
+            create=True, size=control_nbytes + 64
+        )
+        manager = object.__new__(manager_type)
+        manager.transport_abandoned = False
+        manager._CONTROL_TIMEOUT_SECONDS = 5.0
+        try:
+            handle.buf[:] = bytes(control_nbytes + 64)
+            manager._configure_atomic_access(handle, tp_size=2)
+            ready_offset = offsets["ready_generation"][0]
+            child_code = r"""
+import ctypes
+import sys
+from multiprocessing import shared_memory
+
+try:
+    handle = shared_memory.SharedMemory(
+        name=sys.argv[1], create=False, track=False
+    )
+except TypeError:
+    from multiprocessing import resource_tracker
+
+    handle = shared_memory.SharedMemory(name=sys.argv[1], create=False)
+    resource_tracker.unregister(handle._name, "shared_memory")
+anchor = ctypes.c_char.from_buffer(handle.buf)
+address = ctypes.addressof(anchor)
+store = getattr(ctypes.CDLL("libatomic.so.1"), "__atomic_store_8")
+store.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_int]
+store.restype = None
+payload_offset = int(sys.argv[3])
+handle.buf[payload_offset : payload_offset + 9] = b"published"
+store(ctypes.c_void_p(address + int(sys.argv[2])), ctypes.c_uint64(7), 3)
+anchor = None
+handle.close()
+"""
+            process = subprocess.Popen(
+                [
+                    sys.executable,
+                    "-c",
+                    child_code,
+                    handle.name,
+                    str(ready_offset),
+                    str(payload_offset),
+                ]
+            )
+            manager._wait_for_exact_control_value(
+                ready_offset, 7, "child publication"
+            )
+            self.assertEqual(
+                bytes(handle.buf[payload_offset : payload_offset + 9]),
+                b"published",
+            )
+            self.assertEqual(process.wait(timeout=10), 0)
+        finally:
+            manager._transport_control_anchor = None
+            handle.close()
+            handle.unlink()
+
+    def test_generation_drift_is_fail_closed(self):
+        manager_type = kt_ep_wrapper._Glm5NextFp8LayerwisePrefillManager
+        offsets, control_nbytes = manager_type._build_control_offsets(1)
+        handle = shared_memory.SharedMemory(create=True, size=control_nbytes)
+        manager = object.__new__(manager_type)
+        manager.transport_abandoned = False
+        try:
+            handle.buf[:] = bytes(control_nbytes)
+            manager._configure_atomic_access(handle, tp_size=1)
+            ready_offset = offsets["ready_generation"][0]
+            manager._atomic_store(ready_offset, 4)
+            with self.assertRaisesRegex(RuntimeError, "generation drift"):
+                manager._wait_for_exact_control_value(
+                    ready_offset, 3, "stale consumer"
+                )
+            self.assertTrue(manager.transport_abandoned)
+            self.assertEqual(
+                manager._atomic_load(offsets["global_error"][0]), 1
+            )
+        finally:
+            manager._transport_control_anchor = None
+            handle.close()
+            handle.unlink()
+
+    def test_sticky_global_error_immediately_aborts_generation_wait(self):
+        manager_type = kt_ep_wrapper._Glm5NextFp8LayerwisePrefillManager
+        offsets, control_nbytes = manager_type._build_control_offsets(1)
+        handle = shared_memory.SharedMemory(create=True, size=control_nbytes)
+        manager = object.__new__(manager_type)
+        manager.transport_abandoned = False
+        manager._CONTROL_TIMEOUT_SECONDS = 60.0
+        try:
+            handle.buf[:] = bytes(control_nbytes)
+            manager._configure_atomic_access(handle, tp_size=1)
+            manager._atomic_store(offsets["global_error"][0], 1)
+            with self.assertRaisesRegex(RuntimeError, "aborted by another"):
+                manager._wait_for_exact_control_value(
+                    offsets["ready_generation"][0],
+                    1,
+                    "failed writer publication",
+                )
+            self.assertTrue(manager.transport_abandoned)
+        finally:
+            manager._transport_control_anchor = None
+            handle.close()
+            handle.unlink()
+
+    def test_writer_descriptor_mismatch_poison_is_sticky(self):
+        manager_type = kt_ep_wrapper._Glm5NextFp8LayerwisePrefillManager
+        _offsets, control_nbytes = manager_type._build_control_offsets(1)
+        handle = shared_memory.SharedMemory(create=True, size=control_nbytes)
+        manager = object.__new__(manager_type)
+        manager.transport_abandoned = False
+        try:
+            handle.buf[:] = bytes(control_nbytes)
+            manager._configure_atomic_access(handle, tp_size=1)
+            manager._publish_writer_generation(
+                host_slot=0,
+                generation=1,
+                layer_idx=3,
+                expert_id=17,
+                writer_ok=True,
+            )
+            with self.assertRaisesRegex(RuntimeError, "descriptor mismatch"):
+                manager._consume_writer_generation(
+                    host_slot=0,
+                    generation=1,
+                    layer_idx=3,
+                    expert_id=18,
+                )
+            self.assertTrue(manager.transport_abandoned)
+            self.assertTrue(manager._shared_transport_failed())
+        finally:
+            manager._transport_control_anchor = None
+            handle.close()
+            handle.unlink()
+
+    def test_tp_contract_rejects_peer_mask_or_mapping_digest_drift(self):
+        signature = ("glm", "contract")
+        original_layer = SimpleNamespace(
+            **{
+                name: torch.empty(1)
+                for name in kt_ep_wrapper._Glm5NextFp8PrefillSlot.RAW_NAMES
+            }
+        )
+        method = SimpleNamespace(
+            gpu_experts_mask=torch.tensor([True, False]),
+            logical_to_gpu_index=torch.tensor([0, -1], dtype=torch.int32),
+            num_gpu_experts=1,
+            global_num_experts=2,
+            _full_init_args=(4, 2, torch.bfloat16),
+            kt_config=SimpleNamespace(weight_path="weights"),
+        )
+        kt_ep_wrapper._GLM5_NEXT_FP8_PREFILL_LAYER_REGISTRY[signature] = {
+            3: (method, original_layer)
+        }
+        manager = object.__new__(
+            kt_ep_wrapper._Glm5NextFp8LayerwisePrefillManager
+        )
+        manager.signature = signature
+        manager.device = torch.device("cpu")
+        manager.slots = (
+            SimpleNamespace(
+                **{
+                    name: torch.empty(1)
+                    for name in kt_ep_wrapper._Glm5NextFp8PrefillSlot.RAW_NAMES
+                }
+            ),
+        )
+
+        def inject_peer_drift(gathered, local, **_kwargs):
+            gathered[:] = [
+                local,
+                (local[0], "different-digest", local[2], None),
+            ]
+
+        with (
+            mock.patch.object(
+                kt_ep_wrapper.dist, "is_initialized", return_value=True
+            ),
+            mock.patch.object(
+                kt_ep_wrapper,
+                "get_tensor_model_parallel_world_size",
+                return_value=2,
+            ),
+            mock.patch.object(
+                kt_ep_wrapper.dist,
+                "all_gather_object",
+                side_effect=inject_peer_drift,
+            ),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "contract mismatch"):
+                manager.validate_tp_contract()
+
+    def test_tp_contract_rejects_processed_or_repacked_original_gpu_tensor(self):
+        signature = ("glm", "raw-original")
+        names = kt_ep_wrapper._Glm5NextFp8PrefillSlot.RAW_NAMES
+        original_layer = SimpleNamespace(
+            **{name: torch.empty(1) for name in names}
+        )
+        original_layer.w13_weight = torch.empty(1, dtype=torch.int32)
+        method = SimpleNamespace(
+            gpu_experts_mask=torch.tensor([True, False]),
+            logical_to_gpu_index=torch.tensor([0, -1], dtype=torch.int32),
+            num_gpu_experts=1,
+            global_num_experts=2,
+            _full_init_args=(4, 2, torch.bfloat16),
+            kt_config=SimpleNamespace(weight_path="weights"),
+        )
+        kt_ep_wrapper._GLM5_NEXT_FP8_PREFILL_LAYER_REGISTRY[signature] = {
+            3: (method, original_layer)
+        }
+        manager = object.__new__(
+            kt_ep_wrapper._Glm5NextFp8LayerwisePrefillManager
+        )
+        manager.signature = signature
+        manager.device = torch.device("cpu")
+        manager.slots = (
+            SimpleNamespace(**{name: torch.empty(1) for name in names}),
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "failed to build") as raised:
+            manager.validate_tp_contract()
+        self.assertIn("dtype mismatch", str(raised.exception.__cause__))
+
+    def test_transport_control_disables_resource_tracking_when_supported(self):
+        opener = mock.Mock(return_value="untracked")
+        with mock.patch.object(kt_ep_wrapper.shared_memory, "SharedMemory", opener):
+            result = (
+                kt_ep_wrapper._Glm5NextFp8LayerwisePrefillManager
+                ._open_transport_shared_memory(name="control", create=False)
+            )
+
+        self.assertEqual(result, "untracked")
+        opener.assert_called_once_with(
+            name="control", create=False, track=False
+        )
+
+    def test_transport_control_tracking_fallback_is_for_old_python_only(self):
+        opener = mock.Mock(side_effect=[TypeError("no track"), "tracked"])
+        with mock.patch.object(kt_ep_wrapper.shared_memory, "SharedMemory", opener):
+            result = (
+                kt_ep_wrapper._Glm5NextFp8LayerwisePrefillManager
+                ._open_transport_shared_memory(name="control", create=False)
+            )
+
+        self.assertEqual(result, "tracked")
+        self.assertEqual(
+            opener.call_args_list,
+            [
+                mock.call(name="control", create=False, track=False),
+                mock.call(name="control", create=False),
+            ],
+        )
+
+    def test_bind_selects_only_the_four_stable_raw_tensors(self):
+        names = kt_ep_wrapper._Glm5NextFp8PrefillSlot.RAW_NAMES
+        old = {name: torch.nn.Parameter(torch.zeros(1)) for name in names}
+        new = {name: torch.nn.Parameter(torch.ones(1)) for name in names}
+        layer = SimpleNamespace(**old)
+        manager = object.__new__(kt_ep_wrapper._Glm5NextFp8LayerwisePrefillManager)
+        manager.context = SimpleNamespace(gpu_layer=layer)
+
+        manager._bind_slot(SimpleNamespace(**new))
+
+        for name in names:
+            self.assertIs(getattr(layer, name), new[name])
+        self.assertFalse(hasattr(layer, "_v4_marlin_weights"))
+
+    def test_writer_abi_uses_fp8_and_fp32_host_slot_offsets(self):
+        class HostBuffer:
+            def __init__(self, numel, element_size):
+                self._numel = numel
+                self._element_size = element_size
+
+            def numel(self):
+                return self._numel
+
+            def element_size(self):
+                return self._element_size
+
+        names = kt_ep_wrapper._Glm5NextFp8PrefillSlot.RAW_NAMES
+        buffers = {
+            names[0]: HostBuffer(200, 1),
+            names[1]: HostBuffer(80, 4),
+            names[2]: HostBuffer(120, 1),
+            names[3]: HostBuffer(40, 4),
+        }
+        pointers = {
+            name: [1000 + index * 100, 2000 + index * 100]
+            for index, name in enumerate(names)
+        }
+        manager = object.__new__(kt_ep_wrapper._Glm5NextFp8LayerwisePrefillManager)
+        manager.context = SimpleNamespace(
+            cpu_buffers=buffers, all_rank_buffer_ptrs=pointers
+        )
+        wrapper = mock.Mock()
+        method = SimpleNamespace(wrapper=wrapper)
+
+        with mock.patch.object(
+            kt_ep_wrapper, "get_tensor_model_parallel_world_size", return_value=2
+        ):
+            manager._submit_host_write(method, expert_id=17, host_slot=1)
+
+        args = wrapper.submit_write_weight_scale_to_buffer.call_args.args
+        self.assertEqual(args[:2], (2, 17))
+        for position, name in enumerate(names, 2):
+            offset = buffers[name].numel() // 2 * buffers[name].element_size()
+            self.assertEqual(
+                args[position], [pointer + offset for pointer in pointers[name]]
+            )
+        wrapper.sync_write_weight_scale_to_buffer.assert_called_once_with()
+
+
+class TestGlm5NextFp8AllocationContracts(unittest.TestCase):
+    def setUp(self):
+        kt_ep_wrapper._GLM5_NEXT_FP8_PREFILL_LAYER_REGISTRY.clear()
+        kt_ep_wrapper._GLM5_NEXT_FP8_LAYERWISE_MANAGERS.clear()
+
+    def test_exact_two_slot_capacity_is_reserved_before_kv_profile(self):
+        one_slot = kt_ep_wrapper._glm5_next_fp8_raw_slot_storage_nbytes(
+            num_experts=288,
+            hidden_size=4096,
+            intermediate_size=256,
+        )
+        self.assertEqual(one_slot, 906_190_848)
+        self.assertEqual(2 * one_slot, 1_812_381_696)
+
+        model_runner_source = (
+            Path(__file__).resolve().parents[2]
+            / "python/sglang/srt/model_executor/model_runner.py"
+        ).read_text(encoding="utf-8")
+        allocation_pos = model_runner_source.index(
+            "initialize_glm5_next_fp8_layerwise_prefill()"
+        )
+        pool_pos = model_runner_source.index("self.init_memory_pool()", allocation_pos)
+        self.assertLess(allocation_pos, pool_pos)
+
+    def test_registry_requires_all_42_exact_checkpoint_moe_layers(self):
+        mask = torch.zeros(288, dtype=torch.bool)
+        mask[:4] = True
+        mapping = torch.full((288,), -1, dtype=torch.int32)
+        mapping[:4] = torch.arange(4, dtype=torch.int32)
+        method = SimpleNamespace(
+            kt_config=SimpleNamespace(
+                is_glm5_next=True,
+                method="FP8",
+                num_layers=45,
+                kt_enable_dynamic_expert_update=False,
+            ),
+            gpu_prefill_token_threshold=1,
+            tp_rank=0,
+            global_num_experts=288,
+            _full_init_args=(4096, 256, torch.bfloat16),
+            gpu_experts_mask=mask,
+            logical_to_gpu_index=mapping,
+            num_gpu_experts=4,
+        )
+        complete = {idx: (method, object()) for idx in range(3, 45)}
+        kt_ep_wrapper._validate_glm5_next_fp8_registry(("glm",), complete)
+
+        incomplete = dict(complete)
+        incomplete.pop(44)
+        with self.assertRaisesRegex(RuntimeError, "every MoE layer 3..44"):
+            kt_ep_wrapper._validate_glm5_next_fp8_registry(("glm",), incomplete)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "requires a CUDA device")
+    def test_registry_validates_cuda_resident_mask_and_mapping(self):
+        device = torch.device("cuda", torch.cuda.current_device())
+        mask = torch.zeros(288, dtype=torch.bool, device=device)
+        mask[:4] = True
+        mapping = torch.full((288,), -1, dtype=torch.int32, device=device)
+        mapping[:4] = torch.arange(4, dtype=torch.int32, device=device)
+        method = SimpleNamespace(
+            kt_config=SimpleNamespace(
+                is_glm5_next=True,
+                method="FP8",
+                num_layers=45,
+                kt_enable_dynamic_expert_update=False,
+            ),
+            gpu_prefill_token_threshold=1,
+            tp_rank=0,
+            global_num_experts=288,
+            _full_init_args=(4096, 256, torch.bfloat16),
+            gpu_experts_mask=mask,
+            logical_to_gpu_index=mapping,
+            num_gpu_experts=4,
+        )
+        complete = {idx: (method, object()) for idx in range(3, 45)}
+
+        kt_ep_wrapper._validate_glm5_next_fp8_registry(("glm",), complete)
+
+    def test_context_accepts_only_raw_e4m3_and_fp32_128_scales(self):
+        class TensorMetadata:
+            def __init__(self, shape, dtype):
+                self.shape = shape
+                self.dtype = dtype
+
+        layer = SimpleNamespace(
+            w13_weight=TensorMetadata((288, 512, 4096), torch.float8_e4m3fn),
+            w13_weight_scale_inv=TensorMetadata((288, 4, 32), torch.float32),
+            w2_weight=TensorMetadata((288, 4096, 256), torch.float8_e4m3fn),
+            w2_weight_scale_inv=TensorMetadata((288, 32, 2), torch.float32),
+            moe_runner_config=SimpleNamespace(
+                glm5_next_hf_two_round_swiglu=True
+            ),
+        )
+        context = SimpleNamespace(
+            _is_fp8_quant=True,
+            _get_base_quant_method=lambda: SimpleNamespace(
+                block_quant=True,
+                use_mxfp8=False,
+                weight_block_size=[128, 128],
+                runner=SimpleNamespace(
+                    runner_backend=SimpleNamespace(is_triton=lambda: True)
+                ),
+            ),
+            gpu_layer=layer,
+        )
+        kt_ep_wrapper._validate_glm5_next_fp8_context(context)
+
+        layer.moe_runner_config.glm5_next_hf_two_round_swiglu = False
+        with self.assertRaisesRegex(RuntimeError, "private HF two-round"):
+            kt_ep_wrapper._validate_glm5_next_fp8_context(context)
+        layer.moe_runner_config.glm5_next_hf_two_round_swiglu = True
+
+        layer.w2_weight_scale_inv.dtype = torch.bfloat16
+        with self.assertRaisesRegex(RuntimeError, "dtype mismatch"):
+            kt_ep_wrapper._validate_glm5_next_fp8_context(context)
+
+        layer.w2_weight_scale_inv.dtype = torch.float32
+        context._get_base_quant_method = lambda: SimpleNamespace(
+            block_quant=True,
+            use_mxfp8=False,
+            weight_block_size=[128, 128],
+            runner=SimpleNamespace(
+                runner_backend=SimpleNamespace(is_triton=lambda: False)
+            ),
+        )
+        with self.assertRaisesRegex(RuntimeError, "Triton MoE runner"):
+            kt_ep_wrapper._validate_glm5_next_fp8_context(context)
+
+    def test_tp0_writer_abi_is_probed_before_serving(self):
+        complete_wrapper = SimpleNamespace(
+            submit_write_weight_scale_to_buffer=lambda *_args: None,
+            sync_write_weight_scale_to_buffer=lambda: None,
+            moe=SimpleNamespace(write_weight_scale_to_buffer_task=object()),
+        )
+        registry = {
+            3: (SimpleNamespace(wrapper=complete_wrapper), object())
+        }
+        with mock.patch.object(
+            kt_ep_wrapper, "get_tensor_model_parallel_rank", return_value=0
+        ):
+            kt_ep_wrapper._validate_glm5_next_fp8_writer_abi(registry)
+
+            incomplete = {
+                3: (
+                    SimpleNamespace(
+                        wrapper=SimpleNamespace(
+                            submit_write_weight_scale_to_buffer=lambda *_args: None,
+                            sync_write_weight_scale_to_buffer=lambda: None,
+                            moe=object(),
+                        )
+                    ),
+                    object(),
+                )
+            }
+            with self.assertRaisesRegex(
+                RuntimeError, "write_weight_scale_to_buffer_task"
+            ):
+                kt_ep_wrapper._validate_glm5_next_fp8_writer_abi(incomplete)
+
+        with mock.patch.object(
+            kt_ep_wrapper, "get_tensor_model_parallel_rank", return_value=1
+        ):
+            kt_ep_wrapper._validate_glm5_next_fp8_writer_abi(incomplete)
+
+    def test_startup_oom_is_fatal_and_does_not_register_manager(self):
+        signature = ("glm", "oom")
+        mask = torch.zeros(288, dtype=torch.bool)
+        mapping = torch.full((288,), -1, dtype=torch.int32)
+        method = SimpleNamespace(
+            kt_config=SimpleNamespace(
+                is_glm5_next=True,
+                method="FP8",
+                num_layers=45,
+                kt_enable_dynamic_expert_update=False,
+            ),
+            gpu_prefill_token_threshold=1,
+            _full_init_args=(4096, 256, torch.bfloat16),
+            global_num_experts=288,
+            moe_runner_config=object(),
+            tp_rank=0,
+            gpu_experts_mask=mask,
+            logical_to_gpu_index=mapping,
+            num_gpu_experts=0,
+        )
+        registry = {idx: (method, object()) for idx in range(3, 45)}
+        with (
+            mock.patch.object(torch.cuda, "is_available", return_value=True),
+            mock.patch.object(
+                kt_ep_wrapper,
+                "get_tensor_model_parallel_world_size",
+                return_value=8,
+            ),
+            mock.patch.object(
+                kt_ep_wrapper,
+                "SharedFullContext",
+                side_effect=torch.cuda.OutOfMemoryError("slot 0"),
+            ) as context_ctor,
+            mock.patch.object(torch.cuda, "empty_cache"),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "refusing.*fallback"):
+                kt_ep_wrapper._initialize_glm5_next_fp8_layerwise_pipeline(
+                    signature, registry
+                )
+
+        context_ctor.assert_called_once()
+        self.assertNotIn(signature, kt_ep_wrapper._GLM5_NEXT_FP8_LAYERWISE_MANAGERS)
+
+    def test_glm_manager_and_registry_are_not_mxfp4_state(self):
+        self.assertIsNot(
+            kt_ep_wrapper._GLM5_NEXT_FP8_PREFILL_LAYER_REGISTRY,
+            kt_ep_wrapper._MXFP4_PREFILL_LAYER_REGISTRY,
+        )
+        self.assertIsNot(
+            kt_ep_wrapper._GLM5_NEXT_FP8_LAYERWISE_MANAGERS,
+            kt_ep_wrapper._MXFP4_LAYERWISE_MANAGERS,
+        )
+        self.assertFalse(
+            issubclass(
+                kt_ep_wrapper._Glm5NextFp8LayerwisePrefillManager,
+                kt_ep_wrapper._Mxfp4LayerwisePrefillManager,
+            )
+        )
+
+    def test_initializer_has_no_lazy_or_disabled_fallback_branch(self):
+        source = inspect.getsource(
+            kt_ep_wrapper._initialize_glm5_next_fp8_layerwise_pipeline
+        )
+        self.assertNotIn("_MXFP4", source)
+        self.assertNotIn("DISABLED_REASONS", source)
+        self.assertIn("refusing hybrid/serialized fallback", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit/test_glm5_next_fp8_layerwise_prefill.py
+++ b/test/unit/test_glm5_next_fp8_layerwise_prefill.py
@@ -1,14 +1,12 @@
-"""CPU-only contracts for exact GLM-5-Next block-FP8 layerwise prefill."""
+"""CPU-only contracts for GLM-5-Next's generic FP8 prefill path."""
 
-import ast
+import contextlib
 import importlib.util
-import inspect
-import subprocess
+import math
 import sys
 import types
 import unittest
 from collections import namedtuple
-from multiprocessing import shared_memory
 from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
@@ -41,7 +39,9 @@ def _load_test_target():
         "sglang.srt": _package("sglang.srt"),
         "sglang.srt.layers": _package("sglang.srt.layers"),
         "sglang.srt.layers.moe": _package("sglang.srt.layers.moe"),
-        "sglang.srt.layers.quantization": _package("sglang.srt.layers.quantization"),
+        "sglang.srt.layers.quantization": _package(
+            "sglang.srt.layers.quantization"
+        ),
         "sglang.srt.distributed": _module(
             "sglang.srt.distributed",
             get_tensor_model_parallel_rank=lambda: 0,
@@ -94,44 +94,6 @@ def _load_test_target():
 kt_ep_wrapper = _load_test_target()
 
 
-class _RecordingEvent:
-    def __init__(self, name, log):
-        self.name = name
-        self.log = log
-
-    def record(self, stream=None):
-        self.log.append(("record", self.name, getattr(stream, "name", stream)))
-
-
-class _RecordingStream:
-    def __init__(self, name, log):
-        self.name = name
-        self.log = log
-
-    def wait_event(self, event):
-        self.log.append(("wait_event", self.name, event.name))
-
-    def synchronize(self):
-        self.log.append(("synchronize", self.name))
-
-
-class _StateSlot:
-    def __init__(self, index, log):
-        self.index = index
-        self.state = "EMPTY"
-        self.layer_idx = None
-        self.epoch = -1
-        self.has_consumed_event = False
-        self.reuse_guard = None
-        self.ready_event = _RecordingEvent(f"ready{index}", log)
-        self.consumed_event = _RecordingEvent(f"consumed{index}", log)
-
-    def invalidate(self):
-        self.state = "EMPTY"
-        self.layer_idx = None
-        self.epoch = -1
-
-
 class _StandardCombineInput:
     def __init__(self, hidden_states):
         self.hidden_states = hidden_states
@@ -161,35 +123,59 @@ def _runtime_stubs():
     }
 
 
-class TestGlm5NextFp8Gates(unittest.TestCase):
+class _GpuMethod:
+    def __init__(self, fill_value):
+        self.fill_value = fill_value
+        self.calls = []
+
+    def apply(self, layer, dispatch_output):
+        self.calls.append((layer, dispatch_output))
+        return _StandardCombineInput(
+            torch.full_like(dispatch_output.hidden_states, self.fill_value)
+        )
+
+
+class TestGlm5NextFp8GenericRouting(unittest.TestCase):
     def setUp(self):
-        kt_ep_wrapper._GLM5_NEXT_FP8_PREFILL_LAYER_REGISTRY.clear()
-        kt_ep_wrapper._GLM5_NEXT_FP8_LAYERWISE_MANAGERS.clear()
+        kt_ep_wrapper._SHARED_FULL_CONTEXT = None
+        kt_ep_wrapper._MXFP4_LAYERWISE_MANAGERS.clear()
+        kt_ep_wrapper._MXFP4_LAYERWISE_DISABLED_REASONS.clear()
 
     @staticmethod
-    def _wrapper(*, exact=True, method="FP8", threshold=4096, mode="EXTEND"):
+    def _wrapper(*, exact=True, threshold=1024, mode="EXTEND"):
         wrapper = object.__new__(kt_ep_wrapper.KTEPWrapperMethod)
         wrapper.tp_rank = 1
         wrapper.kt_config = SimpleNamespace(
             layer_idx=3,
-            method=method,
+            method="FP8",
             is_glm5_next=exact,
             kt_enable_dynamic_expert_update=False,
         )
         wrapper.gpu_prefill_token_threshold = threshold
-        wrapper._glm5_next_forward_mode = SimpleNamespace(name=mode)
-        wrapper._glm5_next_fp8_pipeline_signature = ("glm", "cuda:0")
+        if mode is not None:
+            wrapper._glm5_next_forward_mode = SimpleNamespace(name=mode)
+        wrapper._glm5_next_has_image_inputs = False
         wrapper.gpu_experts_mask = torch.tensor([True])
         wrapper.gpu_experts_mask_cuda = torch.tensor([True])
+        wrapper.logical_to_gpu_index = torch.tensor([0], dtype=torch.int32)
         wrapper.logical_to_gpu_index_cuda = torch.tensor([0], dtype=torch.int32)
         wrapper.num_gpu_experts = 1
         wrapper._cpu_stream = None
-        wrapper.gpu_method = SimpleNamespace(
-            apply=lambda _layer, dispatch: _StandardCombineInput(
-                torch.full_like(dispatch.hidden_states, 7)
-            )
-        )
+        wrapper.gpu_method = _GpuMethod(fill_value=7)
+        wrapper._full_init_args = (4096, 512, torch.bfloat16)
+        wrapper.global_num_experts = 288
+        wrapper.moe_runner_config = object()
+        wrapper.wrapper = object()
         return wrapper
+
+    @staticmethod
+    def _layer():
+        return SimpleNamespace(
+            w13_weight=object(),
+            w13_weight_scale_inv=object(),
+            w2_weight=object(),
+            w2_weight_scale_inv=object(),
+        )
 
     @staticmethod
     def _dispatch(num_tokens):
@@ -201,7 +187,7 @@ class TestGlm5NextFp8Gates(unittest.TestCase):
         )
         return _DispatchOutput(hidden_states=hidden, topk_output=topk)
 
-    def _apply(self, wrapper, num_tokens):
+    def _apply(self, wrapper, layer, num_tokens):
         with (
             mock.patch.dict(sys.modules, _runtime_stubs()),
             mock.patch.object(
@@ -209,674 +195,453 @@ class TestGlm5NextFp8Gates(unittest.TestCase):
                 "mask_and_remap_expert_ids",
                 side_effect=lambda ids, *_args: ids,
             ),
+            mock.patch.object(torch.cuda, "is_available", return_value=False),
         ):
-            return wrapper.apply(SimpleNamespace(), self._dispatch(num_tokens))
+            return wrapper.apply(layer, self._dispatch(num_tokens))
 
-    def test_gate_is_exact_glm_block_fp8_only(self):
-        self.assertTrue(
-            kt_ep_wrapper._glm5_next_fp8_pipeline_requested(self._wrapper())
-        )
-        self.assertFalse(
-            kt_ep_wrapper._glm5_next_fp8_pipeline_requested(self._wrapper(exact=False))
-        )
-        self.assertFalse(
-            kt_ep_wrapper._glm5_next_fp8_pipeline_requested(
-                self._wrapper(method="MXFP4")
-            )
-        )
-        self.assertFalse(
-            kt_ep_wrapper._glm5_next_fp8_pipeline_requested(self._wrapper(threshold=0))
-        )
-
-    def test_every_extend_chunk_uses_required_manager_below_threshold(self):
-        wrapper = self._wrapper(threshold=4096, mode="EXTEND")
-        manager = mock.Mock()
-        manager.apply.return_value = "required-layerwise"
-        kt_ep_wrapper._GLM5_NEXT_FP8_LAYERWISE_MANAGERS[
-            wrapper._glm5_next_fp8_pipeline_signature
-        ] = manager
-
-        result = self._apply(wrapper, num_tokens=17)
-
-        self.assertEqual(result, "required-layerwise")
-        manager.apply.assert_called_once()
-
-    def test_decode_and_idle_never_touch_manager(self):
-        for mode in ("DECODE", "IDLE"):
-            with self.subTest(mode=mode):
-                wrapper = self._wrapper(mode=mode)
-                manager = mock.Mock()
-                kt_ep_wrapper._GLM5_NEXT_FP8_LAYERWISE_MANAGERS[
-                    wrapper._glm5_next_fp8_pipeline_signature
-                ] = manager
-
-                result = self._apply(wrapper, num_tokens=1)
-
-                manager.apply.assert_not_called()
-                manager.abort_round.assert_not_called()
-                torch.testing.assert_close(
-                    result.hidden_states, torch.full((1, 2), 7.0)
-                )
-
-    def test_image_extend_bypasses_layerwise_and_uses_hybrid_path(self):
-        wrapper = self._wrapper(mode="EXTEND")
-        wrapper._glm5_next_has_image_inputs = True
-        manager = mock.Mock()
-        kt_ep_wrapper._GLM5_NEXT_FP8_LAYERWISE_MANAGERS[
-            wrapper._glm5_next_fp8_pipeline_signature
-        ] = manager
-
-        result = self._apply(wrapper, num_tokens=17)
-
-        manager.apply.assert_not_called()
-        self.assertEqual(wrapper._glm5_next_mm_hybrid_extend_count, 1)
-        torch.testing.assert_close(
-            result.hidden_states, torch.full((17, 2), 7.0)
-        )
-
-    def test_unsupported_modes_and_missing_manager_fail_closed(self):
-        for mode in ("MIXED", "TARGET_VERIFY", "SPLIT_PREFILL", "DLLM_EXTEND"):
-            with self.subTest(mode=mode):
-                with self.assertRaisesRegex(RuntimeError, "supports only plain EXTEND"):
-                    self._apply(self._wrapper(mode=mode), num_tokens=8)
-
-        with self.assertRaisesRegex(RuntimeError, "refusing fallback"):
-            self._apply(self._wrapper(mode="EXTEND"), num_tokens=8)
-
-    def test_generic_fp8_does_not_enter_glm_manager(self):
-        wrapper = self._wrapper(exact=False, mode="EXTEND")
-        manager = mock.Mock()
-        kt_ep_wrapper._GLM5_NEXT_FP8_LAYERWISE_MANAGERS[
-            wrapper._glm5_next_fp8_pipeline_signature
-        ] = manager
-
-        result = self._apply(wrapper, num_tokens=1)
-
-        manager.apply.assert_not_called()
-        torch.testing.assert_close(result.hidden_states, torch.full((1, 2), 7.0))
-
-
-class TestGlm5NextFp8Manager(unittest.TestCase):
-    def setUp(self):
-        kt_ep_wrapper._GLM5_NEXT_FP8_PREFILL_LAYER_REGISTRY.clear()
-        kt_ep_wrapper._GLM5_NEXT_FP8_LAYERWISE_MANAGERS.clear()
-
-    def _manager(self):
-        signature = ("glm", "state")
-        log = []
-        methods = {
-            layer_idx: SimpleNamespace(
-                kt_config=SimpleNamespace(layer_idx=layer_idx), tp_rank=1
-            )
-            for layer_idx in range(3, 45)
-        }
-        layers = {layer_idx: object() for layer_idx in methods}
-        kt_ep_wrapper._GLM5_NEXT_FP8_PREFILL_LAYER_REGISTRY[signature] = {
-            layer_idx: (methods[layer_idx], layers[layer_idx]) for layer_idx in methods
-        }
-        manager = object.__new__(kt_ep_wrapper._Glm5NextFp8LayerwisePrefillManager)
-        manager.signature = signature
-        manager.context = SimpleNamespace(
+    @staticmethod
+    def _generic_context(fill_value=11):
+        return SimpleNamespace(
             gpu_layer=object(),
-            gpu_method=SimpleNamespace(
-                apply=lambda _layer, dispatch: (
-                    log.append(("compute", dispatch)) or dispatch
-                )
-            ),
+            gpu_method=_GpuMethod(fill_value=fill_value),
+            load=mock.Mock(),
+            initialize_cpu_buffers=mock.Mock(),
+            _initialize_glm5_next_fp8_transport=mock.Mock(),
+            _cleanup_cpu_buffers_after_failure=mock.Mock(),
+            _is_mxfp4_quant=False,
         )
-        manager.slots = (_StateSlot(0, log), _StateSlot(1, log))
-        manager.device = torch.device("cpu")
-        manager.epoch = -1
-        manager.last_layer_position = None
-        manager.current_slot_index = None
-        manager.round_active = False
-        manager.failure_reason = None
-        manager.visited_layer_indices = []
-        manager.apply_count = 0
-        manager.prime_count = 0
-        manager.prefetch_hit_count = 0
-        manager.completed_round_count = 0
-        manager.fallback_count = 0
 
-        def load_slot(slot, layer_idx, _method, _layer):
-            log.append(("load", layer_idx, slot.index, manager.epoch))
-            slot.state = "READY"
-            slot.layer_idx = layer_idx
-            slot.epoch = manager.epoch
-            slot.reuse_guard = "ready"
+    def test_1023_is_hybrid_and_1024_lazily_builds_one_shared_context(self):
+        wrapper = self._wrapper()
+        layer = self._layer()
+        context = self._generic_context()
 
-        return manager, methods, layers, log, load_slot
-
-    def test_two_slots_cover_every_moe_layer_and_complete_epoch(self):
-        manager, methods, layers, log, load_slot = self._manager()
-        stream = _RecordingStream("main", log)
         with (
-            mock.patch.object(manager, "_load_slot", side_effect=load_slot),
             mock.patch.object(
-                manager,
-                "_bind_slot",
-                side_effect=lambda slot: log.append(("bind", slot.index)),
-            ),
-            mock.patch.object(manager, "_record_raw_backing_on_stream"),
-            mock.patch.object(manager, "_commit_tp_runtime_phase"),
-            mock.patch.object(torch.cuda, "current_stream", return_value=stream),
+                kt_ep_wrapper, "SharedFullContext", return_value=context
+            ) as context_ctor,
+            mock.patch.object(
+                kt_ep_wrapper,
+                "_validate_glm5_next_fp8_shared_full_context",
+                return_value=(1_812_381_696, 12_585_984),
+            ) as validate_context,
         ):
-            for layer_idx in range(3, 45):
-                self.assertEqual(
-                    manager.apply(
-                        methods[layer_idx], layers[layer_idx], f"layer-{layer_idx}"
-                    ),
-                    f"layer-{layer_idx}",
-                )
+            below = self._apply(wrapper, layer, 1023)
+            context_ctor.assert_not_called()
+            context.load.assert_not_called()
+            validate_context.assert_not_called()
 
-        self.assertEqual(manager.apply_count, 42)
-        self.assertEqual(manager.prime_count, 1)
-        self.assertEqual(manager.prefetch_hit_count, 41)
-        self.assertEqual(manager.completed_round_count, 1)
-        self.assertEqual(manager.fallback_count, 0)
-        self.assertFalse(manager.round_active)
+            at_threshold = self._apply(wrapper, layer, 1024)
+            second_layer = self._layer()
+            wrapper.kt_config.layer_idx = 4
+            second = self._apply(wrapper, second_layer, 1024)
+
+        torch.testing.assert_close(
+            below.hidden_states, torch.full((1023, 2), 7.0)
+        )
+        torch.testing.assert_close(
+            at_threshold.hidden_states, torch.full((1024, 2), 11.0)
+        )
+        torch.testing.assert_close(
+            second.hidden_states, torch.full((1024, 2), 11.0)
+        )
+        context_ctor.assert_called_once_with(
+            layer=layer,
+            init_args=(4096, 512, torch.bfloat16),
+            global_num_experts=288,
+            moe_runner_config=wrapper.moe_runner_config,
+            defer_cpu_buffers=True,
+        )
+        context.initialize_cpu_buffers.assert_called_once_with()
+        context._initialize_glm5_next_fp8_transport.assert_called_once_with()
+        self.assertIs(kt_ep_wrapper._SHARED_FULL_CONTEXT, context)
+        validate_context.assert_called_once_with(context)
+        self.assertEqual(context.load.call_count, 2)
         self.assertEqual(
-            [entry[2] for entry in log if entry[0] == "load"],
-            [index % 2 for index in range(42)],
-        )
-
-    def test_two_consecutive_extend_epochs_keep_monotonic_state(self):
-        manager, methods, layers, _log, load_slot = self._manager()
-        with (
-            mock.patch.object(manager, "_load_slot", side_effect=load_slot),
-            mock.patch.object(manager, "_bind_slot"),
-            mock.patch.object(manager, "_record_raw_backing_on_stream"),
-            mock.patch.object(manager, "_commit_tp_runtime_phase"),
-            mock.patch.object(
-                torch.cuda,
-                "current_stream",
-                return_value=_RecordingStream("main", []),
-            ),
-        ):
-            for _epoch in range(2):
-                for layer_idx in range(3, 45):
-                    manager.apply(
-                        methods[layer_idx], layers[layer_idx], layer_idx
-                    )
-
-        self.assertEqual(manager.epoch, 1)
-        self.assertEqual(manager.apply_count, 84)
-        self.assertEqual(manager.prime_count, 2)
-        self.assertEqual(manager.prefetch_hit_count, 82)
-        self.assertEqual(manager.completed_round_count, 2)
-        self.assertEqual(manager.fallback_count, 0)
-        self.assertFalse(manager.round_active)
-
-    def test_skip_poison_is_sticky_and_never_falls_back(self):
-        manager, methods, layers, _log, load_slot = self._manager()
-        with (
-            mock.patch.object(manager, "_load_slot", side_effect=load_slot),
-            mock.patch.object(manager, "_bind_slot"),
-            mock.patch.object(manager, "_record_raw_backing_on_stream"),
-            mock.patch.object(manager, "_commit_tp_runtime_phase"),
-            mock.patch.object(
-                torch.cuda,
-                "current_stream",
-                return_value=_RecordingStream("main", []),
-            ),
-        ):
-            manager.apply(methods[3], layers[3], object())
-            with self.assertRaisesRegex(RuntimeError, "layer order mismatch"):
-                manager.apply(methods[5], layers[5], object())
-            with self.assertRaisesRegex(RuntimeError, "manager is poisoned"):
-                manager.apply(methods[4], layers[4], object())
-
-        self.assertEqual(manager.fallback_count, 0)
-
-    def test_manager_uses_events_without_global_cuda_synchronize(self):
-        target_path = (
-            Path(__file__).resolve().parents[2]
-            / "python/sglang/srt/layers/moe/kt_ep_wrapper.py"
-        )
-        module_source = target_path.read_text(encoding="utf-8")
-        tree = ast.parse(module_source)
-        node = next(
-            node
-            for node in tree.body
-            if isinstance(node, ast.ClassDef)
-            and node.name == "_Glm5NextFp8LayerwisePrefillManager"
-        )
-        source = ast.get_source_segment(module_source, node)
-        self.assertNotIn("torch.cuda.synchronize", source)
-        self.assertIn("self.transfer_stream", source)
-        self.assertIn("__atomic_load_8", source)
-        self.assertIn("__atomic_store_8", source)
-        self.assertIn("_CONTROL_CACHELINE_BYTES = 64", source)
-        self.assertIn("slot.ready_event", source)
-        self.assertIn("slot.ready_event.synchronize()", source)
-        self.assertIn("slot.consumed_event", source)
-        self.assertNotIn("get_tp_group().device_group", source)
-        load_source = inspect.getsource(
-            kt_ep_wrapper._Glm5NextFp8LayerwisePrefillManager._load_slot
-        )
-        self.assertNotIn("dist.all_reduce", load_source)
-
-    def test_atomic_control_is_cacheline_isolated_and_process_shared(self):
-        manager_type = kt_ep_wrapper._Glm5NextFp8LayerwisePrefillManager
-        offsets, control_nbytes = manager_type._build_control_offsets(2)
-        flat_offsets = sorted(
-            offset for group in offsets.values() for offset in group
-        )
-        self.assertTrue(
-            all(
-                right - left == manager_type._CONTROL_CACHELINE_BYTES
-                for left, right in zip(flat_offsets, flat_offsets[1:])
-            )
-        )
-
-        payload_offset = control_nbytes
-        handle = shared_memory.SharedMemory(
-            create=True, size=control_nbytes + 64
-        )
-        manager = object.__new__(manager_type)
-        manager.transport_abandoned = False
-        manager._CONTROL_TIMEOUT_SECONDS = 5.0
-        try:
-            handle.buf[:] = bytes(control_nbytes + 64)
-            manager._configure_atomic_access(handle, tp_size=2)
-            ready_offset = offsets["ready_generation"][0]
-            child_code = r"""
-import ctypes
-import sys
-from multiprocessing import shared_memory
-
-try:
-    handle = shared_memory.SharedMemory(
-        name=sys.argv[1], create=False, track=False
-    )
-except TypeError:
-    from multiprocessing import resource_tracker
-
-    handle = shared_memory.SharedMemory(name=sys.argv[1], create=False)
-    resource_tracker.unregister(handle._name, "shared_memory")
-anchor = ctypes.c_char.from_buffer(handle.buf)
-address = ctypes.addressof(anchor)
-store = getattr(ctypes.CDLL("libatomic.so.1"), "__atomic_store_8")
-store.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_int]
-store.restype = None
-payload_offset = int(sys.argv[3])
-handle.buf[payload_offset : payload_offset + 9] = b"published"
-store(ctypes.c_void_p(address + int(sys.argv[2])), ctypes.c_uint64(7), 3)
-anchor = None
-handle.close()
-"""
-            process = subprocess.Popen(
-                [
-                    sys.executable,
-                    "-c",
-                    child_code,
-                    handle.name,
-                    str(ready_offset),
-                    str(payload_offset),
-                ]
-            )
-            manager._wait_for_exact_control_value(
-                ready_offset, 7, "child publication"
-            )
-            self.assertEqual(
-                bytes(handle.buf[payload_offset : payload_offset + 9]),
-                b"published",
-            )
-            self.assertEqual(process.wait(timeout=10), 0)
-        finally:
-            manager._transport_control_anchor = None
-            handle.close()
-            handle.unlink()
-
-    def test_generation_drift_is_fail_closed(self):
-        manager_type = kt_ep_wrapper._Glm5NextFp8LayerwisePrefillManager
-        offsets, control_nbytes = manager_type._build_control_offsets(1)
-        handle = shared_memory.SharedMemory(create=True, size=control_nbytes)
-        manager = object.__new__(manager_type)
-        manager.transport_abandoned = False
-        try:
-            handle.buf[:] = bytes(control_nbytes)
-            manager._configure_atomic_access(handle, tp_size=1)
-            ready_offset = offsets["ready_generation"][0]
-            manager._atomic_store(ready_offset, 4)
-            with self.assertRaisesRegex(RuntimeError, "generation drift"):
-                manager._wait_for_exact_control_value(
-                    ready_offset, 3, "stale consumer"
-                )
-            self.assertTrue(manager.transport_abandoned)
-            self.assertEqual(
-                manager._atomic_load(offsets["global_error"][0]), 1
-            )
-        finally:
-            manager._transport_control_anchor = None
-            handle.close()
-            handle.unlink()
-
-    def test_sticky_global_error_immediately_aborts_generation_wait(self):
-        manager_type = kt_ep_wrapper._Glm5NextFp8LayerwisePrefillManager
-        offsets, control_nbytes = manager_type._build_control_offsets(1)
-        handle = shared_memory.SharedMemory(create=True, size=control_nbytes)
-        manager = object.__new__(manager_type)
-        manager.transport_abandoned = False
-        manager._CONTROL_TIMEOUT_SECONDS = 60.0
-        try:
-            handle.buf[:] = bytes(control_nbytes)
-            manager._configure_atomic_access(handle, tp_size=1)
-            manager._atomic_store(offsets["global_error"][0], 1)
-            with self.assertRaisesRegex(RuntimeError, "aborted by another"):
-                manager._wait_for_exact_control_value(
-                    offsets["ready_generation"][0],
-                    1,
-                    "failed writer publication",
-                )
-            self.assertTrue(manager.transport_abandoned)
-        finally:
-            manager._transport_control_anchor = None
-            handle.close()
-            handle.unlink()
-
-    def test_writer_descriptor_mismatch_poison_is_sticky(self):
-        manager_type = kt_ep_wrapper._Glm5NextFp8LayerwisePrefillManager
-        _offsets, control_nbytes = manager_type._build_control_offsets(1)
-        handle = shared_memory.SharedMemory(create=True, size=control_nbytes)
-        manager = object.__new__(manager_type)
-        manager.transport_abandoned = False
-        try:
-            handle.buf[:] = bytes(control_nbytes)
-            manager._configure_atomic_access(handle, tp_size=1)
-            manager._publish_writer_generation(
-                host_slot=0,
-                generation=1,
-                layer_idx=3,
-                expert_id=17,
-                writer_ok=True,
-            )
-            with self.assertRaisesRegex(RuntimeError, "descriptor mismatch"):
-                manager._consume_writer_generation(
-                    host_slot=0,
-                    generation=1,
+            context.load.call_args_list,
+            [
+                mock.call(
                     layer_idx=3,
-                    expert_id=18,
+                    wrapper=wrapper.wrapper,
+                    original_layer=layer,
+                    gpu_experts_mask=wrapper.gpu_experts_mask,
+                    logical_to_gpu_index=wrapper.logical_to_gpu_index,
+                ),
+                mock.call(
+                    layer_idx=4,
+                    wrapper=wrapper.wrapper,
+                    original_layer=second_layer,
+                    gpu_experts_mask=wrapper.gpu_experts_mask,
+                    logical_to_gpu_index=wrapper.logical_to_gpu_index,
+                ),
+            ],
+        )
+
+    def test_image_extend_and_decode_idle_bypass_generic_context(self):
+        cases = (("EXTEND", True), ("DECODE", False), ("IDLE", False))
+        for mode, has_image in cases:
+            with self.subTest(mode=mode, has_image=has_image):
+                kt_ep_wrapper._SHARED_FULL_CONTEXT = None
+                wrapper = self._wrapper(mode=mode)
+                wrapper._glm5_next_has_image_inputs = has_image
+                context = self._generic_context()
+                with mock.patch.object(
+                    kt_ep_wrapper, "SharedFullContext", return_value=context
+                ) as context_ctor:
+                    result = self._apply(wrapper, self._layer(), 1024)
+
+                context_ctor.assert_not_called()
+                context.load.assert_not_called()
+                torch.testing.assert_close(
+                    result.hidden_states, torch.full((1024, 2), 7.0)
                 )
-            self.assertTrue(manager.transport_abandoned)
-            self.assertTrue(manager._shared_transport_failed())
-        finally:
-            manager._transport_control_anchor = None
-            handle.close()
-            handle.unlink()
+                if has_image:
+                    self.assertEqual(wrapper._glm5_next_mm_hybrid_extend_count, 1)
 
-    def test_tp_contract_rejects_peer_mask_or_mapping_digest_drift(self):
-        signature = ("glm", "contract")
-        original_layer = SimpleNamespace(
-            **{
-                name: torch.empty(1)
-                for name in kt_ep_wrapper._Glm5NextFp8PrefillSlot.RAW_NAMES
-            }
-        )
-        method = SimpleNamespace(
-            gpu_experts_mask=torch.tensor([True, False]),
-            logical_to_gpu_index=torch.tensor([0, -1], dtype=torch.int32),
-            num_gpu_experts=1,
-            global_num_experts=2,
-            _full_init_args=(4, 2, torch.bfloat16),
-            kt_config=SimpleNamespace(weight_path="weights"),
-        )
-        kt_ep_wrapper._GLM5_NEXT_FP8_PREFILL_LAYER_REGISTRY[signature] = {
-            3: (method, original_layer)
-        }
-        manager = object.__new__(
-            kt_ep_wrapper._Glm5NextFp8LayerwisePrefillManager
-        )
-        manager.signature = signature
-        manager.device = torch.device("cpu")
-        manager.slots = (
-            SimpleNamespace(
-                **{
-                    name: torch.empty(1)
-                    for name in kt_ep_wrapper._Glm5NextFp8PrefillSlot.RAW_NAMES
-                }
-            ),
-        )
-
-        def inject_peer_drift(gathered, local, **_kwargs):
-            gathered[:] = [
-                local,
-                (local[0], "different-digest", local[2], None),
-            ]
+    def test_single_rank_slot_oom_fails_collectively_before_host_buffers(self):
+        wrapper = self._wrapper()
+        layer = self._layer()
 
         with (
             mock.patch.object(
-                kt_ep_wrapper.dist, "is_initialized", return_value=True
+                kt_ep_wrapper,
+                "SharedFullContext",
+                side_effect=torch.cuda.OutOfMemoryError("test slot OOM"),
+            ),
+            mock.patch.object(torch.cuda, "is_available", return_value=False),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "CUDA out of memory"):
+                wrapper._build_full_context(layer)
+
+        self.assertIsNone(kt_ep_wrapper._SHARED_FULL_CONTEXT)
+
+    def test_cross_rank_validation_failure_cleans_host_buffers(self):
+        wrapper = self._wrapper()
+        context = self._generic_context()
+
+        with (
+            mock.patch.object(
+                kt_ep_wrapper, "SharedFullContext", return_value=context
+            ),
+            mock.patch.object(
+                kt_ep_wrapper,
+                "_validate_glm5_next_fp8_shared_full_context",
+                return_value=(1_812_381_696, 12_585_984),
+            ),
+            mock.patch.object(
+                kt_ep_wrapper,
+                "_all_tp_ranks_succeeded",
+                side_effect=(True, False),
+            ),
+            mock.patch.object(torch.cuda, "is_available", return_value=False),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "validation failed"):
+                wrapper._build_full_context(self._layer())
+
+        context.initialize_cpu_buffers.assert_called_once_with()
+        context._cleanup_cpu_buffers_after_failure.assert_called_once_with()
+        self.assertIsNone(kt_ep_wrapper._SHARED_FULL_CONTEXT)
+
+    def test_missing_and_unsupported_forward_modes_fail_before_allocation(self):
+        for mode, pattern in (
+            (None, "ForwardMode metadata"),
+            ("MIXED", "supports only plain EXTEND"),
+        ):
+            with self.subTest(mode=mode):
+                kt_ep_wrapper._SHARED_FULL_CONTEXT = None
+                wrapper = self._wrapper(mode=mode)
+                context = self._generic_context()
+                with mock.patch.object(
+                    kt_ep_wrapper, "SharedFullContext", return_value=context
+                ) as context_ctor:
+                    with self.assertRaisesRegex(RuntimeError, pattern):
+                        self._apply(wrapper, self._layer(), 1024)
+
+                context_ctor.assert_not_called()
+                context.load.assert_not_called()
+
+    def test_non_glm_keeps_the_existing_generic_threshold_behavior(self):
+        wrapper = self._wrapper(exact=False, mode=None)
+        layer = self._layer()
+        context = self._generic_context(fill_value=13)
+
+        with mock.patch.object(
+            kt_ep_wrapper, "SharedFullContext", return_value=context
+        ) as context_ctor:
+            below = self._apply(wrapper, layer, 1023)
+            at_threshold = self._apply(wrapper, layer, 1024)
+
+        torch.testing.assert_close(
+            below.hidden_states, torch.full((1023, 2), 7.0)
+        )
+        torch.testing.assert_close(
+            at_threshold.hidden_states, torch.full((1024, 2), 13.0)
+        )
+        context_ctor.assert_called_once()
+        context.load.assert_called_once()
+
+
+class _TensorMetadata:
+    def __init__(self, shape, dtype):
+        self.shape = torch.Size(shape)
+        self.dtype = dtype
+
+    def numel(self):
+        return math.prod(self.shape)
+
+    def element_size(self):
+        return torch.empty((), dtype=self.dtype).element_size()
+
+
+class _FakeSharedMemory:
+    instances = []
+
+    def __init__(self, *, name, create, size):
+        self.name = name
+        self.create = create
+        self.size = size
+        self.buf = bytearray(size)
+        self.unlinked = False
+        self.closed = False
+        self.instances.append(self)
+
+    def unlink(self):
+        self.unlinked = True
+
+    def close(self):
+        self.closed = True
+
+
+class _FakeCudaEvent:
+    def __init__(self):
+        self.record_count = 0
+        self.synchronize_count = 0
+
+    def record(self, _stream):
+        self.record_count += 1
+
+    def synchronize(self):
+        self.synchronize_count += 1
+
+
+class _FakeCudaStream:
+    def __init__(self):
+        self.synchronize_count = 0
+        self.waited_streams = []
+
+    def synchronize(self):
+        self.synchronize_count += 1
+
+    def wait_stream(self, stream):
+        self.waited_streams.append(stream)
+
+
+class _FakeFp8Writer:
+    def __init__(self, context):
+        self.context = context
+        self.pending = None
+        self.submitted = []
+        self.sync_count = 0
+
+    def submit_write_weight_scale_to_buffer(
+        self,
+        tp_size,
+        expert_id,
+        w13_weight_ptrs,
+        w13_scale_ptrs,
+        w2_weight_ptrs,
+        w2_scale_ptrs,
+    ):
+        self.submitted.append((tp_size, expert_id))
+        base = self.context.cpu_buffers["w13_weight"].data_ptr()
+        per_slot_bytes = (
+            self.context.cpu_buffers["w13_weight"].numel()
+            // 2
+            * self.context.cpu_buffers["w13_weight"].element_size()
+        )
+        slot = (w13_weight_ptrs[0] - base) // per_slot_bytes
+        self.pending = (expert_id, slot)
+
+    def sync_write_weight_scale_to_buffer(self):
+        expert_id, slot = self.pending
+        for offset, name in enumerate(
+            kt_ep_wrapper.SharedFullContext.WEIGHT_NAMES_FP8
+        ):
+            self.context.cpu_buffers[name][slot].fill_(expert_id + offset * 10)
+        self.sync_count += 1
+        self.pending = None
+
+
+class TestGlm5NextFp8SingleSlotLayout(unittest.TestCase):
+    def setUp(self):
+        kt_ep_wrapper._SHARED_FULL_CONTEXT = None
+        _FakeSharedMemory.instances.clear()
+
+    def test_generic_host_transport_allocates_exactly_two_expert_slots(self):
+        context = object.__new__(kt_ep_wrapper.SharedFullContext)
+        context.gpu_layer = SimpleNamespace(
+            num_experts=3,
+            w13_weight=_TensorMetadata((3, 4, 5), torch.float8_e4m3fn),
+            w13_weight_scale_inv=_TensorMetadata((3, 1, 1), torch.float32),
+            w2_weight=_TensorMetadata((3, 5, 2), torch.float8_e4m3fn),
+            w2_weight_scale_inv=_TensorMetadata((3, 1, 1), torch.float32),
+        )
+        context._is_mxfp4_quant = False
+        context._is_mxfp8_quant = False
+        context._is_fp8_quant = True
+        context._is_fp8_channel_quant = False
+        context._is_bf16_quant = False
+        context._commit_cpu_buffer_phase = mock.Mock()
+        context._collect_all_rank_buffer_pointers = mock.Mock(
+            return_value={name: [index + 1] for index, name in enumerate(
+                kt_ep_wrapper.SharedFullContext.WEIGHT_NAMES_FP8
+            )}
+        )
+        fake_numa = SimpleNamespace(
+            numa_available=lambda: 0,
+            numa_set_localalloc=lambda: None,
+        )
+
+        with (
+            mock.patch.object(kt_ep_wrapper.ctypes, "CDLL", return_value=fake_numa),
+            mock.patch.object(
+                kt_ep_wrapper.shared_memory,
+                "SharedMemory",
+                side_effect=_FakeSharedMemory,
+            ),
+            mock.patch.object(
+                kt_ep_wrapper,
+                "get_tensor_model_parallel_rank",
+                return_value=0,
             ),
             mock.patch.object(
                 kt_ep_wrapper,
                 "get_tensor_model_parallel_world_size",
-                return_value=2,
+                return_value=1,
+            ),
+            mock.patch.object(kt_ep_wrapper.dist, "is_initialized", return_value=False),
+            mock.patch.object(torch.cuda, "is_available", return_value=False),
+        ):
+            context._create_cpu_buffers()
+
+        expected_shapes = {
+            "w13_weight": (2, 4, 5),
+            "w13_weight_scale_inv": (2, 1, 1),
+            "w2_weight": (2, 5, 2),
+            "w2_weight_scale_inv": (2, 1, 1),
+        }
+        self.assertEqual(set(context.cpu_buffers), set(expected_shapes))
+        for name, expected_shape in expected_shapes.items():
+            self.assertEqual(tuple(context.cpu_buffers[name].shape), expected_shape)
+        self.assertEqual(len(_FakeSharedMemory.instances), 4)
+        self.assertTrue(all(item.unlinked for item in _FakeSharedMemory.instances))
+
+    def test_exact_glm_transport_reuses_two_persistent_host_slot_events(self):
+        context = object.__new__(kt_ep_wrapper.SharedFullContext)
+        context._glm5_next_fp8_transport_initialized = True
+        context._glm5_next_fp8_copy_stream = _FakeCudaStream()
+        context._glm5_next_fp8_host_slot_events = (
+            _FakeCudaEvent(),
+            _FakeCudaEvent(),
+        )
+        context._glm5_next_fp8_host_slot_was_used = [False, False]
+        context._glm5_next_fp8_transport_status = None
+        context.gpu_layer = SimpleNamespace(num_experts=4)
+        context.cpu_buffers = {}
+        context.all_rank_buffer_ptrs = {}
+        for name in kt_ep_wrapper.SharedFullContext.WEIGHT_NAMES_FP8:
+            cpu_buffer = torch.empty((2, 1), dtype=torch.float32)
+            gpu_tensor = torch.empty((4, 1), dtype=torch.float32)
+            context.cpu_buffers[name] = cpu_buffer
+            context.all_rank_buffer_ptrs[name] = [cpu_buffer.data_ptr()]
+            setattr(context.gpu_layer, name, gpu_tensor)
+
+        writer = _FakeFp8Writer(context)
+        current_stream = _FakeCudaStream()
+        with (
+            mock.patch.object(
+                kt_ep_wrapper,
+                "get_tensor_model_parallel_rank",
+                return_value=0,
             ),
             mock.patch.object(
-                kt_ep_wrapper.dist,
-                "all_gather_object",
-                side_effect=inject_peer_drift,
+                kt_ep_wrapper,
+                "get_tensor_model_parallel_world_size",
+                return_value=1,
+            ),
+            mock.patch.object(
+                torch.cuda,
+                "stream",
+                side_effect=lambda _stream: contextlib.nullcontext(),
+            ),
+            mock.patch.object(
+                torch.cuda,
+                "current_stream",
+                return_value=current_stream,
             ),
         ):
-            with self.assertRaisesRegex(RuntimeError, "contract mismatch"):
-                manager.validate_tp_contract()
+            context._prepare_weight_fp8_glm5_next(writer)
 
-    def test_tp_contract_rejects_processed_or_repacked_original_gpu_tensor(self):
-        signature = ("glm", "raw-original")
-        names = kt_ep_wrapper._Glm5NextFp8PrefillSlot.RAW_NAMES
-        original_layer = SimpleNamespace(
-            **{name: torch.empty(1) for name in names}
-        )
-        original_layer.w13_weight = torch.empty(1, dtype=torch.int32)
-        method = SimpleNamespace(
-            gpu_experts_mask=torch.tensor([True, False]),
-            logical_to_gpu_index=torch.tensor([0, -1], dtype=torch.int32),
-            num_gpu_experts=1,
-            global_num_experts=2,
-            _full_init_args=(4, 2, torch.bfloat16),
-            kt_config=SimpleNamespace(weight_path="weights"),
-        )
-        kt_ep_wrapper._GLM5_NEXT_FP8_PREFILL_LAYER_REGISTRY[signature] = {
-            3: (method, original_layer)
-        }
-        manager = object.__new__(
-            kt_ep_wrapper._Glm5NextFp8LayerwisePrefillManager
-        )
-        manager.signature = signature
-        manager.device = torch.device("cpu")
-        manager.slots = (
-            SimpleNamespace(**{name: torch.empty(1) for name in names}),
-        )
-
-        with self.assertRaisesRegex(RuntimeError, "failed to build") as raised:
-            manager.validate_tp_contract()
-        self.assertIn("dtype mismatch", str(raised.exception.__cause__))
-
-    def test_transport_control_disables_resource_tracking_when_supported(self):
-        opener = mock.Mock(return_value="untracked")
-        with mock.patch.object(kt_ep_wrapper.shared_memory, "SharedMemory", opener):
-            result = (
-                kt_ep_wrapper._Glm5NextFp8LayerwisePrefillManager
-                ._open_transport_shared_memory(name="control", create=False)
-            )
-
-        self.assertEqual(result, "untracked")
-        opener.assert_called_once_with(
-            name="control", create=False, track=False
-        )
-
-    def test_transport_control_tracking_fallback_is_for_old_python_only(self):
-        opener = mock.Mock(side_effect=[TypeError("no track"), "tracked"])
-        with mock.patch.object(kt_ep_wrapper.shared_memory, "SharedMemory", opener):
-            result = (
-                kt_ep_wrapper._Glm5NextFp8LayerwisePrefillManager
-                ._open_transport_shared_memory(name="control", create=False)
-            )
-
-        self.assertEqual(result, "tracked")
-        self.assertEqual(
-            opener.call_args_list,
-            [
-                mock.call(name="control", create=False, track=False),
-                mock.call(name="control", create=False),
-            ],
-        )
-
-    def test_bind_selects_only_the_four_stable_raw_tensors(self):
-        names = kt_ep_wrapper._Glm5NextFp8PrefillSlot.RAW_NAMES
-        old = {name: torch.nn.Parameter(torch.zeros(1)) for name in names}
-        new = {name: torch.nn.Parameter(torch.ones(1)) for name in names}
-        layer = SimpleNamespace(**old)
-        manager = object.__new__(kt_ep_wrapper._Glm5NextFp8LayerwisePrefillManager)
-        manager.context = SimpleNamespace(gpu_layer=layer)
-
-        manager._bind_slot(SimpleNamespace(**new))
-
-        for name in names:
-            self.assertIs(getattr(layer, name), new[name])
-        self.assertFalse(hasattr(layer, "_v4_marlin_weights"))
-
-    def test_writer_abi_uses_fp8_and_fp32_host_slot_offsets(self):
-        class HostBuffer:
-            def __init__(self, numel, element_size):
-                self._numel = numel
-                self._element_size = element_size
-
-            def numel(self):
-                return self._numel
-
-            def element_size(self):
-                return self._element_size
-
-        names = kt_ep_wrapper._Glm5NextFp8PrefillSlot.RAW_NAMES
-        buffers = {
-            names[0]: HostBuffer(200, 1),
-            names[1]: HostBuffer(80, 4),
-            names[2]: HostBuffer(120, 1),
-            names[3]: HostBuffer(40, 4),
-        }
-        pointers = {
-            name: [1000 + index * 100, 2000 + index * 100]
-            for index, name in enumerate(names)
-        }
-        manager = object.__new__(kt_ep_wrapper._Glm5NextFp8LayerwisePrefillManager)
-        manager.context = SimpleNamespace(
-            cpu_buffers=buffers, all_rank_buffer_ptrs=pointers
-        )
-        wrapper = mock.Mock()
-        method = SimpleNamespace(wrapper=wrapper)
-
-        with mock.patch.object(
-            kt_ep_wrapper, "get_tensor_model_parallel_world_size", return_value=2
+        self.assertEqual(writer.submitted, [(1, 0), (1, 1), (1, 2), (1, 3)])
+        self.assertEqual(writer.sync_count, 4)
+        for offset, name in enumerate(
+            kt_ep_wrapper.SharedFullContext.WEIGHT_NAMES_FP8
         ):
-            manager._submit_host_write(method, expert_id=17, host_slot=1)
-
-        args = wrapper.submit_write_weight_scale_to_buffer.call_args.args
-        self.assertEqual(args[:2], (2, 17))
-        for position, name in enumerate(names, 2):
-            offset = buffers[name].numel() // 2 * buffers[name].element_size()
-            self.assertEqual(
-                args[position], [pointer + offset for pointer in pointers[name]]
+            expected = torch.arange(4, dtype=torch.float32) + offset * 10
+            torch.testing.assert_close(
+                getattr(context.gpu_layer, name).flatten(), expected
             )
-        wrapper.sync_write_weight_scale_to_buffer.assert_called_once_with()
+        event0, event1 = context._glm5_next_fp8_host_slot_events
+        self.assertEqual(event0.record_count, 2)
+        self.assertEqual(event1.record_count, 2)
+        self.assertEqual(event0.synchronize_count, 1)
+        self.assertEqual(event1.synchronize_count, 1)
+        self.assertEqual(context._glm5_next_fp8_copy_stream.synchronize_count, 1)
 
+    def test_tp4_fp8_geometry_and_single_full_layer_slot_bytes(self):
+        num_experts = 288
+        hidden_size = 4096
+        global_intermediate_size = 2048
+        tp_size = 4
+        block_size = 128
+        intermediate_size = global_intermediate_size // tp_size
 
-class TestGlm5NextFp8AllocationContracts(unittest.TestCase):
-    def setUp(self):
-        kt_ep_wrapper._GLM5_NEXT_FP8_PREFILL_LAYER_REGISTRY.clear()
-        kt_ep_wrapper._GLM5_NEXT_FP8_LAYERWISE_MANAGERS.clear()
-
-    def test_exact_two_slot_capacity_is_reserved_before_kv_profile(self):
-        one_slot = kt_ep_wrapper._glm5_next_fp8_raw_slot_storage_nbytes(
-            num_experts=288,
-            hidden_size=4096,
-            intermediate_size=256,
-        )
-        self.assertEqual(one_slot, 906_190_848)
-        self.assertEqual(2 * one_slot, 1_812_381_696)
-
-        model_runner_source = (
-            Path(__file__).resolve().parents[2]
-            / "python/sglang/srt/model_executor/model_runner.py"
-        ).read_text(encoding="utf-8")
-        allocation_pos = model_runner_source.index(
-            "initialize_glm5_next_fp8_layerwise_prefill()"
-        )
-        pool_pos = model_runner_source.index("self.init_memory_pool()", allocation_pos)
-        self.assertLess(allocation_pos, pool_pos)
-
-    def test_registry_requires_all_42_exact_checkpoint_moe_layers(self):
-        mask = torch.zeros(288, dtype=torch.bool)
-        mask[:4] = True
-        mapping = torch.full((288,), -1, dtype=torch.int32)
-        mapping[:4] = torch.arange(4, dtype=torch.int32)
-        method = SimpleNamespace(
-            kt_config=SimpleNamespace(
-                is_glm5_next=True,
-                method="FP8",
-                num_layers=45,
-                kt_enable_dynamic_expert_update=False,
+        self.assertEqual(intermediate_size, 512)
+        gpu_tensors = {
+            "w13_weight": _TensorMetadata(
+                (num_experts, 2 * intermediate_size, hidden_size),
+                torch.float8_e4m3fn,
             ),
-            gpu_prefill_token_threshold=1,
-            tp_rank=0,
-            global_num_experts=288,
-            _full_init_args=(4096, 256, torch.bfloat16),
-            gpu_experts_mask=mask,
-            logical_to_gpu_index=mapping,
-            num_gpu_experts=4,
-        )
-        complete = {idx: (method, object()) for idx in range(3, 45)}
-        kt_ep_wrapper._validate_glm5_next_fp8_registry(("glm",), complete)
-
-        incomplete = dict(complete)
-        incomplete.pop(44)
-        with self.assertRaisesRegex(RuntimeError, "every MoE layer 3..44"):
-            kt_ep_wrapper._validate_glm5_next_fp8_registry(("glm",), incomplete)
-
-    @unittest.skipUnless(torch.cuda.is_available(), "requires a CUDA device")
-    def test_registry_validates_cuda_resident_mask_and_mapping(self):
-        device = torch.device("cuda", torch.cuda.current_device())
-        mask = torch.zeros(288, dtype=torch.bool, device=device)
-        mask[:4] = True
-        mapping = torch.full((288,), -1, dtype=torch.int32, device=device)
-        mapping[:4] = torch.arange(4, dtype=torch.int32, device=device)
-        method = SimpleNamespace(
-            kt_config=SimpleNamespace(
-                is_glm5_next=True,
-                method="FP8",
-                num_layers=45,
-                kt_enable_dynamic_expert_update=False,
+            "w13_weight_scale_inv": _TensorMetadata(
+                (
+                    num_experts,
+                    math.ceil(2 * intermediate_size / block_size),
+                    math.ceil(hidden_size / block_size),
+                ),
+                torch.float32,
             ),
-            gpu_prefill_token_threshold=1,
-            tp_rank=0,
-            global_num_experts=288,
-            _full_init_args=(4096, 256, torch.bfloat16),
-            gpu_experts_mask=mask,
-            logical_to_gpu_index=mapping,
-            num_gpu_experts=4,
-        )
-        complete = {idx: (method, object()) for idx in range(3, 45)}
-
-        kt_ep_wrapper._validate_glm5_next_fp8_registry(("glm",), complete)
-
-    def test_context_accepts_only_raw_e4m3_and_fp32_128_scales(self):
-        class TensorMetadata:
-            def __init__(self, shape, dtype):
-                self.shape = shape
-                self.dtype = dtype
-
-        layer = SimpleNamespace(
-            w13_weight=TensorMetadata((288, 512, 4096), torch.float8_e4m3fn),
-            w13_weight_scale_inv=TensorMetadata((288, 4, 32), torch.float32),
-            w2_weight=TensorMetadata((288, 4096, 256), torch.float8_e4m3fn),
-            w2_weight_scale_inv=TensorMetadata((288, 32, 2), torch.float32),
-            moe_runner_config=SimpleNamespace(
-                glm5_next_hf_two_round_swiglu=True
+            "w2_weight": _TensorMetadata(
+                (num_experts, hidden_size, intermediate_size),
+                torch.float8_e4m3fn,
             ),
-        )
+            "w2_weight_scale_inv": _TensorMetadata(
+                (
+                    num_experts,
+                    math.ceil(hidden_size / block_size),
+                    math.ceil(intermediate_size / block_size),
+                ),
+                torch.float32,
+            ),
+        }
+        host_buffers = {
+            name: _TensorMetadata((2, *tensor.shape[1:]), tensor.dtype)
+            for name, tensor in gpu_tensors.items()
+        }
         context = SimpleNamespace(
             _is_fp8_quant=True,
+            _glm5_next_fp8_transport_initialized=True,
+            _glm5_next_fp8_copy_stream=object(),
+            _glm5_next_fp8_host_slot_events=(object(), object()),
             _get_base_quant_method=lambda: SimpleNamespace(
                 block_quant=True,
                 use_mxfp8=False,
@@ -885,133 +650,66 @@ class TestGlm5NextFp8AllocationContracts(unittest.TestCase):
                     runner_backend=SimpleNamespace(is_triton=lambda: True)
                 ),
             ),
-            gpu_layer=layer,
-        )
-        kt_ep_wrapper._validate_glm5_next_fp8_context(context)
-
-        layer.moe_runner_config.glm5_next_hf_two_round_swiglu = False
-        with self.assertRaisesRegex(RuntimeError, "private HF two-round"):
-            kt_ep_wrapper._validate_glm5_next_fp8_context(context)
-        layer.moe_runner_config.glm5_next_hf_two_round_swiglu = True
-
-        layer.w2_weight_scale_inv.dtype = torch.bfloat16
-        with self.assertRaisesRegex(RuntimeError, "dtype mismatch"):
-            kt_ep_wrapper._validate_glm5_next_fp8_context(context)
-
-        layer.w2_weight_scale_inv.dtype = torch.float32
-        context._get_base_quant_method = lambda: SimpleNamespace(
-            block_quant=True,
-            use_mxfp8=False,
-            weight_block_size=[128, 128],
-            runner=SimpleNamespace(
-                runner_backend=SimpleNamespace(is_triton=lambda: False)
+            gpu_layer=SimpleNamespace(
+                num_experts=num_experts,
+                moe_runner_config=SimpleNamespace(
+                    glm5_next_hf_two_round_swiglu=True
+                ),
+                **gpu_tensors,
             ),
+            cpu_buffers=host_buffers,
         )
-        with self.assertRaisesRegex(RuntimeError, "Triton MoE runner"):
-            kt_ep_wrapper._validate_glm5_next_fp8_context(context)
 
-    def test_tp0_writer_abi_is_probed_before_serving(self):
-        complete_wrapper = SimpleNamespace(
-            submit_write_weight_scale_to_buffer=lambda *_args: None,
-            sync_write_weight_scale_to_buffer=lambda: None,
-            moe=SimpleNamespace(write_weight_scale_to_buffer_task=object()),
-        )
-        registry = {
-            3: (SimpleNamespace(wrapper=complete_wrapper), object())
-        }
         with mock.patch.object(
-            kt_ep_wrapper, "get_tensor_model_parallel_rank", return_value=0
+            kt_ep_wrapper,
+            "get_tensor_model_parallel_world_size",
+            return_value=4,
         ):
-            kt_ep_wrapper._validate_glm5_next_fp8_writer_abi(registry)
-
-            incomplete = {
-                3: (
-                    SimpleNamespace(
-                        wrapper=SimpleNamespace(
-                            submit_write_weight_scale_to_buffer=lambda *_args: None,
-                            sync_write_weight_scale_to_buffer=lambda: None,
-                            moe=object(),
-                        )
-                    ),
-                    object(),
+            gpu_slot_bytes, host_buffer_bytes = (
+                kt_ep_wrapper._validate_glm5_next_fp8_shared_full_context(
+                    context
                 )
-            }
-            with self.assertRaisesRegex(
-                RuntimeError, "write_weight_scale_to_buffer_task"
-            ):
-                kt_ep_wrapper._validate_glm5_next_fp8_writer_abi(incomplete)
+            )
+        self.assertEqual(gpu_slot_bytes, 1_812_381_696)
+        self.assertEqual(host_buffer_bytes, 12_585_984)
 
-        with mock.patch.object(
-            kt_ep_wrapper, "get_tensor_model_parallel_rank", return_value=1
-        ):
-            kt_ep_wrapper._validate_glm5_next_fp8_writer_abi(incomplete)
-
-    def test_startup_oom_is_fatal_and_does_not_register_manager(self):
-        signature = ("glm", "oom")
-        mask = torch.zeros(288, dtype=torch.bool)
-        mapping = torch.full((288,), -1, dtype=torch.int32)
-        method = SimpleNamespace(
-            kt_config=SimpleNamespace(
-                is_glm5_next=True,
-                method="FP8",
-                num_layers=45,
-                kt_enable_dynamic_expert_update=False,
-            ),
-            gpu_prefill_token_threshold=1,
-            _full_init_args=(4096, 256, torch.bfloat16),
-            global_num_experts=288,
-            moe_runner_config=object(),
-            tp_rank=0,
-            gpu_experts_mask=mask,
-            logical_to_gpu_index=mapping,
-            num_gpu_experts=0,
+        context.cpu_buffers["w13_weight"] = _TensorMetadata(
+            (1, *gpu_tensors["w13_weight"].shape[1:]), torch.float8_e4m3fn
         )
-        registry = {idx: (method, object()) for idx in range(3, 45)}
         with (
-            mock.patch.object(torch.cuda, "is_available", return_value=True),
             mock.patch.object(
                 kt_ep_wrapper,
                 "get_tensor_model_parallel_world_size",
-                return_value=8,
+                return_value=4,
             ),
-            mock.patch.object(
-                kt_ep_wrapper,
-                "SharedFullContext",
-                side_effect=torch.cuda.OutOfMemoryError("slot 0"),
-            ) as context_ctor,
-            mock.patch.object(torch.cuda, "empty_cache"),
+            self.assertRaisesRegex(
+                RuntimeError, "exactly two expert Host slots"
+            ),
         ):
-            with self.assertRaisesRegex(RuntimeError, "refusing.*fallback"):
-                kt_ep_wrapper._initialize_glm5_next_fp8_layerwise_pipeline(
-                    signature, registry
-                )
+            kt_ep_wrapper._validate_glm5_next_fp8_shared_full_context(context)
 
-        context_ctor.assert_called_once()
-        self.assertNotIn(signature, kt_ep_wrapper._GLM5_NEXT_FP8_LAYERWISE_MANAGERS)
+    def test_private_glm_two_slot_pipeline_symbols_are_gone(self):
+        removed_symbols = (
+            "_GLM5_NEXT_FP8_PREFILL_LAYER_REGISTRY",
+            "_GLM5_NEXT_FP8_LAYERWISE_MANAGERS",
+            "_Glm5NextFp8PrefillSlot",
+            "_Glm5NextFp8LayerwisePrefillManager",
+            "_register_glm5_next_fp8_prefill_layer",
+            "_initialize_glm5_next_fp8_layerwise_pipeline",
+            "initialize_glm5_next_fp8_layerwise_prefill",
+            "_get_glm5_next_fp8_layerwise_manager",
+        )
+        for symbol in removed_symbols:
+            with self.subTest(symbol=symbol):
+                self.assertFalse(hasattr(kt_ep_wrapper, symbol))
 
-    def test_glm_manager_and_registry_are_not_mxfp4_state(self):
-        self.assertIsNot(
-            kt_ep_wrapper._GLM5_NEXT_FP8_PREFILL_LAYER_REGISTRY,
-            kt_ep_wrapper._MXFP4_PREFILL_LAYER_REGISTRY,
+        model_runner_source = (
+            Path(__file__).resolve().parents[2]
+            / "python/sglang/srt/model_executor/model_runner.py"
+        ).read_text(encoding="utf-8")
+        self.assertNotIn(
+            "initialize_glm5_next_fp8_layerwise_prefill", model_runner_source
         )
-        self.assertIsNot(
-            kt_ep_wrapper._GLM5_NEXT_FP8_LAYERWISE_MANAGERS,
-            kt_ep_wrapper._MXFP4_LAYERWISE_MANAGERS,
-        )
-        self.assertFalse(
-            issubclass(
-                kt_ep_wrapper._Glm5NextFp8LayerwisePrefillManager,
-                kt_ep_wrapper._Mxfp4LayerwisePrefillManager,
-            )
-        )
-
-    def test_initializer_has_no_lazy_or_disabled_fallback_branch(self):
-        source = inspect.getsource(
-            kt_ep_wrapper._initialize_glm5_next_fp8_layerwise_pipeline
-        )
-        self.assertNotIn("_MXFP4", source)
-        self.assertNotIn("DISABLED_REASONS", source)
-        self.assertIn("refusing hybrid/serialized fallback", source)
 
 
 if __name__ == "__main__":

--- a/test/unit/test_glm5_next_fp8_layerwise_prefill.py
+++ b/test/unit/test_glm5_next_fp8_layerwise_prefill.py
@@ -258,6 +258,22 @@ class TestGlm5NextFp8Gates(unittest.TestCase):
                     result.hidden_states, torch.full((1, 2), 7.0)
                 )
 
+    def test_image_extend_bypasses_layerwise_and_uses_hybrid_path(self):
+        wrapper = self._wrapper(mode="EXTEND")
+        wrapper._glm5_next_has_image_inputs = True
+        manager = mock.Mock()
+        kt_ep_wrapper._GLM5_NEXT_FP8_LAYERWISE_MANAGERS[
+            wrapper._glm5_next_fp8_pipeline_signature
+        ] = manager
+
+        result = self._apply(wrapper, num_tokens=17)
+
+        manager.apply.assert_not_called()
+        self.assertEqual(wrapper._glm5_next_mm_hybrid_extend_count, 1)
+        torch.testing.assert_close(
+            result.hidden_states, torch.full((17, 2), 7.0)
+        )
+
     def test_unsupported_modes_and_missing_manager_fail_closed(self):
         for mode in ("MIXED", "TARGET_VERIFY", "SPLIT_PREFILL", "DLLM_EXTEND"):
             with self.subTest(mode=mode):

--- a/test/unit/test_glm5_next_fp8_layerwise_prefill.py
+++ b/test/unit/test_glm5_next_fp8_layerwise_prefill.py
@@ -39,6 +39,11 @@ def _load_test_target():
     stubs = {
         "sglang": _package("sglang"),
         "sglang.srt": _package("sglang.srt"),
+        "sglang.srt.configs": _package("sglang.srt.configs"),
+        "sglang.srt.configs.glm5_next": _module(
+            "sglang.srt.configs.glm5_next",
+            GLM5_NEXT_SUPPORTED_TP_SIZES=frozenset((1, 2, 4, 8)),
+        ),
         "sglang.srt.layers": _package("sglang.srt.layers"),
         "sglang.srt.layers.moe": _package("sglang.srt.layers.moe"),
         "sglang.srt.layers.quantization": _package(
@@ -518,6 +523,8 @@ class _FakeNativeExtension:
         self.calls = calls
         self.initialize_args = None
         self.transport = None
+        self.FP8_LAYERWISE_CONTROL_BYTES = 8192
+        self.FP8_LAYERWISE_MAX_TP_SIZE = 8
 
     def initialize_fp8_layerwise_control(self, control_ptr, control_size, tp_size):
         self.initialize_args = (control_ptr, control_size, tp_size)
@@ -757,7 +764,7 @@ class TestGlm5NextFp8SingleSlotLayout(unittest.TestCase):
         self.assertEqual(context._glm5_next_fp8_copy_stream.synchronize_count, 1)
 
     @staticmethod
-    def _native_context():
+    def _native_context(tp_size=4):
         context = object.__new__(kt_ep_wrapper.SharedFullContext)
         context.shm_unique_id = "native_test"
         context._commit_cpu_buffer_phase = mock.Mock()
@@ -772,14 +779,15 @@ class TestGlm5NextFp8SingleSlotLayout(unittest.TestCase):
             context.cpu_buffers[name] = cpu_buffer
             context.all_rank_buffer_ptrs[name] = [
                 cpu_buffer.data_ptr() + rank * 1_000_000
-                for rank in range(4)
+                for rank in range(tp_size)
             ]
             gpu_tensors[name] = gpu_tensor
         context.gpu_layer = SimpleNamespace(num_experts=3, **gpu_tensors)
         return context
 
-    def test_native_transport_uses_fixed_flattened_pointer_abi(self):
-        context = self._native_context()
+    def test_native_transport_uses_tp8_flattened_pointer_abi(self):
+        tp_size = 8
+        context = self._native_context(tp_size=tp_size)
         calls = []
         extension = _FakeNativeExtension(calls)
         writer = _FakeNativeWriter(calls)
@@ -803,7 +811,7 @@ class TestGlm5NextFp8SingleSlotLayout(unittest.TestCase):
             mock.patch.object(
                 kt_ep_wrapper,
                 "get_tensor_model_parallel_world_size",
-                return_value=4,
+                return_value=tp_size,
             ),
             mock.patch.object(kt_ep_wrapper.dist, "is_initialized", return_value=False),
             mock.patch.object(
@@ -819,17 +827,20 @@ class TestGlm5NextFp8SingleSlotLayout(unittest.TestCase):
 
         self.assertEqual(
             extension.initialize_args[1:],
-            (kt_ep_wrapper._GLM5_NEXT_FP8_CONTROL_BYTES, 4),
+            (extension.FP8_LAYERWISE_CONTROL_BYTES, tp_size),
         )
         args = extension.transport.args
-        self.assertEqual(args[1:5], (4096, 0, 4, 0))
+        self.assertEqual(
+            args[1:5],
+            (extension.FP8_LAYERWISE_CONTROL_BYTES, 0, tp_size, 0),
+        )
         local_host_ptrs = args[5]
         local_gpu_ptrs = args[6]
         all_rank_host_ptrs = args[7]
         expert_nbytes = args[8]
         self.assertEqual(len(local_host_ptrs), 8)
         self.assertEqual(len(local_gpu_ptrs), 4)
-        self.assertEqual(len(all_rank_host_ptrs), 32)
+        self.assertEqual(len(all_rank_host_ptrs), 2 * tp_size * 4)
         self.assertEqual(expert_nbytes, [4, 8, 12, 16])
 
         expected_local = []
@@ -841,7 +852,7 @@ class TestGlm5NextFp8SingleSlotLayout(unittest.TestCase):
                     context.cpu_buffers[name].data_ptr()
                     + slot * expert_nbytes[index]
                 )
-            for rank in range(4):
+            for rank in range(tp_size):
                 for index, name in enumerate(names):
                     expected_all_rank.append(
                         context.all_rank_buffer_ptrs[name][rank]
@@ -1178,81 +1189,101 @@ class TestGlm5NextFp8SingleSlotLayout(unittest.TestCase):
             close_source.index("transport.close()"),
         )
 
-    def test_tp4_fp8_geometry_and_single_full_layer_slot_bytes(self):
+    def test_supported_tp_fp8_geometry_and_single_full_layer_slot_bytes(self):
         num_experts = 288
         hidden_size = 4096
         global_intermediate_size = 2048
-        tp_size = 4
         block_size = 128
-        intermediate_size = global_intermediate_size // tp_size
-
-        self.assertEqual(intermediate_size, 512)
-        gpu_tensors = {
-            "w13_weight": _TensorMetadata(
-                (num_experts, 2 * intermediate_size, hidden_size),
-                torch.float8_e4m3fn,
-            ),
-            "w13_weight_scale_inv": _TensorMetadata(
-                (
-                    num_experts,
-                    math.ceil(2 * intermediate_size / block_size),
-                    math.ceil(hidden_size / block_size),
-                ),
-                torch.float32,
-            ),
-            "w2_weight": _TensorMetadata(
-                (num_experts, hidden_size, intermediate_size),
-                torch.float8_e4m3fn,
-            ),
-            "w2_weight_scale_inv": _TensorMetadata(
-                (
-                    num_experts,
-                    math.ceil(hidden_size / block_size),
-                    math.ceil(intermediate_size / block_size),
-                ),
-                torch.float32,
-            ),
-        }
-        host_buffers = {
-            name: _TensorMetadata((2, *tensor.shape[1:]), tensor.dtype)
-            for name, tensor in gpu_tensors.items()
-        }
-        context = SimpleNamespace(
-            _is_fp8_quant=True,
-            _glm5_next_fp8_transport_initialized=True,
-            _glm5_next_fp8_copy_stream=object(),
-            _glm5_next_fp8_host_slot_events=(object(), object()),
-            _get_base_quant_method=lambda: SimpleNamespace(
-                block_quant=True,
-                use_mxfp8=False,
-                weight_block_size=[128, 128],
-                runner=SimpleNamespace(
-                    runner_backend=SimpleNamespace(is_triton=lambda: True)
-                ),
-            ),
-            gpu_layer=SimpleNamespace(
-                num_experts=num_experts,
-                moe_runner_config=SimpleNamespace(
-                    glm5_next_hf_two_round_swiglu=True
-                ),
-                **gpu_tensors,
-            ),
-            cpu_buffers=host_buffers,
-        )
-
-        with mock.patch.object(
-            kt_ep_wrapper,
-            "get_tensor_model_parallel_world_size",
-            return_value=4,
-        ):
-            gpu_slot_bytes, host_buffer_bytes = (
-                kt_ep_wrapper._validate_glm5_next_fp8_shared_full_context(
-                    context
+        contexts = {}
+        for tp_size in (1, 2, 4, 8):
+            with self.subTest(tp_size=tp_size):
+                intermediate_size = global_intermediate_size // tp_size
+                gpu_tensors = {
+                    "w13_weight": _TensorMetadata(
+                        (num_experts, 2 * intermediate_size, hidden_size),
+                        torch.float8_e4m3fn,
+                    ),
+                    "w13_weight_scale_inv": _TensorMetadata(
+                        (
+                            num_experts,
+                            math.ceil(2 * intermediate_size / block_size),
+                            math.ceil(hidden_size / block_size),
+                        ),
+                        torch.float32,
+                    ),
+                    "w2_weight": _TensorMetadata(
+                        (num_experts, hidden_size, intermediate_size),
+                        torch.float8_e4m3fn,
+                    ),
+                    "w2_weight_scale_inv": _TensorMetadata(
+                        (
+                            num_experts,
+                            math.ceil(hidden_size / block_size),
+                            math.ceil(intermediate_size / block_size),
+                        ),
+                        torch.float32,
+                    ),
+                }
+                host_buffers = {
+                    name: _TensorMetadata((2, *tensor.shape[1:]), tensor.dtype)
+                    for name, tensor in gpu_tensors.items()
+                }
+                context = SimpleNamespace(
+                    _is_fp8_quant=True,
+                    _full_init_args=(hidden_size, intermediate_size, torch.bfloat16),
+                    _global_num_experts=num_experts,
+                    _glm5_next_fp8_transport_initialized=True,
+                    _glm5_next_fp8_copy_stream=object(),
+                    _glm5_next_fp8_host_slot_events=(object(), object()),
+                    _get_base_quant_method=lambda: SimpleNamespace(
+                        block_quant=True,
+                        use_mxfp8=False,
+                        weight_block_size=[128, 128],
+                        runner=SimpleNamespace(
+                            runner_backend=SimpleNamespace(is_triton=lambda: True)
+                        ),
+                    ),
+                    gpu_layer=SimpleNamespace(
+                        num_experts=num_experts,
+                        moe_runner_config=SimpleNamespace(
+                            glm5_next_hf_two_round_swiglu=True
+                        ),
+                        **gpu_tensors,
+                    ),
+                    cpu_buffers=host_buffers,
                 )
-            )
-        self.assertEqual(gpu_slot_bytes, 1_812_381_696)
-        self.assertEqual(host_buffer_bytes, 12_585_984)
+                contexts[tp_size] = context
 
+                with mock.patch.object(
+                    kt_ep_wrapper,
+                    "get_tensor_model_parallel_world_size",
+                    return_value=tp_size,
+                ):
+                    gpu_slot_bytes, host_buffer_bytes = (
+                        kt_ep_wrapper._validate_glm5_next_fp8_shared_full_context(
+                            context
+                        )
+                    )
+                self.assertEqual(
+                    gpu_slot_bytes,
+                    sum(
+                        tensor.numel() * tensor.element_size()
+                        for tensor in gpu_tensors.values()
+                    ),
+                )
+                self.assertEqual(
+                    host_buffer_bytes,
+                    sum(
+                        tensor.numel() * tensor.element_size()
+                        for tensor in host_buffers.values()
+                    ),
+                )
+
+        context = contexts[4]
+        gpu_tensors = {
+            name: getattr(context.gpu_layer, name)
+            for name in kt_ep_wrapper._GLM5_NEXT_FP8_RAW_WEIGHT_NAMES
+        }
         context.cpu_buffers["w13_weight"] = _TensorMetadata(
             (1, *gpu_tensors["w13_weight"].shape[1:]), torch.float8_e4m3fn
         )

--- a/test/unit/test_glm5_next_fp8_layerwise_prefill.py
+++ b/test/unit/test_glm5_next_fp8_layerwise_prefill.py
@@ -2,8 +2,10 @@
 
 import contextlib
 import importlib.util
+import inspect
 import math
 import sys
+import threading
 import types
 import unittest
 from collections import namedtuple
@@ -140,6 +142,8 @@ class TestGlm5NextFp8GenericRouting(unittest.TestCase):
         kt_ep_wrapper._SHARED_FULL_CONTEXT = None
         kt_ep_wrapper._MXFP4_LAYERWISE_MANAGERS.clear()
         kt_ep_wrapper._MXFP4_LAYERWISE_DISABLED_REASONS.clear()
+        kt_ep_wrapper._GLM5_NEXT_FP8_NATIVE_PREFETCH_LAYER_REGISTRY.clear()
+        kt_ep_wrapper._GLM5_NEXT_FP8_NATIVE_PREFETCH_MANAGERS.clear()
 
     @staticmethod
     def _wrapper(*, exact=True, threshold=1024, mode="EXTEND"):
@@ -253,7 +257,10 @@ class TestGlm5NextFp8GenericRouting(unittest.TestCase):
             defer_cpu_buffers=True,
         )
         context.initialize_cpu_buffers.assert_called_once_with()
-        context._initialize_glm5_next_fp8_transport.assert_called_once_with()
+        context._initialize_glm5_next_fp8_transport.assert_called_once_with(
+            wrapper=wrapper.wrapper,
+            num_gpu_experts=wrapper.num_gpu_experts,
+        )
         self.assertIs(kt_ep_wrapper._SHARED_FULL_CONTEXT, context)
         validate_context.assert_called_once_with(context)
         self.assertEqual(context.load.call_count, 2)
@@ -472,10 +479,160 @@ class _FakeFp8Writer:
         self.pending = None
 
 
+class _FakeNativeTransport:
+    def __init__(self, args, calls):
+        self.args = args
+        self.calls = calls
+        self.last_join = None
+        self.close_count = 0
+
+    def join(self, epoch, layer_id, expert_count):
+        self.last_join = (epoch, layer_id, expert_count)
+        self.calls.append(("join", *self.last_join))
+
+    def wait(self, epoch):
+        self.calls.append(("wait", epoch))
+        joined_epoch, layer_id, expert_count = self.last_join
+        return {
+            "epoch": joined_epoch,
+            "layer_id": layer_id,
+            "expert_count": expert_count,
+            "rank": 0,
+            "writer_ms": 3.0,
+            "slot_wait_ms": 1.0,
+            "h2d_ms": 2.0,
+            "total_ms": 4.0,
+            "bytes": 64,
+            "poisoned": False,
+            "error_code": 0,
+            "error_rank": -1,
+        }
+
+    def close(self):
+        self.close_count += 1
+        self.calls.append(("close",))
+
+
+class _FakeNativeExtension:
+    def __init__(self, calls):
+        self.calls = calls
+        self.initialize_args = None
+        self.transport = None
+
+    def initialize_fp8_layerwise_control(self, control_ptr, control_size, tp_size):
+        self.initialize_args = (control_ptr, control_size, tp_size)
+        self.calls.append(("initialize", control_size, tp_size))
+
+    def FP8LayerwiseTransport(self, *args):
+        self.transport = _FakeNativeTransport(args, self.calls)
+        self.calls.append(("construct",))
+        return self.transport
+
+
+class _FakeNativeWriter:
+    def __init__(self, calls, fail=False):
+        self.calls = calls
+        self.fail = fail
+        self.moe = self
+        self.cpu_infer = SimpleNamespace(sync=mock.Mock())
+        self.public_run_count = 0
+
+    def run_layerwise_fp8_batch(
+        self, transport, epoch, layer_id, expert_count
+    ):
+        self.calls.append(("run", epoch, layer_id, expert_count))
+        if self.fail:
+            raise RuntimeError("injected producer failure")
+
+
+class _FakePrefetchEvent:
+    def __init__(self, calls):
+        self.calls = calls
+        self.recorded = threading.Event()
+
+    def record(self, stream):
+        self.calls.append(("consumed-record", stream))
+        self.recorded.set()
+
+    def synchronize(self):
+        self.calls.append(("consumed-wait",))
+        if not self.recorded.wait(timeout=1):
+            raise RuntimeError("consumed event was never recorded")
+
+
+class _FakePrefetchGpuMethod:
+    def __init__(self, calls):
+        self.calls = calls
+
+    def process_weights_after_loading(self, _layer):
+        self.calls.append(("process",))
+
+    def apply(self, _layer, dispatch_output):
+        layer_idx = dispatch_output.layer_idx
+        self.calls.append(("apply", layer_idx))
+        return f"result-{layer_idx}"
+
+
+class _FakePrefetchContext:
+    def __init__(self, calls, fail_layer=None, successor_release=None):
+        self.calls = calls
+        self.fail_layer = fail_layer
+        self.successor_release = successor_release
+        self.successor_entered = threading.Event()
+        self._glm5_next_fp8_transport_poisoned = False
+        self.gpu_layer = SimpleNamespace(
+            w13_weight=torch.empty((1,), dtype=torch.float32)
+        )
+        self.gpu_method = _FakePrefetchGpuMethod(calls)
+
+    def load_glm5_next_fp8_native(
+        self, *, layer_idx, wrapper, consumed_event=None
+    ):
+        self.calls.append(("load-enter", layer_idx, wrapper.name))
+        if consumed_event is not None:
+            consumed_event.synchronize()
+        if layer_idx == 4 and self.successor_release is not None:
+            self.successor_entered.set()
+            if not self.successor_release.wait(timeout=1):
+                raise RuntimeError("test successor release timed out")
+        if layer_idx == self.fail_layer:
+            raise RuntimeError(f"injected layer {layer_idx} load failure")
+        self.calls.append(("load-done", layer_idx))
+
+    def _validate_glm5_next_fp8_native_gpu_slot(self):
+        self.calls.append(("validate-slot",))
+
+
+def _fake_prefetch_method(layer_idx, calls):
+    cpu_infer = SimpleNamespace(
+        sync=mock.Mock(side_effect=lambda: calls.append(("cpu-infer-sync",)))
+    )
+    writer = SimpleNamespace(
+        name=f"writer-{layer_idx}", cpu_infer=cpu_infer, moe=object()
+    )
+    method = SimpleNamespace(
+        kt_config=SimpleNamespace(
+            layer_idx=layer_idx,
+            num_layers=45,
+            is_glm5_next=True,
+            method="FP8",
+        ),
+        tp_rank=0,
+        wrapper=writer,
+    )
+    return method
+
+
 class TestGlm5NextFp8SingleSlotLayout(unittest.TestCase):
     def setUp(self):
         kt_ep_wrapper._SHARED_FULL_CONTEXT = None
         _FakeSharedMemory.instances.clear()
+        for manager in list(
+            kt_ep_wrapper._GLM5_NEXT_FP8_NATIVE_PREFETCH_MANAGERS.values()
+        ):
+            manager.close()
+        kt_ep_wrapper._GLM5_NEXT_FP8_NATIVE_PREFETCH_LAYER_REGISTRY.clear()
+        kt_ep_wrapper._GLM5_NEXT_FP8_NATIVE_PREFETCH_MANAGERS.clear()
 
     def test_generic_host_transport_allocates_exactly_two_expert_slots(self):
         context = object.__new__(kt_ep_wrapper.SharedFullContext)
@@ -539,6 +696,7 @@ class TestGlm5NextFp8SingleSlotLayout(unittest.TestCase):
     def test_exact_glm_transport_reuses_two_persistent_host_slot_events(self):
         context = object.__new__(kt_ep_wrapper.SharedFullContext)
         context._glm5_next_fp8_transport_initialized = True
+        context._glm5_next_fp8_transport_backend = "legacy"
         context._glm5_next_fp8_copy_stream = _FakeCudaStream()
         context._glm5_next_fp8_host_slot_events = (
             _FakeCudaEvent(),
@@ -580,7 +738,7 @@ class TestGlm5NextFp8SingleSlotLayout(unittest.TestCase):
                 return_value=current_stream,
             ),
         ):
-            context._prepare_weight_fp8_glm5_next(writer)
+            context._prepare_weight_fp8_glm5_next(writer, layer_idx=3)
 
         self.assertEqual(writer.submitted, [(1, 0), (1, 1), (1, 2), (1, 3)])
         self.assertEqual(writer.sync_count, 4)
@@ -597,6 +755,428 @@ class TestGlm5NextFp8SingleSlotLayout(unittest.TestCase):
         self.assertEqual(event0.synchronize_count, 1)
         self.assertEqual(event1.synchronize_count, 1)
         self.assertEqual(context._glm5_next_fp8_copy_stream.synchronize_count, 1)
+
+    @staticmethod
+    def _native_context():
+        context = object.__new__(kt_ep_wrapper.SharedFullContext)
+        context.shm_unique_id = "native_test"
+        context._commit_cpu_buffer_phase = mock.Mock()
+        context.cpu_buffers = {}
+        context.all_rank_buffer_ptrs = {}
+        gpu_tensors = {}
+        for index, name in enumerate(
+            kt_ep_wrapper.SharedFullContext.WEIGHT_NAMES_FP8
+        ):
+            cpu_buffer = torch.empty((2, index + 1), dtype=torch.float32)
+            gpu_tensor = torch.empty((3, index + 1), dtype=torch.float32)
+            context.cpu_buffers[name] = cpu_buffer
+            context.all_rank_buffer_ptrs[name] = [
+                cpu_buffer.data_ptr() + rank * 1_000_000
+                for rank in range(4)
+            ]
+            gpu_tensors[name] = gpu_tensor
+        context.gpu_layer = SimpleNamespace(num_experts=3, **gpu_tensors)
+        return context
+
+    def test_native_transport_uses_fixed_flattened_pointer_abi(self):
+        context = self._native_context()
+        calls = []
+        extension = _FakeNativeExtension(calls)
+        writer = _FakeNativeWriter(calls)
+
+        with (
+            mock.patch.dict(
+                "os.environ",
+                {"SGLANG_KT_GLM5_NEXT_FP8_TRANSPORT": "native"},
+                clear=False,
+            ),
+            mock.patch.object(
+                kt_ep_wrapper,
+                "_load_glm5_next_fp8_native_transport_api",
+                return_value=(extension, None),
+            ),
+            mock.patch.object(
+                kt_ep_wrapper,
+                "get_tensor_model_parallel_rank",
+                return_value=0,
+            ),
+            mock.patch.object(
+                kt_ep_wrapper,
+                "get_tensor_model_parallel_world_size",
+                return_value=4,
+            ),
+            mock.patch.object(kt_ep_wrapper.dist, "is_initialized", return_value=False),
+            mock.patch.object(
+                kt_ep_wrapper.shared_memory,
+                "SharedMemory",
+                side_effect=_FakeSharedMemory,
+            ),
+            mock.patch.object(torch.cuda, "current_device", return_value=0),
+        ):
+            context._initialize_glm5_next_fp8_transport(
+                wrapper=writer, num_gpu_experts=0
+            )
+
+        self.assertEqual(
+            extension.initialize_args[1:],
+            (kt_ep_wrapper._GLM5_NEXT_FP8_CONTROL_BYTES, 4),
+        )
+        args = extension.transport.args
+        self.assertEqual(args[1:5], (4096, 0, 4, 0))
+        local_host_ptrs = args[5]
+        local_gpu_ptrs = args[6]
+        all_rank_host_ptrs = args[7]
+        expert_nbytes = args[8]
+        self.assertEqual(len(local_host_ptrs), 8)
+        self.assertEqual(len(local_gpu_ptrs), 4)
+        self.assertEqual(len(all_rank_host_ptrs), 32)
+        self.assertEqual(expert_nbytes, [4, 8, 12, 16])
+
+        expected_local = []
+        expected_all_rank = []
+        names = kt_ep_wrapper.SharedFullContext.WEIGHT_NAMES_FP8
+        for slot in range(2):
+            for index, name in enumerate(names):
+                expected_local.append(
+                    context.cpu_buffers[name].data_ptr()
+                    + slot * expert_nbytes[index]
+                )
+            for rank in range(4):
+                for index, name in enumerate(names):
+                    expected_all_rank.append(
+                        context.all_rank_buffer_ptrs[name][rank]
+                        + slot * expert_nbytes[index]
+                    )
+        self.assertEqual(local_host_ptrs, expected_local)
+        self.assertEqual(all_rank_host_ptrs, expected_all_rank)
+        self.assertEqual(
+            local_gpu_ptrs,
+            [getattr(context.gpu_layer, name).data_ptr() for name in names],
+        )
+        self.assertEqual(args[9:], (3, 60_000))
+        self.assertEqual(context._glm5_next_fp8_transport_backend, "native")
+        self.assertTrue(context._glm5_next_fp8_control_shm.unlinked)
+
+    def test_native_prepare_is_one_join_run_wait_per_layer_and_epochs_advance(self):
+        context = self._native_context()
+        calls = []
+        extension = _FakeNativeExtension(calls)
+        transport = extension.FP8LayerwiseTransport()
+        context._glm5_next_fp8_native_transport = transport
+        context._glm5_next_fp8_transport_backend = "native"
+        context._glm5_next_fp8_transport_initialized = True
+        context._glm5_next_fp8_transport_poisoned = False
+        context._glm5_next_fp8_transport_epoch = 0
+        writer = _FakeNativeWriter(calls)
+
+        with mock.patch.object(
+            kt_ep_wrapper,
+            "get_tensor_model_parallel_rank",
+            return_value=0,
+        ):
+            context._prepare_weight_fp8_glm5_next(writer, layer_idx=3)
+            context._prepare_weight_fp8_glm5_next(writer, layer_idx=4)
+
+        self.assertEqual(
+            [call for call in calls if call[0] in ("join", "run", "wait")],
+            [
+                ("join", 1, 3, 3),
+                ("run", 1, 3, 3),
+                ("wait", 1),
+                ("join", 2, 4, 3),
+                ("run", 2, 4, 3),
+                ("wait", 2),
+            ],
+        )
+        writer.cpu_infer.sync.assert_not_called()
+        source = inspect.getsource(
+            kt_ep_wrapper.SharedFullContext._prepare_weight_fp8_glm5_next_native
+        )
+        self.assertNotIn("dist.", source)
+        self.assertNotIn(".item()", source)
+        self.assertNotIn("for expert", source)
+
+    def test_native_runtime_failure_poisoned_without_legacy_fallback(self):
+        context = self._native_context()
+        calls = []
+        extension = _FakeNativeExtension(calls)
+        transport = extension.FP8LayerwiseTransport()
+        context._glm5_next_fp8_native_transport = transport
+        context._glm5_next_fp8_transport_backend = "native"
+        context._glm5_next_fp8_transport_initialized = True
+        context._glm5_next_fp8_transport_poisoned = False
+        context._glm5_next_fp8_transport_epoch = 0
+        writer = _FakeNativeWriter(calls, fail=True)
+        context._prepare_weight_fp8_glm5_next_legacy = mock.Mock()
+
+        with mock.patch.object(
+            kt_ep_wrapper,
+            "get_tensor_model_parallel_rank",
+            return_value=0,
+        ):
+            with self.assertRaisesRegex(RuntimeError, "runtime fallback is disabled"):
+                context._prepare_weight_fp8_glm5_next(writer, layer_idx=3)
+            with self.assertRaisesRegex(RuntimeError, "poisoned"):
+                context._prepare_weight_fp8_glm5_next(writer, layer_idx=4)
+
+        self.assertTrue(context._glm5_next_fp8_transport_poisoned)
+        self.assertEqual(transport.close_count, 1)
+        context._prepare_weight_fp8_glm5_next_legacy.assert_not_called()
+
+    def test_transport_mode_fallback_and_hard_gates(self):
+        context = self._native_context()
+        context._initialize_glm5_next_fp8_legacy_transport = mock.Mock()
+        writer = _FakeNativeWriter([])
+        with (
+            mock.patch.object(
+                kt_ep_wrapper,
+                "get_tensor_model_parallel_rank",
+                return_value=0,
+            ),
+            mock.patch.object(
+                kt_ep_wrapper,
+                "get_tensor_model_parallel_world_size",
+                return_value=4,
+            ),
+            mock.patch.object(
+                kt_ep_wrapper.dist, "is_initialized", return_value=False
+            ),
+            mock.patch.dict(
+                "os.environ",
+                {"SGLANG_KT_GLM5_NEXT_FP8_TRANSPORT": "auto"},
+                clear=False,
+            ),
+            mock.patch.object(
+                kt_ep_wrapper,
+                "_load_glm5_next_fp8_native_transport_api",
+                return_value=(None, "missing test API"),
+            ),
+        ):
+            context._initialize_glm5_next_fp8_transport(
+                wrapper=writer, num_gpu_experts=0
+            )
+        context._initialize_glm5_next_fp8_legacy_transport.assert_called_once_with()
+
+        context._initialize_glm5_next_fp8_legacy_transport.reset_mock()
+        with (
+            mock.patch.object(
+                kt_ep_wrapper,
+                "get_tensor_model_parallel_rank",
+                return_value=0,
+            ),
+            mock.patch.object(
+                kt_ep_wrapper,
+                "get_tensor_model_parallel_world_size",
+                return_value=4,
+            ),
+            mock.patch.object(kt_ep_wrapper.dist, "is_initialized", return_value=False),
+            mock.patch.dict(
+                "os.environ",
+                {"SGLANG_KT_GLM5_NEXT_FP8_TRANSPORT": "native"},
+                clear=False,
+            ),
+            mock.patch.object(
+                kt_ep_wrapper,
+                "_load_glm5_next_fp8_native_transport_api",
+                return_value=(None, "missing test API"),
+            ),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "was forced"):
+                context._initialize_glm5_next_fp8_transport(
+                    wrapper=writer, num_gpu_experts=0
+                )
+            with self.assertRaisesRegex(RuntimeError, "gpu_experts=0"):
+                context._initialize_glm5_next_fp8_transport(
+                    wrapper=writer, num_gpu_experts=1
+                )
+        context._initialize_glm5_next_fp8_legacy_transport.assert_not_called()
+
+    def test_native_single_slot_state_machine_prefetches_and_wraps(self):
+        calls = []
+        successor_release = threading.Event()
+        context = _FakePrefetchContext(
+            calls, successor_release=successor_release
+        )
+        method3 = _fake_prefetch_method(3, calls)
+        method4 = _fake_prefetch_method(4, calls)
+        layer3 = object()
+        layer4 = object()
+        registry = {3: (method3, layer3), 4: (method4, layer4)}
+        event = _FakePrefetchEvent(calls)
+        main_stream = object()
+
+        with (
+            mock.patch.object(torch.cuda, "Event", return_value=event),
+            mock.patch.object(
+                kt_ep_wrapper,
+                "_GLM5_NEXT_FP8_MOE_LAYER_INDICES",
+                (3, 4),
+            ),
+            mock.patch.object(
+                torch.cuda, "current_stream", return_value=main_stream
+            ),
+            mock.patch.object(
+                kt_ep_wrapper,
+                "get_tensor_model_parallel_rank",
+                return_value=0,
+            ),
+            mock.patch.object(
+                kt_ep_wrapper,
+                "_all_tp_ranks_succeeded",
+                side_effect=lambda success: success,
+            ),
+        ):
+            manager = (
+                kt_ep_wrapper._Glm5NextFp8NativeSingleSlotPrefetchManager(
+                    context, ("test",), registry
+                )
+            )
+            try:
+                first = manager.apply(
+                    method3, layer3, SimpleNamespace(layer_idx=3)
+                )
+                self.assertEqual(first, "result-3")
+                self.assertTrue(context.successor_entered.wait(timeout=1))
+                self.assertIsNotNone(manager.future)
+                self.assertFalse(manager.future.done())
+
+                # The main thread has already returned from layer 3 while its
+                # sole worker remains in successor transport.
+                successor_release.set()
+                second = manager.apply(
+                    method4, layer4, SimpleNamespace(layer_idx=4)
+                )
+                self.assertEqual(second, "result-4")
+                self.assertIsNone(manager.future)  # last layer never prefetches
+
+                # A new chunk/request wraps to the first MoE.  It synchronously
+                # fences layer 4 and re-primes the same GPU slot.
+                wrapped = manager.apply(
+                    method3, layer3, SimpleNamespace(layer_idx=3)
+                )
+                self.assertEqual(wrapped, "result-3")
+                successor = manager.apply(
+                    method4, layer4, SimpleNamespace(layer_idx=4)
+                )
+                self.assertEqual(successor, "result-4")
+            finally:
+                manager.close()
+
+        self.assertEqual(
+            [call[:2] for call in calls if call[0] == "load-enter"],
+            [
+                ("load-enter", 3),
+                ("load-enter", 4),
+                ("load-enter", 3),
+                ("load-enter", 4),
+            ],
+        )
+        self.assertEqual(calls.count(("cpu-infer-sync",)), 1)
+        method3.wrapper.cpu_infer.sync.assert_called_once_with()
+        method4.wrapper.cpu_infer.sync.assert_not_called()
+        self.assertEqual(manager.round_id, 2)
+        self.assertEqual(manager.last_acquired_layer_idx, 4)
+        self.assertFalse(manager.context._glm5_next_fp8_transport_poisoned)
+
+    def test_native_prefetch_rejects_partial_glm_registry_before_prime(self):
+        calls = []
+        context = _FakePrefetchContext(calls)
+        method3 = _fake_prefetch_method(3, calls)
+        with self.assertRaisesRegex(RuntimeError, "complete MoE registry"):
+            kt_ep_wrapper._Glm5NextFp8NativeSingleSlotPrefetchManager(
+                context, ("partial",), {3: (method3, object())}
+            )
+        self.assertNotIn(("cpu-infer-sync",), calls)
+        self.assertFalse(
+            any(call[0] == "load-enter" for call in calls if call)
+        )
+
+    def test_native_successor_failure_poisoned_without_fallback(self):
+        calls = []
+        context = _FakePrefetchContext(calls, fail_layer=4)
+        method3 = _fake_prefetch_method(3, calls)
+        method4 = _fake_prefetch_method(4, calls)
+        layer3 = object()
+        layer4 = object()
+        registry = {3: (method3, layer3), 4: (method4, layer4)}
+        event = _FakePrefetchEvent(calls)
+
+        with (
+            mock.patch.object(torch.cuda, "Event", return_value=event),
+            mock.patch.object(
+                kt_ep_wrapper,
+                "_GLM5_NEXT_FP8_MOE_LAYER_INDICES",
+                (3, 4),
+            ),
+            mock.patch.object(torch.cuda, "current_stream", return_value=object()),
+            mock.patch.object(
+                kt_ep_wrapper,
+                "get_tensor_model_parallel_rank",
+                return_value=0,
+            ),
+            mock.patch.object(
+                kt_ep_wrapper,
+                "_all_tp_ranks_succeeded",
+                side_effect=lambda success: success,
+            ),
+        ):
+            manager = (
+                kt_ep_wrapper._Glm5NextFp8NativeSingleSlotPrefetchManager(
+                    context, ("failure-test",), registry
+                )
+            )
+            try:
+                manager.apply(method3, layer3, SimpleNamespace(layer_idx=3))
+                with self.assertRaisesRegex(
+                    RuntimeError, "runtime fallback is disabled"
+                ):
+                    manager.apply(
+                        method4, layer4, SimpleNamespace(layer_idx=4)
+                    )
+                with self.assertRaisesRegex(RuntimeError, "poisoned"):
+                    manager.apply(
+                        method3, layer3, SimpleNamespace(layer_idx=3)
+                    )
+            finally:
+                manager.close()
+
+        self.assertTrue(context._glm5_next_fp8_transport_poisoned)
+        self.assertNotIn("legacy", " ".join(map(str, calls)).lower())
+
+    def test_native_prefetch_source_contracts(self):
+        exact_load_source = inspect.getsource(
+            kt_ep_wrapper.SharedFullContext.load_glm5_next_fp8_native
+        )
+        self.assertIn("consumed_event.synchronize()", exact_load_source)
+        self.assertNotIn("torch.cuda.synchronize", exact_load_source)
+        self.assertNotIn("_all_tp_ranks_succeeded", exact_load_source)
+
+        native_prepare_source = inspect.getsource(
+            kt_ep_wrapper.SharedFullContext._prepare_weight_fp8_glm5_next_native
+        )
+        self.assertIn('getattr(wrapper, "moe", None)', native_prepare_source)
+        self.assertNotIn("cpu_infer.sync", native_prepare_source)
+
+        worker_source = inspect.getsource(
+            kt_ep_wrapper._Glm5NextFp8NativeSingleSlotPrefetchManager._load_layer
+        )
+        self.assertNotIn("dist.", worker_source)
+        self.assertNotIn("_all_tp_ranks_succeeded", worker_source)
+
+        create_source = inspect.getsource(
+            kt_ep_wrapper.KTEPWrapperMethod.create_weights
+        )
+        self.assertIn(
+            "_register_glm5_next_fp8_native_prefetch_layer", create_source
+        )
+
+        close_source = inspect.getsource(
+            kt_ep_wrapper.SharedFullContext._close_glm5_next_fp8_transport
+        )
+        self.assertLess(
+            close_source.index("prefetch_manager.close()"),
+            close_source.index("transport.close()"),
+        )
 
     def test_tp4_fp8_geometry_and_single_full_layer_slot_bytes(self):
         num_experts = 288


### PR DESCRIPTION
## Summary

- add native GLM-5-Next / GLM-5.3-flash text and multimodal serving
- implement the 34-layer KDA-style linear-attention path and 11-layer DSA path
- add FP8 heterogeneous MoE execution, CUDA Graph decode, and Layerwise Prefill
- support TP1, TP2, TP4, and TP8; Layerwise Prefill uses zero resident GPU experts
- support SM86, SM89, and SM120 consumer GPUs
- support text with up to eight images or text with one video, while rejecting mixed image/video requests
- preserve GLM reasoning and tool-call parsing for OpenAI-compatible coding-agent clients

## Dependency

This branch requires `transformers-kt==5.6.0.post3` for the GLM image/video processors. The package-ready source is pinned on `kvcache-ai/transformers` at commit `3f97700`; it has not been published to PyPI yet. Publication is intentionally handled by the coordinated KTransformers release workflow.

## Validation

- GLM unit/contract suite: 282 passed, 13 skipped locally; the remaining processor import test requires torchvision in the local test environment and is covered by the full runtime environment
- end-to-end text serving and decode CUDA Graph validation on RTX 5090
- TP1/TP2/TP4/TP8 Layerwise Prefill validation on RTX 5090
- TP1/TP2/TP4 serving validation on RTX 4090
- semantically correct image request on RTX 4090 TP4
- multi-image, single-video, reasoning-parser, and tool-call-parser contract coverage
- Qwen3-30B-A3B regression smoke with CUDA Graph enabled

