### PR TITLE
fix(kv-cache): guard compressed pool initialization for non-SWA models

### DIFF
--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -568,7 +568,8 @@ class ModelRunnerKVCacheMixin:
         # the model never uses, so seed it with the configured value instead; the
         # dedicated calculator still profiles VRAM and shrinks the pool from there.
         if (
-            self.model_config.is_swa_with_compressed_attention
+            self.model_config.is_hybrid_swa
+            and self.model_config.is_swa_with_compressed_attention
             and max_total_tokens_configured is not None
         ):
             self.max_total_num_tokens = max_total_tokens_configured

--- a/test/registered/unit/test_model_config_hybrid_flags.py
+++ b/test/registered/unit/test_model_config_hybrid_flags.py
@@ -5,6 +5,7 @@ import logging
 from pathlib import Path
 from types import SimpleNamespace
 from typing import List
+from unittest.mock import Mock
 
 import pytest
 
@@ -15,25 +16,47 @@ def derive(architecture, *, disabled=False):
     # Execute the actual dependency-light config methods without importing CUDA.
     source = ROOT / "python/sglang/srt/configs/model_config.py"
     tree = ast.parse(source.read_bytes())
-    cls = next(n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == "ModelConfig")
-    method = next(n for n in cls.body if isinstance(n, ast.FunctionDef) and n.name == "_derive_hybrid_model")
-    helpers = [n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name in ("is_hybrid_swa_model", "get_hybrid_layer_ids")]
+    cls = next(
+        n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == "ModelConfig"
+    )
+    method = next(
+        n
+        for n in cls.body
+        if isinstance(n, ast.FunctionDef) and n.name == "_derive_hybrid_model"
+    )
+    helpers = [
+        n
+        for n in tree.body
+        if isinstance(n, ast.FunctionDef)
+        and n.name in ("is_hybrid_swa_model", "get_hybrid_layer_ids")
+    ]
     module = ast.Module(body=helpers + [method], type_ignores=[])
-    ns = {"List": List, "PretrainedConfig": object, "logger": logging.getLogger(__name__)}
+    ns = {
+        "List": List,
+        "PretrainedConfig": object,
+        "logger": logging.getLogger(__name__),
+    }
     exec(compile(ast.fix_missing_locations(module), str(source), "exec"), ns)
     config = SimpleNamespace(
         hf_config=SimpleNamespace(architectures=[architecture]),
-        hf_text_config=SimpleNamespace(num_hidden_layers=4, hybrid_layer_pattern=[1, 0, 1, 0]),
+        hf_text_config=SimpleNamespace(
+            num_hidden_layers=4, hybrid_layer_pattern=[1, 0, 1, 0]
+        ),
         disable_hybrid_swa_memory=disabled,
     )
     ns["_derive_hybrid_model"](config)
     return config
 
 
-@pytest.mark.parametrize("architecture", [
-    "KimiK25ForConditionalGeneration", "DeepseekV3ForCausalLM",
-    "Glm5NextForCausalLM", "Qwen3MoeForCausalLM",
-])
+@pytest.mark.parametrize(
+    "architecture",
+    [
+        "KimiK25ForConditionalGeneration",
+        "DeepseekV3ForCausalLM",
+        "Glm5NextForCausalLM",
+        "Qwen3MoeForCausalLM",
+    ],
+)
 def test_non_hybrid_models_have_explicit_false_flags(architecture):
     config = derive(architecture)
     assert config.is_hybrid_swa is False
@@ -41,7 +64,9 @@ def test_non_hybrid_models_have_explicit_false_flags(architecture):
     assert config.is_hybrid_swa_compress is False
 
 
-@pytest.mark.parametrize("architecture", ["DeepseekV4ForCausalLM", "DeepseekV4ForCausalLMNextN"])
+@pytest.mark.parametrize(
+    "architecture", ["DeepseekV4ForCausalLM", "DeepseekV4ForCausalLMNextN"]
+)
 def test_deepseek_compressed_pool_flags_preserved(architecture):
     config = derive(architecture)
     assert config.is_hybrid_swa is True
@@ -55,10 +80,19 @@ def test_mimo_compressed_swa_flags_preserved(architecture):
     assert config.is_hybrid_swa is True
     assert config.is_swa_with_compressed_attention is False
     assert config.is_hybrid_swa_compress is True
