### PR TITLE
[Bug fix] Fix double routed scaling in KT-EP MXFP4 experts

### DIFF
--- a/python/sglang/srt/layers/quantization/mxfp4_deepseek.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_deepseek.py
@@ -485,7 +485,7 @@ class DeepSeekMxfp4MoEMethod:
                     topk_ids + local_expert_offset,
                     topk_ids,
                 )
-            rsf = layer.moe_runner_config.routed_scaling_factor
+            rsf = self.moe_runner_config.routed_scaling_factor
             # 2604B SwiGLU clamp: thread swiglu_limit through so the triton-
             # kernels GPU MoE path applies the same gate/up clamp as
             # trtllm's gemm1_clamp_limit and deep_gemm's _apply_swiglu_limit.
@@ -641,7 +641,7 @@ class DeepSeekMxfp4MoEMethod:
         )[0]
 
         if not envs.SGLANG_OPT_MXFP4_FUSE_RSF_SHARED_ADD.get():
-            rsf = layer.moe_runner_config.routed_scaling_factor
+            rsf = self.moe_runner_config.routed_scaling_factor
             if rsf is not None and rsf != 1.0:
                 output.mul_(rsf)
 


### PR DESCRIPTION
## Summary

  Fixes double application of `routed_scaling_factor` for GPU-resident experts in the KT-EP hybrid MXFP4 MoE path.

  `KTEPWrapperMethod.create_moe_runner()` creates a GPU runner config with
  `routed_scaling_factor=None`, because scaling is applied uniformly after GPU
  and CPU expert outputs are combined. However, `DeepSeekMxfp4MoEMethod.apply()`
  was reading the original `layer.moe_runner_config` instead of the runner config
  stored on the method instance.

  As a result, GPU expert outputs were scaled internally and then scaled again
  by `DeepseekV2MoE.forward_normal()`, while CPU expert outputs were only scaled
  once.

  ## Fix

  Read `routed_scaling_factor` from `self.moe_runner_config` in both MXFP4
  execution paths:

  - Triton-kernel path
  - TRTLLM path

  This honors the `None` value supplied by the KT-EP wrapper, so the combined
  GPU + CPU routed-expert output is scaled exactly once.

  ## Impact

  With `routed_scaling_factor=1.5`, GPU-resident expert contributions previously
  received `1.5 * 1.5 = 2.25` scaling. After this change, they receive the
  intended single `1.5` scaling, matching CPU-resident experts.