### PR TITLE
feat(dsv4): add SGLANG_V4_MARLIN_PARTIAL for partial-expert MoE

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -522,6 +522,8 @@ class Envs:
     SGLANG_OPT_MXFP4_FUSE_RSF_SHARED_ADD = EnvBool(False)
     SGLANG_OPT_MXFP4_STATIC_SCALE_ONES = EnvBool(False)
     SGLANG_OPT_MXFP4_SKIP_DISPATCHER_MAPPING = EnvBool(False)
+    # Allow the Marlin W4A16 MoE backend for a KT resident partial-expert image.
+    SGLANG_V4_MARLIN_PARTIAL = EnvBool(False)
     SGLANG_OPT_USE_JIT_INDEXER_METADATA = EnvBool(False)
     SGLANG_OPT_SWIGLU_CLAMP_FUSION = EnvBool(False)
     SGLANG_OPT_DG_PAGED_MQA_LOGITS_CHUNK_SIZE = EnvInt(-1)

--- a/python/sglang/srt/layers/quantization/mxfp4_deepseek.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_deepseek.py
@@ -316,11 +316,17 @@ class DeepSeekMxfp4MoEMethod:
         # reserved for an ordinary full-expert layer or the manager's full
         # prefill shadow.
         _resident_partial = _resident_experts < _global_experts
+        # SGLANG_V4_MARLIN_PARTIAL=1 opts the resident partial-expert image into
+        # Marlin as well.  The triton_kernels matmul_ogs fallback reserves a
+        # fixed device transient at prefill launch regardless of batch size,
+        # which a 16 GB card that is also holding a large KV pool cannot spare;
+        # Marlin has no such reservation.
+        _allow_partial_marlin = envs.SGLANG_V4_MARLIN_PARTIAL.get()
         _take_marlin_path = (
             not _force_tk
             and not _force_trtllm
             and _capability in _MARLIN_MXFP4_CAPS
-            and not _resident_partial
+            and (not _resident_partial or _allow_partial_marlin)
         )
         if _take_marlin_path:
             from sglang.srt.layers.quantization.v4_marlin_moe import (


### PR DESCRIPTION
When KTransformers keeps only a subset of experts resident on the GPU,
the resident partial-expert image is deliberately excluded from the
Marlin W4A16 path and always runs through the triton_kernels matmul_ogs
fallback.

That fallback reserves a fixed device transient at prefill launch,
independent of batch size: measured at roughly 0.5 GB, and about 0.85 GB
in total at 2048-token chunks. A 16 GB card that is also holding a large
KV pool has no room for it, so every prompt long enough to trigger a
real prefill dies with CUDA OOM in the scheduler while short benchmark
prompts keep working. Marlin has no comparable reservation.

Add an opt-in escape hatch: SGLANG_V4_MARLIN_PARTIAL=1 lets the resident
partial-expert image take the Marlin path too. The default is unchanged,
so this cannot affect existing deployments.

Measured on 2x RTX 5070 Ti (SM120, 16 GB each) with DeepSeek-V4-Flash
MXFP4 and KT CPU experts, at a 1M-token pool and 256-token chunks:

- before: any prompt beyond ~100 tokens OOMs at prefill
- after: 3001-token prefill in 35.6 s, 12001-token in 141 s (~85 tok/s)
- decode unchanged at 32.3 tok/s, output stays coherent