-    assert config.swa_attention_layer_ids == ([0, 2] if architecture == "MiMoV2FlashForCausalLM" else [0])
+    assert config.swa_attention_layer_ids == (
+        [0, 2] if architecture == "MiMoV2FlashForCausalLM" else [0]
+    )
 
 
-@pytest.mark.parametrize("architecture", ["DeepseekV4ForCausalLM", "MiMoV2FlashForCausalLM", "KimiK25ForConditionalGeneration"])
+@pytest.mark.parametrize(
+    "architecture",
+    [
+        "DeepseekV4ForCausalLM",
+        "MiMoV2FlashForCausalLM",
+        "KimiK25ForConditionalGeneration",
+    ],
+)
 def test_disabled_hybrid_memory_has_false_flags(architecture):
     config = derive(architecture, disabled=True)
     assert config.is_hybrid_swa is False
@@ -73,3 +107,117 @@ def test_ordinary_hybrid_layer_mapping_preserved():
     assert config.is_hybrid_swa_compress is False
     assert config.swa_attention_layer_ids == [0, 1, 2]
     assert config.full_attention_layer_ids == [3]
+
+
+@pytest.fixture(scope="module")
+def init_pool_capacity():
+    # Execute the real capacity-selection prefix, stopping before GPU allocation.
+    # Like derive(), this keeps the regression test independent of CUDA imports.
+    source = ROOT / "python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py"
+    tree = ast.parse(source.read_bytes())
+    cls = next(
+        n
+        for n in tree.body
+        if isinstance(n, ast.ClassDef) and n.name == "ModelRunnerKVCacheMixin"
+    )
+    method = next(
+        n
+        for n in cls.body
+        if isinstance(n, ast.FunctionDef) and n.name == "init_memory_pool"
+    )
+    first_branch = next(
+        i for i, node in enumerate(method.body) if isinstance(node, ast.If)
+    )
+    method.body = method.body[: first_branch + 1]
+    assert any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "profile_max_num_token"
+        for node in ast.walk(method)
+    ), "The prefix must include the real KV capacity selection"
+    method.args.args[0].annotation = None
+    module = ast.Module(body=[method], type_ignores=[])
+    namespace = {}
+    exec(compile(ast.fix_missing_locations(module), str(source), "exec"), namespace)
+    return namespace["init_memory_pool"]
+
+
+def capacity_runner(config, max_total_tokens):
+    return SimpleNamespace(
+        model_config=config,
+        server_args=SimpleNamespace(
+            max_running_requests=4, max_total_tokens=max_total_tokens
+        ),
+        profile_max_num_token=Mock(return_value=8192),
+    )
+
+
+@pytest.mark.parametrize(
+    "architecture",
+    [
+        "KimiK25ForConditionalGeneration",
+        "DeepseekV3ForCausalLM",
+        "Glm5NextForCausalLM",
+        "Qwen3MoeForCausalLM",
+    ],
+)
+@pytest.mark.parametrize("max_total_tokens", [None, 4096])
+@pytest.mark.parametrize("legacy_missing_flag", [False, True])
+def test_non_hybrid_kv_capacity_uses_profile(
+    init_pool_capacity, architecture, max_total_tokens, legacy_missing_flag
+):
+    config = derive(architecture)
+    if legacy_missing_flag:
+        # Before the default-flag fix, non-SWA initialization returned here.
+        # The entry-point guard must work independently of that later fix.
+        del config.is_swa_with_compressed_attention
+    runner = capacity_runner(config, max_total_tokens)
+    init_pool_capacity(runner)
+    assert runner.max_total_num_tokens == 8192
+    runner.profile_max_num_token.assert_called_once_with()
+
+
+@pytest.mark.parametrize(
+    "architecture", ["DeepseekV4ForCausalLM", "DeepseekV4ForCausalLMNextN"]
+)
+@pytest.mark.parametrize("max_total_tokens", [None, 4096])
+def test_dsv4_kv_capacity_keeps_configured_ceiling(
+    init_pool_capacity, architecture, max_total_tokens
+):
+    runner = capacity_runner(derive(architecture), max_total_tokens)
+    init_pool_capacity(runner)
+    if max_total_tokens is None:
+        assert runner.max_total_num_tokens == 8192
+        runner.profile_max_num_token.assert_called_once_with()
+    else:
+        assert runner.max_total_num_tokens == max_total_tokens
+        runner.profile_max_num_token.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "architecture",
+    ["MiMoV2FlashForCausalLM", "MiMoV2MTP", "Llama4ForConditionalGeneration"],
+)
+@pytest.mark.parametrize("max_total_tokens", [None, 4096])
+def test_other_hybrid_kv_capacity_uses_profile(
+    init_pool_capacity, architecture, max_total_tokens
+):
+    runner = capacity_runner(derive(architecture), max_total_tokens)
+    init_pool_capacity(runner)
+    assert runner.max_total_num_tokens == 8192
+    runner.profile_max_num_token.assert_called_once_with()
+
+
+@pytest.mark.parametrize(
+    "architecture", ["DeepseekV4ForCausalLM", "DeepseekV4ForCausalLMNextN"]
+)
+@pytest.mark.parametrize("max_total_tokens", [None, 4096])
+def test_disabled_hybrid_kv_capacity_uses_profile(
+    init_pool_capacity, architecture, max_total_tokens
+):
+    config = derive(architecture, disabled=True)
+    del config.is_swa_with_compressed_attention
+    runner = capacity_runner(config, max_total_tokens)
+    init_pool_capacity(runner)
+    assert runner.max_total_num_tokens == 8192
+    runner.profile_max_num_token.assert_called_once_with()

