### PR TITLE
Fix Kimi tokenizer and CUDA payload loading

### DIFF
--- a/python/sglang/srt/constrained/llguidance_backend.py
+++ b/python/sglang/srt/constrained/llguidance_backend.py
@@ -37,6 +37,23 @@ from sglang.srt.constrained.utils import is_legacy_structural_tag
 logger = logging.getLogger(__name__)
 
 
+def _create_llguidance_tokenizer(tokenizer, n_vocab: Optional[int]) -> LLTokenizer:
+    tokenizer_type = type(tokenizer)
+    if (
+        tokenizer_type.__name__ == "TikTokenTokenizer"
+        and tokenizer_type.__module__.rsplit(".", 1)[-1] == "tokenization_kimi"
+    ):
+        import tiktoken
+        from llguidance.tiktoken import lltokenizer_from_encoding
+
+        encoding = getattr(tokenizer, "model", None)
+        if isinstance(encoding, tiktoken.Encoding):
+            return lltokenizer_from_encoding(
+                encoding, n_vocab=n_vocab, eos_token=tokenizer.eos_token_id
+            )
+    return from_tokenizer(tokenizer, n_vocab)
+
+
 class GuidanceGrammar(BaseGrammarObject):
 
     def __init__(self, llguidance_tokenizer: LLTokenizer, serialized_grammar: str):
@@ -120,7 +137,7 @@ class GuidanceBackend(BaseGrammarBackend):
         self.tokenizer = tokenizer
         self.any_whitespace = any_whitespace
         self.whitespace_pattern = whitespace_pattern
-        self.llguidance_tokenizer = from_tokenizer(self.tokenizer, n_vocab)
+        self.llguidance_tokenizer = _create_llguidance_tokenizer(self.tokenizer, n_vocab)
 
     def _from_serialized(self, serialized_grammar) -> Optional[GuidanceGrammar]:
         try:

--- a/python/sglang/srt/constrained/llguidance_backend.py
+++ b/python/sglang/srt/constrained/llguidance_backend.py
@@ -137,7 +137,9 @@ class GuidanceBackend(BaseGrammarBackend):
         self.tokenizer = tokenizer
         self.any_whitespace = any_whitespace
         self.whitespace_pattern = whitespace_pattern
-        self.llguidance_tokenizer = _create_llguidance_tokenizer(self.tokenizer, n_vocab)
+        self.llguidance_tokenizer = _create_llguidance_tokenizer(
+            self.tokenizer, n_vocab
+        )
 
     def _from_serialized(self, serialized_grammar) -> Optional[GuidanceGrammar]:
         try:

--- a/sgl-kernel/python/sgl_kernel/payload_runtime.py
+++ b/sgl-kernel/python/sgl_kernel/payload_runtime.py
@@ -130,6 +130,8 @@ def _materialize_all() -> Path:
 
 def materialize_binary(name: str) -> Path:
     manifest = _manifest()
-    if name not in manifest.FILES:
+    # New carriers retain wheel-relative paths so repaired $ORIGIN links work.
+    relative = getattr(manifest, "BINARIES", {}).get(name, name)
+    if relative not in manifest.FILES:
         raise FileNotFoundError(f"Unknown sgl-kernel-kt payload binary: {name}")
-    return _materialize_all() / name
+    return _materialize_all() / relative

