### PR TITLE
kt: plumb --kt-mmap-experts-dir through to the KT MoE wrapper

### DIFF
--- a/python/sglang/srt/layers/moe/kt_ep_wrapper.py
+++ b/python/sglang/srt/layers/moe/kt_ep_wrapper.py
@@ -190,6 +190,7 @@ class KTConfig:
     num_layers: Optional[int] = None
     gpu_prefill_token_threshold: Optional[int] = None
     kt_enable_dynamic_expert_update: bool = False
+    mmap_experts_dir: Optional[str] = None
     expert_lora_path: Optional[str] = None
     is_glm5_next: bool = False
 
@@ -4724,6 +4725,7 @@ def create_kt_config_from_server_args(
         num_layers=num_layers,
         gpu_prefill_token_threshold=server_args.kt_gpu_prefill_token_threshold,
         kt_enable_dynamic_expert_update=server_args.kt_enable_dynamic_expert_update,
+        mmap_experts_dir=getattr(server_args, "kt_mmap_experts_dir", None),
         expert_lora_path=getattr(server_args, "kt_expert_lora_path", None),
         is_glm5_next=getattr(server_args, "_glm5_next_session_ab_active", False),
     )
@@ -5261,6 +5263,7 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
                     swiglu_alpha=_kt_swiglu_alpha,
                     method=self.kt_config.method,
                     max_deferred_experts_per_token=layer_max_deferred,
+                    mmap_experts_dir=self.kt_config.mmap_experts_dir,
                 )
 
         # Registration happens during model construction, not on the first

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -886,6 +886,7 @@ class ServerArgs:
     kt_gpu_prefill_token_threshold: Optional[int] = None
     record_kt_gpu_expert_distribution: bool = False
     kt_enable_dynamic_expert_update: bool = False
+    kt_mmap_experts_dir: Optional[str] = None
     kt_expert_placement_strategy: str = "uniform"
     kt_lora_path: Optional[str] = None
     kt_expert_lora_path: Optional[str] = None
@@ -5316,6 +5317,17 @@ class ServerArgs:
             action="store_true",
             default=ServerArgs.kt_enable_dynamic_expert_update,
             help="[ktransformers parameter] Enable dynamic GPU expert updates based on runtime statistics. After full GPU fallback computation, updates original layer's GPU experts to match the most frequently activated experts in the current batch.",
+        )
+        parser.add_argument(
+            "--kt-mmap-experts-dir",
+            type=str,
+            default=ServerArgs.kt_mmap_experts_dir,
+            help="[ktransformers parameter] Directory (ideally on fast NVMe) in which to keep the "
+                 "CPU-resident per-expert weight blocks as MAP_SHARED files instead of anonymous "
+                 "RAM. Use when the CPU expert working set is close to total host RAM: cold experts "
+                 "then reclaim without swap and refault from the file. One file per (layer, NUMA "
+                 "part); a few %% of decode throughput is spent on the first pass while pages warm. "
+                 "Unset = keep expert weights in anonymous memory (default).",
         )
         parser.add_argument(
             "--kt-expert-placement-strategy",


### PR DESCRIPTION
## What

Companion to **kvcache-ai/ktransformers#2190** — plumbs `--kt-mmap-experts-dir`
through to the KT MoE wrapper.

When set, the kt-kernel CPU MoE kernels keep each CPU-resident expert's `BufferB`
weight block in a `MAP_SHARED` file under this directory instead of anonymous RAM,
so a host whose CPU expert working set is close to total RAM can serve the model
(cold experts reclaim without swap, refault from the file). Unset (default) →
unchanged anonymous behaviour.

## How

- `server_args.py`: `--kt-mmap-experts-dir` / `ServerArgs.kt_mmap_experts_dir`.
- `kt_ep_wrapper.py`: carried on `KTConfig`, passed to the inference
  `KTMoEWrapper` (the SFT wrapper path is unchanged).

Requires the matching kt-kernel change (`KTMoEWrapper` `mmap_experts_dir` kwarg →
`GeneralMOEConfig.mmap_weights_dir`, kvcache-ai/ktransformers#2190). A `kt_kernel`
build without it simply ignores the flag.

## Testing

End-to-end with kvcache-ai/ktransformers#2190 on 1× CMP-170HX (sm_80) + 128 GB
DDR5, DeepSeek-V4-Flash-0731 native MXFP4/FP8: `--kt-mmap-experts-dir` flows to
`KTConfig` → `KTMoEWrapper` → `MOEConfig.mmap_weights_dir`; scheduler process
anonymous RSS drops from ~105 GiB to ~2.4 GiB; decode throughput, VRAM, and
greedy outputs unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KW36fR7syvcTaG7Yqqq8pP