--- a/test/registered/unit/test_model_config_hybrid_flags.py
+++ b/test/registered/unit/test_model_config_hybrid_flags.py
@@ -5,7 +5,6 @@ import logging
 from pathlib import Path
 from types import SimpleNamespace
 from typing import List
-from unittest.mock import Mock
 
 import pytest
 
@@ -16,47 +15,25 @@ def derive(architecture, *, disabled=False):
     # Execute the actual dependency-light config methods without importing CUDA.
     source = ROOT / "python/sglang/srt/configs/model_config.py"
     tree = ast.parse(source.read_bytes())
-    cls = next(
-        n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == "ModelConfig"
-    )
-    method = next(
-        n
-        for n in cls.body
-        if isinstance(n, ast.FunctionDef) and n.name == "_derive_hybrid_model"
-    )
-    helpers = [
-        n
-        for n in tree.body
-        if isinstance(n, ast.FunctionDef)
-        and n.name in ("is_hybrid_swa_model", "get_hybrid_layer_ids")
-    ]
+    cls = next(n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == "ModelConfig")
+    method = next(n for n in cls.body if isinstance(n, ast.FunctionDef) and n.name == "_derive_hybrid_model")
+    helpers = [n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name in ("is_hybrid_swa_model", "get_hybrid_layer_ids")]
     module = ast.Module(body=helpers + [method], type_ignores=[])
-    ns = {
-        "List": List,
-        "PretrainedConfig": object,
-        "logger": logging.getLogger(__name__),
-    }
+    ns = {"List": List, "PretrainedConfig": object, "logger": logging.getLogger(__name__)}
     exec(compile(ast.fix_missing_locations(module), str(source), "exec"), ns)
     config = SimpleNamespace(
         hf_config=SimpleNamespace(architectures=[architecture]),
-        hf_text_config=SimpleNamespace(
-            num_hidden_layers=4, hybrid_layer_pattern=[1, 0, 1, 0]
-        ),
+        hf_text_config=SimpleNamespace(num_hidden_layers=4, hybrid_layer_pattern=[1, 0, 1, 0]),
         disable_hybrid_swa_memory=disabled,
     )
     ns["_derive_hybrid_model"](config)
     return config
 
 
-@pytest.mark.parametrize(
-    "architecture",
-    [
-        "KimiK25ForConditionalGeneration",
-        "DeepseekV3ForCausalLM",
-        "Glm5NextForCausalLM",
-        "Qwen3MoeForCausalLM",
-    ],
-)
+@pytest.mark.parametrize("architecture", [
+    "KimiK25ForConditionalGeneration", "DeepseekV3ForCausalLM",
+    "Glm5NextForCausalLM", "Qwen3MoeForCausalLM",
+])
 def test_non_hybrid_models_have_explicit_false_flags(architecture):
     config = derive(architecture)
     assert config.is_hybrid_swa is False
@@ -64,9 +41,7 @@ def test_non_hybrid_models_have_explicit_false_flags(architecture):
     assert config.is_hybrid_swa_compress is False
 
 
