### PR TITLE
fix(openai): support DSV4 reasoning in Responses API

### DIFF
--- a/python/sglang/srt/entrypoints/openai/chat_encoding.py
+++ b/python/sglang/srt/entrypoints/openai/chat_encoding.py
@@ -1,0 +1,107 @@
+"""Helpers for model-specific chat encoding configuration.
+
+This module intentionally contains only the DeepSeek-V4 reasoning-effort
+profile logic needed by the KTransformers release branch.  Encoder dispatch
+remains in ``serving_chat.py`` so that unrelated model paths are unchanged.
+"""
+
+from __future__ import annotations
+
+import ast
+import logging
+from pathlib import Path
+from typing import Optional
+
+from sglang.srt.entrypoints.openai import encoding_dsv4
+
+logger = logging.getLogger(__name__)
+
+DSV4_REASONING_EFFORT_PROFILE_OVERRIDE = "dsv4_reasoning_effort_profile"
+_DSV4_REASONING_EFFORT_ENCODER = "encoding/encoding_dsv4.py"
+_MAX_DSV4_ENCODER_BYTES = 1 << 20
+
+
+def _detect_dsv4_reasoning_effort_profile(
+    model_path: str, revision: Optional[str] = None
+) -> Optional[str]:
+    """Detect the preview or official profile without importing model code."""
+
+    encoder_path = Path(model_path) / _DSV4_REASONING_EFFORT_ENCODER
+    try:
+        if not encoder_path.is_file():
+            from huggingface_hub import hf_hub_download
+
+            encoder_path = Path(
+                hf_hub_download(
+                    model_path,
+                    _DSV4_REASONING_EFFORT_ENCODER,
+                    revision=revision,
+                )
+            )
+        if encoder_path.stat().st_size > _MAX_DSV4_ENCODER_BYTES:
+            return None
+        tree = ast.parse(encoder_path.read_text(encoding="utf-8"))
+    except Exception as error:
+        logger.debug(
+            "Could not inspect DeepSeek-V4 checkpoint encoder at %s: %s",
+            encoder_path,
+            error,
+        )
+        return None
+
+    assignments = {}
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            targets = node.targets
+            value = node.value
+        elif isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+            value = node.value
+        else:
+            continue
+
+        for target in targets:
+            if not isinstance(target, ast.Name):
+                continue
+            try:
+                assignments[target.id] = ast.literal_eval(value)
+            except (TypeError, ValueError):
+                continue
+
+    prompts = assignments.get("REASONING_EFFORT_PROMPTS")
+    if (
+        assignments.get("DEFAULT_REASONING_EFFORT") == "low"
+        and isinstance(prompts, dict)
+        and {"low", "high", "max"} <= prompts.keys()
+    ):
+        return "official"
+    if "REASONING_EFFORT_MAX" in assignments:
+        return "preview"
+    return None
+
+
+def _validate_dsv4_reasoning_effort_profile(profile: str) -> str:
+    if profile not in encoding_dsv4.REASONING_EFFORT_PROFILES:
+        raise ValueError(
+            f"Invalid {DSV4_REASONING_EFFORT_PROFILE_OVERRIDE}: {profile!r}; "
+            f"expected one of {list(encoding_dsv4.REASONING_EFFORT_PROFILES)}"
+        )
+    return profile
+
+
+def resolve_dsv4_reasoning_effort_profile(
+    *,
+    model_path: str,
+    revision: Optional[str] = None,
+    override: Optional[str] = None,
+) -> str:
+    if override is not None:
+        return _validate_dsv4_reasoning_effort_profile(override)
+
+    return (
+        _detect_dsv4_reasoning_effort_profile(
+            model_path=model_path,
+            revision=revision,
+        )
+        or "preview"
+    )

--- a/python/sglang/srt/entrypoints/openai/encoding_dsv4.py
+++ b/python/sglang/srt/entrypoints/openai/encoding_dsv4.py
@@ -60,11 +60,29 @@ tool_calls_block_name: str = "tool_calls"
 
 tool_output_template: str = "<tool_result>{content}</tool_result>"
 
