### PR TITLE
fix: restore radix cache namespace isolation

### DIFF
--- a/python/sglang/srt/cache_identity.py
+++ b/python/sglang/srt/cache_identity.py
@@ -1,0 +1,33 @@
+"""Stable encoding for radix-cache namespace identities."""
+
+from __future__ import annotations
+
+import json
+from typing import Optional
+
+_CACHE_IDENTITY_VERSION = 1
+
+
+def encode_cache_identity(domain: str, **components: Optional[str]) -> Optional[str]:
+    """Encode named cache-identity components without semantic collisions."""
+    normalized = {}
+    for name, value in components.items():
+        if value is not None and not isinstance(value, str):
+            raise TypeError(
+                f"Value of {name} must be a string, but got {type(value).__name__}"
+            )
+        normalized[name] = value or None
+
+    if all(value is None for value in normalized.values()):
+        return None
+
+    return json.dumps(
+        {
+            "components": normalized,
+            "domain": domain,
+            "version": _CACHE_IDENTITY_VERSION,
+        },
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    )

--- a/python/sglang/srt/disaggregation/encode_receiver.py
+++ b/python/sglang/srt/disaggregation/encode_receiver.py
@@ -371,6 +371,7 @@ class MMReceiverHTTP(MMReceiverBase):
                 if self.scheduler.enable_metrics
                 else None
             ),
+            extra_key=recv_req.extra_key,
             http_worker_ipc=recv_req.http_worker_ipc,
             dllm_config=self.scheduler.dllm_config,
         )

--- a/python/sglang/srt/entrypoints/openai/serving_base.py
+++ b/python/sglang/srt/entrypoints/openai/serving_base.py
@@ -10,6 +10,7 @@ import orjson
 from fastapi import HTTPException, Request
 from fastapi.responses import ORJSONResponse, StreamingResponse
 
+from sglang.srt.cache_identity import encode_cache_identity
 from sglang.srt.entrypoints.openai.encoding_dsv32 import DS32EncodingError
 from sglang.srt.entrypoints.openai.protocol import ErrorResponse, OpenAIServingRequest
 from sglang.srt.managers.io_struct import EmbeddingReqInput, GenerateReqInput
@@ -144,17 +145,12 @@ class OpenAIServingBase(ABC):
         return f"{self._request_id_prefix()}{uuid.uuid4().hex}"
 
     def _compute_extra_key(self, request: OpenAIServingRequest) -> Optional[str]:
