### PR TITLE
fix(openai): serialize Responses tool constraints

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -68,12 +68,21 @@ from sglang.srt.function_call.json_array_parser import JsonArrayParser
 from sglang.srt.managers.io_struct import GenerateReqInput
 from sglang.srt.parser.reasoning_parser import ReasoningParser
 from sglang.srt.utils import random_uuid
+from sglang.utils import convert_json_schema_to_str
 
 if TYPE_CHECKING:
     from sglang.srt.managers.template_manager import TemplateManager
     from sglang.srt.managers.tokenizer_manager import TokenizerManager
 
 logger = logging.getLogger(__name__)
+
+
+def _serialize_tool_call_constraint(constraint_type: str, constraint_value: Any) -> Any:
+    if constraint_type == "structural_tag":
+        return convert_json_schema_to_str(constraint_value.model_dump(by_alias=True))
+    if constraint_type == "json_schema":
+        return convert_json_schema_to_str(constraint_value)
+    return constraint_value
 
 
 def _response_event(event_type: str, sequence_number: int, **payload: Any) -> str:
@@ -300,6 +309,9 @@ class OpenAIServingResponses(OpenAIServingChat):
                         if processed_messages.tool_call_constraint is not None:
                             constraint_type, constraint_value = (
                                 processed_messages.tool_call_constraint
+                            )
+                            constraint_value = _serialize_tool_call_constraint(
+                                constraint_type, constraint_value
                             )
                             sampling_params[constraint_type] = constraint_value
                         if not getattr(processed_messages, "skip_special_tokens", True):

--- a/test/registered/unit/entrypoints/openai/test_dsv4_reasoning_responses.py
+++ b/test/registered/unit/entrypoints/openai/test_dsv4_reasoning_responses.py
@@ -17,7 +17,10 @@ from sglang.srt.entrypoints.openai.protocol import (
 from sglang.srt.entrypoints.openai.serving_chat import (
     resolve_dsv4_reasoning_controls,
 )
-from sglang.srt.entrypoints.openai.serving_responses import OpenAIServingResponses
+from sglang.srt.entrypoints.openai.serving_responses import (
+    OpenAIServingResponses,
+    _serialize_tool_call_constraint,
+)
 
 
 class TestDSV4ReasoningAndResponses(unittest.TestCase):
@@ -292,6 +295,12 @@ class TestDSV4ReasoningAndResponses(unittest.TestCase):
         self.assertEqual(output[0].type, "function_call")
         self.assertEqual(output[0].name, "exec_command")
         self.assertEqual(json.loads(output[0].arguments), {"cmd": "pwd"})
+
+    def test_required_tool_schema_is_serialized_for_scheduler(self):
+        schema = _serialize_tool_call_constraint("json_schema", {"type": "object"})
+        self.assertIsInstance(schema, str)
+        self.assertEqual(json.loads(schema), {"type": "object"})
+        hash(("json_schema", schema))
 
 
 class TestDSV4ResponsesStream(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
## Summary

- serialize non-Harmony Responses tool-call constraints before they enter the scheduler
- mirror the existing Chat Completions handling for JSON Schema and structural-tag constraints
- add a regression test that verifies the scheduler cache key is hashable

## Failure mode

Follow-up to #92. A `/v1/responses` request with a function tool and
`"tool_choice": "required"` produced a dict-valued `json_schema`. The Responses
adapter copied that dict directly into `sampling_params`; the grammar manager
then called `self.cache.get(key)` and crashed the scheduler with:

```text
TypeError: unhashable type: 'dict'
```

## Validation

- `black --check` on both changed files
- targeted unit suite: `11 passed, 8 subtests passed`
- qj5090 source-build E2E with DeepSeek-V4-Flash-0731:
  - required Responses function call: HTTP 200
  - `previous_response_id` + `function_call_output` continuation: HTTP 200
  - server remained healthy after both requests
