### PR TITLE
fix(kt): support Kimi RAWINT4 LoRA adapter serving

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -151,6 +151,7 @@ from sglang.srt.managers.multi_tokenizer_mixin import (
     write_data_for_multi_tokenizer,
 )
 from sglang.srt.managers.template_manager import TemplateManager
+from sglang.srt.managers.tokenizer_communicator_mixin import get_static_kt_lora_ref
 from sglang.srt.managers.tokenizer_manager import ServerStatus, TokenizerManager
 from sglang.srt.model_loader.remote_instance_weight_loader_utils import (
     parse_remote_instance_transfer_engine_info_from_scheduler_infos,
@@ -1823,6 +1824,9 @@ def _execute_server_warmup(server_args: ServerArgs):
 
     # Send a warmup request
     warmup_timeout = envs.SGLANG_WARMUP_TIMEOUT.get()
+    static_kt_lora = get_static_kt_lora_ref(server_args)
+    if static_kt_lora is not None:
+        json_data["lora_path"] = static_kt_lora.lora_name
     try:
         if server_args.disaggregation_mode == "null":
             res = requests.post(
@@ -1851,6 +1855,8 @@ def _execute_server_warmup(server_args: ServerArgs):
                 ],
                 "input_ids": [[10, 11, 12, 13]] * server_args.dp_size,
             }
