### PR TITLE
fix(dsv4): honor --max-total-tokens for the compressed-attention pool

### DIFF
--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -468,7 +468,21 @@ class ModelRunnerKVCacheMixin:
     def init_memory_pool(self: ModelRunner):
         max_num_reqs = self.server_args.max_running_requests
         max_total_tokens_configured = self.server_args.max_total_tokens
-        self.max_total_num_tokens = self.profile_max_num_token()
+        # DeepSeek V4 keeps its KV state in a dedicated compressed-attention pool
+        # whose per-token footprint is far smaller than the generic KV estimate.
+        # set_num_tokens_hybrid_swa_compress() profiles that real layout itself,
+        # but it also treats self.max_total_num_tokens as the ceiling to apply
+        # when --max-total-tokens was given explicitly. Seeding that ceiling from
+        # the generic estimate caps the pool at a number derived from a layout
+        # the model never uses, so seed it with the configured value instead; the
+        # dedicated calculator still profiles VRAM and shrinks the pool from there.
+        if (
+            self.model_config.is_swa_with_compressed_attention
+            and max_total_tokens_configured is not None
+        ):
+            self.max_total_num_tokens = max_total_tokens_configured
+        else:
+            self.max_total_num_tokens = self.profile_max_num_token()
 
         if max_num_reqs is None:
             max_num_reqs = min(


### PR DESCRIPTION
For DeepSeek V4, init_memory_pool() seeds self.max_total_num_tokens with
profile_max_num_token(), which estimates capacity from the generic KV
cell size. set_num_tokens_hybrid_swa_compress() then profiles the real
compressed layout via DSv4MemoryCalculator, but when --max-total-tokens
was passed explicitly it also treats the already-seeded
self.max_total_num_tokens as a ceiling and falls back to
get_pool_sizes_by_configuration() with it.

The ceiling therefore comes from a layout the model never uses. On a
2x16 GB SM120 setup with KT CPU experts, a configured 1M-token context
was clamped to roughly 143K tokens even though the compressed pool fits
the full 1M.

Seed the ceiling with the configured value instead when the model uses
compressed attention and --max-total-tokens was given. The dedicated
calculator still profiles available VRAM and still reduces the pool when
it does not fit, and the configuration path is only ever taken to shrink
below the profiled size, so a large configured value cannot inflate the
pool past what profiling allows.

Runs that do not pass --max-total-tokens are unaffected: the ceiling is
never consulted there, and profile_max_num_token() keeps seeding the
value that max_running_requests is derived from.

Verified on DeepSeek-V4-Flash MXFP4: full_max_total_num_tokens reaches
1,048,576 with mem_fraction_static 0.985 and decoding stays coherent.