-        """Compute the final extra_key by concatenating cache_salt and extra_key if both are provided."""
-        parts = []
-        for key in ["cache_salt", "extra_key"]:
-            value = getattr(request, key, None)
-            if value:
-                if not isinstance(value, str):
-                    raise TypeError(
-                        f"Value of {key} must be a string, but got {type(value).__name__}"
-                    )
-                parts.append(value)
-        return "".join(parts) if parts else None
+        """Compute a collision-free OpenAI cache namespace."""
+        return encode_cache_identity(
+            "openai",
+            cache_salt=getattr(request, "cache_salt", None),
+            extra_key=getattr(request, "extra_key", None),
+        )
 
     @abstractmethod
     def _convert_to_internal_request(

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -48,6 +48,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union
 import numpy as np
 import torch
 
+from sglang.srt.cache_identity import encode_cache_identity
 from sglang.srt.constrained.base_grammar_backend import BaseGrammarObject
 from sglang.srt.disaggregation.base import BaseKVSender
 from sglang.srt.disaggregation.decode_schedule_batch_mixin import (
@@ -629,13 +630,10 @@ class Req(ReqDllmMixin):
         self.custom_logit_processor = custom_logit_processor
         self.return_hidden_states = return_hidden_states
 
-        # extra key for classifying the request (e.g. cache_salt)
-        if lora_id is not None:
-            extra_key = (
-                extra_key or ""
-            ) + lora_id  # lora_id is concatenated to the extra key
-
-        self.extra_key = extra_key
+        # Fold the caller namespace and adapter into one unambiguous radix key.
+        self.extra_key = encode_cache_identity(
+            "request", extra_key=extra_key, lora_id=lora_id
+        )
         self.lora_id = lora_id
         self.routing_key = routing_key
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1530,6 +1530,7 @@ class Scheduler(
                     self.metrics_collector if self.enable_metrics else None
                 ),
                 routing_key=recv_req.routing_key,
+                extra_key=recv_req.extra_key,
                 http_worker_ipc=recv_req.http_worker_ipc,
                 dllm_config=self.dllm_config,
                 time_stats=recv_req.time_stats,

--- a/python/sglang/srt/managers/session_controller.py
+++ b/python/sglang/srt/managers/session_controller.py
@@ -150,6 +150,7 @@ class Session:
             top_logprobs_num=req.top_logprobs_num,
             token_ids_logprob=req.token_ids_logprob,
             vocab_size=vocab_size,
+            extra_key=req.extra_key,
         )
         if last_req is not None:
             new_req.multimodal_inputs = last_req.multimodal_inputs

--- a/test/manual/openai_server/features/test_cache_report.py
+++ b/test/manual/openai_server/features/test_cache_report.py
@@ -307,6 +307,7 @@ class TestCacheReport(CustomTestCase):
 
         for index, (first_identity, second_identity) in enumerate(collision_pairs):
             with self.subTest(index=index):
+                requests.post(self.base_url + "/flush_cache")
                 message = (
                     f"Unique cache identity collision regression case {index}: "
                     "the same prompt must remain isolated across namespaces."

--- a/test/manual/openai_server/features/test_cache_report.py
+++ b/test/manual/openai_server/features/test_cache_report.py
@@ -78,6 +78,15 @@ class TestCacheReport(CustomTestCase):
         )
         return response
 
+    def run_openai_with_cache_identity(self, message, identity):
+        return self.client.chat.completions.create(
+            model=self.model,
+            messages=[{"role": "user", "content": message}],
+            temperature=0,
+            max_tokens=1,
+            extra_body=identity,
+        )
+
     async def run_openai_async(self, message):
         response = await self.aclient.chat.completions.create(
             model=self.model,
@@ -283,6 +292,72 @@ class TestCacheReport(CustomTestCase):
         assert (
             cached_tokens_2_second == cached_tokens_2_first
         ), "Should have cache hit with same cache_salt for salt2"
+
+    def test_cache_identity_collision_resistance(self):
+        collision_pairs = [
+            (
+                {"cache_salt": "same-value"},
+                {"extra_key": "same-value"},
+            ),
+            (
+                {"cache_salt": "a", "extra_key": "bc"},
+                {"cache_salt": "ab", "extra_key": "c"},
+            ),
+        ]
+
+        for index, (first_identity, second_identity) in enumerate(collision_pairs):
+            with self.subTest(index=index):
+                message = (
+                    f"Unique cache identity collision regression case {index}: "
+                    "the same prompt must remain isolated across namespaces."
+                )
+                first = self.run_openai_with_cache_identity(message, first_identity)
+                repeated = self.run_openai_with_cache_identity(message, first_identity)
+                isolated = self.run_openai_with_cache_identity(message, second_identity)
+
+                first_cached = int(first.usage.prompt_tokens_details.cached_tokens)
+                repeated_cached = int(
+                    repeated.usage.prompt_tokens_details.cached_tokens
+                )
+                isolated_cached = int(
+                    isolated.usage.prompt_tokens_details.cached_tokens
+                )
+
+                assert repeated_cached == int(repeated.usage.prompt_tokens) - 1
+                assert isolated_cached <= first_cached + self.min_cached
+
+    def test_session_extra_key_isolation(self):
+        requests.post(self.base_url + "/flush_cache")
+        session_id = requests.post(
+            self.base_url + "/open_session",
+            json={"capacity_of_str_len": 1000},
+        ).json()
+        payload = {
+            "text": (
+                "Unique session cache namespace regression prompt whose KV cache "
+                "must not be reused by another extra key."
+            ),
+            "session_params": {
+                "id": session_id,
+                "rid": None,
+                "offset": 0,
+                "replace": False,
+            },
+            "sampling_params": {"temperature": 0, "max_new_tokens": 1},
+            "extra_key": "session-a",
+        }
+
+        first = requests.post(self.base_url + "/generate", json=payload).json()
+        repeated = requests.post(self.base_url + "/generate", json=payload).json()
+        payload["extra_key"] = "session-b"
+        isolated = requests.post(self.base_url + "/generate", json=payload).json()
+
+        first_cached = int(first["meta_info"]["cached_tokens"])
+        repeated_cached = int(repeated["meta_info"]["cached_tokens"])
+        isolated_cached = int(isolated["meta_info"]["cached_tokens"])
+
+        assert repeated_cached == int(repeated["meta_info"]["prompt_tokens"]) - 1
+        assert isolated_cached <= first_cached + self.min_cached
 
 
 if __name__ == "__main__":

--- a/test/unit/test_extra_key_cache_isolation.py
+++ b/test/unit/test_extra_key_cache_isolation.py
@@ -1,0 +1,157 @@
+"""Regression tests for cache_salt/extra_key radix-cache isolation."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang.srt.cache_identity import encode_cache_identity
+from sglang.srt.disaggregation.utils import DisaggregationMode
+from sglang.srt.entrypoints.openai.serving_base import OpenAIServingBase
+from sglang.srt.managers import scheduler as scheduler_module
+from sglang.srt.managers import session_controller as session_controller_module
+from sglang.srt.managers.io_struct import SessionParams, TokenizedGenerateReqInput
+from sglang.srt.managers.schedule_batch import Req
+from sglang.srt.mem_cache.base_prefix_cache import InsertParams, MatchPrefixParams
+from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey
+from sglang.srt.sampling.sampling_params import SamplingParams
+
+
+def _compute_openai_key(cache_salt, extra_key):
+    request = SimpleNamespace(cache_salt=cache_salt, extra_key=extra_key)
+    return OpenAIServingBase._compute_extra_key(None, request)
+
+
+def _make_req(cache_salt=None, extra_key=None, lora_id=None):
+    return Req(
+        rid="test-request",
+        origin_input_text="test",
+        origin_input_ids=[1, 2, 3],
+        sampling_params=SamplingParams(max_new_tokens=1),
+        extra_key=_compute_openai_key(cache_salt, extra_key),
+        lora_id=lora_id,
+    )
+
+
+def _make_tokenized_req(extra_key, session_params=None):
+    return TokenizedGenerateReqInput(
+        input_text="test",
+        input_ids=[1, 2, 3],
+        mm_inputs=None,
+        sampling_params=SamplingParams(max_new_tokens=1),
+        return_logprob=False,
+        logprob_start_len=-1,
+        top_logprobs_num=0,
+        token_ids_logprob=None,
+        stream=False,
+        rid="test-request",
+        session_params=session_params,
+        extra_key=extra_key,
+        bootstrap_port=12345,
+    )
+
+
+def test_cache_identity_encoding_is_canonical_and_validated():
+    expected = encode_cache_identity(
+        "openai", cache_salt="tenant", extra_key="retrieval-context"
+    )
+    assert expected == encode_cache_identity(
+        "openai", extra_key="retrieval-context", cache_salt="tenant"
+    )
+
+    assert _compute_openai_key(None, None) is None
+    assert _compute_openai_key("", "context") == _compute_openai_key(None, "context")
+
+    with pytest.raises(TypeError, match="cache_salt must be a string"):
+        _compute_openai_key(1, None)
+
+
+def test_request_cache_identities_do_not_collide():
+    # The final pair is the nested-encoding collision from the previous patch.
+    cases = [
+        ("a", "bc", None),
+        ("ab", "c", None),
+        (None, "abc", None),
+        ("abc", None, None),
+        ("1:a", "b", None),
+        (None, "a", "b"),
+    ]
+    reqs = [_make_req(*case) for case in cases]
+    identities = [req.extra_key for req in reqs]
+
+    assert None not in identities
+    assert len(identities) == len(set(identities))
+    assert _make_req().extra_key is None
+
+    tree = RadixCache.create_simulated(page_size=1)
+    tokens = [1, 2, 3, 4]
+    for index, identity in enumerate(identities):
+        tree.insert(
+            InsertParams(
+                key=RadixKey(token_ids=tokens, extra_key=identity),
+                value=torch.tensor([index] * len(tokens), dtype=torch.int64),
+            )
+        )
+
+    for index, identity in enumerate(identities):
+        result = tree.match_prefix(
+            MatchPrefixParams(key=RadixKey(tokens + [5], extra_key=identity))
+        )
+        assert result.device_indices.tolist() == [index] * len(tokens)
+
+
+def test_scheduler_delivers_extra_key_to_req(monkeypatch):
+    captured = {}
+
+    class StubReq:
+        def __init__(self, *args, **kwargs):
+            captured.update(kwargs)
+            self.tokenizer = None
+
+        def set_finish_with_abort(self, _message):
+            pass
+
+    monkeypatch.setattr(scheduler_module, "Req", StubReq)
+
+    scheduler = SimpleNamespace(
+        sessions={},
+        server_args=SimpleNamespace(disaggregation_bootstrap_port=12345),
+        model_config=SimpleNamespace(hf_eos_token_id={2}, vocab_size=100),
+        disaggregation_mode=DisaggregationMode.NULL,
+        enable_metrics=False,
+        tokenizer=None,
+        dllm_config=None,
+        init_req_max_new_tokens=lambda _req: None,
+        _add_request_to_queue=lambda _req: None,
+    )
+    recv_req = _make_tokenized_req(
+        "openai-cache-identity", session_params=SessionParams(id="missing-session")
+    )
+
+    scheduler_module.Scheduler.handle_generate_request(scheduler, recv_req)
+
+    assert captured["extra_key"] == recv_req.extra_key
+
+
+def test_session_delivers_extra_key_to_req(monkeypatch):
+    captured = {}
+
+    class StubReq:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            self.rid = kwargs["rid"]
+            self.finished_reason = None
+            self.tokenizer = None
+
+    monkeypatch.setattr(session_controller_module, "Req", StubReq)
+
+    session = session_controller_module.Session(
+        capacity_of_str_len=100, session_id="test-session"
+    )
+    recv_req = _make_tokenized_req(
+        "openai-cache-identity", session_params=SessionParams(id=session.session_id)
+    )
+
+    session.create_req(recv_req, tokenizer=None, vocab_size=100)
+
+    assert captured["extra_key"] == recv_req.extra_key


### PR DESCRIPTION
## Motivation

Fixes https://github.com/kvcache-ai/ktransformers/issues/2184.

The OpenAI serving layer computes a per-request cache namespace from
`cache_salt` and `extra_key`, and the request structs carry that value to the
scheduler. However, the normal scheduler path did not pass the value into
`Req`, so caller-provided cache namespaces were dropped before radix-cache
lookup. Session requests and the asynchronous multimodal receiver had the same
problem when constructing a new `Req`.

As a result, affected requests with different `cache_salt` or `extra_key`
values could reuse each other's KV cache entries. A pre-patch reproduction with
Qwen2.5-0.5B on an 8x RTX 3090 server showed the same full cache hit
(`#cached-token: 458`) for five semantically distinct cache contexts, while the
cold request prefetched 457 new tokens. The reproduction log is attached to
the linked issue.

Simply propagating the existing value would also expose two ambiguous string
concatenations: `(cache_salt, extra_key)` in the OpenAI layer and
`(extra_key, lora_id)` in `Req`. Different component tuples could therefore
produce the same radix-cache key.

## Modifications

- Add a canonical cache-identity encoder with an explicit version, domain,
  component names, and null positions.
- Encode OpenAI `(cache_salt, extra_key)` identities without delimiter or
  field-position collisions.
- Propagate `extra_key` through normal scheduler requests, session requests,
  and asynchronous multimodal receiver requests.
- Encode the final `(extra_key, lora_id)` identity in `Req`, preserving LoRA
  isolation without ambiguous concatenation.
- Add unit coverage for canonical encoding, previously colliding identities,
  the `OpenAIServingBase -> Req -> RadixCache` path, and scheduler/session
  propagation.
- Add manual server regressions for field-position collisions, concatenation
  collisions, and native session `extra_key` isolation.

The encoded namespace is internal and opaque; no request or response schema is
changed. Requests that do not provide a cache namespace or LoRA adapter retain
`None` as their radix-cache `extra_key`.

## Accuracy Tests

This change does not modify model kernels, forward computation, sampling, or
generated-token selection. It only controls which radix-cache namespace is
eligible for prefix reuse, so model accuracy evaluation is not applicable.

- `python -m pytest -q test/unit/test_extra_key_cache_isolation.py`: 4 passed.
- `python -m pytest -q test/registered/radix_cache/test_radix_cache_unit.py::TestRadixCache::test_extra_key_isolation`: 1 passed.
- Server E2E regressions were added to
  `test/manual/openai_server/features/test_cache_report.py`, but were not run
  locally because this workspace does not have the GPU/model-server
  environment required by that test module.

## Benchmarking and Profiling

No inference benchmark was run. The change adds deterministic JSON encoding on
the CPU request-control path when a cache namespace or LoRA adapter is present;
it does not alter GPU inference kernels. No material throughput impact is
expected, but this has not been measured.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). Black, isort, Ruff (`F401,F821`), `py_compile`, and `git diff --check` passed for the changed files.
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). No documentation update is required because this restores the documented cache-isolation behavior without changing the API.
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Accuracy testing is not applicable, and a performance benchmark was not run; see the sections above.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