-REASONING_EFFORT_MAX = (
+REASONING_EFFORT_PREVIEW_MAX = (
     "Reasoning Effort: Absolute maximum with no shortcuts permitted.\n"
     "You MUST be very thorough in your thinking and comprehensively decompose the problem to resolve the root cause, rigorously stress-testing your logic against all potential paths, edge cases, and adversarial scenarios.\n"
     "Explicitly write out your entire deliberation process, documenting every intermediate step, considered alternative, and rejected hypothesis to ensure absolutely no assumption is left unchecked.\n\n"
 )
+
+REASONING_EFFORT_OFFICIAL_MAX = (
+    "Reasoning Effort: Beyond maximum — exhaustive, relentless, and uncompromising.\n"
+    "You MUST reason with the utmost depth and rigor, leaving absolutely nothing to chance: exhaustively decompose the problem into its most fundamental components, trace every causal chain to its root, and resolve the underlying cause rather than any surface symptom.\n"
+    "Do not stop reasoning until you have independently verified the solution from multiple angles and are certain that no assumption remains unchecked and no error remains undiscovered.\n\n"
+)
+
+REASONING_EFFORT_PROFILES = {
+    "preview": {
+        "high": "",
+        "max": REASONING_EFFORT_PREVIEW_MAX,
+    },
+    "official": {
+        "low": "",
+        "high": REASONING_EFFORT_PREVIEW_MAX,
+        "max": REASONING_EFFORT_OFFICIAL_MAX,
+    },
+}
 
 TOOLS_TEMPLATE = """## Tools
 
@@ -236,6 +254,7 @@ def render_message(
     thinking_mode: str,
     drop_thinking: bool = True,
     reasoning_effort: Optional[str] = None,
+    reasoning_effort_profile: str = "preview",
 ) -> str:
     """
     Render a single message at the given index into its encoded string form.
@@ -248,7 +267,9 @@ def render_message(
         messages: Full list of messages in the conversation.
         thinking_mode: Either "chat" or "thinking".
         drop_thinking: Whether to drop reasoning content from earlier turns.
-        reasoning_effort: Optional reasoning effort level ("max", "high", or None).
+        reasoning_effort: Optional reasoning effort level. The preview profile accepts
+            "high" and "max"; the official profile accepts "low", "high", and "max".
+        reasoning_effort_profile: DeepSeek-V4 effort mapping ("preview" or "official").
 
     Returns:
         Encoded string for this message.
@@ -276,14 +297,21 @@ def render_message(
     if tool_calls:
         tool_calls = tool_calls_from_openai_format(tool_calls)
 
-    # Reasoning effort prefix (only at index 0 in thinking mode with max effort)
-    assert reasoning_effort in [
-        "max",
-        None,
-        "high",
-    ], f"Invalid reasoning effort: {reasoning_effort}"
-    if index == 0 and thinking_mode == "thinking" and reasoning_effort == "max":
-        prompt += REASONING_EFFORT_MAX
+    if reasoning_effort_profile not in REASONING_EFFORT_PROFILES:
+        raise ValueError(
+            f"Invalid reasoning effort profile: {reasoning_effort_profile!r}; "
+            f"expected one of {list(REASONING_EFFORT_PROFILES)}"
+        )
+    effort_prompts = REASONING_EFFORT_PROFILES[reasoning_effort_profile]
+    if reasoning_effort is None:
+        reasoning_effort = "low" if reasoning_effort_profile == "official" else "high"
+    if reasoning_effort not in effort_prompts:
+        raise ValueError(
+            f"Invalid reasoning effort {reasoning_effort!r} for profile "
+            f"{reasoning_effort_profile!r}; expected one of {list(effort_prompts)}"
+        )
+    if index == 0 and thinking_mode == "thinking":
+        prompt += effort_prompts[reasoning_effort]
 
     if role == "system":
         prompt += system_msg_template.format(content=content or "")
@@ -512,7 +540,7 @@ def merge_tool_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
 
 
 def sort_tool_results_by_call_order(
-    messages: List[Dict[str, Any]]
+    messages: List[Dict[str, Any]],
 ) -> List[Dict[str, Any]]:
     """
     Sort tool_result blocks within user messages by the order of tool_calls
@@ -569,6 +597,7 @@ def encode_messages(
     drop_thinking: bool = True,
     add_default_bos_token: bool = True,
     reasoning_effort: Optional[str] = None,
+    reasoning_effort_profile: str = "preview",
 ) -> str:
     """
     Encode a list of messages into the DeepSeek-V4 prompt format.
@@ -586,7 +615,9 @@ def encode_messages(
         drop_thinking: If True, drop reasoning_content from earlier assistant turns
                       (only keep reasoning for messages after the last user message).
         add_default_bos_token: Whether to prepend BOS token at conversation start.
-        reasoning_effort: Optional reasoning effort level ("max", "high", or None).
+        reasoning_effort: Optional reasoning effort level. The preview profile accepts
+            "high" and "max"; the official profile accepts "low", "high", and "max".
+        reasoning_effort_profile: DeepSeek-V4 effort mapping ("preview" or "official").
 
     Returns:
         The encoded prompt string.
@@ -626,6 +657,7 @@ def encode_messages(
             thinking_mode=thinking_mode,
             drop_thinking=effective_drop_thinking,
             reasoning_effort=reasoning_effort,
+            reasoning_effort_profile=reasoning_effort_profile,
         )
 
     return prompt

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -589,12 +589,11 @@ class ChatCompletionRequest(BaseModel):
     return_hidden_states: bool = False
     return_routed_experts: bool = False
     return_cached_tokens_details: bool = False
-    reasoning_effort: Optional[Literal["low", "medium", "high"]] = Field(
-        default="medium",
+    reasoning_effort: Optional[str] = Field(
+        default=None,
         description="Constrains effort on reasoning for reasoning models. "
-        "'low' is the least effort, 'high' is the most effort. Reducing reasoning effort can "
-        "result in faster responses and fewer tokens used on reasoning in a response. "
-        "Currently only supported for OpenAI models in the harmony path, i.e GPT-OSS models.",
+        "Supported values are model-specific. DeepSeek-V4 accepts low, high, max, and none; "
+        "unsupported values are resolved by its model-specific compatibility policy.",
     )
 
     # Extra parameters for SRT backend only and will be ignored by OpenAI models.
@@ -678,7 +677,7 @@ class ChatCompletionRequest(BaseModel):
 
         if isinstance(r, dict):
             effort = r.get("effort") or r.get("reasoning_effort")
-            if effort in {"low", "medium", "high"}:
+            if isinstance(effort, str) and values.get("reasoning_effort") is None:
                 values["reasoning_effort"] = effort
 
             enabled = (
@@ -1111,24 +1110,34 @@ OpenAIServingRequest = Union[
 class ResponseReasoningParam(BaseModel):
     """Reasoning parameters for responses."""
 
-    effort: Optional[Literal["low", "medium", "high"]] = Field(
-        default="medium",
+    effort: Optional[str] = Field(
+        default=None,
         description="Constrains effort on reasoning for reasoning models.",
+    )
+    summary: Optional[str] = Field(
+        default=None,
+        description="Requests a reasoning summary in Responses API output.",
     )
 
 
 class ResponseTool(BaseModel):
     """Tool definition for responses."""
 
-    type: Literal["web_search_preview", "code_interpreter"] = Field(
-        description="Type of tool to enable"
-    )
+    model_config = {"extra": "allow"}
+
+    type: str = Field(description="Type of tool to enable")
+    name: Optional[str] = None
+    description: Optional[str] = None
+    parameters: Optional[Dict[str, Any]] = None
+    strict: Optional[bool] = None
+    tools: Optional[List[Dict[str, Any]]] = None
 
 
 ResponseInputOutputItem: TypeAlias = Union[
     ResponseInputItemParam,
     "ResponseReasoningItem",
     ResponseFunctionToolCall,
+    Dict[str, Any],
 ]
 
 
@@ -1137,18 +1146,7 @@ class ResponsesRequest(BaseModel):
 
     # Core OpenAI API fields (ordered by official documentation)
     background: Optional[bool] = False
-    include: Optional[
-        List[
-            Literal[
-                "code_interpreter_call.outputs",
-                "computer_call_output.output.image_url",
-                "file_search_call.results",
-                "message.input_image.image_url",
-                "message.output_text.logprobs",
-                "reasoning.encrypted_content",
-            ]
-        ]
-    ] = None
+    include: Optional[List[str]] = None
     input: Union[str, List[ResponseInputOutputItem]]
     instructions: Optional[str] = None
     max_output_tokens: Optional[int] = None
@@ -1162,7 +1160,7 @@ class ResponsesRequest(BaseModel):
     store: Optional[bool] = True
     stream: Optional[bool] = False
     temperature: Optional[float] = None
-    tool_choice: Literal["auto", "required", "none"] = "auto"
+    tool_choice: Union[Literal["auto", "required", "none"], Dict[str, Any]] = "auto"
     tools: List[ResponseTool] = Field(default_factory=list)
     top_logprobs: Optional[int] = 0
     top_p: Optional[float] = None
@@ -1182,6 +1180,7 @@ class ResponsesRequest(BaseModel):
     cache_salt: Optional[str] = Field(
         default=None, description="Cache salt for request caching"
     )
+    chat_template_kwargs: Optional[Dict[str, Any]] = None
 
     # SGLang-specific sampling parameters
     frequency_penalty: float = 0.0
@@ -1253,6 +1252,46 @@ class PromptTokenUsageInfo(BaseModel):
     cached_tokens: int = 0
 
 
+class ResponseInputTokensDetails(BaseModel):
+    """Responses API input token details."""
+
+    cached_tokens: int = 0
+
+
+class ResponseOutputTokensDetails(BaseModel):
+    """Responses API output token details."""
+
+    reasoning_tokens: int = 0
+
+
+class ResponseUsageInfo(BaseModel):
+    """OpenAI-compatible token usage for the Responses API."""
+
+    input_tokens: int
+    input_tokens_details: ResponseInputTokensDetails
+    output_tokens: int
+    output_tokens_details: ResponseOutputTokensDetails
+    total_tokens: int
+
+    @classmethod
+    def from_usage_info(cls, usage: UsageInfo) -> "ResponseUsageInfo":
+        return cls(
+            input_tokens=usage.prompt_tokens,
+            input_tokens_details=ResponseInputTokensDetails(
+                cached_tokens=(
+                    usage.prompt_tokens_details.cached_tokens
+                    if usage.prompt_tokens_details is not None
+                    else 0
+                )
+            ),
+            output_tokens=usage.completion_tokens or 0,
+            output_tokens_details=ResponseOutputTokensDetails(
+                reasoning_tokens=usage.reasoning_tokens or 0
+            ),
+            total_tokens=usage.total_tokens,
+        )
+
+
 class ResponsesResponse(BaseModel):
     """Response body for v1/responses endpoint."""
 
@@ -1265,9 +1304,9 @@ class ResponsesResponse(BaseModel):
         Union[ResponseOutputItem, ResponseReasoningItem, ResponseFunctionToolCall]
     ] = Field(default_factory=list)
     status: Literal["queued", "in_progress", "completed", "failed", "cancelled"]
-    usage: Optional[UsageInfo] = None
+    usage: Optional[ResponseUsageInfo] = None
     parallel_tool_calls: bool = True
-    tool_choice: str = "auto"
+    tool_choice: Union[str, Dict[str, Any]] = "auto"
     tools: List[ResponseTool] = Field(default_factory=list)
 
     # OpenAI compatibility fields. not all are used at the moment.
@@ -1345,8 +1384,12 @@ class ResponsesResponse(BaseModel):
             model=model_name,
             output=output,
             status=status,
-            usage=usage,
-            parallel_tool_calls=request.parallel_tool_calls or True,
+            usage=(ResponseUsageInfo.from_usage_info(usage) if usage else None),
+            parallel_tool_calls=(
+                True
+                if request.parallel_tool_calls is None
+                else request.parallel_tool_calls
+            ),
             tool_choice=request.tool_choice,
             tools=request.tools,
             # fields for parity with v1/responses
@@ -1357,7 +1400,7 @@ class ResponsesResponse(BaseModel):
             previous_response_id=request.previous_response_id,  # TODO(v): ensure this is propagated if retrieved from store
             reasoning={
                 "effort": request.reasoning.effort if request.reasoning else None,
-                "summary": None,  # unused
+                "summary": request.reasoning.summary if request.reasoning else None,
             },
             store=request.store,
             temperature=request.temperature,
@@ -1420,7 +1463,10 @@ class ResponseReasoningTextContent(BaseModel):
 
 
 ResponseInputOutputItem: TypeAlias = Union[
-    ResponseInputItemParam, "ResponseReasoningItem", ResponseFunctionToolCall
+    ResponseInputItemParam,
+    "ResponseReasoningItem",
+    ResponseFunctionToolCall,
+    Dict[str, Any],
 ]
 
 

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import json
 import logging
+import os
 import time
 import uuid
 from typing import TYPE_CHECKING, Any, AsyncGenerator, Dict, List, Optional, Union
@@ -13,7 +14,7 @@ from fastapi import Request
 from fastapi.responses import ORJSONResponse, StreamingResponse
 from jsonschema import Draft202012Validator, SchemaError
 
-from sglang.srt.entrypoints.openai import encoding_dsv32
+from sglang.srt.entrypoints.openai import chat_encoding, encoding_dsv32, encoding_dsv4
 from sglang.srt.entrypoints.openai.protocol import (
     ChatCompletionRequest,
     ChatCompletionResponse,
@@ -57,6 +58,78 @@ if TYPE_CHECKING:
     from sglang.srt.managers.tokenizer_manager import TokenizerManager
 
 logger = logging.getLogger(__name__)
+
+
+def _coerce_optional_bool(value: Any) -> Optional[bool]:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "y", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "n", "off"}:
+            return False
+    return bool(value)
+
+
+def resolve_dsv4_reasoning_controls(
+    *,
+    request_effort: Optional[str],
+    chat_template_kwargs: Optional[Dict[str, Any]],
+    reasoning_effort_profile: str,
+    dsv4_env_effort: str = "",
+    legacy_env_effort: str = "",
+    legacy_env_thinking: Optional[bool] = None,
+) -> tuple[str, Optional[str]]:
+    """Resolve DSV4 thinking and effort once for Chat and Responses requests.
+
+    A non-null standard API field wins over all SGLang compatibility inputs.
+    Unsupported DSV4 values intentionally fall back to max instead of becoming
+    protocol errors, matching the DSV4 Docker API contract.
+    """
+
+    ctk = chat_template_kwargs or {}
+    if request_effort is not None:
+        effort = request_effort
+        source = "reasoning_effort"
+        thinking_override = None
+    elif ctk.get("reasoning_effort") is not None:
+        effort = ctk["reasoning_effort"]
+        source = "chat_template_kwargs.reasoning_effort"
+        thinking_override = _coerce_optional_bool(ctk.get("thinking"))
+    elif dsv4_env_effort:
+        effort = dsv4_env_effort
+        source = "SGLANG_DSV4_REASONING_EFFORT"
+        thinking_override = _coerce_optional_bool(ctk.get("thinking"))
+    elif legacy_env_effort:
+        effort = legacy_env_effort
+        source = "SGLANG_REASONING_EFFORT"
+        thinking_override = _coerce_optional_bool(ctk.get("thinking"))
+    else:
+        effort = "max"
+        source = "default"
+        thinking_override = _coerce_optional_bool(ctk.get("thinking"))
+
+    if request_effort is None and thinking_override is None:
+        thinking_override = legacy_env_thinking
+
+    if effort == "none":
+        return "chat", None
+
+    accepted_efforts = encoding_dsv4.REASONING_EFFORT_PROFILES[reasoning_effort_profile]
+    if not isinstance(effort, str) or effort not in accepted_efforts:
+        logger.warning(
+            "Unsupported DeepSeek-V4 reasoning effort %r from %s; "
+            "falling back to thinking + max",
+            effort,
+            source,
+        )
+        effort = "max"
+
+    thinking_enabled = True if thinking_override is None else thinking_override
+    return ("thinking" if thinking_enabled else "chat"), effort
 
 
 def _extract_max_dynamic_patch(request: ChatCompletionRequest):
@@ -123,6 +196,22 @@ class OpenAIServingChat(OpenAIServingBase):
         # Which Python-based chat encoder (if any) bypasses apply_chat_template.
         # Values: "dsv32", "dsv4", or None.
         self.chat_encoding_spec = self._resolve_chat_encoding_spec()
+        self._dsv4_reasoning_effort_profile = (
+            chat_encoding.resolve_dsv4_reasoning_effort_profile(
+                model_path=self.tokenizer_manager.model_path,
+                revision=self.tokenizer_manager.server_args.revision,
+                override=self.tokenizer_manager.model_config.hf_config.to_dict().get(
+                    chat_encoding.DSV4_REASONING_EFFORT_PROFILE_OVERRIDE
+                ),
+            )
+            if self.chat_encoding_spec == "dsv4"
+            else None
+        )
+        if self._dsv4_reasoning_effort_profile is not None:
+            logger.info(
+                "DeepSeek-V4 reasoning effort profile=%s default_effort=max",
+                self._dsv4_reasoning_effort_profile,
+            )
 
     def _handle_last_assistant_message(
         self,
@@ -208,6 +297,17 @@ class OpenAIServingChat(OpenAIServingBase):
         if not request.messages:
             return "Messages cannot be empty."
 
+        if self.chat_encoding_spec != "dsv4" and request.reasoning_effort not in (
+            None,
+            "low",
+            "medium",
+            "high",
+        ):
+            return (
+                f"Unsupported reasoning_effort={request.reasoning_effort!r} for "
+                "this model. Expected one of: low, medium, high."
+            )
+
         if (
             isinstance(request.tool_choice, str)
             and request.tool_choice.lower() == "required"
@@ -256,13 +356,13 @@ class OpenAIServingChat(OpenAIServingBase):
         request: ChatCompletionRequest,
         raw_request: Request = None,
     ) -> tuple[GenerateReqInput, ChatCompletionRequest]:
-        reasoning_effort = (
-            request.chat_template_kwargs.pop("reasoning_effort", None)
-            if request.chat_template_kwargs
-            else None
-        )
-        if reasoning_effort is not None:
-            request.reasoning_effort = reasoning_effort
+        if self.chat_encoding_spec != "dsv4" and request.reasoning_effort is None:
+            legacy_reasoning_effort = (
+                request.chat_template_kwargs.get("reasoning_effort")
+                if request.chat_template_kwargs
+                else None
+            )
+            request.reasoning_effort = legacy_reasoning_effort or "medium"
 
         """Convert OpenAI chat completion request to internal format"""
         is_multimodal = self.tokenizer_manager.model_config.is_multimodal
@@ -395,12 +495,31 @@ class OpenAIServingChat(OpenAIServingBase):
         template_content_format = self.template_manager.jinja_template_content_format
 
         if self.chat_encoding_spec is not None:
-            # Per-request wins; env is fallback so existing
-            # `export SGLANG_ENABLE_THINKING=1` workflow keeps working here.
-            thinking_requested = (request.chat_template_kwargs or {}).get(
-                "thinking", envs.SGLANG_ENABLE_THINKING.get()
-            )
-            thinking_mode = "thinking" if thinking_requested else "chat"
+            if self.chat_encoding_spec == "dsv4":
+                assert self._dsv4_reasoning_effort_profile is not None
+                legacy_env_thinking = (
+                    envs.SGLANG_ENABLE_THINKING.get()
+                    if "SGLANG_ENABLE_THINKING" in os.environ
+                    else None
+                )
+                thinking_mode, v4_reasoning_effort = resolve_dsv4_reasoning_controls(
+                    request_effort=request.reasoning_effort,
+                    chat_template_kwargs=request.chat_template_kwargs,
+                    reasoning_effort_profile=self._dsv4_reasoning_effort_profile,
+                    dsv4_env_effort=envs.SGLANG_DSV4_REASONING_EFFORT.get(),
+                    legacy_env_effort=envs.SGLANG_REASONING_EFFORT.get(),
+                    legacy_env_thinking=legacy_env_thinking,
+                )
+                if request.chat_template_kwargs is None:
+                    request.chat_template_kwargs = {}
+                # The response parsers need the resolved toggle because the
+                # DSV4 prompt consumes the opening <think> marker.
+                request.chat_template_kwargs["thinking"] = thinking_mode == "thinking"
+            else:
+                thinking_requested = (request.chat_template_kwargs or {}).get(
+                    "thinking", envs.SGLANG_ENABLE_THINKING.get()
+                )
+                thinking_mode = "thinking" if thinking_requested else "chat"
             messages = [msg.model_dump() for msg in request.messages]
 
             for msg in messages:
@@ -429,23 +548,11 @@ class OpenAIServingChat(OpenAIServingBase):
                 messages[0]["tools"] = [tool.model_dump() for tool in request.tools]
 
             if self.chat_encoding_spec == "dsv4":
-                # V4 encoder only accepts "max" / "high" / None.
-                # OpenAI protocol defaults to "medium" which V4 rejects; drop it.
-                # Fallback: if request didn't set it, try env SGLANG_REASONING_EFFORT.
-                effort_source = request.reasoning_effort
-                if effort_source is None:
-                    env_val = envs.SGLANG_REASONING_EFFORT.get()
-                    if env_val:
-                        effort_source = env_val
-                v4_reasoning_effort = (
-                    effort_source if effort_source in ("max", "high") else None
-                )
-                from sglang.srt.entrypoints.openai import encoding_dsv4
-
                 real_input = encoding_dsv4.encode_messages(
                     messages,
                     thinking_mode=thinking_mode,
                     reasoning_effort=v4_reasoning_effort,
+                    reasoning_effort_profile=self._dsv4_reasoning_effort_profile,
                 )
             else:
                 real_input = encoding_dsv32.encode_messages(
@@ -1120,10 +1227,7 @@ class OpenAIServingChat(OpenAIServingBase):
         native_forced_tool_format = self.tool_call_parser == "glm47"
         if not native_forced_tool_format and (
             tool_choice == "required"
-            or (
-                isinstance(tool_choice, ToolChoice)
-                and tool_choice.type == "function"
-            )
+            or (isinstance(tool_choice, ToolChoice) and tool_choice.type == "function")
         ):
             # Set finish reason to tool_calls since we're processing tool calls
             if finish_reason["type"] == "stop":

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -14,7 +14,7 @@ from fastapi import Request
 from fastapi.responses import ORJSONResponse, StreamingResponse
 from jsonschema import Draft202012Validator, SchemaError
 
-from sglang.srt.entrypoints.openai import chat_encoding, encoding_dsv32, encoding_dsv4
+from sglang.srt.entrypoints.openai import chat_encoding, encoding_dsv4, encoding_dsv32
 from sglang.srt.entrypoints.openai.protocol import (
     ChatCompletionRequest,
     ChatCompletionResponse,

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -27,6 +27,9 @@ from openai.types.responses.response_function_tool_call import ResponseFunctionT
 from openai.types.responses.response_reasoning_item import (
     Content as ResponseReasoningTextContent,
 )
+from openai.types.responses.response_reasoning_item import (
+    Summary as ResponseReasoningSummary,
+)
 from openai_harmony import Message as OpenAIMessage
 
 from sglang.srt.entrypoints.context import (
@@ -48,14 +51,20 @@ from sglang.srt.entrypoints.harmony_utils import (
 from sglang.srt.entrypoints.openai.protocol import (
     ChatCompletionMessageParam,
     ChatCompletionRequest,
+    Function,
     PromptTokenUsageInfo,
     RequestResponseMetadata,
     ResponsesRequest,
     ResponsesResponse,
+    Tool,
+    ToolChoice,
     UsageInfo,
 )
 from sglang.srt.entrypoints.openai.serving_chat import OpenAIServingChat
 from sglang.srt.entrypoints.openai.tool_server import MCPToolServer, ToolServer
+from sglang.srt.function_call.core_types import ToolCallItem
+from sglang.srt.function_call.function_call_parser import FunctionCallParser
+from sglang.srt.function_call.json_array_parser import JsonArrayParser
 from sglang.srt.managers.io_struct import GenerateReqInput
 from sglang.srt.parser.reasoning_parser import ReasoningParser
 from sglang.srt.utils import random_uuid
@@ -65,6 +74,11 @@ if TYPE_CHECKING:
     from sglang.srt.managers.tokenizer_manager import TokenizerManager
 
 logger = logging.getLogger(__name__)
+
+
+def _response_event(event_type: str, sequence_number: int, **payload: Any) -> str:
+    data = {"type": event_type, "sequence_number": sequence_number, **payload}
+    return f"event: {event_type}\ndata: {json.dumps(data, ensure_ascii=False)}\n\n"
 
 
 class OpenAIServingResponses(OpenAIServingChat):
@@ -186,17 +200,23 @@ class OpenAIServingResponses(OpenAIServingChat):
             prev_response = None
 
         try:
-            model_name = request.model
+            model_name = request.model or "default"
             tokenizer = self.tokenizer_manager.tokenizer
+            processed_messages = None
+            require_reasoning = False
 
             if self.use_harmony:
                 messages, request_prompts, engine_prompts = (
                     self._make_request_with_harmony(request, prev_response)
                 )
             else:
-                messages, request_prompts, engine_prompts = await self._make_request(
-                    request, prev_response, tokenizer
-                )
+                (
+                    messages,
+                    request_prompts,
+                    engine_prompts,
+                    processed_messages,
+                    require_reasoning,
+                ) = await self._make_request(request, prev_response, tokenizer)
 
         except (ValueError, TypeError, RuntimeError, jinja2.TemplateError) as e:
             logger.exception("Error in preprocessing prompt inputs")
@@ -205,6 +225,17 @@ class OpenAIServingResponses(OpenAIServingChat):
         request_metadata = RequestResponseMetadata(request_id=request.request_id)
         if raw_request:
             raw_request.state.request_metadata = request_metadata
+
+        if not self.use_harmony:
+            ignored_tool_types = sorted(
+                {tool.type for tool in request.tools if tool.type != "function"}
+            )
+            if ignored_tool_types:
+                logger.warning(
+                    "Responses API accepted but did not expose unsupported DSV4 "
+                    "tool types to the model: %s",
+                    ", ".join(ignored_tool_types),
+                )
 
         if (
             self.tool_server is not None
@@ -264,6 +295,15 @@ class OpenAIServingResponses(OpenAIServingChat):
                     sampling_params = request.to_sampling_params(
                         default_max_tokens, self.default_sampling_params
                     )
+                    if processed_messages is not None:
+                        sampling_params["stop"] = processed_messages.stop
+                        if processed_messages.tool_call_constraint is not None:
+                            constraint_type, constraint_value = (
+                                processed_messages.tool_call_constraint
+                            )
+                            sampling_params[constraint_type] = constraint_value
+                        if not getattr(processed_messages, "skip_special_tokens", True):
+                            sampling_params["skip_special_tokens"] = False
 
                     context: ConversationContext
                     if self.use_harmony:
@@ -275,13 +315,39 @@ class OpenAIServingResponses(OpenAIServingChat):
                         context = SimpleContext()
 
                     # Create GenerateReqInput for SGLang
+                    prompt_kwargs = (
+                        {"text": engine_prompt}
+                        if isinstance(engine_prompt, str)
+                        else {"input_ids": engine_prompt}
+                    )
                     adapted_request = GenerateReqInput(
-                        input_ids=engine_prompt,
+                        **prompt_kwargs,
+                        image_data=(
+                            processed_messages.image_data
+                            if processed_messages is not None
+                            else None
+                        ),
+                        video_data=(
+                            processed_messages.video_data
+                            if processed_messages is not None
+                            else None
+                        ),
+                        audio_data=(
+                            processed_messages.audio_data
+                            if processed_messages is not None
+                            else None
+                        ),
+                        modalities=(
+                            processed_messages.modalities
+                            if processed_messages is not None
+                            else None
+                        ),
                         sampling_params=sampling_params,
                         stream=request.stream,
                         rid=request.request_id,
                         extra_key=self._compute_extra_key(request),
                         background=request.background,
+                        require_reasoning=require_reasoning,
                     )
 
                     generator = self._generate_with_builtin_tools(
@@ -329,6 +395,7 @@ class OpenAIServingResponses(OpenAIServingChat):
                         tokenizer,
                         request_metadata,
                         created_time,
+                        require_reasoning=require_reasoning,
                     ),
                     name=f"create_{response.id}",
                 )
@@ -341,6 +408,16 @@ class OpenAIServingResponses(OpenAIServingChat):
                 return response
 
             if request.stream:
+                if not self.use_harmony:
+                    return self.responses_stream_generator_non_harmony(
+                        request,
+                        sampling_params,
+                        result_generator,
+                        model_name,
+                        tokenizer,
+                        request_metadata,
+                        require_reasoning=require_reasoning,
+                    )
                 return self.responses_stream_generator(
                     request,
                     sampling_params,
@@ -360,6 +437,7 @@ class OpenAIServingResponses(OpenAIServingChat):
                         model_name,
                         tokenizer,
                         request_metadata,
+                        require_reasoning=require_reasoning,
                     )
                 )
                 return result
@@ -367,49 +445,94 @@ class OpenAIServingResponses(OpenAIServingChat):
                 return self.create_error_response(str(e))
         return self.create_error_response("Unknown error")
 
+    @staticmethod
+    def _chat_tool_choice(tool_choice: Any) -> Any:
+        if not isinstance(tool_choice, dict):
+            return tool_choice
+        if tool_choice.get("type") != "function" or not tool_choice.get("name"):
+            raise ValueError(
+                "Only named top-level function tool_choice is supported for "
+                "non-Harmony Responses requests."
+            )
+        return ToolChoice(function={"name": tool_choice["name"]})
+
+    @staticmethod
+    def _response_tools_to_chat_tools(request: ResponsesRequest) -> list[Tool]:
+        chat_tools = []
+        for response_tool in request.tools:
+            if response_tool.type != "function":
+                continue
+            if not response_tool.name:
+                raise ValueError("Responses function tools require a non-empty name.")
+            chat_tools.append(
+                Tool(
+                    type="function",
+                    function=Function(
+                        name=response_tool.name,
+                        description=response_tool.description,
+                        parameters=response_tool.parameters,
+                        strict=bool(response_tool.strict),
+                    ),
+                )
+            )
+        return chat_tools
+
     async def _make_request(
         self,
         request: ResponsesRequest,
         prev_response: Optional[ResponsesResponse],
         tokenizer: Any,
     ):
-        # Construct the input messages
         messages = self._construct_input_messages(request, prev_response)
+        chat_tools = self._response_tools_to_chat_tools(request)
+        chat_request = ChatCompletionRequest(
+            model=request.model or "default",
+            messages=messages,
+            stream=bool(request.stream),
+            tools=chat_tools or None,
+            tool_choice=(
+                self._chat_tool_choice(request.tool_choice) if chat_tools else "none"
+            ),
+            parallel_tool_calls=(
+                True
+                if request.parallel_tool_calls is None
+                else request.parallel_tool_calls
+            ),
+            stop=request.stop,
+            max_completion_tokens=request.max_output_tokens,
+            reasoning_effort=(
+                request.reasoning.effort if request.reasoning is not None else None
+            ),
+            chat_template_kwargs=(
+                dict(request.chat_template_kwargs)
+                if request.chat_template_kwargs is not None
+                else None
+            ),
+        )
+        validation_error = self._validate_request(chat_request)
+        if validation_error is not None:
+            raise ValueError(validation_error)
 
-        # Follow SGLang's pattern: create a ChatCompletionRequest and process messages
-        try:
-            # Convert ResponsesRequest to ChatCompletionRequest for processing
-            chat_request = ChatCompletionRequest(
-                model=request.model,
-                messages=messages,
-                stream=request.stream,
-            )
+        is_multimodal = self.tokenizer_manager.model_config.is_multimodal
+        processed_messages = self._process_messages(chat_request, is_multimodal)
+        processed_messages.skip_special_tokens = chat_request.skip_special_tokens
+        request.chat_template_kwargs = chat_request.chat_template_kwargs
+        require_reasoning = self._get_reasoning_from_request(chat_request)
 
-            # Follow SGLang's _process_messages pattern
-            is_multimodal = self.tokenizer_manager.model_config.is_multimodal
-            processed_messages = self._process_messages(chat_request, is_multimodal)
+        if is_multimodal:
+            request_prompts = [processed_messages.prompt]
+            engine_prompts = [processed_messages.prompt]
+        else:
+            request_prompts = [processed_messages.prompt_ids]
+            engine_prompts = [processed_messages.prompt_ids]
 
-            # Extract the results
-            if is_multimodal:
-                request_prompts = [processed_messages.prompt]
-                engine_prompts = [processed_messages.prompt]
-            else:
-                request_prompts = [processed_messages.prompt_ids]
-                engine_prompts = [processed_messages.prompt_ids]
-
-        except Exception as e:
-            logger.warning(f"Chat processing failed, using fallback: {e}")
-            # Fallback to simple encoding
-            prompt_text = ""
-            for msg in messages:
-                role = msg.get("role", "user")
-                content = msg.get("content", "")
-                prompt_text += f"{role}: {content}\n"
-            prompt_ids = tokenizer.encode(prompt_text)
-            request_prompts = [prompt_ids]
-            engine_prompts = [prompt_ids]
-
-        return messages, request_prompts, engine_prompts
+        return (
+            messages,
+            request_prompts,
+            engine_prompts,
+            processed_messages,
+            require_reasoning,
+        )
 
     def _make_request_with_harmony(
         self,
@@ -435,6 +558,8 @@ class OpenAIServingResponses(OpenAIServingChat):
         tokenizer: Any,
         request_metadata: RequestResponseMetadata,
         created_time: Optional[int] = None,
+        *,
+        require_reasoning: bool = False,
     ) -> Union[ResponsesResponse, ORJSONResponse]:
         if created_time is None:
             created_time = int(time.time())
@@ -461,14 +586,21 @@ class OpenAIServingResponses(OpenAIServingChat):
             assert final_res is not None
 
             output = self._make_response_output_items(
-                request, final_res["text"], tokenizer
+                request,
+                final_res["text"],
+                tokenizer,
+                require_reasoning=require_reasoning,
             )
 
             # Calculate usage from actual output
-            if hasattr(final_res, "meta_info"):
-                num_prompt_tokens = final_res.meta_info.get("prompt_tokens", 0)
-                num_generated_tokens = final_res.meta_info.get("completion_tokens", 0)
-                num_cached_tokens = final_res.meta_info.get("cached_tokens", 0)
+            meta_info = (
+                final_res.get("meta_info") if isinstance(final_res, dict) else None
+            )
+            if isinstance(meta_info, dict):
+                num_prompt_tokens = meta_info.get("prompt_tokens", 0)
+                num_generated_tokens = meta_info.get("completion_tokens", 0)
+                num_cached_tokens = meta_info.get("cached_tokens", 0)
+                num_reasoning_tokens = meta_info.get("reasoning_tokens", 0)
             elif hasattr(final_res, "prompt_token_ids") and hasattr(
                 final_res, "outputs"
             ):
@@ -526,13 +658,14 @@ class OpenAIServingResponses(OpenAIServingChat):
         request: ResponsesRequest,
         final_output: Any,
         tokenizer: Any,
+        *,
+        require_reasoning: bool = False,
     ):
-        # Handle reasoning parsing if enabled
         if self.reasoning_parser:
-            # Use standard reasoning parser (openai maps to T4Detector internally)
             reasoning_parser = ReasoningParser(
                 model_type=self.reasoning_parser,
                 stream_reasoning=False,
+                force_reasoning=require_reasoning,
                 request=request,
             )
             reasoning_content, content = reasoning_parser.parse_non_stream(final_output)
@@ -542,10 +675,21 @@ class OpenAIServingResponses(OpenAIServingChat):
 
         output_items = []
         if reasoning_content:
+            wants_summary = (
+                request.reasoning is not None and request.reasoning.summary is not None
+            )
             reasoning_item = ResponseReasoningItem(
                 id=f"rs_{random_uuid()}",
                 type="reasoning",
-                summary=[],
+                summary=(
+                    [
+                        ResponseReasoningSummary(
+                            type="summary_text", text=reasoning_content
+                        )
+                    ]
+                    if wants_summary
+                    else []
+                ),
                 content=[
                     ResponseReasoningTextContent(
                         type="reasoning_text", text=reasoning_content
@@ -554,7 +698,55 @@ class OpenAIServingResponses(OpenAIServingChat):
                 status=None,
             )
             output_items.append(reasoning_item)
-        if content:
+
+        tool_call_items = []
+        chat_tools = self._response_tools_to_chat_tools(request)
+        if (
+            content
+            and chat_tools
+            and self.tool_call_parser
+            and request.tool_choice != "none"
+        ):
+            tool_choice = self._chat_tool_choice(request.tool_choice)
+            try:
+                if tool_choice == "required" or isinstance(tool_choice, ToolChoice):
+                    tool_call_data = orjson.loads(content)
+                    calls = [
+                        ToolCallItem(
+                            tool_index=index,
+                            name=item["name"],
+                            parameters=json.dumps(
+                                item["parameters"], ensure_ascii=False
+                            ),
+                        )
+                        for index, item in enumerate(tool_call_data)
+                    ]
+                    content = ""
+                else:
+                    parser = FunctionCallParser(
+                        chat_tools,
+                        self.tool_call_parser,
+                        tool_choice=tool_choice,
+                    )
+                    if not parser.has_tool_call(content):
+                        calls = []
+                    else:
+                        content, calls = parser.parse_non_stream(content)
+                for call in calls:
+                    tool_call_items.append(
+                        ResponseFunctionToolCall(
+                            arguments=call.parameters or "",
+                            call_id=f"call_{random_uuid()[:24]}",
+                            type="function_call",
+                            name=call.name,
+                            id=f"fc_{random_uuid()[:8]}",
+                            status="completed",
+                        )
+                    )
+            except (KeyError, TypeError, ValueError, orjson.JSONDecodeError) as error:
+                logger.warning("Responses tool-call parsing failed: %s", error)
+
+        if content and content.strip():
             output_text = ResponseOutputText(
                 text=content,
                 annotations=[],  # TODO
@@ -569,6 +761,7 @@ class OpenAIServingResponses(OpenAIServingChat):
                 type="message",
             )
             output_items.append(message)
+        output_items.extend(tool_call_items)
         return output_items
 
     def _make_response_output_items_with_harmony(
@@ -584,6 +777,166 @@ class OpenAIServingResponses(OpenAIServingChat):
         if last_items:
             output_items.extend(last_items)
         return output_items
+
+    @staticmethod
+    def _normalize_response_content_part_for_chat(content_part: Any) -> Any:
+        if hasattr(content_part, "model_dump"):
+            content_part = content_part.model_dump(exclude_none=True)
+        if not isinstance(content_part, dict):
+            return content_part
+        if content_part.get("type") in ("input_text", "output_text"):
+            return {"type": "text", "text": content_part.get("text", "")}
+        if content_part.get("type") == "input_image":
+            image_url = content_part.get("image_url")
+            if isinstance(image_url, str):
+                image_url = {
+                    "url": image_url,
+                    "detail": content_part.get("detail", "auto"),
+                }
+            return {"type": "image_url", "image_url": image_url}
+        return content_part
+
+    @classmethod
+    def _normalize_response_message_for_chat(cls, message: Any) -> Any:
+        if hasattr(message, "model_dump"):
+            message = message.model_dump(exclude_none=True)
+        if not isinstance(message, dict):
+            raise ValueError(f"Unsupported Responses input item: {message!r}")
+
+        message_type = message.get("type")
+        if message_type == "function_call":
+            arguments = message.get("arguments", "{}")
+            if isinstance(arguments, dict):
+                arguments = json.dumps(arguments, ensure_ascii=False)
+            elif not isinstance(arguments, str):
+                arguments = "{}"
+            else:
+                try:
+                    parsed_arguments = json.loads(arguments or "{}")
+                except json.JSONDecodeError:
+                    arguments = "{}"
+                    parsed_arguments = {}
+                if not isinstance(parsed_arguments, dict):
+                    arguments = "{}"
+            return {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": message.get("call_id") or message.get("id"),
+                        "type": "function",
+                        "function": {
+                            "name": message.get("name"),
+                            "arguments": arguments,
+                        },
+                    }
+                ],
+            }
+
+        if message_type == "function_call_output":
+            output = message.get("output", "")
+            if isinstance(output, list):
+                output = "".join(
+                    part.get("text", "") for part in output if isinstance(part, dict)
+                )
+            if not isinstance(output, str):
+                output = json.dumps(output, ensure_ascii=False)
+            return {
+                "role": "tool",
+                "tool_call_id": message.get("call_id"),
+                "content": output,
+            }
+
+        if message_type == "reasoning":
+            text_parts = []
+            for part in message.get("summary") or message.get("content") or []:
+                if hasattr(part, "model_dump"):
+                    part = part.model_dump(exclude_none=True)
+                if isinstance(part, dict) and part.get("text"):
+                    text_parts.append(part["text"])
+            if not text_parts:
+                return None
+            return {
+                "role": "assistant",
+                "reasoning_content": "\n".join(text_parts),
+                "content": "",
+            }
+
+        if message_type not in (None, "message"):
+            raise ValueError(
+                f"Unsupported Responses API input item type: {message_type!r}"
+            )
+
+        content = message.get("content")
+        normalized = {
+            key: value
+            for key, value in message.items()
+            if value is not None and key not in ("id", "status", "type")
+        }
+        if isinstance(content, list):
+            normalized_parts = [
+                cls._normalize_response_content_part_for_chat(part) for part in content
+            ]
+            if normalized.get("role") in ("assistant", "developer", "system"):
+                normalized["content"] = "\n\n".join(
+                    part.get("text", "")
+                    for part in normalized_parts
+                    if isinstance(part, dict) and part.get("type") == "text"
+                )
+            else:
+                normalized["content"] = normalized_parts
+        return normalized
+
+    @staticmethod
+    def _merge_consecutive_assistant_messages(messages: list) -> list:
+        merged = []
+        for message in messages:
+            if (
+                message.get("role") == "assistant"
+                and merged
+                and merged[-1].get("role") == "assistant"
+            ):
+                previous = merged[-1]
+                if message.get("reasoning_content"):
+                    previous_reasoning = previous.get("reasoning_content", "")
+                    previous["reasoning_content"] = "\n".join(
+                        part
+                        for part in (
+                            previous_reasoning,
+                            message["reasoning_content"],
+                        )
+                        if part
+                    )
+                if message.get("content"):
+                    previous_content = previous.get("content", "")
+                    current_content = message["content"]
+                    if isinstance(previous_content, str) and isinstance(
+                        current_content, str
+                    ):
+                        previous["content"] = "\n\n".join(
+                            part for part in (previous_content, current_content) if part
+                        )
+                    else:
+                        previous_parts = (
+                            previous_content
+                            if isinstance(previous_content, list)
+                            else (
+                                [{"type": "text", "text": previous_content}]
+                                if previous_content
+                                else []
+                            )
+                        )
+                        current_parts = (
+                            current_content
+                            if isinstance(current_content, list)
+                            else [{"type": "text", "text": current_content}]
+                        )
+                        previous["content"] = previous_parts + current_parts
+                if message.get("tool_calls"):
+                    previous.setdefault("tool_calls", []).extend(message["tool_calls"])
+                continue
+            merged.append(message)
+        return merged
 
     def _construct_input_messages(
         self,
@@ -605,26 +958,21 @@ class OpenAIServingResponses(OpenAIServingChat):
             prev_msg = self.msg_store[prev_response.id]
             messages.extend(prev_msg)
 
-            # Add the previous output
             for output_item in prev_response.output:
-                # NOTE: We skip the reasoning output of the previous response
-                if isinstance(output_item, ResponseReasoningItem):
-                    continue
-                for content in output_item.content:
-                    messages.append(
-                        {
-                            "role": "system",
-                            "content": request.instructions,
-                        }
-                    )
+                normalized = self._normalize_response_message_for_chat(output_item)
+                if normalized is not None:
+                    messages.append(normalized)
 
         # Append the new input
         # Responses API supports simple text inputs without chat format
         if isinstance(request.input, str):
             messages.append({"role": "user", "content": request.input})
         else:
-            messages.extend(request.input)  # type: ignore
-        return messages
+            for input_item in request.input:
+                normalized = self._normalize_response_message_for_chat(input_item)
+                if normalized is not None:
+                    messages.append(normalized)
+        return self._merge_consecutive_assistant_messages(messages)
 
     def _construct_input_messages_with_harmony(
         self,
@@ -810,6 +1158,441 @@ class OpenAIServingResponses(OpenAIServingChat):
             status_code=HTTPStatus.NOT_FOUND,
             param="response_id",
         )
+
+    async def responses_stream_generator_non_harmony(
+        self,
+        request: ResponsesRequest,
+        sampling_params: Any,
+        result_generator: AsyncIterator[Any],
+        model_name: str,
+        tokenizer: Any,
+        request_metadata: RequestResponseMetadata,
+        created_time: Optional[int] = None,
+        *,
+        require_reasoning: bool = False,
+    ) -> AsyncGenerator[str, None]:
+        """Stream typed Responses API events for non-Harmony models."""
+
+        created_time = created_time or int(time.time())
+        sequence_number = 0
+
+        def emit(event_type: str, **payload: Any) -> str:
+            nonlocal sequence_number
+            event = _response_event(event_type, sequence_number, **payload)
+            sequence_number += 1
+            return event
+
+        initial_response = ResponsesResponse.from_request(
+            request,
+            sampling_params,
+            model_name=model_name,
+            created_time=created_time,
+            output=[],
+            status="in_progress",
+            usage=None,
+        ).model_dump(mode="json")
+        # The pinned OpenAI SDK has a narrower response-side Tool union than
+        # the request schema. Tool echoing is optional, so avoid rejecting
+        # namespace/web_search objects after accepting them on input.
+        initial_response["tools"] = []
+        yield emit("response.created", response=initial_response)
+        yield emit("response.in_progress", response=initial_response)
+
+        reasoning_parser = (
+            ReasoningParser(
+                model_type=self.reasoning_parser,
+                stream_reasoning=True,
+                force_reasoning=require_reasoning,
+                request=request,
+            )
+            if self.reasoning_parser
+            else None
+        )
+        chat_tools = self._response_tools_to_chat_tools(request)
+        chat_tool_choice = self._chat_tool_choice(request.tool_choice)
+        tool_parser = None
+        if chat_tools and self.tool_call_parser and request.tool_choice != "none":
+            if chat_tool_choice == "required" or isinstance(
+                chat_tool_choice, ToolChoice
+            ):
+                tool_parser = JsonArrayParser()
+            else:
+                tool_parser = FunctionCallParser(
+                    chat_tools,
+                    self.tool_call_parser,
+                    tool_choice=chat_tool_choice,
+                )
+
+        output_index = -1
+        emitted_items = []
+        reasoning_state = {
+            "open": False,
+            "id": "",
+            "index": -1,
+            "text": "",
+        }
+        message_state = {
+            "open": False,
+            "id": "",
+            "index": -1,
+            "text": "",
+        }
+        tool_states: dict[int, dict[str, Any]] = {}
+        wants_summary = (
+            request.reasoning is not None and request.reasoning.summary is not None
+        )
+
+        def open_reasoning() -> list[str]:
+            nonlocal output_index
+            if reasoning_state["open"]:
+                return []
+            output_index += 1
+            reasoning_state.update(
+                open=True,
+                id=f"rs_{random_uuid()}",
+                index=output_index,
+                text="",
+            )
+            item = {
+                "id": reasoning_state["id"],
+                "type": "reasoning",
+                "summary": [],
+                "content": [],
+                "status": "in_progress",
+            }
+            events = [
+                emit(
+                    "response.output_item.added",
+                    output_index=reasoning_state["index"],
+                    item=item,
+                )
+            ]
+            if wants_summary:
+                events.append(
+                    emit(
+                        "response.reasoning_summary_part.added",
+                        item_id=reasoning_state["id"],
+                        output_index=reasoning_state["index"],
+                        summary_index=0,
+                        part={"type": "summary_text", "text": ""},
+                    )
+                )
+            return events
+
+        def close_reasoning() -> list[str]:
+            if not reasoning_state["open"]:
+                return []
+            text = reasoning_state["text"]
+            item = {
+                "id": reasoning_state["id"],
+                "type": "reasoning",
+                "summary": (
+                    [{"type": "summary_text", "text": text}] if wants_summary else []
+                ),
+                "content": [{"type": "reasoning_text", "text": text}],
+                "status": "completed",
+            }
+            if wants_summary:
+                events = [
+                    emit(
+                        "response.reasoning_summary_text.done",
+                        item_id=reasoning_state["id"],
+                        output_index=reasoning_state["index"],
+                        summary_index=0,
+                        text=text,
+                    ),
+                    emit(
+                        "response.reasoning_summary_part.done",
+                        item_id=reasoning_state["id"],
+                        output_index=reasoning_state["index"],
+                        summary_index=0,
+                        part={"type": "summary_text", "text": text},
+                    ),
+                ]
+            else:
+                events = [
+                    emit(
+                        "response.reasoning_text.done",
+                        item_id=reasoning_state["id"],
+                        output_index=reasoning_state["index"],
+                        content_index=0,
+                        text=text,
+                    )
+                ]
+            events.append(
+                emit(
+                    "response.output_item.done",
+                    output_index=reasoning_state["index"],
+                    item=item,
+                )
+            )
+            emitted_items.append(item)
+            reasoning_state["open"] = False
+            return events
+
+        def open_message() -> list[str]:
+            nonlocal output_index
+            if message_state["open"]:
+                return []
+            output_index += 1
+            message_state.update(
+                open=True,
+                id=f"msg_{random_uuid()}",
+                index=output_index,
+                text="",
+            )
+            return [
+                emit(
+                    "response.output_item.added",
+                    output_index=message_state["index"],
+                    item={
+                        "id": message_state["id"],
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [],
+                        "status": "in_progress",
+                    },
+                ),
+                emit(
+                    "response.content_part.added",
+                    item_id=message_state["id"],
+                    output_index=message_state["index"],
+                    content_index=0,
+                    part={
+                        "type": "output_text",
+                        "text": "",
+                        "annotations": [],
+                        "logprobs": None,
+                    },
+                ),
+            ]
+
+        def close_message() -> list[str]:
+            if not message_state["open"]:
+                return []
+            text = message_state["text"]
+            part = {
+                "type": "output_text",
+                "text": text,
+                "annotations": [],
+                "logprobs": None,
+            }
+            item = {
+                "id": message_state["id"],
+                "type": "message",
+                "role": "assistant",
+                "content": [part],
+                "status": "completed",
+            }
+            events = [
+                emit(
+                    "response.output_text.done",
+                    item_id=message_state["id"],
+                    output_index=message_state["index"],
+                    content_index=0,
+                    text=text,
+                    logprobs=[],
+                ),
+                emit(
+                    "response.content_part.done",
+                    item_id=message_state["id"],
+                    output_index=message_state["index"],
+                    content_index=0,
+                    part=part,
+                ),
+                emit(
+                    "response.output_item.done",
+                    output_index=message_state["index"],
+                    item=item,
+                ),
+            ]
+            emitted_items.append(item)
+            message_state["open"] = False
+            return events
+
+        def open_tool(tool_index: int, name: str) -> list[str]:
+            nonlocal output_index
+            if tool_index in tool_states:
+                if name:
+                    tool_states[tool_index]["name"] = name
+                return []
+            output_index += 1
+            state = {
+                "id": f"fc_{random_uuid()[:8]}",
+                "call_id": f"call_{random_uuid()[:24]}",
+                "name": name,
+                "arguments": "",
+                "index": output_index,
+            }
+            tool_states[tool_index] = state
+            return [
+                emit(
+                    "response.output_item.added",
+                    output_index=state["index"],
+                    item={
+                        "id": state["id"],
+                        "call_id": state["call_id"],
+                        "type": "function_call",
+                        "name": state["name"],
+                        "arguments": "",
+                        "status": "in_progress",
+                    },
+                )
+            ]
+
+        last_output = None
+        raw_text_buffer = ""
+        try:
+            async for context in result_generator:
+                last_output = context.last_output
+                if not isinstance(last_output, dict):
+                    continue
+                raw_text = last_output.get("text", "")
+                # SGLang's generation stream contains the cumulative decoded
+                # text. Feed only the new suffix to the reasoning/tool parsers.
+                delta = raw_text[len(raw_text_buffer) :]
+                raw_text_buffer = raw_text
+                if not delta:
+                    continue
+
+                if reasoning_parser is not None:
+                    reasoning_delta, normal_delta = reasoning_parser.parse_stream_chunk(
+                        delta
+                    )
+                else:
+                    reasoning_delta, normal_delta = None, delta
+
+                if reasoning_delta:
+                    for event in open_reasoning():
+                        yield event
+                    reasoning_state["text"] += reasoning_delta
+                    event_type = (
+                        "response.reasoning_summary_text.delta"
+                        if wants_summary
+                        else "response.reasoning_text.delta"
+                    )
+                    payload = {
+                        "item_id": reasoning_state["id"],
+                        "output_index": reasoning_state["index"],
+                        "delta": reasoning_delta,
+                    }
+                    if wants_summary:
+                        payload["summary_index"] = 0
+                    else:
+                        payload["content_index"] = 0
+                    yield emit(event_type, **payload)
+
+                if normal_delta:
+                    for event in close_reasoning():
+                        yield event
+                    if isinstance(tool_parser, JsonArrayParser):
+                        parse_result = tool_parser.parse_streaming_increment(
+                            normal_delta, chat_tools
+                        )
+                        visible_text, calls = (
+                            parse_result.normal_text,
+                            parse_result.calls,
+                        )
+                    elif tool_parser is not None:
+                        visible_text, calls = tool_parser.parse_stream_chunk(
+                            normal_delta
+                        )
+                    else:
+                        visible_text, calls = normal_delta, []
+
+                    if visible_text and visible_text.strip():
+                        for event in open_message():
+                            yield event
+                        message_state["text"] += visible_text
+                        yield emit(
+                            "response.output_text.delta",
+                            item_id=message_state["id"],
+                            output_index=message_state["index"],
+                            content_index=0,
+                            delta=visible_text,
+                            logprobs=[],
+                        )
+
+                    if calls:
+                        for event in close_message():
+                            yield event
+                        for call in calls:
+                            for event in open_tool(call.tool_index, call.name or ""):
+                                yield event
+                            state = tool_states[call.tool_index]
+                            if call.parameters:
+                                state["arguments"] += call.parameters
+                                yield emit(
+                                    "response.function_call_arguments.delta",
+                                    item_id=state["id"],
+                                    output_index=state["index"],
+                                    delta=call.parameters,
+                                )
+        except asyncio.CancelledError:
+            return
+        except ValueError as error:
+            yield emit(
+                "error",
+                error={
+                    "message": str(error),
+                    "type": "invalid_request_error",
+                    "param": None,
+                    "code": 400,
+                },
+            )
+            return
+
+        for event in close_reasoning():
+            yield event
+        for event in close_message():
+            yield event
+        for tool_index in sorted(tool_states):
+            state = tool_states[tool_index]
+            item = {
+                "id": state["id"],
+                "call_id": state["call_id"],
+                "type": "function_call",
+                "name": state["name"],
+                "arguments": state["arguments"],
+                "status": "completed",
+            }
+            yield emit(
+                "response.function_call_arguments.done",
+                item_id=state["id"],
+                output_index=state["index"],
+                arguments=state["arguments"],
+            )
+            yield emit(
+                "response.output_item.done",
+                output_index=state["index"],
+                item=item,
+            )
+            emitted_items.append(item)
+
+        meta_info = (
+            last_output.get("meta_info", {}) if isinstance(last_output, dict) else {}
+        )
+        usage = UsageInfo(
+            prompt_tokens=meta_info.get("prompt_tokens", 0),
+            completion_tokens=meta_info.get("completion_tokens", 0),
+            total_tokens=(
+                meta_info.get("prompt_tokens", 0)
+                + meta_info.get("completion_tokens", 0)
+            ),
+            reasoning_tokens=meta_info.get("reasoning_tokens", 0),
+        )
+        request_metadata.final_usage_info = usage
+        completed_response = ResponsesResponse.from_request(
+            request,
+            sampling_params,
+            model_name=model_name,
+            created_time=created_time,
+            output=emitted_items,
+            status="completed",
+            usage=usage,
+        ).model_dump(mode="json")
+        completed_response["tools"] = []
+        yield emit("response.completed", response=completed_response)
 
     async def responses_stream_generator(
         self,
@@ -1230,21 +2013,6 @@ class OpenAIServingResponses(OpenAIServingChat):
         )
         # Convert final_response to the format expected by ResponseCompletedEvent
         response_dict = final_response.model_dump()
-
-        # Convert UsageInfo to ResponseUsage format
-        if response_dict.get("usage"):
-            usage_info = response_dict["usage"]
-            response_dict["usage"] = {
-                "input_tokens": usage_info.get("prompt_tokens", 0),
-                "input_tokens_details": {
-                    "cached_tokens": usage_info.get("cached_tokens", 0)
-                },
-                "output_tokens": usage_info.get("completion_tokens", 0),
-                "output_tokens_details": {
-                    "reasoning_tokens": usage_info.get("reasoning_tokens", 0)
-                },
-                "total_tokens": usage_info.get("total_tokens", 0),
-            }
 
         yield _send_event(
             openai_responses_types.ResponseCompletedEvent(

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -486,8 +486,9 @@ class Envs:
     SGLANG_REQUEST_STATE_WAIT_TIMEOUT = EnvInt(4)
 
     SGLANG_ENABLE_THINKING = EnvBool(False)
-    # Default reasoning_effort for dsv4 chat encoder when request doesn't set it.
-    # Accepts "", "max", "high" (empty string means unset). Other values filtered to None.
+    # Model-specific DeepSeek-V4 effort default. Empty means use the product default.
+    SGLANG_DSV4_REASONING_EFFORT = EnvStr("")
+    # Deprecated compatibility alias for SGLANG_DSV4_REASONING_EFFORT.
     SGLANG_REASONING_EFFORT = EnvStr("")
 
     SGLANG_DSV4_MODE = EnvStr("")

--- a/test/registered/unit/entrypoints/openai/test_dsv4_reasoning_responses.py
+++ b/test/registered/unit/entrypoints/openai/test_dsv4_reasoning_responses.py
@@ -1,0 +1,397 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+from openai.types.responses import Response as OpenAIResponse
+
+from sglang.srt.entrypoints.openai import chat_encoding, encoding_dsv4
+from sglang.srt.entrypoints.openai.protocol import (
+    ChatCompletionRequest,
+    RequestResponseMetadata,
+    ResponsesResponse,
+    ResponsesRequest,
+    UsageInfo,
+)
+from sglang.srt.entrypoints.openai.serving_chat import (
+    resolve_dsv4_reasoning_controls,
+)
+from sglang.srt.entrypoints.openai.serving_responses import OpenAIServingResponses
+
+
+class TestDSV4ReasoningAndResponses(unittest.TestCase):
+    def test_dsv4_reasoning_profile_detection_and_override(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            encoding_dir = Path(temp_dir) / "encoding"
+            encoding_dir.mkdir()
+            (encoding_dir / "encoding_dsv4.py").write_text(
+                "DEFAULT_REASONING_EFFORT = 'low'\n"
+                "REASONING_EFFORT_PROMPTS = "
+                "{'low': '', 'high': 'high', 'max': 'max'}\n",
+                encoding="utf-8",
+            )
+            self.assertEqual(
+                chat_encoding.resolve_dsv4_reasoning_effort_profile(
+                    model_path=temp_dir
+                ),
+                "official",
+            )
+        self.assertEqual(
+            chat_encoding.resolve_dsv4_reasoning_effort_profile(
+                model_path="unused", override="preview"
+            ),
+            "preview",
+        )
+        with self.assertRaises(ValueError):
+            chat_encoding.resolve_dsv4_reasoning_effort_profile(
+                model_path="unused", override="invalid"
+            )
+
+    def test_dsv4_reasoning_resolution(self):
+        cases = [
+            (None, "thinking", "max"),
+            ("low", "thinking", "low"),
+            ("high", "thinking", "high"),
+            ("max", "thinking", "max"),
+            ("none", "chat", None),
+            ("medium", "thinking", "max"),
+            ("xhigh", "thinking", "max"),
+            ("invalid", "thinking", "max"),
+        ]
+        for effort, thinking_mode, resolved in cases:
+            with self.subTest(effort=effort):
+                if effort in {"medium", "xhigh", "invalid"}:
+                    with self.assertLogs(
+                        "sglang.srt.entrypoints.openai.serving_chat", level="WARNING"
+                    ) as logs:
+                        result = resolve_dsv4_reasoning_controls(
+                            request_effort=effort,
+                            chat_template_kwargs=None,
+                            reasoning_effort_profile="official",
+                        )
+                    self.assertIn(
+                        "falling back to thinking + max", "\n".join(logs.output)
+                    )
+                else:
+                    result = resolve_dsv4_reasoning_controls(
+                        request_effort=effort,
+                        chat_template_kwargs=None,
+                        reasoning_effort_profile="official",
+                    )
+                self.assertEqual(result, (thinking_mode, resolved))
+
+    def test_standard_effort_wins_and_legacy_thinking_can_disable(self):
+        self.assertEqual(
+            resolve_dsv4_reasoning_controls(
+                request_effort="high",
+                chat_template_kwargs={"thinking": False, "reasoning_effort": "low"},
+                reasoning_effort_profile="official",
+            ),
+            ("thinking", "high"),
+        )
+        self.assertEqual(
+            resolve_dsv4_reasoning_controls(
+                request_effort=None,
+                chat_template_kwargs={"thinking": False, "reasoning_effort": "low"},
+                reasoning_effort_profile="official",
+            ),
+            ("chat", "low"),
+        )
+
+    def test_official_prompt_mapping_is_distinct(self):
+        messages = [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "question"},
+        ]
+        prompts = {
+            effort: encoding_dsv4.encode_messages(
+                messages,
+                thinking_mode="thinking",
+                reasoning_effort=effort,
+                reasoning_effort_profile="official",
+            )
+            for effort in ("low", "high", "max")
+        }
+        self.assertNotIn(encoding_dsv4.REASONING_EFFORT_PREVIEW_MAX, prompts["low"])
+        self.assertNotIn(encoding_dsv4.REASONING_EFFORT_OFFICIAL_MAX, prompts["low"])
+        self.assertIn(encoding_dsv4.REASONING_EFFORT_PREVIEW_MAX, prompts["high"])
+        self.assertNotIn(encoding_dsv4.REASONING_EFFORT_OFFICIAL_MAX, prompts["high"])
+        self.assertIn(encoding_dsv4.REASONING_EFFORT_OFFICIAL_MAX, prompts["max"])
+
+    def test_protocol_accepts_standard_max_and_codex_tool_shapes(self):
+        chat = ChatCompletionRequest(
+            messages=[{"role": "user", "content": "hello"}],
+            reasoning_effort="max",
+        )
+        self.assertEqual(chat.reasoning_effort, "max")
+
+        response = ResponsesRequest(
+            input=[{"role": "user", "content": "hello"}],
+            reasoning={"effort": "max", "summary": "auto"},
+            include=["reasoning.encrypted_content"],
+            tools=[
+                {
+                    "type": "function",
+                    "name": "exec_command",
+                    "description": "Run a command",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"cmd": {"type": "string"}},
+                        "required": ["cmd"],
+                    },
+                },
+                {
+                    "type": "namespace",
+                    "name": "functions",
+                    "description": "Namespaced tools",
+                    "tools": [{"type": "function", "name": "nested"}],
+                },
+                {"type": "web_search"},
+            ],
+            store=False,
+            stream=True,
+        )
+        self.assertEqual(response.reasoning.effort, "max")
+        self.assertEqual(response.reasoning.summary, "auto")
+        self.assertEqual(
+            [tool.type for tool in response.tools],
+            ["function", "namespace", "web_search"],
+        )
+
+        response_payload = ResponsesResponse.from_request(
+            response,
+            {"max_new_tokens": 16},
+            model_name="dsv4",
+            created_time=1,
+            output=[],
+            status="completed",
+            usage=UsageInfo(
+                prompt_tokens=3,
+                completion_tokens=4,
+                reasoning_tokens=2,
+                total_tokens=7,
+            ),
+        ).model_dump(mode="json")
+        self.assertEqual(response_payload["usage"]["input_tokens"], 3)
+        self.assertEqual(response_payload["usage"]["output_tokens"], 4)
+        self.assertEqual(
+            response_payload["usage"]["output_tokens_details"]["reasoning_tokens"],
+            2,
+        )
+
+    def test_responses_normalizes_function_round_trip(self):
+        request = ResponsesRequest(
+            input=[
+                {
+                    "type": "function_call",
+                    "id": "fc_1",
+                    "call_id": "call_1",
+                    "name": "exec_command",
+                    "arguments": '{"cmd":"pwd"}',
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": "/tmp",
+                },
+            ]
+        )
+        serving = object.__new__(OpenAIServingResponses)
+        messages = serving._construct_input_messages(request)
+        self.assertEqual(messages[0]["role"], "assistant")
+        self.assertEqual(
+            messages[0]["tool_calls"][0]["function"]["name"], "exec_command"
+        )
+        self.assertEqual(
+            messages[1],
+            {
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": "/tmp",
+            },
+        )
+
+        retry_request = ResponsesRequest(
+            input=[
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "first"}],
+                },
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "second"}],
+                },
+            ]
+        )
+        retry_messages = serving._construct_input_messages(retry_request)
+        self.assertEqual(retry_messages[0]["content"], "first\n\nsecond")
+
+    def test_non_stream_output_parses_reasoning_and_function_call(self):
+        request = ResponsesRequest(
+            input="use the tool",
+            reasoning={"effort": "max", "summary": "auto"},
+            tools=[
+                {
+                    "type": "function",
+                    "name": "exec_command",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"cmd": {"type": "string"}},
+                        "required": ["cmd"],
+                    },
+                }
+            ],
+        )
+        serving = object.__new__(OpenAIServingResponses)
+        serving.reasoning_parser = "deepseek-v4"
+        serving.tool_call_parser = "deepseekv4"
+        output = serving._make_response_output_items(
+            request,
+            "reason first</think>"
+            "<｜DSML｜tool_calls>"
+            '<｜DSML｜invoke name="exec_command">'
+            '<｜DSML｜parameter name="cmd" string="true">pwd</｜DSML｜parameter>'
+            "</｜DSML｜invoke>"
+            "</｜DSML｜tool_calls>",
+            tokenizer=None,
+            require_reasoning=True,
+        )
+        self.assertEqual([item.type for item in output], ["reasoning", "function_call"])
+        self.assertEqual(output[0].summary[0].text, "reason first")
+        self.assertEqual(output[1].name, "exec_command")
+        self.assertEqual(json.loads(output[1].arguments), {"cmd": "pwd"})
+
+    def test_non_stream_output_parses_named_function_choice(self):
+        request = ResponsesRequest(
+            input="use the tool",
+            tool_choice={"type": "function", "name": "exec_command"},
+            tools=[
+                {
+                    "type": "function",
+                    "name": "exec_command",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"cmd": {"type": "string"}},
+                        "required": ["cmd"],
+                    },
+                }
+            ],
+        )
+        serving = object.__new__(OpenAIServingResponses)
+        serving.reasoning_parser = None
+        serving.tool_call_parser = "deepseekv4"
+        output = serving._make_response_output_items(
+            request,
+            '[{"name":"exec_command","parameters":{"cmd":"pwd"}}]',
+            tokenizer=None,
+        )
+        self.assertEqual(len(output), 1)
+        self.assertEqual(output[0].type, "function_call")
+        self.assertEqual(output[0].name, "exec_command")
+        self.assertEqual(json.loads(output[0].arguments), {"cmd": "pwd"})
+
+
+class TestDSV4ResponsesStream(unittest.IsolatedAsyncioTestCase):
+    async def test_emits_reasoning_text_and_completion(self):
+        request = ResponsesRequest(
+            input="answer",
+            reasoning={"effort": "max", "summary": "auto"},
+            stream=True,
+            store=False,
+        )
+        serving = object.__new__(OpenAIServingResponses)
+        serving.reasoning_parser = "deepseek-v4"
+        serving.tool_call_parser = None
+        serving.tokenizer_manager = SimpleNamespace(server_args=SimpleNamespace())
+
+        async def results():
+            for text in ("reason", "reason</think>", "reason</think>answer"):
+                yield SimpleNamespace(
+                    last_output={
+                        "text": text,
+                        "meta_info": {"prompt_tokens": 3, "completion_tokens": 4},
+                    }
+                )
+
+        events = []
+        async for chunk in serving.responses_stream_generator_non_harmony(
+            request,
+            {"max_new_tokens": 16},
+            results(),
+            "dsv4",
+            None,
+            RequestResponseMetadata(request_id=request.request_id),
+            require_reasoning=True,
+        ):
+            if chunk.startswith("event: "):
+                events.append(chunk.splitlines()[0].removeprefix("event: "))
+
+        self.assertEqual(events[0:2], ["response.created", "response.in_progress"])
+        self.assertIn("response.reasoning_summary_text.delta", events)
+        self.assertIn("response.output_text.delta", events)
+        self.assertEqual(events.count("response.reasoning_summary_text.delta"), 1)
+        self.assertEqual(events.count("response.output_text.delta"), 1)
+        self.assertEqual(events[-1], "response.completed")
+
+    async def test_emits_function_call_events(self):
+        request = ResponsesRequest(
+            input="use the tool",
+            stream=True,
+            store=False,
+            tools=[
+                {
+                    "type": "function",
+                    "name": "exec_command",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"cmd": {"type": "string"}},
+                        "required": ["cmd"],
+                    },
+                }
+            ],
+        )
+        serving = object.__new__(OpenAIServingResponses)
+        serving.reasoning_parser = None
+        serving.tool_call_parser = "deepseekv4"
+        serving.tokenizer_manager = SimpleNamespace(server_args=SimpleNamespace())
+        context = SimpleNamespace(
+            last_output={
+                "text": "<｜DSML｜tool_calls>"
+                '<｜DSML｜invoke name="exec_command">'
+                '<｜DSML｜parameter name="cmd" string="true">pwd</｜DSML｜parameter>'
+                "</｜DSML｜invoke>"
+                "</｜DSML｜tool_calls>",
+                "meta_info": {"prompt_tokens": 4, "completion_tokens": 5},
+            }
+        )
+
+        async def results():
+            yield context
+
+        chunks = []
+        async for chunk in serving.responses_stream_generator_non_harmony(
+            request,
+            {"max_new_tokens": 16},
+            results(),
+            "dsv4",
+            None,
+            RequestResponseMetadata(request_id=request.request_id),
+        ):
+            chunks.append(chunk)
+
+        event_names = [chunk.splitlines()[0][7:] for chunk in chunks]
+        self.assertIn("response.function_call_arguments.delta", event_names)
+        self.assertIn("response.function_call_arguments.done", event_names)
+        completed = json.loads(chunks[-1].split("data: ", 1)[1])
+        OpenAIResponse.model_validate(completed["response"])
+        call = completed["response"]["output"][0]
+        self.assertEqual(call["type"], "function_call")
+        self.assertEqual(call["name"], "exec_command")
+        self.assertEqual(json.loads(call["arguments"]), {"cmd": "pwd"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/entrypoints/openai/test_dsv4_reasoning_responses.py
+++ b/test/registered/unit/entrypoints/openai/test_dsv4_reasoning_responses.py
@@ -10,8 +10,8 @@ from sglang.srt.entrypoints.openai import chat_encoding, encoding_dsv4
 from sglang.srt.entrypoints.openai.protocol import (
     ChatCompletionRequest,
     RequestResponseMetadata,
-    ResponsesResponse,
     ResponsesRequest,
+    ResponsesResponse,
     UsageInfo,
 )
 from sglang.srt.entrypoints.openai.serving_chat import (


### PR DESCRIPTION
## Summary

- mirror the DeepSeek-V4-Flash-0731 `low` / `high` / `max` prompt mapping while preserving the older preview checkpoint mapping
- resolve Chat Completions `reasoning_effort` and Responses `reasoning.effort` through one DSV4 policy; omitted/null defaults to thinking + `max`, `none` disables thinking, and unsupported strings warn and fall back to thinking + `max`
- keep `chat_template_kwargs` and the old environment variable as compatibility-only fallbacks
- add non-Harmony Responses streaming, official Responses usage fields, reasoning summaries, and top-level function-tool round trips required by Codex
- accept `namespace`, `web_search`, and `reasoning.encrypted_content` request shapes for wire compatibility without claiming to execute unsupported tools or synthesize encrypted reasoning

This fixes the one-level-off encoder mapping described in [sgl-project/sglang#33185](https://github.com/sgl-project/sglang/issues/33185), and also fixes the intermediate Responses API path where Codex's standard effort field previously did not reach the DSV4 encoder.

## DSV4 behavior

| Input | Effective behavior |
| --- | --- |
| omitted / `null` | thinking + `max` |
| `low` | thinking + `low` |
| `high` | thinking + `high` |
| `max` | thinking + `max` |
| `none` | thinking disabled |
| `minimal` / `medium` / `xhigh` / other strings | warning + thinking + `max` |

Effort selects a model prompt prefix. It does not alter the token budget or kernel scheduler.

## Compatibility boundary

- Chat Completions: top-level `reasoning_effort`
- Responses/Codex: `reasoning: {"effort": ..., "summary": ...}`
- top-level Responses `function` tools are exposed to DSV4 and round-trip through `function_call_output`
- `namespace` and `web_search` objects are accepted but deliberately not exposed or executed in the non-Harmony path

## Validation

- targeted unit suite: 10/10 passed in the source-wheel validation image; the only later source change was import sorting
- Black check, Python byte compilation, and `git diff --check`: passed
- qj5090, 2 x RTX 5090, Chat API: all 10 effort cases returned HTTP 200 with the expected thinking state and fallback warnings
- qj5090 Responses API: non-stream response passed the official OpenAI SDK schema and returned `input_tokens` / `output_tokens` usage fields
- Codex CLI 0.153.4 end to end: captured `reasoning.effort=max`, generated an `exec_command` call, consumed its `function_call_output`, returned the marker exactly, and exited 0

The qj5090 run used an immutable image rebuilt with a wheel from the functional SGLang commit. The subsequent PR-head change only sorted imports. The already-running production container was not modified.

## CI note

The heavyweight test workflows are gated on the maintainer-controlled `run-ci` label. The automatic lint workflow runs pre-commit over the entire fork and currently fails on existing files outside this PR (including 79 Black rewrites, existing shebang modes, and unrelated Ruff errors). After the import-only fix, none of this PR's seven files appears in the formatter rewrite list; their targeted isort, Black, Ruff `F401/F821`, AST/bytecode, codespell, and whitespace checks pass.
