### PR TITLE
fix(glm5-next): accept official MTP index sharing metadata

### DIFF
--- a/python/sglang/srt/models/glm5_next_dsa.py
+++ b/python/sglang/srt/models/glm5_next_dsa.py
@@ -70,18 +70,15 @@ def _validate_glm5_next_dsa_config(config: Glm5NextTextConfig) -> None:
     if config.qk_rope_head_dim != 0:
         raise ValueError("GLM-5-Next DSA is zero-RoPE and requires qk_rope_head_dim=0")
 
-    # KPool's CP/MTP and cross-layer top-k reuse contracts are deliberately
-    # not enabled yet.  Refuse those modes instead of silently entering the
-    # generic DeepSeek paths with a wider (index_topk + 3) index tensor.
+    # KPool's CP and cross-layer top-k reuse contracts are deliberately not
+    # enabled yet. Refuse those modes instead of silently entering the generic
+    # DeepSeek paths with a wider (index_topk + 3) index tensor.
     if config.index_topk_freq != 1:
         raise ValueError("GLM-5-Next KPool does not support index_topk_freq != 1")
     if config.index_topk_pattern is not None:
         raise ValueError("GLM-5-Next KPool does not support index_topk_pattern")
     if config.index_skip_topk_offset is not None:
         raise ValueError("GLM-5-Next KPool does not support index_skip_topk_offset")
-    if config.index_share_for_mtp_iteration is not False:
-        raise ValueError("GLM-5-Next KPool does not support index sharing for MTP")
-
 
 class Glm5NextDSAAttention(DeepseekV2AttentionMLA):
     """DeepSeek MLA tensor layout with GLM's KPool4 DSA indexer."""
@@ -159,6 +156,10 @@ class Glm5NextDSAAttention(DeepseekV2AttentionMLA):
         # still initialized by DeepseekV2AttentionMLA.
         base_config = copy.copy(config)
         base_config.index_topk = None
+        # The official checkpoint advertises MTP index sharing even when MTP
+        # is not requested. Keep that metadata on the real config, but prevent
+        # the generic DeepSeek base from enabling its unsupported MTP path.
+        base_config.index_share_for_mtp_iteration = False
         base_rope_scaling = copy.deepcopy(rope_scaling)
         super().__init__(
             config=base_config,

--- a/test/registered/unit/test_glm5_next_dsa.py
+++ b/test/registered/unit/test_glm5_next_dsa.py
@@ -245,12 +245,11 @@ class TestGlm5NextDSAAttention(unittest.TestCase):
                 with self.assertRaisesRegex(AssertionError, message):
                     _build(self.module.Glm5NextDSAAttention, config=config)
 
-    def test_rejects_cp_mtp_and_index_sharing_modes(self):
+    def test_rejects_cp_mtp_and_cross_layer_topk_modes(self):
         invalid_configs = (
             ("index_topk_freq", 2),
             ("index_topk_pattern", "N"),
             ("index_skip_topk_offset", 1),
-            ("index_share_for_mtp_iteration", True),
         )
         for field, value in invalid_configs:
             with self.subTest(field=field):
@@ -258,12 +257,27 @@ class TestGlm5NextDSAAttention(unittest.TestCase):
                 with self.assertRaises(ValueError):
                     _build(self.module.Glm5NextDSAAttention, config=config)
 
+        mtp_config = _Glm5NextTextConfig(index_share_for_mtp_iteration=True)
         with self.assertRaisesRegex(NotImplementedError, "MTP"):
-            _build(self.module.Glm5NextDSAAttention, is_nextn=True)
+            _build(
+                self.module.Glm5NextDSAAttention,
+                config=mtp_config,
+                is_nextn=True,
+            )
 
         cp_module = _load_module(cp_enabled=True)
         with self.assertRaisesRegex(NotImplementedError, "context parallel"):
             _build(cp_module.Glm5NextDSAAttention)
+
+    def test_accepts_official_mtp_index_sharing_metadata_for_base_inference(self):
+        config = _Glm5NextTextConfig(index_share_for_mtp_iteration=True)
+        attention = _build(self.module.Glm5NextDSAAttention, config=config)
+
+        self.assertTrue(config.index_share_for_mtp_iteration)
+        self.assertIs(attention.config, config)
+        self.assertFalse(
+            attention.base_kwargs["config"].index_share_for_mtp_iteration
+        )
 
     def test_rejects_rope_or_dimension_drift(self):
         with self.assertRaisesRegex(ValueError, "skip_rope=True"):


### PR DESCRIPTION
## Summary

- Accept the official GLM-5.3-Flash `index_share_for_mtp_iteration=true` checkpoint metadata during normal inference.
- Preserve the original Hugging Face text config while disabling MTP index sharing only on the private config copy passed to the generic DeepSeek attention base.
- Keep actual GLM-5-Next MTP/NextN execution unsupported and guarded by the existing `is_nextn` `NotImplementedError`.

## Context

The official [`zai-org/GLM-5.3-Flash` config](https://huggingface.co/zai-org/GLM-5.3-Flash/blob/main/config.json) sets `index_share_for_mtp_iteration` to `true`. The GLM KPool validator previously rejected that field unconditionally, so the model failed during ordinary attention construction even when speculative decoding was not enabled:

```text
ValueError: GLM-5-Next KPool does not support index sharing for MTP
```

The field describes an MTP capability, not a request to run MTP. This change accepts the checkpoint metadata for base inference without enabling the unsupported execution path.

## Tests

```text
python -m pytest -q test/registered/unit/test_glm5_next_dsa.py
8 passed, 6 subtests passed
```

The regression coverage verifies that normal inference accepts the official `true` value without mutating the source config, the DeepSeek base receives an effective `false` value, and an actual `is_nextn=True` construction still fails with the explicit MTP guard.