-@pytest.mark.parametrize(
-    "architecture", ["DeepseekV4ForCausalLM", "DeepseekV4ForCausalLMNextN"]
-)
+@pytest.mark.parametrize("architecture", ["DeepseekV4ForCausalLM", "DeepseekV4ForCausalLMNextN"])
 def test_deepseek_compressed_pool_flags_preserved(architecture):
     config = derive(architecture)
     assert config.is_hybrid_swa is True
@@ -80,19 +55,10 @@ def test_mimo_compressed_swa_flags_preserved(architecture):
     assert config.is_hybrid_swa is True
     assert config.is_swa_with_compressed_attention is False
     assert config.is_hybrid_swa_compress is True
-    assert config.swa_attention_layer_ids == (
-        [0, 2] if architecture == "MiMoV2FlashForCausalLM" else [0]
-    )
+    assert config.swa_attention_layer_ids == ([0, 2] if architecture == "MiMoV2FlashForCausalLM" else [0])
 
 
-@pytest.mark.parametrize(
-    "architecture",
-    [
-        "DeepseekV4ForCausalLM",
-        "MiMoV2FlashForCausalLM",
-        "KimiK25ForConditionalGeneration",
-    ],
-)
+@pytest.mark.parametrize("architecture", ["DeepseekV4ForCausalLM", "MiMoV2FlashForCausalLM", "KimiK25ForConditionalGeneration"])
 def test_disabled_hybrid_memory_has_false_flags(architecture):
     config = derive(architecture, disabled=True)
     assert config.is_hybrid_swa is False
@@ -107,117 +73,3 @@ def test_ordinary_hybrid_layer_mapping_preserved():
     assert config.is_hybrid_swa_compress is False
     assert config.swa_attention_layer_ids == [0, 1, 2]
     assert config.full_attention_layer_ids == [3]
-
-
-@pytest.fixture(scope="module")
-def init_pool_capacity():
-    # Execute the real capacity-selection prefix, stopping before GPU allocation.
-    # Like derive(), this keeps the regression test independent of CUDA imports.
-    source = ROOT / "python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py"
-    tree = ast.parse(source.read_bytes())
-    cls = next(
-        n
-        for n in tree.body
-        if isinstance(n, ast.ClassDef) and n.name == "ModelRunnerKVCacheMixin"
-    )
-    method = next(
-        n
-        for n in cls.body
-        if isinstance(n, ast.FunctionDef) and n.name == "init_memory_pool"
-    )
-    first_branch = next(
-        i for i, node in enumerate(method.body) if isinstance(node, ast.If)
-    )
-    method.body = method.body[: first_branch + 1]
-    assert any(
-        isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Attribute)
-        and node.func.attr == "profile_max_num_token"
-        for node in ast.walk(method)
-    ), "The prefix must include the real KV capacity selection"
-    method.args.args[0].annotation = None
-    module = ast.Module(body=[method], type_ignores=[])
-    namespace = {}
-    exec(compile(ast.fix_missing_locations(module), str(source), "exec"), namespace)
-    return namespace["init_memory_pool"]
-
-
-def capacity_runner(config, max_total_tokens):
-    return SimpleNamespace(
-        model_config=config,
-        server_args=SimpleNamespace(
-            max_running_requests=4, max_total_tokens=max_total_tokens
-        ),
-        profile_max_num_token=Mock(return_value=8192),
-    )
-
-
-@pytest.mark.parametrize(
-    "architecture",
-    [
-        "KimiK25ForConditionalGeneration",
-        "DeepseekV3ForCausalLM",
-        "Glm5NextForCausalLM",
-        "Qwen3MoeForCausalLM",
-    ],
-)
-@pytest.mark.parametrize("max_total_tokens", [None, 4096])
-@pytest.mark.parametrize("legacy_missing_flag", [False, True])
-def test_non_hybrid_kv_capacity_uses_profile(
-    init_pool_capacity, architecture, max_total_tokens, legacy_missing_flag
-):
-    config = derive(architecture)
-    if legacy_missing_flag:
-        # Before the default-flag fix, non-SWA initialization returned here.
-        # The entry-point guard must work independently of that later fix.
-        del config.is_swa_with_compressed_attention
-    runner = capacity_runner(config, max_total_tokens)
-    init_pool_capacity(runner)
-    assert runner.max_total_num_tokens == 8192
-    runner.profile_max_num_token.assert_called_once_with()
-
-
-@pytest.mark.parametrize(
-    "architecture", ["DeepseekV4ForCausalLM", "DeepseekV4ForCausalLMNextN"]
-)
-@pytest.mark.parametrize("max_total_tokens", [None, 4096])
-def test_dsv4_kv_capacity_keeps_configured_ceiling(
-    init_pool_capacity, architecture, max_total_tokens
-):
-    runner = capacity_runner(derive(architecture), max_total_tokens)
-    init_pool_capacity(runner)
-    if max_total_tokens is None:
-        assert runner.max_total_num_tokens == 8192
-        runner.profile_max_num_token.assert_called_once_with()
-    else:
-        assert runner.max_total_num_tokens == max_total_tokens
-        runner.profile_max_num_token.assert_not_called()
-
-
-@pytest.mark.parametrize(
-    "architecture",
-    ["MiMoV2FlashForCausalLM", "MiMoV2MTP", "Llama4ForConditionalGeneration"],
-)
-@pytest.mark.parametrize("max_total_tokens", [None, 4096])
-def test_other_hybrid_kv_capacity_uses_profile(
-    init_pool_capacity, architecture, max_total_tokens
-):
-    runner = capacity_runner(derive(architecture), max_total_tokens)
-    init_pool_capacity(runner)
-    assert runner.max_total_num_tokens == 8192
-    runner.profile_max_num_token.assert_called_once_with()
-
-
-@pytest.mark.parametrize(
-    "architecture", ["DeepseekV4ForCausalLM", "DeepseekV4ForCausalLMNextN"]
-)
-@pytest.mark.parametrize("max_total_tokens", [None, 4096])
-def test_disabled_hybrid_kv_capacity_uses_profile(
-    init_pool_capacity, architecture, max_total_tokens
-):
-    config = derive(architecture, disabled=True)
-    del config.is_swa_with_compressed_attention
-    runner = capacity_runner(config, max_total_tokens)
-    init_pool_capacity(runner)
-    assert runner.max_total_num_tokens == 8192
-    runner.profile_max_num_token.assert_called_once_with()


