### PR TITLE
Fix Qwen3 MoE RoPE parameters with Transformers 5

### DIFF
--- a/python/sglang/srt/models/qwen3_moe.py
+++ b/python/sglang/srt/models/qwen3_moe.py
@@ -78,6 +78,7 @@ from sglang.srt.utils import (
     is_non_idle_and_non_empty,
     is_npu,
 )
+from sglang.srt.utils.hf_transformers_utils import get_rope_config
 
 _is_cuda = is_cuda()
 
@@ -559,7 +560,7 @@ class Qwen3MoeAttention(nn.Module):
     def apply_qk_norm_rope(self, qkv, positions, forward_batch):
         use_fused = self.use_fused_qk_norm_rope and qkv.dtype == torch.bfloat16
         if use_fused:
-            theta = getattr(self.config, "rope_theta", 10000.0)
+            theta = self.rope_theta
             positions = (
                 positions.view(-1).to(dtype=torch.int32, device=qkv.device).contiguous()
             )
@@ -681,8 +682,8 @@ class Qwen3MoeDecoderLayer(nn.Module):
         super().__init__()
         self.config = config
         self.hidden_size = config.hidden_size
-        rope_theta = getattr(config, "rope_theta", 10000)
-        rope_scaling = getattr(config, "rope_scaling", None)
+        rope_theta, rope_scaling = get_rope_config(config)
+        self.rope_theta = rope_theta
         max_position_embeddings = getattr(config, "max_position_embeddings", 8192)
         head_dim = getattr(
             config, "head_dim", config.hidden_size // config.num_attention_heads


### PR DESCRIPTION
## Summary

- Read Qwen3 MoE RoPE parameters through `get_rope_config` for Transformers 4/5 compatibility.
- Use the resolved `rope_theta` in the fused QK-Norm-RoPE path.

With Transformers 5, Qwen3 configurations can store `rope_theta` in `rope_parameters` while the top-level `rope_theta` is unset.

## Validation

- `python -m py_compile python/sglang/srt/models/qwen3_moe.py`
- `git diff --check`
- Verified with the Qwen3-30B configuration under Transformers 5.15.1.