+            if static_kt_lora is not None:
+                json_data["lora_path"] = static_kt_lora.lora_name
             res = requests.post(
                 url + request_name,
                 json=json_data,

--- a/python/sglang/srt/layers/moe/kt_ep_wrapper.py
+++ b/python/sglang/srt/layers/moe/kt_ep_wrapper.py
@@ -213,6 +213,7 @@ _KT_SFT_METHOD_BY_INFERENCE_METHOD = {
     "FP8": "AMXFP8_SFT",
     "AMXINT8": "AMXINT8_SFT",
     "AMXINT4": "AMXINT4_SFT",
+    "RAWINT4": "RAWINT4_SFT",
 }
 
 _KT_SFT_METHODS_REQUIRING_SHARED_BACKWARD_BB = frozenset(
@@ -237,6 +238,11 @@ def _configure_kt_sft_wrapper_for_serving(wrapper, method: str) -> None:
 
 def _validate_kt_sft_runtime(method: str) -> None:
     """Feature-probe quantized SFT kernels before allocating layer state."""
+    if method == "RAWINT4_SFT":
+        from kt_kernel.sft import get_rawint4_runtime
+
+        get_rawint4_runtime()
+        return
     if method != "AMXFP8_SFT":
         return
     try:
@@ -247,6 +253,59 @@ def _validate_kt_sft_runtime(method: str) -> None:
             "get_fp8_runtime() and AMXFP8_SFT_MOE."
         ) from exc
     get_fp8_runtime()
+
+
+def _load_rawint4_sft_weights(
+    *,
+    weight_path: str,
+    layer_idx: int,
+    num_experts: int,
+    hidden_size: int,
+    moe_intermediate_size: int,
+    num_experts_per_tok: int,
+):
+    """Read signed group-32 experts from an indexed HF checkpoint."""
+    from kt_kernel.sft import (
+        MOEArchConfig,
+        get_rawint4_checkpoint_contract,
+        load_rawint4_experts_from_checkpoint_files,
+    )
+
+    checkpoint_dir = Path(weight_path)
+    with (checkpoint_dir / "config.json").open(encoding="utf-8") as handle:
+        get_rawint4_checkpoint_contract(json.load(handle))
+    with (checkpoint_dir / "model.safetensors.index.json").open(
+        encoding="utf-8"
+    ) as handle:
+        metadata = json.load(handle)
+    weight_map = metadata.get("weight_map")
+    if not isinstance(weight_map, dict) or not weight_map:
+        raise ValueError("RAWINT4 expert LoRA requires a non-empty safetensors index.")
+
+    suffix = f".{layer_idx}.mlp.experts.0.gate_proj.weight_packed"
+    prefixes = {key[: -len(suffix)] for key in weight_map if key.endswith(suffix)}
+    if len(prefixes) != 1:
+        raise ValueError(
+            f"Cannot resolve one RAWINT4 expert prefix for layer {layer_idx}."
+        )
+    moe_config = MOEArchConfig(
+        moe_layer_attr="mlp",
+        router_attr="gate",
+        experts_attr="experts",
+        weight_names=("gate_proj", "up_proj", "down_proj"),
+        expert_num=num_experts,
+        intermediate_size=moe_intermediate_size,
+        num_experts_per_tok=num_experts_per_tok,
+    )
+    return load_rawint4_experts_from_checkpoint_files(
+        checkpoint_files=sorted({str(checkpoint_dir / f) for f in weight_map.values()}),
+        sharded_metadata=metadata,
+        layers_prefix=prefixes.pop(),
+        moe_config=moe_config,
+        layer_idx=layer_idx,
+        hidden_size=hidden_size,
+        group_size=32,
+    )
 
 
 def _load_native_fp8_sft_weights(
@@ -5306,7 +5365,19 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
                 if self.kt_expert_lora_enabled
                 else None
             )
-            if sft_method == "AMXFP8_SFT":
+            if sft_method == "RAWINT4_SFT":
+                raw_weights = _load_rawint4_sft_weights(
+                    weight_path=self.kt_config.weight_path,
+                    layer_idx=self.kt_config.layer_idx,
+                    num_experts=self.global_num_experts,
+                    hidden_size=self._full_init_args[0],
+                    moe_intermediate_size=self._full_init_args[1] * layer.moe_tp_size,
+                    num_experts_per_tok=layer.top_k,
+                )
+                self.wrapper.load_rawint4_weights(
+                    raw_weights, physical_to_logical_map_cpu
+                )
+            elif sft_method == "AMXFP8_SFT":
                 if not hasattr(self.wrapper, "load_block_fp8_weights"):
                     raise RuntimeError(
                         "The loaded kt-kernel FP8 SFT wrapper has no "

--- a/python/sglang/srt/models/kimi_k25.py
+++ b/python/sglang/srt/models/kimi_k25.py
@@ -682,6 +682,19 @@ class KimiK25ForConditionalGeneration(nn.Module):
             self.vision_tower = self.vision_tower.to(dtype=target_dtype)
             self.mm_projector = self.mm_projector.to(dtype=target_dtype)
 
+    def get_hidden_dim(self, module_name: str, layer_idx: int):
+        return self.language_model.get_hidden_dim(module_name, layer_idx)
+
+    def finalize_static_lora_weights(
+        self, adapter_id: str, buffer_id: int, lora_rank: int, scaling: float
+    ) -> None:
+        self.language_model.finalize_static_lora_weights(
+            adapter_id=adapter_id,
+            buffer_id=buffer_id,
+            lora_rank=lora_rank,
+            scaling=scaling,
+        )
+
     def get_image_feature(self, items: List[MultimodalDataItem]) -> torch.Tensor:
         pixel_values = torch.cat([item.feature for item in items], dim=0).type(
             self.vision_tower.dtype

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -155,7 +155,7 @@ def _validate_kt_expert_lora_adapter_path(
         )
 
     keys = _safetensor_keys(weight_path)
-    expert_keys = [key for key in keys if _is_kt_expert_lora_key(key)]
+    expert_keys = {key for key in keys if _is_kt_expert_lora_key(key)}
     lora_keys = [
         key
         for key in keys
@@ -278,7 +278,7 @@ def _prepare_kt_composite_lora_adapter(adapter_path: str) -> Optional[tuple[str,
         # Let the normal LoRA loader handle non-safetensors or malformed adapters.
         return None
 
-    expert_keys = [key for key in tensor_keys if _is_kt_expert_lora_key(key)]
+    expert_keys = {key for key in tensor_keys if _is_kt_expert_lora_key(key)}
     if not expert_keys:
         if raw_compact_path.is_file():
             raise ValueError(


### PR DESCRIPTION
## Motivation

Enable SGLang to reload and serve Kimi K2.5 LoRA adapters saved by KT RAWINT4 SFT.

## Modifications

- Connect RAWINT4 expert LoRA to KT's existing SFT runtime and strict group-32 weight loader.
- Forward Kimi's LoRA dimension and MLA initialization hooks to its language model.
- Avoid quadratic key classification for large composite adapters.
- Select the bound adapter during server warmup, preserving static-adapter request restrictions.

Only four production files change. No training kernels, dependency pins or release workflow changes.

## Validation

- 58 targeted tests passed on the rebased `main` plus this patch: RAWINT4 loading, Kimi hook delegation, composite adapters, request restrictions and warmup.
- sap4 end-to-end: a newly saved Kimi K2.5 adapter was loaded in a fresh 4-GPU TP server. All 60 expert LoRA layers loaded; all four ranks installed MLA LoRA corrections on 61 layers. Three requests selecting the adapter completed with nonempty answers and `finish_reason=stop`.
- The full-model check used the previously built candidate wheels containing these runtime changes; it is not a clean-install or full-model logits-equivalence claim. No end-to-end speedup is claimed.

Related: kvcache-ai/ktransformers#2186 and kvcache-ai/ktransformers#2194.