### PR DESCRIPTION
## Summary

Scope the compressed-attention capacity branch introduced by #83 to hybrid-SWA models. Kimi and other non-SWA models retain the original `profile_max_num_token()` path, without accessing an inapplicable compressed-attention flag.

## Why

#83 added a direct read of `model_config.is_swa_with_compressed_attention` at the shared KV-pool initialization entry point. Historically, `_derive_hybrid_model()` returned early for non-SWA models before defining that field. This caused Kimi's initialization to fail with `AttributeError`, independently of the `compressed-tensors` package.

Current main already initializes the flags to `False` in `4afb5b541`. This PR preserves that fix and additionally guards the consumer with `is_hybrid_swa`, so correctness does not rely solely on the new default. It does not claim that current main still reproduces the historical missing-field error.

## Changes and scope

- Add `model_config.is_hybrid_swa` as the first short-circuit condition before reading `is_swa_with_compressed_attention`.
- Preserve #83's configured capacity seed for DeepSeek V4 / NextN when hybrid SWA is active and `--max-total-tokens` is supplied.
- Preserve generic profiling for non-SWA models, other hybrid models, disabled hybrid memory, and DeepSeek V4 without an explicit token limit.
- No test-file changes are included; the existing test file has been restored exactly to the base revision.

Only one runtime condition changes. No Kimi whitelist, model/config-file modifications, kernel changes, dependency/version changes, tokenizer changes, or unrelated experimental patches are included. The later GPU-memory profiling and capacity clamping code is untouched.

## Validation

```bash
python -m pytest -q -c /dev/null test/registered/unit/test_model_config_hybrid_flags.py
# 12 passed
```

The unchanged 12 hybrid-configuration tests pass after the cleanup. Before removing the additional test changes, 42 CPU cases passed, including the capacity-selection branches and legacy configurations without the compressed-attention field. An in-memory negative control failed the 12 missing-field cases without the guard. Those additional tests are not part of the final PR diff.

Ruff (`F401,F821`), isort, `git diff --check`, and Black for the changed runtime lines passed. Existing formatting elsewhere is untouched.

**Validation boundary:** these are CPU configuration/branch regressions, not GPU inference or Adapter end-to-end acceptance. This PR addresses the KV initialization regression only; it does not claim to resolve every Kimi loading issue. No PyPI release is part of this PR.