--- a/test/registered/unit/test_llguidance_kimi_tokenizer.py
+++ b/test/registered/unit/test_llguidance_kimi_tokenizer.py
@@ -1,0 +1,167 @@
+"""CPU tokenizer tests; these do not replace server generation acceptance."""
+
+import ast
+import os
+from pathlib import Path
+from typing import Optional
+import unittest
+from unittest.mock import Mock
+
+from llguidance import LLMatcher, LLTokenizer
+from llguidance.hf import from_tokenizer
+import tiktoken
+
+SOURCE = (
+    Path(__file__).resolve().parents[3]
+    / "python/sglang/srt/constrained/llguidance_backend.py"
+)
+
+
+def load_factory(hf_factory=from_tokenizer):
+    # Isolate the production factory from unrelated CUDA/server imports.
+    tree = ast.parse(SOURCE.read_bytes())
+    function = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "_create_llguidance_tokenizer"
+    )
+    namespace = {
+        "Optional": Optional,
+        "LLTokenizer": LLTokenizer,
+        "from_tokenizer": hf_factory,
+    }
+    exec(
+        compile(ast.Module(body=[function], type_ignores=[]), str(SOURCE), "exec"),
+        namespace,
+    )
+    return namespace[function.name]
+
+
+def kimi_fixture():
+    tokenizer_type = type("TikTokenTokenizer", (), {"__module__": "tokenization_kimi"})
+    tokenizer = tokenizer_type()
+    tokenizer.is_fast = False
+    tokenizer.eos_token_id = 257
+    tokenizer.model = tiktoken.Encoding(
+        name="kimi-unit",
+        pat_str=r"(?s).",
+        mergeable_ranks={bytes([value]): value for value in range(256)},
+        special_tokens={"<|endoftext|>": 256, "[EOS]": 257},
+    )
+    return tokenizer
+
+
+def accepts(tokenizer, text):
+    schema = '{"type":"object","properties":{"answer":{"const":"喵"}},"required":["answer"],"additionalProperties":false}'
+    matcher = LLMatcher(tokenizer, LLMatcher.grammar_from_json_schema(schema))
+    for token in tokenizer.tokenize_str(text):
+        if not matcher.consume_token(token):
+            return False
+    return (
+        matcher.consume_token(tokenizer.eos_token)
+        and matcher.is_stopped()
+        and not matcher.is_error()
+    )
+
+
+def assert_special_tokens(test, tokenizer, native):
+    # llguidance parses <...> literals only; generation consumes token IDs.
+    for text, token_id in tokenizer.model._special_tokens.items():
+        with test.subTest(special_token=text, token_id=token_id):
+            test.assertTrue(native.is_special_token(token_id))
+            test.assertEqual(native.decode_bytes([token_id]), text.encode("utf-8"))
+
+
+class KimiGuidanceTokenizerTest(unittest.TestCase):
+    def test_tokenization_eos_and_padded_vocabulary(self):
+        tokenizer = kimi_fixture()
+        native = load_factory()(tokenizer, 260)
+        self.assertEqual(native.eos_token, 257)
+        self.assertEqual(native.vocab_size, 260)
+        self.assertFalse(tokenizer.is_fast)
+        for text in ("你好，世界！", "Hello world", "12345", "a\nb"):
+            with self.subTest(text=text):
+                expected = tokenizer.model.encode_ordinary(text)
+                self.assertEqual(native.tokenize_str(text), expected)
+        assert_special_tokens(self, tokenizer, native)
+
+    def test_json_schema_accepts_and_rejects(self):
+        native = load_factory()(kimi_fixture(), None)
+        self.assertTrue(accepts(native, '{"answer":"喵"}'))
+        self.assertFalse(accepts(native, '{"answer":"汪"}'))
+
+    def test_other_tokenizers_keep_hf_dispatch(self):
+        hf_factory = Mock(return_value=object())
+        tokenizer = object()
+        self.assertIs(load_factory(hf_factory)(tokenizer, 300), hf_factory.return_value)
+        hf_factory.assert_called_once_with(tokenizer, 300)
+
+    def test_foreign_slow_tokenizer_is_not_misclassified(self):
+        tokenizer = kimi_fixture()
+        tokenizer.__class__ = type(
+            "TikTokenTokenizer", (), {"__module__": "another_model"}
+        )
+        with self.assertRaisesRegex(ValueError, "Only fast tokenizers"):
+            load_factory()(tokenizer, None)
+
+    def test_invalid_encoding_does_not_use_kimi_dispatch(self):
+        tokenizer = kimi_fixture()
+        tokenizer.model = {}
+        with self.assertRaisesRegex(ValueError, "Only fast tokenizers"):
+            load_factory()(tokenizer, None)
+
+    def test_hf_fast_tokenizer(self):
+        from tokenizers import Tokenizer, decoders, models, pre_tokenizers
+        from transformers import PreTrainedTokenizerFast
+
+        vocab = {
+            char: index
+            for index, char in enumerate(sorted(pre_tokenizers.ByteLevel.alphabet()))
+        }
+        vocab["<|endoftext|>"] = len(vocab)
+        backend = Tokenizer(models.BPE(vocab=vocab, merges=[]))
+        backend.pre_tokenizer = pre_tokenizers.ByteLevel(add_prefix_space=False)
+        backend.decoder = decoders.ByteLevel()
+        tokenizer = PreTrainedTokenizerFast(
+            tokenizer_object=backend, eos_token="<|endoftext|>"
+        )
+        native = load_factory()(tokenizer, len(vocab))
+        self.assertEqual(
+            native.tokenize_str("hello world"),
+            tokenizer.encode("hello world", add_special_tokens=False),
+        )
+
+    @unittest.skipUnless(
+        os.environ.get("KT_KIMI_TOKENIZER_PATH"), "Set path to official Kimi tokenizer"
+    )
+    def test_official_kimi_tokenizer(self):
+        from transformers import AutoTokenizer
+
+        tokenizer = AutoTokenizer.from_pretrained(
+            os.environ["KT_KIMI_TOKENIZER_PATH"],
+            trust_remote_code=True,
+            use_fast=False,
+            local_files_only=True,
+        )
+        native = load_factory()(tokenizer, len(tokenizer))
+        self.assertEqual(native.eos_token, tokenizer.eos_token_id)
+        self.assertEqual(native.vocab_size, len(tokenizer))
+        for text in (
+            "你好，世界！",
+            "Hello, world!",
+            "1234567890",
+            "第一行\n第二行\n",
+        ):
+            with self.subTest(text=text):
+                self.assertEqual(
+                    native.tokenize_str(text),
+                    tokenizer.encode(text, add_special_tokens=False),
+                )
+        assert_special_tokens(self, tokenizer, native)
+        self.assertTrue(accepts(native, '{"answer":"喵"}'))
+        self.assertFalse(accepts(native, '{"answer":"汪"}'))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/test_llguidance_kimi_tokenizer.py
+++ b/test/registered/unit/test_llguidance_kimi_tokenizer.py
@@ -2,14 +2,14 @@
 
 import ast
 import os
+import unittest
 from pathlib import Path
 from typing import Optional
-import unittest
 from unittest.mock import Mock
 
+import tiktoken
 from llguidance import LLMatcher, LLTokenizer
 from llguidance.hf import from_tokenizer
-import tiktoken
 
 SOURCE = (
     Path(__file__).resolve().parents[3]

--- a/test/registered/unit/test_llguidance_kimi_tokenizer.py
+++ b/test/registered/unit/test_llguidance_kimi_tokenizer.py
@@ -1,167 +1,50 @@
-"""CPU tokenizer tests; these do not replace server generation acceptance."""
+"""Kimi native tokenization and unchanged Hugging Face dispatch."""
 
-import ast
-import os
-import unittest
-from pathlib import Path
-from typing import Optional
 from unittest.mock import Mock
 
+import pytest
 import tiktoken
-from llguidance import LLMatcher, LLTokenizer
-from llguidance.hf import from_tokenizer
 
-SOURCE = (
-    Path(__file__).resolve().parents[3]
-    / "python/sglang/srt/constrained/llguidance_backend.py"
-)
+from sglang.srt.constrained import llguidance_backend as guidance
 
 
-def load_factory(hf_factory=from_tokenizer):
-    # Isolate the production factory from unrelated CUDA/server imports.
-    tree = ast.parse(SOURCE.read_bytes())
-    function = next(
-        node
-        for node in tree.body
-        if isinstance(node, ast.FunctionDef)
-        and node.name == "_create_llguidance_tokenizer"
-    )
-    namespace = {
-        "Optional": Optional,
-        "LLTokenizer": LLTokenizer,
-        "from_tokenizer": hf_factory,
-    }
-    exec(
-        compile(ast.Module(body=[function], type_ignores=[]), str(SOURCE), "exec"),
-        namespace,
-    )
-    return namespace[function.name]
-
-
-def kimi_fixture():
-    tokenizer_type = type("TikTokenTokenizer", (), {"__module__": "tokenization_kimi"})
-    tokenizer = tokenizer_type()
-    tokenizer.is_fast = False
-    tokenizer.eos_token_id = 257
+def kimi_tokenizer():
+    cls = type("TikTokenTokenizer", (), {"__module__": "tokenization_kimi"})
+    tokenizer = cls()
+    tokenizer.eos_token_id = 256
     tokenizer.model = tiktoken.Encoding(
-        name="kimi-unit",
+        name="kimi-test",
         pat_str=r"(?s).",
         mergeable_ranks={bytes([value]): value for value in range(256)},
-        special_tokens={"<|endoftext|>": 256, "[EOS]": 257},
+        special_tokens={"[EOS]": 256},
     )
     return tokenizer
 
 
-def accepts(tokenizer, text):
-    schema = '{"type":"object","properties":{"answer":{"const":"喵"}},"required":["answer"],"additionalProperties":false}'
-    matcher = LLMatcher(tokenizer, LLMatcher.grammar_from_json_schema(schema))
-    for token in tokenizer.tokenize_str(text):
-        if not matcher.consume_token(token):
-            return False
-    return (
-        matcher.consume_token(tokenizer.eos_token)
-        and matcher.is_stopped()
-        and not matcher.is_error()
-    )
+def test_kimi_preserves_tokens_eos_and_vocabulary():
+    tokenizer = kimi_tokenizer()
+    native = guidance._create_llguidance_tokenizer(tokenizer, 260)
+    assert native.eos_token == 256
+    assert native.vocab_size == 260
+    assert native.decode_bytes([256]) == b"[EOS]"
+    for text in ("Hello", "你好，世界！", "123\n456"):
+        assert native.tokenize_str(text) == tokenizer.model.encode_ordinary(text)
 
 
-def assert_special_tokens(test, tokenizer, native):
-    # llguidance parses <...> literals only; generation consumes token IDs.
-    for text, token_id in tokenizer.model._special_tokens.items():
-        with test.subTest(special_token=text, token_id=token_id):
-            test.assertTrue(native.is_special_token(token_id))
-            test.assertEqual(native.decode_bytes([token_id]), text.encode("utf-8"))
-
-
-class KimiGuidanceTokenizerTest(unittest.TestCase):
-    def test_tokenization_eos_and_padded_vocabulary(self):
-        tokenizer = kimi_fixture()
-        native = load_factory()(tokenizer, 260)
-        self.assertEqual(native.eos_token, 257)
-        self.assertEqual(native.vocab_size, 260)
-        self.assertFalse(tokenizer.is_fast)
-        for text in ("你好，世界！", "Hello world", "12345", "a\nb"):
-            with self.subTest(text=text):
-                expected = tokenizer.model.encode_ordinary(text)
-                self.assertEqual(native.tokenize_str(text), expected)
-        assert_special_tokens(self, tokenizer, native)
-
-    def test_json_schema_accepts_and_rejects(self):
-        native = load_factory()(kimi_fixture(), None)
-        self.assertTrue(accepts(native, '{"answer":"喵"}'))
-        self.assertFalse(accepts(native, '{"answer":"汪"}'))
-
-    def test_other_tokenizers_keep_hf_dispatch(self):
-        hf_factory = Mock(return_value=object())
+@pytest.mark.parametrize("kind", ["ordinary", "foreign", "invalid_encoding"])
+def test_other_tokenizers_keep_existing_dispatch(monkeypatch, kind):
+    tokenizer = kimi_tokenizer()
+    if kind == "ordinary":
         tokenizer = object()
-        self.assertIs(load_factory(hf_factory)(tokenizer, 300), hf_factory.return_value)
-        hf_factory.assert_called_once_with(tokenizer, 300)
-
-    def test_foreign_slow_tokenizer_is_not_misclassified(self):
-        tokenizer = kimi_fixture()
+    elif kind == "foreign":
         tokenizer.__class__ = type(
-            "TikTokenTokenizer", (), {"__module__": "another_model"}
+            "TikTokenTokenizer", (), {"__module__": "other_model"}
         )
-        with self.assertRaisesRegex(ValueError, "Only fast tokenizers"):
-            load_factory()(tokenizer, None)
-
-    def test_invalid_encoding_does_not_use_kimi_dispatch(self):
-        tokenizer = kimi_fixture()
-        tokenizer.model = {}
-        with self.assertRaisesRegex(ValueError, "Only fast tokenizers"):
-            load_factory()(tokenizer, None)
-
-    def test_hf_fast_tokenizer(self):
-        from tokenizers import Tokenizer, decoders, models, pre_tokenizers
-        from transformers import PreTrainedTokenizerFast
-
-        vocab = {
-            char: index
-            for index, char in enumerate(sorted(pre_tokenizers.ByteLevel.alphabet()))
-        }
-        vocab["<|endoftext|>"] = len(vocab)
-        backend = Tokenizer(models.BPE(vocab=vocab, merges=[]))
-        backend.pre_tokenizer = pre_tokenizers.ByteLevel(add_prefix_space=False)
-        backend.decoder = decoders.ByteLevel()
-        tokenizer = PreTrainedTokenizerFast(
-            tokenizer_object=backend, eos_token="<|endoftext|>"
-        )
-        native = load_factory()(tokenizer, len(vocab))
-        self.assertEqual(
-            native.tokenize_str("hello world"),
-            tokenizer.encode("hello world", add_special_tokens=False),
-        )
-
-    @unittest.skipUnless(
-        os.environ.get("KT_KIMI_TOKENIZER_PATH"), "Set path to official Kimi tokenizer"
+    else:
+        tokenizer.model = None
+    fallback = Mock(return_value=object())
+    monkeypatch.setattr(guidance, "from_tokenizer", fallback)
+    assert (
+        guidance._create_llguidance_tokenizer(tokenizer, 260) is fallback.return_value
     )
-    def test_official_kimi_tokenizer(self):
-        from transformers import AutoTokenizer
-
-        tokenizer = AutoTokenizer.from_pretrained(
-            os.environ["KT_KIMI_TOKENIZER_PATH"],
-            trust_remote_code=True,
-            use_fast=False,
-            local_files_only=True,
-        )
-        native = load_factory()(tokenizer, len(tokenizer))
-        self.assertEqual(native.eos_token, tokenizer.eos_token_id)
-        self.assertEqual(native.vocab_size, len(tokenizer))
-        for text in (
-            "你好，世界！",
-            "Hello, world!",
-            "1234567890",
-            "第一行\n第二行\n",
-        ):
-            with self.subTest(text=text):
-                self.assertEqual(
-                    native.tokenize_str(text),
-                    tokenizer.encode(text, add_special_tokens=False),
-                )
-        assert_special_tokens(self, tokenizer, native)
-        self.assertTrue(accepts(native, '{"answer":"喵"}'))
-        self.assertFalse(accepts(native, '{"answer":"汪"}'))
-
-
-if __name__ == "__main__":
-    unittest.main()
+    fallback.assert_called_once_with(tokenizer, 260)

--- a/test/registered/unit/test_payload_runtime_layout.py
+++ b/test/registered/unit/test_payload_runtime_layout.py
@@ -1,148 +1,28 @@
-"""CPU-only loader checks, including an actual ELF $ORIGIN dependency."""
+"""Resolve new wheel-relative payloads while retaining legacy manifests."""
 
-import hashlib
 import importlib.util
-import io
-import shutil
-import subprocess
-import sys
-import tarfile
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
 
-@pytest.fixture
-def loader():
-    path = (
+@pytest.mark.parametrize("mapped", [False, True])
+def test_payload_binary_layout(tmp_path, monkeypatch, mapped):
+    source = (
         Path(__file__).resolve().parents[3]
         / "sgl-kernel/python/sgl_kernel/payload_runtime.py"
     )
-    spec = importlib.util.spec_from_file_location("_payload_runtime_test", path)
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
-
-
-def install_fixture(loader, tmp_path, monkeypatch, files, binaries=None):
-    part = tmp_path / "payload.part"
-    with tarfile.open(part, "w:gz") as archive:
-        for name, content in files.items():
-            info = tarfile.TarInfo(name)
-            info.size = len(content)
-            archive.addfile(info, io.BytesIO(content))
-    manifest = SimpleNamespace(
-        VERSION="test",
-        ARCHIVE_SHA256=hashlib.sha256(part.read_bytes()).hexdigest(),
-        PAYLOAD_MODULES=("test_payload",),
-        FILES={
-            name: hashlib.sha256(content).hexdigest() for name, content in files.items()
-        },
-    )
-    if binaries is not None:
-        manifest.BINARIES = binaries
-    cache = tmp_path / "cache"
-    monkeypatch.setattr(loader, "_manifest", lambda: manifest)
-    monkeypatch.setattr(loader, "_cache_root", lambda *args: cache)
-    monkeypatch.setattr(loader, "_payload_part", lambda name: part)
-    return cache, manifest
-
-
-@pytest.mark.parametrize("mapped", [False, True])
-def test_legacy_and_wheel_relative_payloads(loader, tmp_path, monkeypatch, mapped):
+    spec = importlib.util.spec_from_file_location("payload_layout_test", source)
+    loader = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(loader)
     name = "sm100/common_ops.abi3.so"
     relative = "sgl_kernel/" + name if mapped else name
-    cache, _ = install_fixture(
-        loader,
-        tmp_path,
-        monkeypatch,
-        {relative: b"fixture"},
-        {name: relative} if mapped else None,
-    )
-    binary = loader.materialize_binary(name)
-    assert binary == cache / relative
-    assert binary.read_bytes() == b"fixture"
-    assert loader.materialize_binary(name) == binary
+    manifest = SimpleNamespace(FILES={relative: "checksum"})
+    if mapped:
+        manifest.BINARIES = {name: relative}
+    monkeypatch.setattr(loader, "_manifest", lambda: manifest)
+    monkeypatch.setattr(loader, "_materialize_all", lambda: tmp_path)
+    assert loader.materialize_binary(name) == tmp_path / relative
     with pytest.raises(FileNotFoundError, match="Unknown"):
-        loader.materialize_binary("not-present.so")
-
-
-def test_bad_payload_checksum_fails(loader, tmp_path, monkeypatch):
-    _, manifest = install_fixture(
-        loader, tmp_path, monkeypatch, {"flash_ops.abi3.so": b"fixture"}
-    )
-    manifest.ARCHIVE_SHA256 = "0" * 64
-    with pytest.raises(RuntimeError, match="checksum mismatch"):
-        loader.materialize_binary("flash_ops.abi3.so")
-
-
-def test_materialized_elf_resolves_sibling_library(loader, tmp_path, monkeypatch):
-    compiler = shutil.which("gcc")
-    if compiler is None:
-        pytest.skip("ELF linkage probe requires gcc")
-    library = tmp_path / "libkt_payload_probe.so"
-    binary = tmp_path / "common_ops.abi3.so"
-    subprocess.run(
-        [
-            compiler,
-            "-shared",
-            "-fPIC",
-            "-x",
-            "c",
-            "-",
-            "-Wl,-soname,libkt_payload_probe.so",
-            "-o",
-            str(library),
-        ],
-        input="int payload_probe(void) { return 42; }\n",
-        text=True,
-        check=True,
-    )
-    subprocess.run(
-        [
-            compiler,
-            "-shared",
-            "-fPIC",
-            "-x",
-            "c",
-            "-",
-            "-L" + str(tmp_path),
-            "-lkt_payload_probe",
-            "-Wl,-rpath,$ORIGIN/../../sgl_kernel_kt.libs",
-            "-o",
-            str(binary),
-        ],
-        input="extern int payload_probe(void); int result(void) { return payload_probe(); }\n",
-        text=True,
-        check=True,
-    )
-    name = "sm100/common_ops.abi3.so"
-    files = {
-        "sgl_kernel/" + name: binary.read_bytes(),
-        "sgl_kernel_kt.libs/" + library.name: library.read_bytes(),
-    }
-    cache, _ = install_fixture(
-        loader, tmp_path, monkeypatch, files, {name: "sgl_kernel/" + name}
-    )
-    probe = "import ctypes, sys; print(ctypes.CDLL(sys.argv[1]).result())"
-    loaded = subprocess.check_output(
-        [sys.executable, "-c", probe, str(loader.materialize_binary(name))], text=True
-    )
-    assert loaded.strip() == "42"
-    flat = tmp_path / "legacy-flat"
-    (flat / "sm100").mkdir(parents=True)
-    (flat / "sgl_kernel_kt.libs").mkdir()
-    shutil.copyfile(binary, flat / name)
-    shutil.copyfile(library, flat / "sgl_kernel_kt.libs" / library.name)
-    broken = subprocess.run(
-        [sys.executable, "-c", probe, str(flat / name)], capture_output=True, text=True
-    )
-    assert broken.returncode != 0
-    assert library.name in broken.stderr
-    # Corrupted dependencies must be re-extracted on the next materialization.
-    (cache / "sgl_kernel_kt.libs" / library.name).write_bytes(b"corrupted")
-    loader.materialize_binary(name)
-    assert (cache / "sgl_kernel_kt.libs" / library.name).read_bytes() == files[
-        "sgl_kernel_kt.libs/" + library.name
-    ]
+        loader.materialize_binary("unknown.so")

--- a/test/registered/unit/test_payload_runtime_layout.py
+++ b/test/registered/unit/test_payload_runtime_layout.py
@@ -1,0 +1,148 @@
+"""CPU-only loader checks, including an actual ELF $ORIGIN dependency."""
+
+import hashlib
+import importlib.util
+import io
+import shutil
+import subprocess
+import sys
+import tarfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture
+def loader():
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "sgl-kernel/python/sgl_kernel/payload_runtime.py"
+    )
+    spec = importlib.util.spec_from_file_location("_payload_runtime_test", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def install_fixture(loader, tmp_path, monkeypatch, files, binaries=None):
+    part = tmp_path / "payload.part"
+    with tarfile.open(part, "w:gz") as archive:
+        for name, content in files.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(content)
+            archive.addfile(info, io.BytesIO(content))
+    manifest = SimpleNamespace(
+        VERSION="test",
+        ARCHIVE_SHA256=hashlib.sha256(part.read_bytes()).hexdigest(),
+        PAYLOAD_MODULES=("test_payload",),
+        FILES={
+            name: hashlib.sha256(content).hexdigest() for name, content in files.items()
+        },
+    )
+    if binaries is not None:
+        manifest.BINARIES = binaries
+    cache = tmp_path / "cache"
+    monkeypatch.setattr(loader, "_manifest", lambda: manifest)
+    monkeypatch.setattr(loader, "_cache_root", lambda *args: cache)
+    monkeypatch.setattr(loader, "_payload_part", lambda name: part)
+    return cache, manifest
+
+
+@pytest.mark.parametrize("mapped", [False, True])
+def test_legacy_and_wheel_relative_payloads(loader, tmp_path, monkeypatch, mapped):
+    name = "sm100/common_ops.abi3.so"
+    relative = "sgl_kernel/" + name if mapped else name
+    cache, _ = install_fixture(
+        loader,
+        tmp_path,
+        monkeypatch,
+        {relative: b"fixture"},
+        {name: relative} if mapped else None,
+    )
+    binary = loader.materialize_binary(name)
+    assert binary == cache / relative
+    assert binary.read_bytes() == b"fixture"
+    assert loader.materialize_binary(name) == binary
+    with pytest.raises(FileNotFoundError, match="Unknown"):
+        loader.materialize_binary("not-present.so")
+
+
+def test_bad_payload_checksum_fails(loader, tmp_path, monkeypatch):
+    _, manifest = install_fixture(
+        loader, tmp_path, monkeypatch, {"flash_ops.abi3.so": b"fixture"}
+    )
+    manifest.ARCHIVE_SHA256 = "0" * 64
+    with pytest.raises(RuntimeError, match="checksum mismatch"):
+        loader.materialize_binary("flash_ops.abi3.so")
+
+
+def test_materialized_elf_resolves_sibling_library(loader, tmp_path, monkeypatch):
+    compiler = shutil.which("gcc")
+    if compiler is None:
+        pytest.skip("ELF linkage probe requires gcc")
+    library = tmp_path / "libkt_payload_probe.so"
+    binary = tmp_path / "common_ops.abi3.so"
+    subprocess.run(
+        [
+            compiler,
+            "-shared",
+            "-fPIC",
+            "-x",
+            "c",
+            "-",
+            "-Wl,-soname,libkt_payload_probe.so",
+            "-o",
+            str(library),
+        ],
+        input="int payload_probe(void) { return 42; }\n",
+        text=True,
+        check=True,
+    )
+    subprocess.run(
+        [
+            compiler,
+            "-shared",
+            "-fPIC",
+            "-x",
+            "c",
+            "-",
+            "-L" + str(tmp_path),
+            "-lkt_payload_probe",
+            "-Wl,-rpath,$ORIGIN/../../sgl_kernel_kt.libs",
+            "-o",
+            str(binary),
+        ],
+        input="extern int payload_probe(void); int result(void) { return payload_probe(); }\n",
+        text=True,
+        check=True,
+    )
+    name = "sm100/common_ops.abi3.so"
+    files = {
+        "sgl_kernel/" + name: binary.read_bytes(),
+        "sgl_kernel_kt.libs/" + library.name: library.read_bytes(),
+    }
+    cache, _ = install_fixture(
+        loader, tmp_path, monkeypatch, files, {name: "sgl_kernel/" + name}
+    )
+    probe = "import ctypes, sys; print(ctypes.CDLL(sys.argv[1]).result())"
+    loaded = subprocess.check_output(
+        [sys.executable, "-c", probe, str(loader.materialize_binary(name))], text=True
+    )
+    assert loaded.strip() == "42"
+    flat = tmp_path / "legacy-flat"
+    (flat / "sm100").mkdir(parents=True)
+    (flat / "sgl_kernel_kt.libs").mkdir()
+    shutil.copyfile(binary, flat / name)
+    shutil.copyfile(library, flat / "sgl_kernel_kt.libs" / library.name)
+    broken = subprocess.run(
+        [sys.executable, "-c", probe, str(flat / name)], capture_output=True, text=True
+    )
+    assert broken.returncode != 0
+    assert library.name in broken.stderr
+    # Corrupted dependencies must be re-extracted on the next materialization.
+    (cache / "sgl_kernel_kt.libs" / library.name).write_bytes(b"corrupted")
+    loader.materialize_binary(name)
+    assert (cache / "sgl_kernel_kt.libs" / library.name).read_bytes() == files[
+        "sgl_kernel_kt.libs/" + library.name
+    ]


### PR DESCRIPTION
## What does this PR do?

- Use llguidance's native tiktoken support for Kimi tokenizers; other models keep the existing dispatch.
- Resolve lazy native binaries using their wheel-relative paths, preserving bundled library lookup. Legacy manifests remain supported.

Two production files, +24/-3 lines, with two focused test files. The packaging counterpart is kvcache-ai/ktransformers#2204.

## Tests

- Focused tokenizer/payload tests: 6 passed in a fresh wheel-only environment.
- Original Kimi tokenizer: multilingual token IDs, EOS, vocabulary, and JSON grammar acceptance/rejection passed.
- Fresh native wheels: dependency / architecture audit and eight concurrent cold imports passed.
- Clean training/serving installation passed. Qwen two-GPU, Kimi four-GPU, and public FP8 GLM-5.3-Flash eight-GPU generation and JSON-schema checks passed.
- Kimi loaded both ordinary and expert LoRA from a freshly resumed training checkpoint; all converted tensors passed exact comparison. Full Neko style validation remains pending.

No model weights, attention kernels, or training runtime changes. Not a release sign-off.
